### PR TITLE
feat(skills): toggle skill enabled state

### DIFF
--- a/HermesMobile/Features/Skills/SkillsView.swift
+++ b/HermesMobile/Features/Skills/SkillsView.swift
@@ -75,6 +75,10 @@ struct SkillsView: View {
                             category: group.category,
                             skills: group.skills,
                             server: server,
+                            togglingSkillNames: viewModel.togglingSkillNames,
+                            onToggleSkill: { skill, enabled in
+                                await toggle(skill: skill, enabled: enabled)
+                            },
                             onAPIError: onAPIError
                         )
                     }
@@ -97,12 +101,21 @@ struct SkillsView: View {
             onAPIError(error)
         }
     }
+
+    private func toggle(skill: SkillSummary, enabled: Bool) async {
+        await viewModel.setSkill(skill, enabled: enabled)
+        if let error = viewModel.lastError {
+            onAPIError(error)
+        }
+    }
 }
 
 private struct SkillCategorySection: View {
     let category: String
     let skills: [SkillSummary]
     let server: URL
+    let togglingSkillNames: Set<String>
+    let onToggleSkill: (SkillSummary, Bool) async -> Void
     let onAPIError: (Error) -> Void
 
     var body: some View {
@@ -125,6 +138,20 @@ private struct SkillCategorySection: View {
                         SkillRow(skill: skill)
                     }
                     .buttonStyle(.plain)
+                    .opacity(skill.disabled == true ? 0.55 : 1)
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        if skill.disabled != nil,
+                           let name = skill.name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+                            let isDisabled = skill.disabled == true
+                            Button {
+                                Task { await onToggleSkill(skill, isDisabled) }
+                            } label: {
+                                Label(isDisabled ? "Enable" : "Disable", systemImage: isDisabled ? "checkmark.circle" : "pause.circle")
+                            }
+                            .tint(isDisabled ? .green : .orange)
+                            .disabled(togglingSkillNames.contains(name))
+                        }
+                    }
 
                     if index < skills.count - 1 {
                         Divider()
@@ -159,6 +186,28 @@ private struct SkillRow: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(3)
                 }
+
+                if skill.disabled == true || !tags.isEmpty {
+                    HStack(spacing: 6) {
+                        if skill.disabled == true {
+                            Text("Disabled")
+                                .font(.caption2.weight(.semibold))
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .foregroundStyle(.secondary)
+                                .background(Color(.tertiarySystemFill), in: Capsule())
+                        }
+
+                        ForEach(tags, id: \.self) { tag in
+                            Text(tag)
+                                .font(.caption2.weight(.medium))
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .foregroundStyle(.secondary)
+                                .background(Color(.secondarySystemFill).opacity(0.8), in: Capsule())
+                        }
+                    }
+                }
             }
 
             Spacer(minLength: 8)
@@ -184,6 +233,12 @@ private struct SkillRow: View {
     private var description: String? {
         let text = skill.description?.trimmingCharacters(in: .whitespacesAndNewlines)
         return text?.isEmpty == false ? text : nil
+    }
+
+    private var tags: [String] {
+        (skill.tags ?? [])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 }
 

--- a/HermesMobile/Features/Skills/SkillsView.swift
+++ b/HermesMobile/Features/Skills/SkillsView.swift
@@ -135,21 +135,25 @@ private struct SkillCategorySection: View {
                             onAPIError: onAPIError
                         )
                     } label: {
-                        SkillRow(skill: skill)
+                        SkillRow(
+                            skill: skill,
+                            isToggling: isToggling(skill),
+                            onToggle: canToggle(skill) ? { enabled in
+                                Task { await onToggleSkill(skill, enabled) }
+                            } : nil
+                        )
                     }
                     .buttonStyle(.plain)
                     .opacity(skill.disabled == true ? 0.55 : 1)
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        if skill.disabled != nil,
-                           let name = skill.name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+                    .contextMenu {
+                        if canToggle(skill) {
                             let isDisabled = skill.disabled == true
                             Button {
                                 Task { await onToggleSkill(skill, isDisabled) }
                             } label: {
                                 Label(isDisabled ? "Enable" : "Disable", systemImage: isDisabled ? "checkmark.circle" : "pause.circle")
                             }
-                            .tint(isDisabled ? .green : .orange)
-                            .disabled(togglingSkillNames.contains(name))
+                            .disabled(isToggling(skill))
                         }
                     }
 
