### PR TITLE
Add FUNDING.yml and allowlist it in the PR CI docs-only filter

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: callmeuzi

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -45,7 +45,7 @@ jobs:
           echo "${files}"
           # Fail closed: anything NOT on the docs-only allowlist triggers the
           # full suite (including workflow, project, and config changes).
-          non_docs=$(echo "${files}" | grep -vE '^(docs/.*|LICENSE|\.gitignore|\.github/ISSUE_TEMPLATE/.*|\.github/CODEOWNERS|\.github/dependabot\.yml|.*\.md)$' || true)
+          non_docs=$(echo "${files}" | grep -vE '^(docs/.*|LICENSE|\.gitignore|\.github/ISSUE_TEMPLATE/.*|\.github/CODEOWNERS|\.github/dependabot\.yml|\.github/FUNDING\.yml|.*\.md)$' || true)
           if [[ -n "${non_docs}" ]]; then
             echo "Non-docs changes detected — running the full suite:"
             echo "${non_docs}"


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` (Buy Me a Coffee) to enable the repo Sponsor button. Split out of #10 so that PR stayed docs-only.
- Adds `.github/FUNDING.yml` to the PR CI docs-only allowlist: it is CI-inert like CODEOWNERS/dependabot.yml, so funding tweaks should not trigger the full macOS suite.

## Testing

- This PR itself triggers the full suite (it touches `pr-ci.yml`, and the filter fails closed on workflow changes) — expected and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)