### PR TITLE
Chat: Listen prefers server TTS (POST /api/tts) with on-device fallback

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -204,6 +204,8 @@
 		C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */; };
 		C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F105 /* APIClientTranscribeTests.swift */; };
 		C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */; };
+		C03260000000000000B101 /* APIClient+TTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F101 /* APIClient+TTS.swift */; };
+		C03260000000000000B102 /* APIClientTTSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F102 /* APIClientTTSTests.swift */; };
 		C03140000000000000B001 /* GitBranchPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03140000000000000F001 /* GitBranchPickerView.swift */; };
 		C03120000000000000B006 /* APIClientGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F006 /* APIClientGitTests.swift */; };
 		C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */; };
@@ -514,6 +516,8 @@
 		C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorder.swift; sourceTree = "<group>"; };
 		C03250000000000000F105 /* APIClientTranscribeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTranscribeTests.swift; sourceTree = "<group>"; };
 		C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorderTests.swift; sourceTree = "<group>"; };
+		C03260000000000000F101 /* APIClient+TTS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+TTS.swift"; sourceTree = "<group>"; };
+		C03260000000000000F102 /* APIClientTTSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTTSTests.swift; sourceTree = "<group>"; };
 		C03140000000000000F001 /* GitBranchPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranchPickerView.swift; sourceTree = "<group>"; };
 		C03120000000000000F006 /* APIClientGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientGitTests.swift; sourceTree = "<group>"; };
 		C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceViewModelTests.swift; sourceTree = "<group>"; };
@@ -709,6 +713,7 @@
 				C0390000000000000000000C /* APIClientSkillEndpointTests.swift */,
 				C0390000000000000000000D /* APIClientUploadTests.swift */,
 				C03250000000000000F105 /* APIClientTranscribeTests.swift */,
+				C03260000000000000F102 /* APIClientTTSTests.swift */,
 				C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */,
 					C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */,
 					C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */,
@@ -797,6 +802,7 @@
 				C04000000000000000000019 /* APIClient+Upload.swift */,
 				1A2B3C4D5E6F7000000000B8 /* Endpoints.swift */,
 				C03250000000000000F102 /* APIClient+Transcribe.swift */,
+				C03260000000000000F101 /* APIClient+TTS.swift */,
 				C03250000000000000F103 /* MultipartFormData.swift */,
 				1A2B3C4D5E6F7000000000D7 /* SSEClient.swift */,
 				C0FF000000000000000000A2 /* CustomHeader.swift */,
@@ -1348,6 +1354,7 @@
 				1A2B3C4D5E6F7000000000A8 /* Endpoints.swift in Sources */,
 				C03250000000000000B101 /* TranscribeResponse.swift in Sources */,
 				C03250000000000000B102 /* APIClient+Transcribe.swift in Sources */,
+				C03260000000000000B101 /* APIClient+TTS.swift in Sources */,
 				C03250000000000000B103 /* MultipartFormData.swift in Sources */,
 				C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */,
 				1A2B3C4D5E6F7000000000A3 /* APIError.swift in Sources */,
@@ -1514,6 +1521,7 @@
 				C0391000000000000000000C /* APIClientSkillEndpointTests.swift in Sources */,
 				C0391000000000000000000D /* APIClientUploadTests.swift in Sources */,
 				C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */,
+				C03260000000000000B102 /* APIClientTTSTests.swift in Sources */,
 				C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */,
 					C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */,
 					C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -3250,9 +3250,11 @@ final class ChatViewModel {
         }
 
         stopListening()
