### PR TITLE
Add CHANGELOG stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Notable changes to Hermex. Version headings correspond to App Store releases;
+unreleased changes accumulate at the top. Format follows
+[Keep a Changelog](https://keepachangelog.com/) with Added / Changed / Fixed /
+Security sections per release.
+
+## [Unreleased]
+
+### Added
+- Public open-source release of the Hermex codebase.


### PR DESCRIPTION
Starts the CHANGELOG convention from the migration plan: Keep a Changelog format, one heading per App Store release, Added/Changed/Fixed/Security sections.

This PR doubles as the end-to-end verification for the new repo's gates: PR CI (Build and Test) must pass as a required check, and the automated review should fire on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)