@@ -161,10 +165,23 @@ private struct SkillCategorySection: View {
             }
         }
     }
+
+    private func canToggle(_ skill: SkillSummary) -> Bool {
+        guard skill.disabled != nil else { return false }
+        let name = skill.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !(name ?? "").isEmpty
+    }
+
+    private func isToggling(_ skill: SkillSummary) -> Bool {
+        guard let name = skill.name?.trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+        return togglingSkillNames.contains(name)
+    }
 }
 
 private struct SkillRow: View {
     let skill: SkillSummary
+    var isToggling: Bool = false
+    var onToggle: ((Bool) -> Void)? = nil
 
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
@@ -212,6 +229,18 @@ private struct SkillRow: View {
 
             Spacer(minLength: 8)
 
+            if let onToggle {
+                Toggle(skill.disabled == true ? "Enable" : "Disable", isOn: Binding(
+                    get: { skill.disabled != true },
+                    set: { onToggle($0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .scaleEffect(0.8, anchor: .trailing)
+                .disabled(isToggling)
+                .padding(.top, 6)
+            }
+
             Image(systemName: "chevron.forward")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.tertiary)
@@ -220,6 +249,14 @@ private struct SkillRow: View {
         .padding(.vertical, 10)
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
+        .accessibilityActions {
+            if let onToggle {
+                Button(skill.disabled == true ? "Enable" : "Disable") {
+                    guard !isToggling else { return }
+                    onToggle(skill.disabled == true)
+                }
+            }
+        }
     }
 
     private var displayName: String {

--- a/HermesMobile/Features/Skills/SkillsViewModel.swift
+++ b/HermesMobile/Features/Skills/SkillsViewModel.swift
@@ -58,11 +58,10 @@ final class SkillsViewModel {
 
     func setSkill(_ skill: SkillSummary, enabled: Bool) async {
         guard let name = skill.name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else { return }
+        guard togglingSkillNames.insert(name).inserted else { return }
 
-        let previousSkills = skills
         lastError = nil
         errorMessage = nil
-        togglingSkillNames.insert(name)
         updateSkill(named: name, disabled: !enabled)
         defer { togglingSkillNames.remove(name) }
 
@@ -70,7 +69,7 @@ final class SkillsViewModel {
             _ = try await client.toggleSkill(name: name, enabled: enabled)
             await load()
         } catch {
-            skills = previousSkills
+            updateSkill(named: name, disabled: enabled)
             lastError = error
             errorMessage = error.localizedDescription
         }
@@ -109,7 +108,7 @@ final class SkillsViewModel {
 
     private func updateSkill(named name: String, disabled: Bool) {
         skills = skills.map { skill in
-            guard skill.name == name else { return skill }
+            guard skill.name?.trimmingCharacters(in: .whitespacesAndNewlines) == name else { return skill }
             return SkillSummary(
                 name: skill.name,
                 category: skill.category,

--- a/HermesMobile/Features/Skills/SkillsViewModel.swift
+++ b/HermesMobile/Features/Skills/SkillsViewModel.swift
@@ -8,11 +8,16 @@ final class SkillsViewModel {
     private(set) var isLoading = false
     private(set) var errorMessage: String?
     private(set) var lastError: Error?
+    private(set) var togglingSkillNames: Set<String> = []
 
     private let client: APIClient
 
     init(server: URL) {
         client = APIClient(baseURL: server)
+    }
+
+    init(client: APIClient) {
+        self.client = client
     }
 
     func load() async {
@@ -42,12 +47,33 @@ final class SkillsViewModel {
             let name = skill.name?.localizedCaseInsensitiveContains(query) ?? false
             let description = skill.description?.localizedCaseInsensitiveContains(query) ?? false
             let category = skill.category?.localizedCaseInsensitiveContains(query) ?? false
-            return name || description || category
+            let tags = skill.tags?.contains { $0.localizedCaseInsensitiveContains(query) } ?? false
+            return name || description || category || tags
         }
 
         guard !filtered.isEmpty else { return [] }
 
         return Self.groupedSkills(for: filtered)
+    }
+
+    func setSkill(_ skill: SkillSummary, enabled: Bool) async {
+        guard let name = skill.name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else { return }
+
+        let previousSkills = skills
+        lastError = nil
+        errorMessage = nil
+        togglingSkillNames.insert(name)
+        updateSkill(named: name, disabled: !enabled)
+        defer { togglingSkillNames.remove(name) }
+
+        do {
+            _ = try await client.toggleSkill(name: name, enabled: enabled)
+            await load()
+        } catch {
+            skills = previousSkills
+            lastError = error
+            errorMessage = error.localizedDescription
+        }
     }
 
     static func groupedSkills(for skills: [SkillSummary]) -> [(category: String, skills: [SkillSummary])] {
@@ -79,5 +105,20 @@ final class SkillsViewModel {
             return String(localized: "Unnamed Skill")
         }
         return name
+    }
+
+    private func updateSkill(named name: String, disabled: Bool) {
+        skills = skills.map { skill in
+            guard skill.name == name else { return skill }
+            return SkillSummary(
+                name: skill.name,
+                category: skill.category,
+                description: skill.description,
+                path: skill.path,
+                disabled: disabled,
+                tags: skill.tags,
+                relatedSkills: skill.relatedSkills
+            )
+        }
     }
 }

--- a/HermesMobile/Models/Skills.swift
+++ b/HermesMobile/Models/Skills.swift
@@ -13,6 +13,38 @@ struct SkillSummary: Decodable, Equatable, Identifiable {
     let category: String?
     let description: String?
     let path: String?
+    let disabled: Bool?
+    let tags: [String]?
+    let relatedSkills: [String]?
+
+    init(
+        name: String?,
+        category: String?,
+        description: String?,
+        path: String?,
+        disabled: Bool? = nil,
+        tags: [String]? = nil,
+        relatedSkills: [String]? = nil
+    ) {
+        self.name = name
+        self.category = category
+        self.description = description
+        self.path = path
+        self.disabled = disabled
+        self.tags = tags
+        self.relatedSkills = relatedSkills
+    }
+}
+
+struct ToggleSkillRequest: Encodable, Equatable {
+    let name: String
+    let enabled: Bool
+}
+
+struct ToggleSkillResponse: Decodable, Equatable {
+    let ok: Bool?
+    let name: String?
+    let enabled: Bool?
 }
 
 struct SkillSlashSuggestion: Identifiable, Equatable {

--- a/HermesMobile/Networking/APIClient+Skills.swift
+++ b/HermesMobile/Networking/APIClient+Skills.swift
@@ -8,5 +8,13 @@ extension APIClient {
     func skillContent(name: String, file: String? = nil) async throws -> SkillDetailResponse {
         try await send(endpoint: .skillContent(name: name, file: file), method: "GET")
     }
+
+    func toggleSkill(name: String, enabled: Bool) async throws -> ToggleSkillResponse {
+        try await send(
+            endpoint: .toggleSkill,
+            method: "POST",
+            body: ToggleSkillRequest(name: name, enabled: enabled)
+        )
+    }
 }
 

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -91,6 +91,7 @@ enum Endpoint {
     case memoryWrite
     case skills
     case skillContent(name: String, file: String?)
+    case toggleSkill
     case upload
     case transcribe
 
@@ -276,6 +277,8 @@ enum Endpoint {
             return "/api/skills"
         case .skillContent:
             return "/api/skills/content"
+        case .toggleSkill:
+            return "/api/skills/toggle"
         case .upload:
             return "/api/upload"
         case .transcribe:

--- a/HermesMobileTests/APIClientSkillEndpointTests.swift
+++ b/HermesMobileTests/APIClientSkillEndpointTests.swift
@@ -15,7 +15,7 @@ final class APIClientSkillEndpointTests: APIClientTestCase {
             return apiTestJSONResponse("""
             {
               "skills": [
-                {"name": "swift-refactor", "category": "coding", "description": "Refactors Swift code", "path": "/skills/coding/swift-refactor"},
+                {"name": "swift-refactor", "category": "coding", "description": "Refactors Swift code", "path": "/skills/coding/swift-refactor", "disabled": true, "tags": ["swift", "refactor"], "related_skills": ["test-driven-development"]},
                 {"name": "doc-search", "category": "research", "description": "Searches docs"}
               ]
             }
@@ -27,6 +27,9 @@ final class APIClientSkillEndpointTests: APIClientTestCase {
         XCTAssertEqual(response.skills?[0].name, "swift-refactor")
         XCTAssertEqual(response.skills?[0].category, "coding")
         XCTAssertEqual(response.skills?[0].description, "Refactors Swift code")
+        XCTAssertEqual(response.skills?[0].disabled, true)
+        XCTAssertEqual(response.skills?[0].tags, ["swift", "refactor"])
+        XCTAssertEqual(response.skills?[0].relatedSkills, ["test-driven-development"])
         XCTAssertEqual(response.skills?[1].name, "doc-search")
         XCTAssertEqual(response.skills?[1].category, "research")
     }
@@ -44,6 +47,29 @@ final class APIClientSkillEndpointTests: APIClientTestCase {
         XCTAssertEqual(response.skills?[0].name, "minimal-skill")
         XCTAssertNil(response.skills?[0].category)
         XCTAssertNil(response.skills?[0].description)
+        XCTAssertNil(response.skills?[0].disabled)
+        XCTAssertNil(response.skills?[0].tags)
+        XCTAssertNil(response.skills?[0].relatedSkills)
+    }
+
+    func testToggleSkillPostsExpectedBodyAndDecodesResponse() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/skills/toggle")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let body = try apiTestJSONBody(from: request)
+            XCTAssertEqual(body["name"] as? String, "swift-refactor")
+            XCTAssertEqual(body["enabled"] as? Bool, false)
+
+            return apiTestJSONResponse("""
+            {"ok": true, "name": "swift-refactor", "enabled": false}
+            """, for: request)
+        }
+
+        let response = try await client.toggleSkill(name: "swift-refactor", enabled: false)
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.name, "swift-refactor")
+        XCTAssertEqual(response.enabled, false)
     }
 
     func testSkillContentBuildsExpectedQueryAndDecodesResponse() async throws {

--- a/HermesMobileTests/SkillsViewModelTests.swift
+++ b/HermesMobileTests/SkillsViewModelTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import HermesMobile
 
-final class SkillsViewModelTests: XCTestCase {
+final class SkillsViewModelTests: APIClientTestCase {
     @MainActor
     func testGroupedSkillsNormalizesBlankCategoriesAndSortsRows() {
         let groups = SkillsViewModel.groupedSkills(for: [
@@ -14,5 +14,67 @@ final class SkillsViewModelTests: XCTestCase {
         XCTAssertEqual(groups.map(\.category), ["coding", "Uncategorized"])
         XCTAssertEqual(groups.first?.skills.map(\.name), ["Alpha", "zed"])
         XCTAssertEqual(groups.last?.skills.map { $0.name ?? "Unnamed Skill" }, ["loose", "Unnamed Skill"])
+    }
+
+    @MainActor
+    func testToggleSkillOptimisticallyUpdatesThenReloadsServerState() async throws {
+        var paths: [String] = []
+        var skillsLoadCount = 0
+        let client = makeClient { request in
+            paths.append(request.url?.path ?? "")
+            switch request.url?.path {
+            case "/api/skills":
+                skillsLoadCount += 1
+                let disabled = skillsLoadCount > 1
+                return apiTestJSONResponse("""
+                {"skills": [{"name": "swift-refactor", "category": "coding", "disabled": \(disabled)}]}
+                """, for: request)
+            case "/api/skills/toggle":
+                let body = try apiTestJSONBody(from: request)
+                XCTAssertEqual(body["name"] as? String, "swift-refactor")
+                XCTAssertEqual(body["enabled"] as? Bool, false)
+                return apiTestJSONResponse("""
+                {"ok": true, "name": "swift-refactor", "enabled": false}
+                """, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = SkillsViewModel(client: client)
+
+        await model.load()
+        await model.setSkill(try XCTUnwrap(model.skills.first), enabled: false)
+
+        XCTAssertEqual(paths, ["/api/skills", "/api/skills/toggle", "/api/skills"])
+        XCTAssertEqual(model.skills.first?.disabled, true)
+        XCTAssertNil(model.lastError)
+    }
+
+    @MainActor
+    func testToggleSkillRevertsOnFailure() async throws {
+        var shouldFailToggle = false
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/skills":
+                return apiTestJSONResponse("""
+                {"skills": [{"name": "swift-refactor", "category": "coding", "disabled": false}]}
+                """, for: request)
+            case "/api/skills/toggle":
+                shouldFailToggle = true
+                throw URLError(.notConnectedToInternet)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = SkillsViewModel(client: client)
+
+        await model.load()
+        await model.setSkill(try XCTUnwrap(model.skills.first), enabled: false)
+
+        XCTAssertTrue(shouldFailToggle)
+        XCTAssertEqual(model.skills.first?.disabled, false)
+        XCTAssertNotNil(model.lastError)
     }
 }

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -93,7 +93,7 @@ sub-paths of a group. Do not reorder casually.
 | `/api/model/` | roadmap | P3 | — | Provider / Model Management |
 | `/api/settings` | roadmap | P3 | secret | Settings Write — bot name + password operations |
 | `/api/profile/` | roadmap | P3 | write | Profile Management — active/create/delete |
-| `/api/skills/` | roadmap | P3 | write | Skill Management — save/delete |
+| `/api/skills/` | roadmap | P3 | write | Skill Management — toggle shipped; save/delete remain roadmap |
 | `/api/transcribe` | roadmap | P3 | privacy | Audio Transcription — server-side; audio leaves the device |
 | `/api/workspaces/` | roadmap | P3 | write | Workspace Management — add/remove/rename/reorder |
 | `/api/workspace/` | roadmap | P3 | write | Workspace Management |


### PR DESCRIPTION
## Summary
- Decodes `disabled`, `tags`, and `related_skills` on skill summaries.
- Adds `POST /api/skills/toggle` client support.
- Marks disabled skills in the list and adds enable/disable swipe actions when the server exposes toggle state.
- Reverts optimistic UI changes on toggle failure and refetches after successful toggles.
- Updates the feature-gap note for `/api/skills/`.

Fixes #16

## Validation
- Verified upstream `hermes-webui` route shape in `.codex-tmp/hermes-webui/api/routes.py`: request `{name, enabled}`, response `{ok, name, enabled}`.
- `git diff --check`
- Targeted static content checks for changed endpoint/model/UI/test files.

Not run here:
- Full XCTest suite / simulator validation — this environment is Linux and does not have `xcodebuild` or `swift` installed.

## AI disclosure
Built with Hermes Agent / OpenAI Codex.