-        // Route speech to the speaker (not the receiver/earpiece) before speaking;
-        // released again in `finishListening()` once playback ends. See #252.
-        listenAudioSession.activate()
+        // The audio session is NOT activated here: `/api/tts` can be slow or
+        // unreachable, and activating the non-mixable playback session before the
+        // fetch would silence other audio while Hermex has nothing to play (review
+        // on #35). Activation happens at the two playback-start points instead —
+        // `startServerAudioPlayback` and `speakWithOnDeviceSynthesizer`.
         listeningMessageID = context.messageID
 
         guard ServerTTSPolicy.shouldUseServerTTS(for: listenText) else {
@@ -4224,6 +4226,11 @@ final class ChatViewModel {
     /// Speaks `text` with the on-device `AVSpeechSynthesizer` — the pre-#15 Listen
     /// path, kept as the offline/failure fallback for server TTS.
     private func speakWithOnDeviceSynthesizer(_ text: String) {
+        // Route speech to the speaker (not the receiver/earpiece) immediately before
+        // speech starts — not when the Listen tap lands — so a slow `/api/tts` fetch
+        // never interrupts other audio while Hermex is silent (review on #35).
+        // Released again in `finishListening()` once playback ends. See #252.
+        listenAudioSession.activate()
         let speechSynthesizer = speechSynthesizerForListening()
         let utterance = AVSpeechUtterance(string: text)
         utterance.rate = AVSpeechUtteranceDefaultSpeechRate
@@ -4244,6 +4251,11 @@ final class ChatViewModel {
             self?.handleListenPlayerCompletion(for: playerID)
         }
 
+        // Activate the session only once decodable audio is in hand, immediately
+        // before playback, so the network wait never held it (review on #35). If
+        // `play()` still fails, the on-device fallback re-activates for itself —
+        // `activate()` is idempotent, and `finishListening()` releases it either way.
+        listenAudioSession.activate()
         guard player.play() else {
             return false
         }

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -241,6 +241,23 @@ final class ChatViewModel {
     // from a superseded utterance (e.g. switching messages mid-playback) is ignored so
     // it can't clear the new listen state or deactivate the session. See #252.
     private var activeListeningUtteranceID: ObjectIdentifier?
+    // Server-TTS playback seam (#15): the factory builds an audio player from the
+    // server's synthesized bytes; injectable so tests never construct a real
+    // `AVAudioPlayer` (which requires decodable audio data).
+    private let serverTTSAudioPlayerFactory: @MainActor (Data) throws -> any ListenAudioPlaying
+    private var listenAudioPlayer: (any ListenAudioPlaying)?
+    // Identity of the server-TTS player currently playing. Mirrors
+    // `activeListeningUtteranceID`: a stale finish callback from a superseded player
+    // must not clear the new listen state or deactivate the session.
+    private var activeListenPlayerID: ObjectIdentifier?
+    // In-flight `POST /api/tts` fetch for the Listen action. Cancelled by
+    // `stopListening()`; exposed (read-only) so tests can await the async
+    // server-first path deterministically.
+    @ObservationIgnored private(set) var listenPreparationTask: Task<Void, Never>?
+    // Identity of the Listen request the in-flight fetch belongs to. A response
+    // arriving after stop/switch carries a stale ID and is dropped instead of
+    // starting audio the user no longer wants.
+    private var activeListenRequestID: UUID?
     private var showsLiveActivityResponseExcerpts: Bool
     private var hasCompletedCurrentResponse: Bool { streamCoordinator.hasCompletedCurrentResponse }
     private var isStreamConnectionSuspended: Bool { streamCoordinator.isConnectionSuspended }
@@ -283,7 +300,8 @@ final class ChatViewModel {
         streamingWordRevealCadenceNanoseconds: UInt64 = 48_000_000,
         streamingMaxRevealLagNanoseconds: UInt64 = 1_000_000_000,
         speechSynthesizerFactory: @escaping () -> any ChatSpeechSynthesizing = { AVSpeechSynthesizer() },
-        listenAudioSession: (any ListenAudioSessionControlling)? = nil
+        listenAudioSession: (any ListenAudioSessionControlling)? = nil,
+        serverTTSAudioPlayerFactory: (@MainActor (Data) throws -> any ListenAudioPlaying)? = nil
     ) {
         sessionID = session.sessionId
         currentWorkspace = session.workspace
@@ -318,6 +336,8 @@ final class ChatViewModel {
         self.streamingMaxRevealLagNanoseconds = streamingMaxRevealLagNanoseconds
         self.speechSynthesizerFactory = speechSynthesizerFactory
         self.listenAudioSession = listenAudioSession ?? ListenAudioSessionController()
+        self.serverTTSAudioPlayerFactory = serverTTSAudioPlayerFactory
+            ?? { try ServerTTSAudioPlayer(data: $0) }
         displayTitle = Self.displayTitle(from: session.title)
         self.streamCoordinator.attach(delegate: self)
         self.pendingActionCoordinator.delegate = self
@@ -3218,30 +3238,76 @@ final class ChatViewModel {
             return
         }
 
-        if listeningMessageID == context.messageID, speechSynthesizer?.isSpeaking == true {
+        // Tapping the message that is already listening — fetching server audio or
+        // playing on either engine — toggles it off. Matching on `listeningMessageID`
+        // alone (not `isSpeaking`) also debounces rapid double-taps: the second tap
+        // stops cleanly instead of firing a second `/api/tts` call into the server's
+        // ~2 s rate limit or stacking audio (#15).
+        if listeningMessageID == context.messageID {
             stopListening()
             return
         }
 
         stopListening()
-        let speechSynthesizer = speechSynthesizerForListening()
         // Route speech to the speaker (not the receiver/earpiece) before speaking;
         // released again in `finishListening()` once playback ends. See #252.
         listenAudioSession.activate()
-        let utterance = AVSpeechUtterance(string: listenText)
-        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
-        activeListeningUtteranceID = ObjectIdentifier(utterance)
         listeningMessageID = context.messageID
-        speechSynthesizer.speak(utterance)
-    }
 
-    func stopListening() {
-        guard let speechSynthesizer else {
-            finishListening()
+        guard ServerTTSPolicy.shouldUseServerTTS(for: listenText) else {
+            // Over the server's 5000-char request cap: go straight to the on-device
+            // path (chunking is a non-goal of #15).
+            speakWithOnDeviceSynthesizer(listenText)
             return
         }
 
-        if speechSynthesizer.isSpeaking || speechSynthesizer.isPaused {
+        // Prefer the server's neural TTS; on any failure (offline, 4xx/5xx, rate
+        // limit, undecodable audio) fall back silently to the on-device
+        // synthesizer — no error alert (#15).
+        let requestID = UUID()
+        activeListenRequestID = requestID
+        listenPreparationTask = Task { [weak self, client] in
+            guard !Task.isCancelled else {
+                // Stopped before the fetch began (e.g. a rapid second tap): skip
+                // the request entirely instead of issuing one whose response
+                // would be dropped anyway.
+                return
+            }
+            let audioData: Data?
+            do {
+                audioData = try await client.synthesizeSpeech(
+                    text: listenText,
+                    voice: ServerTTSPolicy.defaultVoice
+                )
+            } catch {
+                audioData = nil
+            }
+
+            guard let self, !Task.isCancelled, self.activeListenRequestID == requestID else {
+                // Stopped or superseded while the fetch was in flight — the user no
+                // longer wants this audio; never start playback from a stale response.
+                return
+            }
+
+            if let audioData, self.startServerAudioPlayback(audioData) {
+                return
+            }
+            self.speakWithOnDeviceSynthesizer(listenText)
+        }
+    }
+
+    func stopListening() {
+        // Cancel any in-flight server-TTS fetch so a late response can't start
+        // audio after the user asked to stop (or switched messages).
+        listenPreparationTask?.cancel()
+        listenPreparationTask = nil
+        activeListenRequestID = nil
+
+        // `AVAudioPlayer.stop()` does not fire the finish delegate, so no stale
+        // callback follows; state is torn down synchronously in `finishListening()`.
+        listenAudioPlayer?.stop()
+
+        if let speechSynthesizer, speechSynthesizer.isSpeaking || speechSynthesizer.isPaused {
             speechSynthesizer.stopSpeaking(at: .immediate)
         }
         finishListening()
@@ -4145,10 +4211,53 @@ final class ChatViewModel {
 
     private func finishListening() {
         activeListeningUtteranceID = nil
+        activeListenPlayerID = nil
+        activeListenRequestID = nil
+        listenAudioPlayer = nil
         listeningMessageID = nil
         // Release the shared session so any audio we interrupted can resume. Safe to
         // call when nothing was speaking: `setActive(false)` no-ops via `try?`.
         listenAudioSession.deactivate()
+    }
+
+    /// Speaks `text` with the on-device `AVSpeechSynthesizer` — the pre-#15 Listen
+    /// path, kept as the offline/failure fallback for server TTS.
+    private func speakWithOnDeviceSynthesizer(_ text: String) {
+        let speechSynthesizer = speechSynthesizerForListening()
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+        activeListeningUtteranceID = ObjectIdentifier(utterance)
+        speechSynthesizer.speak(utterance)
+    }
+
+    /// Attempts to start playback of server-synthesized audio bytes. Returns
+    /// `false` when the bytes can't be decoded into a player or playback fails to
+    /// start, so the caller can fall back to the on-device synthesizer.
+    private func startServerAudioPlayback(_ audioData: Data) -> Bool {
+        guard let player = try? serverTTSAudioPlayerFactory(audioData) else {
+            return false
+        }
+
+        let playerID = ObjectIdentifier(player)
+        player.onFinish = { [weak self] in
+            self?.handleListenPlayerCompletion(for: playerID)
+        }
+
+        guard player.play() else {
+            return false
+        }
+
+        listenAudioPlayer = player
+        activeListenPlayerID = playerID
+        return true
+    }
+
+    /// Completion routed from the server-TTS audio player. Mirrors
+    /// `handleListenCompletion(for:)`: a stale callback from a superseded player
+    /// must not clear the new listen state or deactivate the session.
+    private func handleListenPlayerCompletion(for playerID: ObjectIdentifier) {
+        guard playerID == activeListenPlayerID else { return }
+        finishListening()
     }
 
     /// Completion routed from the speech-synthesizer delegate. Switching messages mid-
@@ -4983,6 +5092,72 @@ struct SpeechTextNormalizer {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return normalized.isEmpty ? nil : normalized
+    }
+}
+
+/// Routing policy for the "Listen" action (#15): prefer the server's neural TTS
+/// (`POST /api/tts`, edge engine — no API key needed) and fall back to the
+/// on-device synthesizer when the server can't serve the request.
+enum ServerTTSPolicy {
+    /// Server-enforced request cap (`400 text too long` above it); longer text
+    /// routes straight to the on-device synthesizer (chunking is a non-goal).
+    static let maximumTextLength = 5000
+    /// The server's own default voice is `zh-CN-XiaoxiaoNeural`, so the client
+    /// must always send an explicit voice. A voice picker is a non-goal of #15;
+    /// this is the issue-specified default (verified live 2026-07-02).
+    static let defaultVoice = "en-US-AriaNeural"
+
+    static func shouldUseServerTTS(for text: String) -> Bool {
+        text.count <= maximumTextLength
+    }
+}
+
+/// Playback seam for server-synthesized "Listen" audio. Injectable so tests can
+/// drive playback outcomes without constructing a real `AVAudioPlayer` (which
+/// requires decodable audio bytes).
+@MainActor
+protocol ListenAudioPlaying: AnyObject {
+    /// Fired on the main actor when playback finishes naturally.
+    /// `stop()` must not fire it.
+    var onFinish: (@MainActor () -> Void)? { get set }
+
+    @discardableResult
+    func play() -> Bool
+    func stop()
+}
+
+/// Production `ListenAudioPlaying`: wraps `AVAudioPlayer` and forwards its finish
+/// delegate onto the main actor. `init` throws when the bytes aren't decodable
+/// audio, which the caller treats as "fall back to the on-device synthesizer".
+@MainActor
+final class ServerTTSAudioPlayer: NSObject, ListenAudioPlaying {
+    private let player: AVAudioPlayer
+    var onFinish: (@MainActor () -> Void)?
+
+    init(data: Data) throws {
+        player = try AVAudioPlayer(data: data)
+        super.init()
+        player.delegate = self
+    }
+
+    @discardableResult
+    func play() -> Bool {
+        player.play()
+    }
+
+    func stop() {
+        player.stop()
+    }
+}
+
+extension ServerTTSAudioPlayer: AVAudioPlayerDelegate {
+    // `AVAudioPlayer` may call its delegate off the main thread; hop back before
+    // touching main-actor listen state. Finished-with-error still ends playback,
+    // so both flag values route to `onFinish`.
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            self.onFinish?()
+        }
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -348,6 +348,7 @@ final class ChatViewModel {
         backgroundPollTask?.cancel()
         pendingStreamingScrollTriggerTask?.cancel()
         pendingStreamingContentFlushTask?.cancel()
+        listenPreparationTask?.cancel()
     }
 
     func setShowsLiveActivityResponseExcerpts(_ shows: Bool) {
@@ -5155,6 +5156,16 @@ extension ServerTTSAudioPlayer: AVAudioPlayerDelegate {
     // touching main-actor listen state. Finished-with-error still ends playback,
     // so both flag values route to `onFinish`.
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            self.onFinish?()
+        }
+    }
+
+    // A mid-playback decode error fires this callback instead of (or as well as)
+    // the finish one — without it the listen state would stay stuck "listening"
+    // forever. Route it to `onFinish` too; a double fire is harmless because the
+    // completion handler drops callbacks from a no-longer-active player.
+    nonisolated func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
         Task { @MainActor in
             self.onFinish?()
         }

--- a/HermesMobile/Networking/APIClient+TTS.swift
+++ b/HermesMobile/Networking/APIClient+TTS.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// JSON body for `POST /api/tts`. Only `text` and `voice` are sent: the server
+/// defaults `engine` to `edge` (no API key needed) and `rate`/`pitch` to neutral,
+/// and a voice/engine picker is a non-goal of #15. `voice` must always be sent
+/// explicitly — the server's own default is `zh-CN-XiaoxiaoNeural`.
+struct TTSSynthesisRequest: Encodable {
+    let text: String
+    let voice: String
+}
+
+extension APIClient {
+    /// Synthesizes `text` into speech via the server's neural TTS
+    /// (`POST /api/tts`, edge engine) and returns the raw audio bytes
+    /// (`audio/mpeg` for edge).
+    ///
+    /// The server fully buffers the response (`Content-Length` is set, not
+    /// chunked), so a single-shot `Data` download is correct — no streaming
+    /// logic. Reuses `sendData`, which maps 401 → `.unauthorized` and every
+    /// other non-2xx to `.http` carrying the server's `{"error": ...}` body
+    /// text (400 invalid input, 429 rate limit, 503 missing engine key).
+    /// Callers treat any thrown error as "fall back to the on-device
+    /// synthesizer" (#15).
+    func synthesizeSpeech(text: String, voice: String) async throws -> Data {
+        try await sendData(
+            endpoint: .tts,
+            method: "POST",
+            body: TTSSynthesisRequest(text: text, voice: voice)
+        )
+    }
+}

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -94,6 +94,7 @@ enum Endpoint {
     case toggleSkill
     case upload
     case transcribe
+    case tts
 
     var path: String {
         switch self {
@@ -283,6 +284,8 @@ enum Endpoint {
             return "/api/upload"
         case .transcribe:
             return "/api/transcribe"
+        case .tts:
+            return "/api/tts"
         }
     }
 

--- a/HermesMobileTests/APIClientTTSTests.swift
+++ b/HermesMobileTests/APIClientTTSTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import HermesMobile
+
+final class APIClientTTSTests: APIClientTestCase {
+    func testSynthesizeSpeechPostsJSONAndReturnsRawAudioBytes() async throws {
+        // Not valid MPEG audio — the client must return the bytes untouched,
+        // never attempt to JSON-decode a 2xx TTS response.
+        let audioBytes = Data([0xFF, 0xF3, 0x18, 0xC4, 0x00, 0x01])
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/tts")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+            guard let body = apiTestBodyData(from: request) else {
+                XCTFail("Missing request body")
+                throw URLError(.badServerResponse)
+            }
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(json["text"] as? String, "Hello from Hermex.")
+            // The server defaults to `zh-CN-XiaoxiaoNeural`, so the voice must
+            // always be sent explicitly.
+            XCTAssertEqual(json["voice"] as? String, "en-US-AriaNeural")
+            // No engine/rate/pitch: the server defaults to the keyless edge engine
+            // with neutral prosody, and a picker is a non-goal (#15).
+            XCTAssertEqual(json.count, 2)
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, audioBytes)
+        }
+
+        let data = try await client.synthesizeSpeech(text: "Hello from Hermex.", voice: "en-US-AriaNeural")
+
+        XCTAssertEqual(data, audioBytes)
+    }
+
+    func testSynthesizeSpeechThrowsHTTPCarryingServerErrorBodyOnRateLimit() async {
+        let client = makeClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 429,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"error": "rate limit exceeded — please wait"}"#.utf8))
+        }
+
+        do {
+            _ = try await client.synthesizeSpeech(text: "Too fast.", voice: "en-US-AriaNeural")
+            XCTFail("Expected APIError.http")
+        } catch let APIError.http(statusCode, body) {
+            // The caller treats any thrown error as "fall back to the on-device
+            // synthesizer"; the status/body are only for diagnostics.
+            XCTAssertEqual(statusCode, 429)
+            XCTAssertEqual(body?.contains("rate limit exceeded"), true)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testSynthesizeSpeechMapsUnauthorized() async {
+        let client = makeClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        do {
+            _ = try await client.synthesizeSpeech(text: "Hello.", voice: "en-US-AriaNeural")
+            XCTFail("Expected APIError.unauthorized")
+        } catch APIError.unauthorized {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -98,6 +98,10 @@ final class ChatViewModelSendTests: XCTestCase {
         ))
 
         viewModel.toggleListening(to: context)
+        // Regression (review on #35): the tap itself must NOT activate the session —
+        // a slow `/api/tts` fetch would otherwise silence other audio while Hermex
+        // has nothing to play. Activation belongs to the moment playback starts.
+        XCTAssertEqual(audioSession.activateCount, 0)
         await viewModel.listenPreparationTask?.value
 
         XCTAssertEqual(audioSession.activateCount, 1)
@@ -232,6 +236,9 @@ final class ChatViewModelSendTests: XCTestCase {
         ))
 
         viewModel.toggleListening(to: context)
+        // Regression (review on #35): no session activation while the fetch is in
+        // flight — only once decoded server audio is about to play.
+        XCTAssertEqual(audioSession.activateCount, 0)
         await viewModel.listenPreparationTask?.value
 
         // Server audio plays; the on-device synthesizer is never touched.

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -31,7 +31,7 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
-    func testListenCreatesSpeechSynthesizerOnlyWhenRequested() throws {
+    func testListenCreatesSpeechSynthesizerOnlyWhenRequested() async throws {
         let speechSynthesizer = SpySpeechSynthesizer()
         var createdSynthesizers = 0
         let viewModel = try makeViewModel(
@@ -40,8 +40,10 @@ final class ChatViewModelSendTests: XCTestCase {
                 return speechSynthesizer
             }
         ) { request in
-            XCTFail("Listening to an already loaded message should not request network work.")
-            return apiTestJSONResponse("{}", for: request)
+            // Listen now prefers server TTS (#15); refuse it so the on-device
+            // fallback path is what creates the synthesizer.
+            XCTAssertEqual(request.url?.path, "/api/tts")
+            return Self.ttsUnavailableResponse(for: request)
         }
         let context = try XCTUnwrap(MessageActionContext(
             message: ChatMessage(
@@ -55,6 +57,8 @@ final class ChatViewModelSendTests: XCTestCase {
         ))
 
         viewModel.toggleListening(to: context)
+        XCTAssertEqual(viewModel.listeningMessageID, "assistant-1")
+        await viewModel.listenPreparationTask?.value
 
         XCTAssertEqual(createdSynthesizers, 1)
         XCTAssertEqual(speechSynthesizer.spokenStrings, ["Playback should be explicit."])
@@ -72,7 +76,7 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
-    func testListenActivatesAudioSessionBeforeSpeaking() throws {
+    func testListenActivatesAudioSessionBeforeSpeaking() async throws {
         let recorder = ListenCallRecorder()
         let speechSynthesizer = SpySpeechSynthesizer(recorder: recorder)
         let audioSession = SpyListenAudioSession(recorder: recorder)
@@ -80,8 +84,7 @@ final class ChatViewModelSendTests: XCTestCase {
             speechSynthesizerFactory: { speechSynthesizer },
             listenAudioSession: audioSession
         ) { request in
-            XCTFail("Listening should not request network work.")
-            return apiTestJSONResponse("{}", for: request)
+            Self.ttsUnavailableResponse(for: request)
         }
         let context = try XCTUnwrap(MessageActionContext(
             message: ChatMessage(
@@ -95,6 +98,7 @@ final class ChatViewModelSendTests: XCTestCase {
         ))
 
         viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
 
         XCTAssertEqual(audioSession.activateCount, 1)
         XCTAssertEqual(speechSynthesizer.spokenStrings, ["Out loud, please."])
@@ -114,8 +118,7 @@ final class ChatViewModelSendTests: XCTestCase {
             speechSynthesizerFactory: { speechSynthesizer },
             listenAudioSession: audioSession
         ) { request in
-            XCTFail("Listening should not request network work.")
-            return apiTestJSONResponse("{}", for: request)
+            Self.ttsUnavailableResponse(for: request)
         }
         func makeContext(_ id: String, _ text: String, _ timestamp: Double) throws -> MessageActionContext {
             try XCTUnwrap(MessageActionContext(
@@ -127,8 +130,10 @@ final class ChatViewModelSendTests: XCTestCase {
 
         // Start listening to A, then switch to B while A is still "speaking".
         viewModel.toggleListening(to: try makeContext("assistant-A", "First message.", 1_770_000_010))
+        await viewModel.listenPreparationTask?.value
         let utteranceA = try XCTUnwrap(speechSynthesizer.spokenUtterances.first)
         viewModel.toggleListening(to: try makeContext("assistant-B", "Second message.", 1_770_000_011))
+        await viewModel.listenPreparationTask?.value
 
         XCTAssertEqual(viewModel.listeningMessageID, "assistant-B")
         let deactivationsBeforeStaleCallback = audioSession.deactivateCount
@@ -151,15 +156,14 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
-    func testStoppingListeningReleasesAudioSession() throws {
+    func testStoppingListeningReleasesAudioSession() async throws {
         let speechSynthesizer = SpySpeechSynthesizer()
         let audioSession = SpyListenAudioSession()
         let viewModel = try makeViewModel(
             speechSynthesizerFactory: { speechSynthesizer },
             listenAudioSession: audioSession
         ) { request in
-            XCTFail("Listening should not request network work.")
-            return apiTestJSONResponse("{}", for: request)
+            Self.ttsUnavailableResponse(for: request)
         }
         let context = try XCTUnwrap(MessageActionContext(
             message: ChatMessage(
@@ -173,12 +177,238 @@ final class ChatViewModelSendTests: XCTestCase {
         ))
 
         viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
         let deactivationsAfterStart = audioSession.deactivateCount
 
         viewModel.stopListening()
 
         XCTAssertGreaterThan(audioSession.deactivateCount, deactivationsAfterStart)
         XCTAssertNil(viewModel.listeningMessageID)
+    }
+
+    @MainActor
+    func testListenPrefersServerTTSAndPlaysReturnedAudio() async throws {
+        let audioSession = SpyListenAudioSession()
+        let player = SpyListenAudioPlayer()
+        var receivedAudioData: [Data] = []
+        var createdSynthesizers = 0
+        let serverAudio = Data([0xFF, 0xF3, 0x18, 0xC4])
+        let viewModel = try makeViewModel(
+            speechSynthesizerFactory: {
+                createdSynthesizers += 1
+                return SpySpeechSynthesizer()
+            },
+            listenAudioSession: audioSession,
+            serverTTSAudioPlayerFactory: { data in
+                receivedAudioData.append(data)
+                return player
+            }
+        ) { request in
+            XCTAssertEqual(request.url?.path, "/api/tts")
+            guard let body = apiTestBodyData(from: request),
+                  let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] else {
+                XCTFail("Missing TTS request body")
+                throw URLError(.badServerResponse)
+            }
+            XCTAssertEqual(json["text"] as? String, "Neural, please.")
+            XCTAssertEqual(json["voice"] as? String, ServerTTSPolicy.defaultVoice)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, serverAudio)
+        }
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: "Neural, please.",
+                timestamp: 1_770_000_020,
+                messageId: "assistant-20"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
+
+        // Server audio plays; the on-device synthesizer is never touched.
+        XCTAssertEqual(receivedAudioData, [serverAudio])
+        XCTAssertEqual(player.playCount, 1)
+        XCTAssertEqual(createdSynthesizers, 0)
+        XCTAssertEqual(viewModel.listeningMessageID, "assistant-20")
+        XCTAssertEqual(audioSession.activateCount, 1)
+
+        // Natural finish tears listen state down and releases the session. The
+        // defensive stopListening() at the start of toggleListening also
+        // deactivates once, so assert the finish-driven delta, not a total.
+        let deactivationsBeforeFinish = audioSession.deactivateCount
+        player.finishPlayback()
+        XCTAssertNil(viewModel.listeningMessageID)
+        XCTAssertGreaterThan(audioSession.deactivateCount, deactivationsBeforeFinish)
+    }
+
+    @MainActor
+    func testListenFallsBackToSynthesizerSilentlyWhenServerTTSFails() async throws {
+        let speechSynthesizer = SpySpeechSynthesizer()
+        var playerFactoryCalls = 0
+        let viewModel = try makeViewModel(
+            speechSynthesizerFactory: { speechSynthesizer },
+            serverTTSAudioPlayerFactory: { _ in
+                playerFactoryCalls += 1
+                return SpyListenAudioPlayer()
+            }
+        ) { request in
+            // A raw 429 from the ~2 s rate limit must never surface to the user.
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 429,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"error": "rate limit exceeded — please wait"}"#.utf8))
+        }
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: "Fall back quietly.",
+                timestamp: 1_770_000_021,
+                messageId: "assistant-21"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
+
+        XCTAssertEqual(playerFactoryCalls, 0)
+        XCTAssertEqual(speechSynthesizer.spokenStrings, ["Fall back quietly."])
+        XCTAssertEqual(viewModel.listeningMessageID, "assistant-21")
+        // Silent fallback: no error alert for the user (#15).
+        XCTAssertNil(viewModel.messageActionErrorMessage)
+    }
+
+    @MainActor
+    func testListenFallsBackToSynthesizerWhenServerAudioIsUndecodable() async throws {
+        let speechSynthesizer = SpySpeechSynthesizer()
+        let viewModel = try makeViewModel(
+            speechSynthesizerFactory: { speechSynthesizer },
+            serverTTSAudioPlayerFactory: { _ in
+                throw URLError(.cannotDecodeContentData)
+            }
+        ) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, Data("not really audio".utf8))
+        }
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: "Bad bytes, good fallback.",
+                timestamp: 1_770_000_022,
+                messageId: "assistant-22"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
+
+        XCTAssertEqual(speechSynthesizer.spokenStrings, ["Bad bytes, good fallback."])
+        XCTAssertNil(viewModel.messageActionErrorMessage)
+    }
+
+    @MainActor
+    func testListenOverServerLimitSkipsServerTTSEntirely() async throws {
+        let speechSynthesizer = SpySpeechSynthesizer()
+        let viewModel = try makeViewModel(
+            speechSynthesizerFactory: { speechSynthesizer }
+        ) { request in
+            XCTFail("Text over the 5000-char cap must not hit /api/tts.")
+            return apiTestJSONResponse("{}", for: request)
+        }
+        let longText = String(repeating: "a", count: ServerTTSPolicy.maximumTextLength + 1)
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: longText,
+                timestamp: 1_770_000_023,
+                messageId: "assistant-23"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+
+        // Straight to the on-device path — synchronous, no preparation task.
+        XCTAssertNil(viewModel.listenPreparationTask)
+        XCTAssertEqual(speechSynthesizer.spokenStrings, [longText])
+        XCTAssertEqual(viewModel.listeningMessageID, "assistant-23")
+    }
+
+    @MainActor
+    func testSecondTapWhileFetchingServerAudioStopsInsteadOfRestarting() async throws {
+        let speechSynthesizer = SpySpeechSynthesizer()
+        var playerFactoryCalls = 0
+        var ttsRequests = 0
+        let viewModel = try makeViewModel(
+            speechSynthesizerFactory: { speechSynthesizer },
+            serverTTSAudioPlayerFactory: { _ in
+                playerFactoryCalls += 1
+                return SpyListenAudioPlayer()
+            }
+        ) { request in
+            ttsRequests += 1
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, Data([0xFF, 0xF3]))
+        }
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: "Tap tap.",
+                timestamp: 1_770_000_024,
+                messageId: "assistant-24"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+        let firstFetch = viewModel.listenPreparationTask
+        // Second tap lands while the server fetch is still in flight: it must act
+        // as "Stop Listening", not queue a second /api/tts call (#15 double-tap).
+        viewModel.toggleListening(to: context)
+
+        XCTAssertNil(viewModel.listeningMessageID)
+        XCTAssertNil(viewModel.listenPreparationTask)
+
+        // Even if the first response completes after the stop, its stale request
+        // ID must not start playback or speech.
+        await firstFetch?.value
+        XCTAssertEqual(playerFactoryCalls, 0)
+        XCTAssertTrue(speechSynthesizer.spokenStrings.isEmpty)
+        XCTAssertNil(viewModel.listeningMessageID)
+        XCTAssertLessThanOrEqual(ttsRequests, 1)
+    }
+
+    func testServerTTSPolicyRoutesByServerTextCap() {
+        XCTAssertTrue(ServerTTSPolicy.shouldUseServerTTS(for: String(repeating: "a", count: 5000)))
+        XCTAssertFalse(ServerTTSPolicy.shouldUseServerTTS(for: String(repeating: "a", count: 5001)))
+        XCTAssertEqual(ServerTTSPolicy.defaultVoice, "en-US-AriaNeural")
     }
 
     @MainActor
@@ -6156,6 +6386,18 @@ final class ChatViewModelSendTests: XCTestCase {
         await Task { @MainActor in }.value
     }
 
+    /// A `503 {"error": ...}` for `/api/tts` — the canonical "server TTS refused,
+    /// use the on-device fallback" stimulus for Listen tests (#15).
+    private static func ttsUnavailableResponse(for request: URLRequest) -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 503,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        return (response, Data(#"{"error": "TTS engine unavailable"}"#.utf8))
+    }
+
     @MainActor
     private func makeViewModel(
         streamClient: SSEStreamingClient? = nil,
@@ -6167,6 +6409,7 @@ final class ChatViewModelSendTests: XCTestCase {
         streamingScrollCoalescingDelayNanoseconds: UInt64 = 16_000_000,
         speechSynthesizerFactory: @escaping () -> any ChatSpeechSynthesizing = { AVSpeechSynthesizer() },
         listenAudioSession: (any ListenAudioSessionControlling)? = nil,
+        serverTTSAudioPlayerFactory: (@MainActor (Data) throws -> any ListenAudioPlaying)? = nil,
         handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
     ) throws -> ChatViewModel {
         MockURLProtocol.requestHandler = handler
@@ -6196,7 +6439,8 @@ final class ChatViewModelSendTests: XCTestCase {
             streamingScrollCoalescingDelayNanoseconds: streamingScrollCoalescingDelayNanoseconds,
             speechSynthesizerFactory: speechSynthesizerFactory,
             // Default to a spy so unit tests never drive the live shared AVAudioSession.
-            listenAudioSession: listenAudioSession ?? SpyListenAudioSession()
+            listenAudioSession: listenAudioSession ?? SpyListenAudioSession(),
+            serverTTSAudioPlayerFactory: serverTTSAudioPlayerFactory
         )
 
         if let spyStreamClient = resolvedStreamClient as? SpySSEStreamingClient {
@@ -6427,6 +6671,28 @@ private final class SpySpeechSynthesizer: ChatSpeechSynthesizing {
     /// delegate ignores the synthesizer argument, so a throwaway instance is fine.
     func fireDidCancel(_ utterance: AVSpeechUtterance) {
         delegate?.speechSynthesizer?(AVSpeechSynthesizer(), didCancel: utterance)
+    }
+}
+
+@MainActor
+private final class SpyListenAudioPlayer: ListenAudioPlaying {
+    var onFinish: (@MainActor () -> Void)?
+    var playResult = true
+    private(set) var playCount = 0
+    private(set) var stopCount = 0
+
+    func play() -> Bool {
+        playCount += 1
+        return playResult
+    }
+
+    func stop() {
+        stopCount += 1
+    }
+
+    /// Simulates the wrapped `AVAudioPlayer` finishing naturally.
+    func finishPlayback() {
+        onFinish?()
     }
 }
 


### PR DESCRIPTION
Fixes #15

> [!IMPORTANT]
> **Owner manual validation required before merge** (issue is labeled `needs-manual-validation`; express mode used per owner override for the unattended 2026-07-03 batch run).

## Manual validation checklist (owner)

- [ ] **Neural server audio:** Long-press an assistant message → **Listen**. After a short fetch, audio plays through the **speaker** with a neural voice (noticeably better than the robotic on-device voice).
- [ ] **Offline fallback:** Enable Airplane Mode → Listen still speaks via the on-device synthesizer, and **no error alert** appears for the silent fallback.
- [ ] **Rapid double-tap:** Tap Listen twice quickly on the same message. The second tap acts as Stop; audio never stacks and no raw "429/rate limit" error surfaces.
- [ ] **Stop semantics (both engines):** "Stop Listening" stops server audio mid-play; it also stops the on-device voice (test in Airplane Mode). Starting Listen on another message stops the current one.
- [ ] **Long message:** Listen on a >5000-character assistant reply speaks immediately with the on-device voice (server call skipped by design).
- [ ] **No earpiece regression:** Audio comes from the loudspeaker, not the receiver/earpiece (#252 behavior preserved).

## What changed

"Listen" on assistant messages now prefers the server's neural TTS (`POST /api/tts`, edge engine — no API key needed) and falls back **silently** to the existing on-device `AVSpeechSynthesizer` when the server can't serve the request (offline, 4xx/5xx, rate limit, undecodable audio).

- `Endpoints.swift`: new `case tts` → `/api/tts`.
- `APIClient+TTS.swift` (new): `synthesizeSpeech(text:voice:)` returns raw audio `Data` via the existing `sendData` seam (401 → `.unauthorized`; other non-2xx → `.http` carrying the server's `{"error": …}` body). The server fully buffers the response, so a single-shot download is correct — no streaming.
- `ChatViewModel.swift`:
  - `ServerTTSPolicy`: 5000-char server cap routes long text straight to the on-device path (chunking is a non-goal); default voice `en-US-AriaNeural` (the server's own default is `zh-CN-XiaoxiaoNeural`, so the client must always send a voice — verified live 2026-07-02).
  - `ListenAudioPlaying` protocol + `ServerTTSAudioPlayer` (`AVAudioPlayer` wrapper) with an injectable factory so playback is unit-testable.
  - `toggleListening`: tapping the already-listening message — while fetching **or** playing on either engine — toggles off. This also debounces rapid double-taps so a second `/api/tts` call never fires into the server's ~2 s rate limit.
  - `stopListening`: cancels the in-flight fetch (stale responses are dropped by request-ID guard), stops the `AVAudioPlayer`, stops the synthesizer, releases the audio session. The #252 `.playback`/speaker routing and stale-callback guards are preserved and mirrored for the new player.

## Plan (E1, pre-approved for this unattended run)

1. Add `/api/tts` endpoint case. 2. Raw-`Data` APIClient method reusing `sendData`. 3. Server-first Listen with silent on-device fallback, >5000-char bypass, double-tap debounce, unified stop semantics. 4. Unit tests for endpoint/body construction, error mapping, fallback routing, cancellation, and the 5000-char boundary. 5. Register new files in `project.pbxproj`. Playback itself is owner manual validation.

## Decisions made unattended

- **Voice constant, not locale-mapped:** always sends `en-US-AriaNeural` (the issue's example voice, verified live). A locale-aware voice map (13 app languages) risks inventing voice names outside the verified allowlist; a voice picker is an explicit non-goal. Flagged as a possible follow-up.
- **Toggle-off on second tap of the same message** (previously required `isSpeaking`): matches the menu's "Stop Listening" label state and is what debounces double-taps during the async fetch.

## Validation

- `git diff --check` clean.
- Full XCTest suite (`xcodebuild test`, scheme `HermesMobile`) on simulator Hermex-W0 (iPhone 17): **1198 passed, 0 failures** on the head commit.
- No new third-party dependencies; no new user-facing strings (silent fallback), so no localization changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
