### PR TITLE
Error-surfacing batch: terminal apperror SSE · stale-approval 409 · session-move 503 (#25)

### DIFF
--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -7,6 +7,26 @@ private let chatPendingActionCoordinatorLogger = Logger(
     category: "ChatPendingActionCoordinator"
 )
 
+/// Friendly stand-in for the server's 409 `{"stale": true}` respond rejection:
+/// the prompt already expired, so the card is dismissed instead of erroring (issue #25).
+struct PendingPromptExpiredError: LocalizedError, Equatable {
+    enum Prompt: Equatable {
+        case approval
+        case clarification
+    }
+
+    let prompt: Prompt
+
+    var errorDescription: String? {
+        switch prompt {
+        case .approval:
+            String(localized: "That approval request already expired, so the agent has moved on.")
+        case .clarification:
+            String(localized: "That clarification prompt already expired, so the agent has moved on.")
+        }
+    }
+}
+
 @MainActor
 protocol ChatPendingActionCoordinatorDelegate: AnyObject {
     var pendingActionSessionID: String? { get }
@@ -103,6 +123,16 @@ final class ChatPendingActionCoordinator {
             await refreshApprovalPending(sessionID: prompt.sessionID)
             return true
         } catch {
+            if (error as? APIError)?.indicatesExpiredPendingPrompt == true {
+                // The prompt already expired server-side: dismiss the stale card and
+                // explain, instead of leaving a stuck card behind a generic failure.
+                approvalPendingBySession[prompt.sessionID] = nil
+                approvalPrompt = nil
+                delegate?.pendingActionCoordinatorDidFailAction(PendingPromptExpiredError(prompt: .approval))
+                await refreshApprovalPending(sessionID: prompt.sessionID)
+                return false
+            }
+
             approvalErrorMessage = error.localizedDescription
             delegate?.pendingActionCoordinatorDidFailAction(error)
             return false
@@ -186,6 +216,16 @@ final class ChatPendingActionCoordinator {
             await refreshClarificationPending(sessionID: prompt.sessionID)
             return true
         } catch {
+            if (error as? APIError)?.indicatesExpiredPendingPrompt == true {
+                // The prompt already expired server-side: dismiss the stale card and
+                // explain, instead of leaving a stuck card behind a generic failure.
+                clarificationPendingBySession[prompt.sessionID] = nil
+                clarificationPrompt = nil
+                delegate?.pendingActionCoordinatorDidFailAction(PendingPromptExpiredError(prompt: .clarification))
+                await refreshClarificationPending(sessionID: prompt.sessionID)
+                return false
+            }
+
             clarificationErrorMessage = error.localizedDescription
             delegate?.pendingActionCoordinatorDidFailAction(error)
             return false

--- a/HermesMobile/Features/SessionList/SessionMutator.swift
+++ b/HermesMobile/Features/SessionList/SessionMutator.swift
@@ -5,6 +5,15 @@ struct SessionDuplicateResult {
     let errorMessage: String?
 }
 
+/// The server refuses `/api/session/move` with a 503 while the session is
+/// streaming (it holds the per-session agent lock). Surface that as a specific,
+/// actionable message instead of the generic "server unavailable" copy (issue #25).
+struct SessionMoveWhileStreamingError: LocalizedError, Equatable {
+    var errorDescription: String? {
+        String(localized: "This session is still responding, so it can't be moved yet. Try again when it finishes.")
+    }
+}
+
 struct SessionMutator {
     let client: APIClient
 
@@ -25,7 +34,19 @@ struct SessionMutator {
     }
 
     func move(sessionID: String, to projectID: String?) async throws {
-        _ = try await client.moveSession(id: sessionID, projectID: projectID)
+        do {
+            _ = try await client.moveSession(id: sessionID, projectID: projectID)
+        } catch let error as APIError {
+            // Only a 503 carrying the server's JSON error payload is the documented
+            // "session is busy (streaming)" refusal; a proxy/tunnel 503 has no JSON
+            // body and keeps the generic connectivity message.
+            guard case .http(let statusCode, _) = error,
+                  statusCode == 503,
+                  error.serverMessage != nil
+            else { throw error }
+
+            throw SessionMoveWhileStreamingError()
+        }
     }
 
     func duplicate(sessionID: String, title: String) async throws -> SessionDuplicateResult {

--- a/HermesMobile/Models/Approval.swift
+++ b/HermesMobile/Models/Approval.swift
@@ -143,16 +143,30 @@ struct PendingApproval: Decodable, Equatable, Identifiable {
 struct ApprovalRespondResponse: Decodable, Equatable {
     let ok: Bool?
     let choice: ApprovalChoice?
+    /// Server cleared a stale card whose approval already resolved (benign 200; issue #25).
+    let staleCleared: Bool?
+    /// The respond was relayed to a gateway-managed run rather than resolved locally.
+    let relayed: Bool?
+    /// The prompt already expired (paired with a 409 on the docs' respond contract).
+    let stale: Bool?
 
     enum CodingKeys: String, CodingKey {
         case ok
         case choice
+        case staleCleared
+        case staleClearedSnake = "stale_cleared"
+        case relayed
+        case stale
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         ok = container.decodeLossyBoolIfPresent(forKey: .ok)
         choice = try? container.decodeIfPresent(ApprovalChoice.self, forKey: .choice)
+        staleCleared = container.decodeLossyBoolIfPresent(forKey: .staleCleared)
+            ?? container.decodeLossyBoolIfPresent(forKey: .staleClearedSnake)
+        relayed = container.decodeLossyBoolIfPresent(forKey: .relayed)
+        stale = container.decodeLossyBoolIfPresent(forKey: .stale)
     }
 }
 

--- a/HermesMobile/Models/Clarification.swift
+++ b/HermesMobile/Models/Clarification.swift
@@ -168,16 +168,30 @@ struct PendingClarification: Decodable, Equatable, Identifiable {
 struct ClarificationRespondResponse: Decodable, Equatable {
     let ok: Bool?
     let response: String?
+    /// The prompt already expired or was resolved (paired with a 409; issue #25).
+    let stale: Bool?
+    /// Server cleared a stale card whose prompt already resolved (mirrors approvals).
+    let staleCleared: Bool?
+    /// The respond was relayed to a gateway-managed run rather than resolved locally.
+    let relayed: Bool?
 
     enum CodingKeys: String, CodingKey {
         case ok
         case response
+        case stale
+        case staleCleared
+        case staleClearedSnake = "stale_cleared"
+        case relayed
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         ok = container.decodeLossyBoolIfPresent(forKey: .ok)
         response = container.decodeLossyStringIfPresent(forKey: .response)
+        stale = container.decodeLossyBoolIfPresent(forKey: .stale)
+        staleCleared = container.decodeLossyBoolIfPresent(forKey: .staleCleared)
+            ?? container.decodeLossyBoolIfPresent(forKey: .staleClearedSnake)
+        relayed = container.decodeLossyBoolIfPresent(forKey: .relayed)
     }
 }
 

--- a/HermesMobile/Networking/APIError.swift
+++ b/HermesMobile/Networking/APIError.swift
@@ -79,6 +79,14 @@ enum APIError: LocalizedError {
         return Self.serverErrorMessage(from: body)
     }
 
+    /// True for the documented "prompt already expired" respond rejection:
+    /// HTTP 409 with `{"stale": true, …}` in the body (issue #25). Used to show
+    /// a friendly expired state instead of a generic failure.
+    var indicatesExpiredPendingPrompt: Bool {
+        guard case .http(let statusCode, let body) = self, statusCode == 409 else { return false }
+        return Self.serverErrorPayload(from: body)?.stale == true
+    }
+
     static func privacySafeLogCategory(for error: Error) -> String {
         if let apiError = error as? APIError {
             return apiError.privacySafeLogCategory
@@ -102,6 +110,7 @@ private extension APIError {
         let message: String?
         let detail: String?
         let code: String?
+        let stale: Bool?
     }
 
     static func networkMessage(for error: Error) -> String {

--- a/HermesMobile/Networking/SSEClient.swift
+++ b/HermesMobile/Networking/SSEClient.swift
@@ -235,7 +235,13 @@ struct SSEEventDecoder {
             return .streamEnd
         case "cancel":
             return .cancelled
-        case "error":
+        case "error", "apperror":
+            // "apperror" is one of the four socket-closing frames (stream_end, cancel,
+            // error, apperror). The docs describe its payload as {error, type, session,
+            // terminal_state?} while the pinned upstream emits {message, type, hint,
+            // details, …}; decoding both `error` and `message` covers either shape.
+            // Mapping it onto `.error` reuses the existing terminal error path
+            // (surface the message, finish the stream) unchanged.
             guard let payload = decodePayload(ErrorPayload.self, eventType: eventType, from: eventData, decoder: decoder) else {
                 return .error(String(localized: "The stream returned a malformed error event."))
             }

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -1803,6 +1803,324 @@
         }
       }
     },
+    "That approval request already expired, so the agent has moved on." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "انتهت صلاحية طلب الموافقة هذا بالفعل، لذا واصل العميل عمله."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diese Genehmigungsanfrage ist bereits abgelaufen, der Agent hat daher weitergemacht."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esa solicitud de aprobación ya expiró, así que el agente ha continuado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cette demande d'approbation a déjà expiré, l'agent a donc continué."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בקשת האישור הזו כבר פגה, ולכן הסוכן המשיך הלאה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Questa richiesta di approvazione è già scaduta, quindi l'agente è andato avanti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "この承認リクエストはすでに期限切れのため、エージェントは先に進みました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "해당 승인 요청이 이미 만료되어 에이전트가 계속 진행했어요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dit goedkeuringsverzoek is al verlopen, dus de agent is verdergegaan."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ta prośba o zatwierdzenie już wygasła, więc agent kontynuował pracę."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Essa solicitação de aprovação já expirou, então o agente seguiu em frente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Срок этого запроса на подтверждение уже истёк, поэтому агент продолжил работу."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu onay isteğinin süresi zaten dolduğu için ajan devam etti."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "منظوری کی یہ درخواست پہلے ہی ختم ہو چکی ہے، اس لیے ایجنٹ آگے بڑھ گیا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該審批要求已過期，代理已繼續執行。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "该审批请求已过期，智能体已继续执行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該審核要求已過期，代理人已繼續執行。"
+          }
+        }
+      }
+    },
+    "That clarification prompt already expired, so the agent has moved on." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "انتهت صلاحية طلب التوضيح هذا بالفعل، لذا واصل العميل عمله."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diese Rückfrage ist bereits abgelaufen, der Agent hat daher weitergemacht."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esa solicitud de aclaración ya expiró, así que el agente ha continuado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cette demande de clarification a déjà expiré, l'agent a donc continué."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בקשת ההבהרה הזו כבר פגה, ולכן הסוכן המשיך הלאה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Questa richiesta di chiarimento è già scaduta, quindi l'agente è andato avanti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "この確認プロンプトはすでに期限切れのため、エージェントは先に進みました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "해당 설명 요청이 이미 만료되어 에이전트가 계속 진행했어요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dit verduidelijkingsverzoek is al verlopen, dus de agent is verdergegaan."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ta prośba o wyjaśnienie już wygasła, więc agent kontynuował pracę."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esse pedido de esclarecimento já expirou, então o agente seguiu em frente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Срок этого запроса на уточнение уже истёк, поэтому агент продолжил работу."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu açıklama isteminin süresi zaten dolduğu için ajan devam etti."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "وضاحت کا یہ پرامپٹ پہلے ہی ختم ہو چکا ہے، اس لیے ایجنٹ آگے بڑھ گیا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該澄清提示已過期，代理已繼續執行。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "该澄清提示已过期，智能体已继续执行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該釐清提示已過期，代理人已繼續執行。"
+          }
+        }
+      }
+    },
+    "This session is still responding, so it can't be moved yet. Try again when it finishes." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لا تزال هذه الجلسة تردّ، لذا لا يمكن نقلها بعد. حاول مرة أخرى عند انتهائها."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diese Sitzung antwortet noch und kann deshalb noch nicht verschoben werden. Versuche es erneut, sobald sie fertig ist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta sesión todavía está respondiendo, así que aún no se puede mover. Inténtalo de nuevo cuando termine."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cette session est encore en train de répondre et ne peut pas encore être déplacée. Réessayez quand elle aura terminé."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "המפגש הזה עדיין מגיב, ולכן אי אפשר להעביר אותו כעת. נסה שוב כשיסתיים."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Questa sessione sta ancora rispondendo, quindi non può ancora essere spostata. Riprova quando ha finito."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "このセッションはまだ応答中のため、まだ移動できません。完了してからもう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 세션은 아직 응답 중이라 지금은 이동할 수 없어요. 완료된 후 다시 시도하세요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deze sessie is nog aan het antwoorden en kan daarom nog niet worden verplaatst. Probeer het opnieuw zodra deze klaar is."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ta sesja wciąż odpowiada, więc nie można jej jeszcze przenieść. Spróbuj ponownie, gdy się zakończy."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta sessão ainda está respondendo, então não pode ser movida agora. Tente novamente quando ela terminar."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Эта сессия ещё отвечает, поэтому её пока нельзя переместить. Повторите попытку, когда она завершится."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu oturum hâlâ yanıt veriyor, bu yüzden henüz taşınamıyor. Bittiğinde yeniden deneyin."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "یہ سیشن ابھی جواب دے رہا ہے، اس لیے فی الحال اسے منتقل نہیں کیا جا سکتا۔ مکمل ہونے پر دوبارہ کوشش کریں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該工作階段仍在回覆中，暫時無法移動。請待其完成後再試。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "该会话仍在回复中，暂时无法移动。请等它完成后再试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該工作階段仍在回覆中，暫時無法移動。請待其完成後再試。"
+          }
+        }
+      }
+    },
     "Write" : {
       "localizations" : {
         "de" : {

--- a/HermesMobileTests/APIClientAgentControlTests.swift
+++ b/HermesMobileTests/APIClientAgentControlTests.swift
@@ -96,6 +96,37 @@ final class APIClientAgentControlTests: APIClientTestCase {
         XCTAssertNil(observedBodies[3]["approval_id"])
     }
 
+    func testApprovalRespondResponseDecodesStaleFieldsTolerantly() async throws {
+        // Upstream signals a benign stale click with 200 {"ok": true, "stale_cleared": true}
+        // and gateway relays with "relayed" (issue #25).
+        let client = makeClient { request in
+            apiTestJSONResponse(
+                #"{"ok": true, "choice": "once", "stale_cleared": true, "relayed": "true", "future": {"x": 1}}"#,
+                for: request
+            )
+        }
+
+        let response = try await client.respondApproval(
+            sessionID: "abc123",
+            choice: .once,
+            approvalID: "approval-1"
+        )
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.choice, .once)
+        XCTAssertEqual(response.staleCleared, true)
+        XCTAssertEqual(response.relayed, true)
+        XCTAssertNil(response.stale)
+
+        let stale = try JSONDecoder().decode(
+            ApprovalRespondResponse.self,
+            from: Data(#"{"ok": false, "error": "Approval prompt expired.", "stale": true}"#.utf8)
+        )
+        XCTAssertEqual(stale.ok, false)
+        XCTAssertEqual(stale.stale, true)
+        XCTAssertNil(stale.staleCleared)
+    }
+
     func testSessionYoloGetAndPostUseUpstreamShape() async throws {
         var requestCount = 0
         let client = makeClient { request in

--- a/HermesMobileTests/APIClientSessionMutationTests.swift
+++ b/HermesMobileTests/APIClientSessionMutationTests.swift
@@ -279,6 +279,54 @@ final class APIClientSessionMutationTests: APIClientTestCase {
         XCTAssertNil(response.session?.projectId)
     }
 
+    func testSessionMutatorMove503WithServerPayloadMapsToStreamingBusyError() async throws {
+        // Upstream refuses a move while the session streams: 503 + JSON error payload.
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/session/move")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"error": "Session is busy (streaming). Please try again in a moment."}"#.utf8))
+        }
+
+        do {
+            try await SessionMutator(client: client).move(sessionID: "abc123", to: "proj123")
+            XCTFail("Expected SessionMoveWhileStreamingError")
+        } catch is SessionMoveWhileStreamingError {
+            XCTAssertEqual(
+                SessionMoveWhileStreamingError().errorDescription,
+                String(localized: "This session is still responding, so it can't be moved yet. Try again when it finishes.")
+            )
+        }
+    }
+
+    func testSessionMutatorMoveProxy503WithoutJSONPayloadKeepsGenericAPIError() async throws {
+        // A tunnel/proxy 503 serves HTML, not the server's JSON payload; keep the
+        // generic connectivity message for that case (issue #25).
+        let client = makeClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html"]
+            )!
+            return (response, Data("<html>Service Unavailable</html>".utf8))
+        }
+
+        do {
+            try await SessionMutator(client: client).move(sessionID: "abc123", to: nil)
+            XCTFail("Expected APIError.http(503)")
+        } catch let error as APIError {
+            guard case .http(let statusCode, _) = error else {
+                return XCTFail("Expected APIError.http, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 503)
+        }
+    }
+
     func testArchiveSessionBuildsExpectedBodyAndDecodesResponse() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/session/archive")

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -542,6 +542,32 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testDecodedAppErrorEventTerminatesStreamAndSurfacesMessage() {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-apperror")
+        streamClient.emit(SSEEventDecoder.decode(
+            eventType: "apperror",
+            data: #"{"message": "Auto-compression failed", "type": "compression_error"}"#
+        ))
+
+        // apperror rides the terminal `.error` path: message surfaced, run failed,
+        // socket stopped, stream fully finished (issue #25).
+        XCTAssertEqual(delegate.errorMessages, ["Auto-compression failed"])
+        XCTAssertEqual(liveActivityManager.ends.last?.status, .failed)
+        XCTAssertNil(coordinator.activeStreamID)
+        XCTAssertEqual(streamClient.stopCount, 1)
+        XCTAssertEqual(delegate.finishCount, 1)
+    }
+
+    @MainActor
     private func makeCoordinator(
         streamClient: CoordinatorSpySSEStreamingClient? = nil,
         liveActivityManager: CoordinatorSpyLiveActivityManager? = nil,

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -969,6 +969,64 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testApprovalStale409DismissesPromptWithFriendlyExpiredMessage() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let approvalStreamClient = SpySSEStreamingClient()
+        let clarifyStreamClient = SpySSEStreamingClient()
+        var didRefreshPendingAfterStale = false
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            approvalStreamClient: approvalStreamClient,
+            clarifyStreamClient: clarifyStreamClient
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(#"{"session_id": "session-abc", "stream_id": "stream-123"}"#, for: request)
+            case "/api/approval/respond":
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 409,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (response, Data(#"{"ok": false, "error": "Approval prompt expired or not found.", "stale": true}"#.utf8))
+            case "/api/approval/pending":
+                didRefreshPendingAfterStale = true
+                return apiTestJSONResponse(#"{"pending": null}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Run the installer")
+        XCTAssertTrue(didStart)
+        approvalStreamClient.emit(.approvalPending(ApprovalPendingResponse(
+            pending: PendingApproval(
+                approvalId: "approval-1",
+                command: "make install",
+                description: "Install command",
+                patternKey: "install"
+            ),
+            pendingCount: 1
+        )))
+
+        let didRespond = await viewModel.respondToApproval(.once)
+
+        // Expired prompt: the stale card dismisses with a friendly explanation
+        // instead of sticking around behind a generic failure (issue #25).
+        XCTAssertFalse(didRespond)
+        XCTAssertNil(viewModel.approvalPrompt)
+        XCTAssertNil(viewModel.approvalErrorMessage)
+        XCTAssertEqual(
+            viewModel.sendErrorMessage,
+            PendingPromptExpiredError(prompt: .approval).localizedDescription
+        )
+        XCTAssertTrue(didRefreshPendingAfterStale)
+        XCTAssertEqual(viewModel.activeStreamID, "stream-123")
+    }
+
+    @MainActor
     func testApprovalFallbackPollingFailureStaysDiagnosticOnly() async throws {
         let streamClient = SpySSEStreamingClient()
         let approvalStreamClient = SpySSEStreamingClient()

--- a/HermesMobileTests/ClarificationTests.swift
+++ b/HermesMobileTests/ClarificationTests.swift
@@ -109,6 +109,81 @@ final class ClarificationTests: XCTestCase {
         XCTAssertEqual(client.clarifyStreamURL(sessionID: "session-abc").path, "/api/clarify/stream")
     }
 
+    func testClarificationRespondResponseDecodesStaleFieldsTolerantly() throws {
+        let stale = try JSONDecoder().decode(
+            ClarificationRespondResponse.self,
+            from: Data(#"{"ok": false, "error": "Clarification prompt expired or not found.", "stale": true}"#.utf8)
+        )
+        XCTAssertEqual(stale.ok, false)
+        XCTAssertEqual(stale.stale, true)
+        XCTAssertNil(stale.staleCleared)
+        XCTAssertNil(stale.relayed)
+
+        let cleared = try JSONDecoder().decode(
+            ClarificationRespondResponse.self,
+            from: Data(#"{"ok": true, "response": "A", "stale_cleared": "true", "relayed": 1}"#.utf8)
+        )
+        XCTAssertEqual(cleared.ok, true)
+        XCTAssertEqual(cleared.staleCleared, true)
+        XCTAssertEqual(cleared.relayed, true)
+        XCTAssertNil(cleared.stale)
+    }
+
+    @MainActor
+    func testClarificationStale409DismissesPromptWithFriendlyExpiredMessage() async throws {
+        let streamClient = ClarificationSpySSEStreamingClient()
+        let approvalStreamClient = ClarificationSpySSEStreamingClient()
+        let clarifyStreamClient = ClarificationSpySSEStreamingClient()
+        var didRefreshPendingAfterStale = false
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            approvalStreamClient: approvalStreamClient,
+            clarifyStreamClient: clarifyStreamClient
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return jsonResponse(#"{"session_id": "session-abc", "stream_id": "stream-123"}"#, for: request)
+            case "/api/clarify/respond":
+                return jsonResponse(
+                    #"{"ok": false, "error": "Clarification prompt expired or not found. The agent may have already proceeded.", "stale": true}"#,
+                    statusCode: 409,
+                    for: request
+                )
+            case "/api/clarify/pending":
+                didRefreshPendingAfterStale = true
+                return jsonResponse(#"{"pending": null}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Continue")
+        XCTAssertTrue(didStart)
+        clarifyStreamClient.emit(.clarificationPending(ClarificationPendingResponse(
+            pending: PendingClarification(
+                clarifyId: "clarify-1",
+                question: "Which branch?",
+                sessionId: "session-abc"
+            ),
+            pendingCount: 1
+        )))
+
+        let didRespond = await viewModel.respondToClarification("Use main")
+
+        // Expired prompt: the stale card dismisses with a friendly explanation
+        // instead of sticking around behind a generic failure (issue #25).
+        XCTAssertFalse(didRespond)
+        XCTAssertNil(viewModel.clarificationPrompt)
+        XCTAssertNil(viewModel.clarificationErrorMessage)
+        XCTAssertEqual(
+            viewModel.sendErrorMessage,
+            PendingPromptExpiredError(prompt: .clarification).localizedDescription
+        )
+        XCTAssertTrue(didRefreshPendingAfterStale)
+        XCTAssertEqual(viewModel.activeStreamID, "stream-123")
+    }
+
     func testSSEDecoderHandlesClarifyAndInitialEvents() {
         let clarify = SSEEventDecoder.decode(
             eventType: "clarify",

--- a/HermesMobileTests/SSEClientTests.swift
+++ b/HermesMobileTests/SSEClientTests.swift
@@ -449,6 +449,38 @@ final class SSEClientTests: XCTestCase {
         XCTAssertEqual(event, .error("The stream returned a malformed error event."))
     }
 
+    func testAppErrorEventDecodesPinnedUpstreamMessageShape() {
+        // Pinned upstream `_provider_error_payload`: {message, type, hint, details, session, …}.
+        let event = SSEEventDecoder.decode(
+            eventType: "apperror",
+            data: #"{"message": "Provider exploded", "type": "no_response", "hint": "Check the provider keys.", "details": "Provider exploded", "session_id": "session-abc", "session": {"session_id": "session-abc"}}"#
+        )
+
+        XCTAssertEqual(event, .error("Provider exploded"))
+    }
+
+    func testAppErrorEventDecodesDocsErrorShape() {
+        // API docs describe the payload as {error, type, session, terminal_state?}.
+        let event = SSEEventDecoder.decode(
+            eventType: "apperror",
+            data: #"{"error": "Terminal failure", "type": "tool_limit_reached", "terminal_state": "tool_limit_reached"}"#
+        )
+
+        XCTAssertEqual(event, .error("Terminal failure"))
+    }
+
+    func testAppErrorEventWithoutMessageFallsBackToGenericError() {
+        let event = SSEEventDecoder.decode(eventType: "apperror", data: "{}")
+
+        XCTAssertEqual(event, .error("The stream returned an error."))
+    }
+
+    func testMalformedAppErrorPayloadSurfacesExplicitError() {
+        let event = SSEEventDecoder.decode(eventType: "apperror", data: "{")
+
+        XCTAssertEqual(event, .error("The stream returned a malformed error event."))
+    }
+
     func testUnknownStreamEventTypeIsIgnored() {
         let event = SSEEventDecoder.decode(
             eventType: "future_server_event",


### PR DESCRIPTION
Fixes #25

## Plan (E1 — pre-approved for this unattended run)

Smallest slice per the issue:

1. **`SSEClient.decode`**: add `"apperror"` to the existing `"error"` case — decode via the existing `ErrorPayload` (`error`/`message` keys) and emit the existing terminal `.error` event so ChatStreamCoordinator/ChatViewModel error handling runs unchanged. Unknown event types stay `.ignored`.
2. **Respond responses**: add tolerant optional `stale`, `staleCleared` (`stale_cleared`), `relayed` to `ApprovalRespondResponse` / `ClarificationRespondResponse`; add `APIError.indicatesExpiredPendingPrompt` (409 + `{"stale": true}` body). In `ChatPendingActionCoordinator`, on that error dismiss the stale card, surface a friendly "already expired" message, and refresh pending state.
3. **Session move**: in `SessionMutator.move`, map a 503 that carries the server's JSON error payload to a specific `SessionMoveWhileStreamingError`; a proxy/tunnel 503 without a JSON body keeps the generic connectivity message.
4. **Tests**: apperror decode (upstream + docs shapes, missing message, malformed payload), terminality through the stream coordinator, unknown-event tolerance regression, respond-response tolerant decode, approval + clarification stale-409 end-to-end through ChatViewModel, move-503 mapping and proxy-503 passthrough.
5. New user-facing strings externalized and translated in all 17 app languages.

## Upstream shape validation (recorded per issue instructions)

Validated just-in-time against the pinned upstream @ `312d3fab`:

- **`apperror` payload** — `api/streaming.py` `_provider_error_payload`: `{"message", "type", "hint"?, "details"?}`; docs describe `{"error", "type", "session", "terminal_state"?}`. The existing `ErrorPayload {error?, message?}` covers both; both shapes are unit-tested.
- **Clarify respond stale** — `api/routes.py` `_handle_clarify_respond`: 409 `{"ok": false, "error": "Clarification prompt expired or not found. …", "stale": true}`.
- **Approval respond** — benign stale click on an empty queue returns **200** `{"ok": true, "choice": …, "stale_cleared": true}` (decoded, treated as success); gateway relay adds `"relayed"`; the docs' 409-with-`stale` contract is what `indicatesExpiredPendingPrompt` matches. A gateway `gateway_run_unavailable` 409 has no `stale` field and intentionally keeps the generic error.
- **Session move busy** — `api/routes.py` `/api/session/move`: bounded lock acquire → 503 `{"error": "Session is busy (streaming). Please try again in a moment."}`.

## Behavior changed (plain English)

- A server-sent terminal `apperror` frame now shows its message in the chat error surface and ends the turn cleanly, instead of being silently ignored until reconnect gives up.
- Answering an approval/clarification that already expired now dismisses the card and says the prompt expired, instead of a generic failure with a stuck card.
- Moving a session while it is still responding now says exactly that, instead of a generic server error.

## Validation

- `git diff --check` clean.
- Full XCTest suite: `xcodebuild test -scheme HermesMobile` on iPhone 17 simulator (Hermex-W1) — **TEST SUCCEEDED** on the head commit.

## Owner manual checks

- [ ] Start a chat turn that triggers a provider failure (e.g. break the provider key server-side) → the error message appears in chat; turn ends cleanly; no stuck spinner.
- [ ] Trigger an approval, let it expire/resolve elsewhere (respond from the WebUI first), then answer it in the app → card dismisses with the "already expired" message, no generic failure alert.
- [ ] Same for a clarification prompt.
- [ ] While a session is actively streaming, try to move it to another project → specific "still responding, try again when it finishes" message; moving an idle session still works.
- [ ] Normal streaming, fresh approvals/clarifications, and session moves behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)