### PR TITLE
perf(chat): lazily render transcript rows

### DIFF
--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -265,6 +265,9 @@ struct ChatTranscriptView: View {
                 .id(bottomAnchorID)
                 .allowsHitTesting(false)
         }
+        // Keep lazy transcript rows registered as scroll targets so older-message
+        // prepends can restore the captured row ID without falling back to eager layout.
+        .scrollTargetLayout()
         .padding(.top, 16)
         .frame(width: contentWidth, alignment: .leading)
         .padding(.horizontal, transcriptHorizontalPadding)

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -194,7 +194,7 @@ struct ChatTranscriptView: View {
         viewportWidth: CGFloat,
         contentWidth: CGFloat
     ) -> some View {
-        VStack(spacing: transcriptMessageSpacing) {
+        LazyVStack(spacing: transcriptMessageSpacing) {
             olderMessagesButton(proxy: proxy)
 
             if let compressionReferenceCard, compressionReferenceCard.afterRenderID == nil {

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -4,6 +4,7 @@ import UIKit
 struct ChatTranscriptView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @State private var transcriptScrollPositionID: String?
 
     let isLoading: Bool
     let errorMessage: String?
@@ -119,6 +120,7 @@ struct ChatTranscriptView: View {
                         )
                     }
                     .frame(width: viewportWidth)
+                    .scrollPosition(id: $transcriptScrollPositionID, anchor: .top)
                     .refreshable {
                         if hasOlderMessages {
                             await loadOlderMessagesPreservingPosition(proxy: proxy)
@@ -308,9 +310,14 @@ struct ChatTranscriptView: View {
 
     private func loadOlderMessagesPreservingPosition(proxy: ScrollViewProxy) async {
         let renderID = displayedTranscriptMessages.first?.renderID
+        if let renderID {
+            transcriptScrollPositionID = renderID
+        }
+
         let didLoad = await onLoadOlderMessages()
         guard didLoad, let renderID else { return }
 
+        transcriptScrollPositionID = renderID
         await Task.yield()
         if reduceMotion {
             proxy.scrollTo(renderID, anchor: .top)

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -538,5 +538,19 @@ final class ChatTranscriptViewPerformanceGuardTests: XCTestCase {
             ) != nil,
             "The lazy transcript stack should opt into scroll target layout so prepending older messages can restore the captured row ID."
         )
+        XCTAssertTrue(
+            sourceWithoutComments.range(
+                of: #"@State\s+private\s+var\s+transcriptScrollPositionID\s*:\s*String\?"#,
+                options: .regularExpression
+            ) != nil,
+            "The transcript scroll position ID should be state-backed so older-message pagination can preserve a row anchor across prepends."
+        )
+        XCTAssertTrue(
+            sourceWithoutComments.range(
+                of: #"\.scrollPosition\s*\(\s*id:\s*\$transcriptScrollPositionID\s*,\s*anchor:\s*\.top\s*\)"#,
+                options: .regularExpression
+            ) != nil,
+            "The scroll view should bind its scroll position to the captured transcript row anchor."
+        )
     }
 }

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -504,3 +504,27 @@ final class AssistantTurnTimestampFormatterTests: XCTestCase {
         XCTAssertNotNil(AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: fixedTimestamp))
     }
 }
+
+final class ChatTranscriptViewPerformanceGuardTests: XCTestCase {
+    func testTranscriptUsesLazyStackForLongConversationScrollPerformance() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let sourceURL = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("HermesMobile/Features/Chat/ChatTranscriptView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let sourceLines = source.components(separatedBy: .newlines).map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }
+
+        XCTAssertTrue(
+            sourceLines.contains("LazyVStack(spacing: transcriptMessageSpacing) {"),
+            "The chat transcript should lazily realize message rows so long conversations do not lay out every bubble while scrolling."
+        )
+        XCTAssertFalse(
+            sourceLines.contains("VStack(spacing: transcriptMessageSpacing) {"),
+            "A plain VStack eagerly builds every transcript row and regresses long-chat scroll performance."
+        )
+    }
+}

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -513,18 +513,30 @@ final class ChatTranscriptViewPerformanceGuardTests: XCTestCase {
             .deletingLastPathComponent()
             .appendingPathComponent("HermesMobile/Features/Chat/ChatTranscriptView.swift")
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
-
-        let sourceLines = source.components(separatedBy: .newlines).map {
-            $0.trimmingCharacters(in: .whitespaces)
-        }
+        let sourceWithoutComments = source
+            .replacingOccurrences(of: #"(?s)/\*.*?\*/"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"(?m)//.*$"#, with: "", options: .regularExpression)
 
         XCTAssertTrue(
-            sourceLines.contains("LazyVStack(spacing: transcriptMessageSpacing) {"),
+            sourceWithoutComments.range(
+                of: #"\bLazyVStack\s*\(\s*spacing:\s*transcriptMessageSpacing\s*\)"#,
+                options: .regularExpression
+            ) != nil,
             "The chat transcript should lazily realize message rows so long conversations do not lay out every bubble while scrolling."
         )
         XCTAssertFalse(
-            sourceLines.contains("VStack(spacing: transcriptMessageSpacing) {"),
+            sourceWithoutComments.range(
+                of: #"\bVStack\s*\(\s*spacing:\s*transcriptMessageSpacing\s*\)"#,
+                options: .regularExpression
+            ) != nil,
             "A plain VStack eagerly builds every transcript row and regresses long-chat scroll performance."
+        )
+        XCTAssertTrue(
+            sourceWithoutComments.range(
+                of: #"\.scrollTargetLayout\s*\(\s*\)"#,
+                options: .regularExpression
+            ) != nil,
+            "The lazy transcript stack should opt into scroll target layout so prepending older messages can restore the captured row ID."
         )
     }
 }


### PR DESCRIPTION
## Linked issue

Fixes #32

## What changed

Chat transcript rows now render inside a `LazyVStack` instead of a plain `VStack`, so long conversations do not eagerly realize every message bubble while scrolling. The existing render IDs, bottom anchor, load-older control, and scroll observer placement are unchanged.

Older-message pagination now keeps a state-backed transcript scroll-position ID, registers the lazy rows with `.scrollTargetLayout()`, and binds the containing `ScrollView` with `.scrollPosition(id:anchor:)` so prepends can preserve the captured visible row without reverting to eager layout.

A source-level XCTest guard was added to catch accidental regressions back to eager transcript row rendering or unbound scroll anchoring.

AI usage: Built with Hermes Agent (Zora) on GPT-5.5.

## How it was tested

- [x] `git diff --check upstream/master` — passed
- [x] `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HermesMobileTests/ChatTranscriptViewPerformanceGuardTests` — passed
- [x] `xcodebuild test -quiet -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'` — passed
- [x] `xcodebuild build -quiet -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'` + `xcrun simctl install booted ...` + `xcrun simctl launch booted com.uzairansar.hermesmobile` — build/install/launch passed

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no Codable model changes)
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [x] No invented API endpoints or JSON shapes (no API or JSON-shape changes)

