### PR TITLE
Chat: gate the reasoning-effort picker per model via supported_efforts (#18)

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerConfigLoader.swift
+++ b/HermesMobile/Features/Chat/ChatComposerConfigLoader.swift
@@ -7,6 +7,12 @@ struct ChatComposerConfigState: Equatable, Sendable {
     var currentProfile: String?
     var selectedProfileName: String?
     var selectedReasoningEffort: String?
+    /// Model-aware effort vocabulary (`supported_efforts`); `nil` on older
+    /// servers → composer falls back to the full static list (issue #18).
+    var supportedReasoningEfforts: [String]?
+    /// `supports_reasoning_effort`; `false` hides the effort control, `nil`
+    /// (older servers) keeps it visible.
+    var supportsReasoningEffort: Bool?
     var modelCatalogGroups: [ModelCatalogGroup]
     var agentCommands: [AgentCommand]
     var workspaceRoots: [WorkspaceRoot]
@@ -21,6 +27,8 @@ struct ChatComposerConfigState: Equatable, Sendable {
         currentProfile: String? = nil,
         selectedProfileName: String? = nil,
         selectedReasoningEffort: String? = nil,
+        supportedReasoningEfforts: [String]? = nil,
+        supportsReasoningEffort: Bool? = nil,
         modelCatalogGroups: [ModelCatalogGroup] = [],
         agentCommands: [AgentCommand] = [],
         workspaceRoots: [WorkspaceRoot] = [],
@@ -34,6 +42,8 @@ struct ChatComposerConfigState: Equatable, Sendable {
         self.currentProfile = currentProfile
         self.selectedProfileName = selectedProfileName
         self.selectedReasoningEffort = selectedReasoningEffort
+        self.supportedReasoningEfforts = supportedReasoningEfforts
+        self.supportsReasoningEffort = supportsReasoningEffort
         self.modelCatalogGroups = modelCatalogGroups
         self.agentCommands = agentCommands
         self.workspaceRoots = workspaceRoots
@@ -101,8 +111,16 @@ struct ChatComposerConfigLoader {
                     ?? Self.uniqueProvider(for: state.currentModel, in: state.modelCatalogGroups)
             }
 
-            let reasoningResponse = try await client.reasoning()
+            // Scope the query to the session's resolved model/provider so the
+            // gating fields are model-accurate (issue #18); the seeded effort is
+            // the server's already-coerced value for that model.
+            let reasoningResponse = try await client.reasoning(
+                model: Self.nonEmpty(state.currentModel),
+                provider: Self.nonEmpty(state.currentModelProvider)
+            )
             state.selectedReasoningEffort = reasoningResponse.effectiveEffort
+            state.supportedReasoningEfforts = reasoningResponse.normalizedSupportedEfforts
+            state.supportsReasoningEffort = reasoningResponse.supportsReasoningEffort
 
             let workspaceResponse = try await client.workspaces()
             state.workspaceRoots = workspaceResponse.workspaces ?? []

--- a/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
@@ -241,6 +241,9 @@ struct ComposerModelMenu: View {
 
 struct ComposerReasoningMenu: View {
     let selectedReasoningEffort: String?
+    /// Server-provided effort vocabulary for the current model; `nil` falls
+    /// back to the full static list (older servers, issue #18).
+    let supportedEfforts: [String]?
     let reasoningTitle: String
     let isDisabled: Bool
     let width: CGFloat
@@ -272,7 +275,7 @@ struct ComposerReasoningMenu: View {
         UIMenu(
             title: String(localized: "Reasoning"),
             options: [.displayInline],
-            children: ReasoningEffortOption.allCases.map { option in
+            children: ReasoningEffortOption.options(forSupportedEfforts: supportedEfforts).map { option in
                 UIAction(
                     title: option.title,
                     state: selectedReasoningEffort == option.id ? .on : .off
@@ -445,5 +448,35 @@ struct ReasoningEffortOption: Identifiable, CaseIterable {
     static func title(for effort: String) -> String {
         allCases.first(where: { $0.id == effort })?.title
             ?? effort.capitalized
+    }
+
+    /// Menu options for a server-provided effort vocabulary (issue #18).
+    /// `nil` or empty → the full static list (older servers / defensive fallback;
+    /// an empty list also means `supports_reasoning_effort == false`, which hides
+    /// the control before this is ever rendered). Unknown ids are kept with a
+    /// capitalized title so a newer server's vocabulary still works.
+    static func options(forSupportedEfforts supportedEfforts: [String]?) -> [ReasoningEffortOption] {
+        guard let supportedEfforts, !supportedEfforts.isEmpty else { return allCases }
+
+        var seen = Set<String>()
+        return supportedEfforts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+            .map { id in
+                allCases.first(where: { $0.id == id })
+                    ?? ReasoningEffortOption(id: id, title: id.capitalized)
+            }
+    }
+
+    /// Whether the composer should show the effort control at all (issue #18).
+    /// `supports_reasoning_effort == false` hides it; older servers (both fields
+    /// absent) keep today's behavior and show it.
+    static func showsEffortControl(
+        supportsReasoningEffort: Bool?,
+        supportedEfforts: [String]?
+    ) -> Bool {
+        if let supportsReasoningEffort { return supportsReasoningEffort }
+        if let supportedEfforts { return !supportedEfforts.isEmpty }
+        return true
     }
 }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -93,6 +93,10 @@ struct MessageComposerView: View {
     let selectedProfileTitle: String
     let isLoadingModels: Bool
     let selectedReasoningEffort: String?
+    /// Model-aware effort vocabulary; `nil` → full static list (issue #18).
+    let supportedReasoningEfforts: [String]?
+    /// When false the model has no effort control — hide the reasoning menu.
+    let showsReasoningControl: Bool
     let isUpdatingConfiguration: Bool
     let pendingAttachments: [PendingAttachment]
     let isUploadingAttachment: Bool
@@ -304,7 +308,9 @@ struct MessageComposerView: View {
 
                         modelMenu
 
-                        reasoningMenu
+                        if showsReasoningControl {
+                            reasoningMenu
+                        }
 
                         Spacer(minLength: 0)
 
@@ -763,6 +769,7 @@ struct MessageComposerView: View {
     private var reasoningMenu: some View {
         ComposerReasoningMenu(
             selectedReasoningEffort: selectedReasoningEffort,
+            supportedEfforts: supportedReasoningEfforts,
             reasoningTitle: reasoningTitle,
             isDisabled: isConfigurationControlDisabled,
             width: reasoningControlWidth,

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -168,6 +168,8 @@ struct ChatView: View {
             selectedProfileTitle: viewModel.selectedProfileTitle,
             isLoadingModels: viewModel.isLoadingComposerConfiguration,
             selectedReasoningEffort: viewModel.selectedReasoningEffort,
+            supportedReasoningEfforts: viewModel.supportedReasoningEfforts,
+            showsReasoningControl: viewModel.showsReasoningEffortControl,
             isUpdatingConfiguration: viewModel.isUpdatingComposerConfiguration,
             pendingAttachments: viewModel.pendingAttachments,
             isUploadingAttachment: viewModel.isUploadingAttachment,

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -188,6 +188,20 @@ final class ChatViewModel {
     private(set) var isSingleProfileMode = false
     private(set) var selectedProfileName: String?
     private(set) var selectedReasoningEffort: String?
+    /// Model-aware effort vocabulary (`supported_efforts` from `GET /api/reasoning`).
+    /// `nil` on older servers → the composer falls back to the static list (issue #18).
+    private(set) var supportedReasoningEfforts: [String]?
+    /// `supports_reasoning_effort`; `false` hides the composer effort control.
+    private(set) var supportsReasoningEffort: Bool?
+    /// Drops out-of-order `GET /api/reasoning` responses after rapid model switches
+    /// so the gating never reflects a stale model (upstream #3750 class of bug).
+    private var reasoningGatingFetchToken = 0
+    var showsReasoningEffortControl: Bool {
+        ReasoningEffortOption.showsEffortControl(
+            supportsReasoningEffort: supportsReasoningEffort,
+            supportedEfforts: supportedReasoningEfforts
+        )
+    }
     private(set) var isLoadingComposerConfiguration = false
     private(set) var isUpdatingComposerConfiguration = false
     private(set) var composerConfigurationErrorMessage: String?
@@ -578,6 +592,8 @@ final class ChatViewModel {
             currentProfile: currentProfile,
             selectedProfileName: selectedProfileName,
             selectedReasoningEffort: selectedReasoningEffort,
+            supportedReasoningEfforts: supportedReasoningEfforts,
+            supportsReasoningEffort: supportsReasoningEffort,
             modelCatalogGroups: modelCatalogGroups,
             agentCommands: agentCommands,
             workspaceRoots: workspaceRoots,
@@ -594,6 +610,8 @@ final class ChatViewModel {
         currentProfile = state.currentProfile
         selectedProfileName = state.selectedProfileName
         selectedReasoningEffort = state.selectedReasoningEffort
+        supportedReasoningEfforts = state.supportedReasoningEfforts
+        supportsReasoningEffort = state.supportsReasoningEffort
         modelCatalogGroups = state.modelCatalogGroups
         agentCommands = state.agentCommands
         workspaceRoots = state.workspaceRoots
@@ -644,11 +662,45 @@ final class ChatViewModel {
             currentModelProvider = response.session?.modelProvider ?? option.providerID
             currentWorkspace = response.session?.workspace ?? currentWorkspace
             pendingExplicitModelPick = true
+            // Still inside the isUpdatingComposerConfiguration window, so the
+            // effort menu stays disabled until the new model's gating lands —
+            // no interactable flash of the previous model's options (issue #18).
+            await refreshReasoningEffortGating()
             return true
         } catch {
             lastError = error
             composerConfigurationErrorMessage = error.localizedDescription
             return false
+        }
+    }
+
+    /// Re-queries `GET /api/reasoning` for the current model/provider and updates
+    /// the effort gating (issue #18). Failures are silent — the composer keeps
+    /// whatever gating it already shows. If the selected effort is no longer
+    /// supported, snaps to the server's coerced `reasoning_effort`.
+    func refreshReasoningEffortGating() async {
+        guard !isViewingCachedData else { return }
+
+        reasoningGatingFetchToken += 1
+        let token = reasoningGatingFetchToken
+
+        guard let response = try? await client.reasoning(
+            model: Self.nonEmpty(currentModel),
+            provider: Self.nonEmpty(currentModelProvider)
+        ) else {
+            return
+        }
+
+        guard token == reasoningGatingFetchToken else { return }
+
+        supportedReasoningEfforts = response.normalizedSupportedEfforts
+        supportsReasoningEffort = response.supportsReasoningEffort
+
+        if let selected = Self.nonEmpty(selectedReasoningEffort)?.lowercased(),
+           let supported = supportedReasoningEfforts,
+           !supported.contains(selected),
+           let serverEffort = Self.nonEmpty(response.effectiveEffort) {
+            selectedReasoningEffort = serverEffort
         }
     }
 
@@ -2283,6 +2335,7 @@ final class ChatViewModel {
             currentModelProvider = response.session?.modelProvider ?? match?.providerID ?? currentModelProvider
             currentWorkspace = response.session?.workspace ?? currentWorkspace
             pendingExplicitModelPick = true
+            await refreshReasoningEffortGating()
             return .executed(message: nil)
         } catch {
             lastError = error

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -675,9 +675,12 @@ final class ChatViewModel {
     }
 
     /// Re-queries `GET /api/reasoning` for the current model/provider and updates
-    /// the effort gating (issue #18). Failures are silent — the composer keeps
-    /// whatever gating it already shows. If the selected effort is no longer
-    /// supported, snaps to the server's coerced `reasoning_effort`.
+    /// the effort gating (issue #18). Failures are silent to the user, but reset
+    /// the gating to the "unknown" fallback (static effort list, control shown) —
+    /// keeping the previous model's gating after a successful model switch could
+    /// hide the control for a model that supports it, or offer efforts the new
+    /// model rejects. If the selected effort is no longer supported, snaps to the
+    /// server's coerced `reasoning_effort`.
     func refreshReasoningEffortGating() async {
         guard !isViewingCachedData else { return }
 
@@ -688,6 +691,10 @@ final class ChatViewModel {
             model: Self.nonEmpty(currentModel),
             provider: Self.nonEmpty(currentModelProvider)
         ) else {
+            if token == reasoningGatingFetchToken {
+                supportedReasoningEfforts = nil
+                supportsReasoningEffort = nil
+            }
             return
         }
 

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -295,10 +295,27 @@ struct ReasoningStatusResponse: Decodable, Equatable {
     let showReasoning: Bool?
     let reasoningEffort: String?
     let effort: String?
+    /// Model-aware effort vocabulary from `GET /api/reasoning` (`supported_efforts`).
+    /// `nil` on older servers that don't send the field — callers must fall back
+    /// to the static effort list (issue #18).
+    let supportedEfforts: [String]?
+    /// `supports_reasoning_effort` — `false` means the resolved model has no
+    /// effort control at all (hide the picker). `nil` on older servers.
+    let supportsReasoningEffort: Bool?
     let error: String?
 
     var effectiveEffort: String? {
         reasoningEffort ?? effort
+    }
+
+    /// `supported_efforts` trimmed, lowercased, de-duplicated, order preserved.
+    /// Stays `nil` when the server omitted the field (legacy fallback signal).
+    var normalizedSupportedEfforts: [String]? {
+        guard let supportedEfforts else { return nil }
+        var seen = Set<String>()
+        return supportedEfforts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
     }
 }
 

--- a/HermesMobile/Networking/APIClient+ServerPanels.swift
+++ b/HermesMobile/Networking/APIClient+ServerPanels.swift
@@ -24,13 +24,17 @@ extension APIClient {
         )
     }
 
-    func reasoning() async throws -> ReasoningStatusResponse {
-        try await send(endpoint: .reasoning, method: "GET")
+    /// Reasoning status for a specific model/provider (`GET /api/reasoning`).
+    /// Passing the session's current model + provider makes `supported_efforts`
+    /// model-accurate (mirrors the upstream WebUI composer chip, issue #18);
+    /// with no params the server resolves the config default model instead.
+    func reasoning(model: String? = nil, provider: String? = nil) async throws -> ReasoningStatusResponse {
+        try await send(endpoint: .reasoning(model: model, provider: provider), method: "GET")
     }
 
     func saveReasoningEffort(_ effort: String) async throws -> ReasoningStatusResponse {
         try await send(
-            endpoint: .reasoning,
+            endpoint: .reasoning(),
             method: "POST",
             body: ReasoningEffortRequest(effort: effort)
         )
@@ -38,7 +42,7 @@ extension APIClient {
 
     func saveReasoningDisplay(_ display: String) async throws -> ReasoningStatusResponse {
         try await send(
-            endpoint: .reasoning,
+            endpoint: .reasoning(),
             method: "POST",
             body: ReasoningDisplayRequest(display: display)
         )

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -67,7 +67,7 @@ enum Endpoint {
     case modelsLive
     case commands
     case defaultModel
-    case reasoning
+    case reasoning(model: String? = nil, provider: String? = nil)
     case personalities
     case setPersonality
     case profiles
@@ -365,6 +365,15 @@ enum Endpoint {
             var items = [URLQueryItem(name: "job_id", value: jobID)]
             if let limit {
                 items.append(URLQueryItem(name: "limit", value: "\(limit)"))
+            }
+            return items
+        case let .reasoning(model, provider):
+            var items: [URLQueryItem] = []
+            if let model, !model.isEmpty {
+                items.append(URLQueryItem(name: "model", value: model))
+            }
+            if let provider, !provider.isEmpty {
+                items.append(URLQueryItem(name: "provider", value: provider))
             }
             return items
         case let .insights(days):

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -239,6 +239,54 @@ final class APIClientConfigurationTests: APIClientTestCase {
         XCTAssertEqual(response.showReasoning, true)
         XCTAssertEqual(response.reasoningEffort, "high")
         XCTAssertEqual(response.effectiveEffort, "high")
+        XCTAssertNil(response.supportedEfforts)
+        XCTAssertNil(response.supportsReasoningEffort)
+        XCTAssertNil(response.normalizedSupportedEfforts)
+    }
+
+    func testReasoningStatusPassesModelProviderQueryAndDecodesSupportedEfforts() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/reasoning")
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(
+                uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) }
+            )
+            XCTAssertEqual(query["model"], "gpt-5.4")
+            XCTAssertEqual(query["provider"], "openai")
+
+            return apiTestJSONResponse("""
+            {
+              "show_reasoning": true,
+              "reasoning_effort": "medium",
+              "supported_efforts": ["minimal", "low", "medium", "high", "xhigh"],
+              "supports_reasoning_effort": true
+            }
+            """, for: request)
+        }
+
+        let response = try await client.reasoning(model: "gpt-5.4", provider: "openai")
+
+        XCTAssertEqual(response.supportedEfforts, ["minimal", "low", "medium", "high", "xhigh"])
+        XCTAssertEqual(response.supportsReasoningEffort, true)
+        XCTAssertEqual(response.normalizedSupportedEfforts, ["minimal", "low", "medium", "high", "xhigh"])
+    }
+
+    func testReasoningStatusNormalizesSupportedEfforts() throws {
+        let json = """
+        {
+          "reasoning_effort": "low",
+          "supported_efforts": [" Low ", "low", "", "HIGH"],
+          "supports_reasoning_effort": false
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(ReasoningStatusResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.normalizedSupportedEfforts, ["low", "high"])
+        XCTAssertEqual(response.supportsReasoningEffort, false)
     }
 
     func testSaveReasoningEffortBuildsExpectedBodyAndDecodesResponse() async throws {

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -175,8 +175,15 @@ final class ContractReadinessTests: XCTestCase {
             .init(name: "models live", method: "GET", endpoint: .modelsLive, path: "/api/models/live"),
             .init(name: "commands", method: "GET", endpoint: .commands, path: "/api/commands"),
             .init(name: "default model", method: "POST", endpoint: .defaultModel, path: "/api/default-model"),
-            .init(name: "reasoning read", method: "GET", endpoint: .reasoning, path: "/api/reasoning"),
-            .init(name: "reasoning save", method: "POST", endpoint: .reasoning, path: "/api/reasoning"),
+            .init(name: "reasoning read", method: "GET", endpoint: .reasoning(), path: "/api/reasoning"),
+            .init(
+                name: "reasoning read scoped to model",
+                method: "GET",
+                endpoint: .reasoning(model: "gpt-5.4", provider: "openai"),
+                path: "/api/reasoning",
+                query: ["model": "gpt-5.4", "provider": "openai"]
+            ),
+            .init(name: "reasoning save", method: "POST", endpoint: .reasoning(), path: "/api/reasoning"),
             .init(name: "personalities", method: "GET", endpoint: .personalities, path: "/api/personalities"),
             .init(name: "set personality", method: "POST", endpoint: .setPersonality, path: "/api/personality/set"),
             .init(name: "profiles", method: "GET", endpoint: .profiles, path: "/api/profiles"),

--- a/HermesMobileTests/ChatComposerConfigLoaderTests.swift
+++ b/HermesMobileTests/ChatComposerConfigLoaderTests.swift
@@ -71,6 +71,9 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
         XCTAssertEqual(result.state.currentModelProvider, "openrouter")
         XCTAssertEqual(result.state.currentWorkspace, "/tmp/workspace")
         XCTAssertEqual(result.state.selectedReasoningEffort, "medium")
+        // Older server: no supported_efforts / supports_reasoning_effort fields.
+        XCTAssertNil(result.state.supportedReasoningEfforts)
+        XCTAssertNil(result.state.supportsReasoningEffort)
         XCTAssertEqual(result.state.workspaceSuggestions, ["/tmp/workspace"])
         XCTAssertEqual(result.state.agentCommands.map(\.name), ["status"])
         XCTAssertEqual(requestPaths, [
@@ -86,6 +89,7 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
     func testLoadKeepsSessionModelOverrideWhenProfileHasDifferentDefault() async throws {
         let sessionModel = "@openai:gpt-5.5"
         let profileDefault = "deepseek/deepseek-chat-v3-0324:free"
+        var reasoningQueryItems: [String: String?] = [:]
         let client = makeClient { request in
             switch request.url?.path {
             case "/api/profiles":
@@ -116,7 +120,17 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
                 }
                 """, for: request)
             case "/api/reasoning":
-                return apiTestJSONResponse(#"{"reasoning_effort": "high"}"#, for: request)
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                reasoningQueryItems = Dictionary(
+                    uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) }
+                )
+                return apiTestJSONResponse("""
+                {
+                  "reasoning_effort": "high",
+                  "supported_efforts": ["low", "medium", "high"],
+                  "supports_reasoning_effort": true
+                }
+                """, for: request)
             case "/api/workspaces":
                 return apiTestJSONResponse(#"{"workspaces": [{"path": "/tmp/workspace"}]}"#, for: request)
             case "/api/commands":
@@ -144,6 +158,12 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
         XCTAssertEqual(result.state.currentModelProvider, "openai")
         XCTAssertEqual(result.state.selectedProfileName, "work")
         XCTAssertEqual(result.state.selectedReasoningEffort, "high")
+        // The reasoning query is scoped to the session's model/provider so the
+        // gating fields are model-accurate (issue #18).
+        XCTAssertEqual(reasoningQueryItems["model"], sessionModel)
+        XCTAssertEqual(reasoningQueryItems["provider"], "openai")
+        XCTAssertEqual(result.state.supportedReasoningEfforts, ["low", "medium", "high"])
+        XCTAssertEqual(result.state.supportsReasoningEffort, true)
     }
 
     func testLoadReturnsPartialStateAndStillRefreshesCommandsWhenConfigurationFails() async throws {
@@ -223,5 +243,62 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
 
         XCTAssertNil(result.configurationError)
         XCTAssertTrue(result.state.isSingleProfileMode)
+    }
+}
+
+/// Pure gating logic for the composer reasoning-effort menu (issue #18):
+/// building the option list from `supported_efforts` and deciding whether
+/// the control is shown at all.
+final class ReasoningEffortGatingTests: XCTestCase {
+    func testOptionsFallBackToStaticListWithoutServerVocabulary() {
+        XCTAssertEqual(
+            ReasoningEffortOption.options(forSupportedEfforts: nil).map(\.id),
+            ["none", "minimal", "low", "medium", "high", "xhigh"]
+        )
+        // Defensive: an empty list also falls back (the control is hidden
+        // before this is rendered because supports_reasoning_effort is false).
+        XCTAssertEqual(
+            ReasoningEffortOption.options(forSupportedEfforts: []).map(\.id),
+            ["none", "minimal", "low", "medium", "high", "xhigh"]
+        )
+    }
+
+    func testOptionsFilterToServerVocabularyPreservingServerOrder() {
+        let options = ReasoningEffortOption.options(forSupportedEfforts: ["high", "low"])
+        XCTAssertEqual(options.map(\.id), ["high", "low"])
+        XCTAssertEqual(options.map(\.title), ["High", "Low"])
+    }
+
+    func testOptionsNormalizeAndKeepUnknownServerEfforts() {
+        let options = ReasoningEffortOption.options(forSupportedEfforts: [" Low ", "low", "", "turbo"])
+        XCTAssertEqual(options.map(\.id), ["low", "turbo"])
+        XCTAssertEqual(options.map(\.title), ["Low", "Turbo"])
+    }
+
+    func testShowsEffortControlFollowsServerFlag() {
+        XCTAssertFalse(ReasoningEffortOption.showsEffortControl(
+            supportsReasoningEffort: false,
+            supportedEfforts: ["low"]
+        ))
+        XCTAssertTrue(ReasoningEffortOption.showsEffortControl(
+            supportsReasoningEffort: true,
+            supportedEfforts: []
+        ))
+    }
+
+    func testShowsEffortControlInfersFromEffortsWhenFlagMissing() {
+        XCTAssertFalse(ReasoningEffortOption.showsEffortControl(
+            supportsReasoningEffort: nil,
+            supportedEfforts: []
+        ))
+        XCTAssertTrue(ReasoningEffortOption.showsEffortControl(
+            supportsReasoningEffort: nil,
+            supportedEfforts: ["low"]
+        ))
+        // Older servers send neither field: keep today's behavior (visible).
+        XCTAssertTrue(ReasoningEffortOption.showsEffortControl(
+            supportsReasoningEffort: nil,
+            supportedEfforts: nil
+        ))
     }
 }

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -4593,6 +4593,8 @@ final class ChatViewModelSendTests: XCTestCase {
             case "/api/default-model":
                 XCTFail("Composer model selection must not save profile defaults.")
                 throw URLError(.badURL)
+            case "/api/reasoning":
+                return apiTestJSONResponse(#"{"reasoning_effort": "medium"}"#, for: request)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)
@@ -4609,7 +4611,7 @@ final class ChatViewModelSendTests: XCTestCase {
         let didStart = await viewModel.sendMessage("Use the selected OpenRouter model")
 
         XCTAssertTrue(didStart)
-        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/chat/start"])
+        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/reasoning", "/api/chat/start"])
         XCTAssertEqual(streamClient.startedURLs.count, 1)
     }
 
@@ -4645,6 +4647,8 @@ final class ChatViewModelSendTests: XCTestCase {
                   "stream_id": "stream-second"
                 }
                 """, for: request)
+            case "/api/reasoning":
+                return apiTestJSONResponse(#"{"reasoning_effort": "medium"}"#, for: request)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)
@@ -4706,6 +4710,8 @@ final class ChatViewModelSendTests: XCTestCase {
             case "/api/default-model":
                 XCTFail("Custom composer models must not save Settings defaults.")
                 throw URLError(.badURL)
+            case "/api/reasoning":
+                return apiTestJSONResponse(#"{"reasoning_effort": "medium"}"#, for: request)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)
@@ -4724,7 +4730,7 @@ final class ChatViewModelSendTests: XCTestCase {
         let didStart = await viewModel.sendMessage("Use the custom OpenRouter model")
 
         XCTAssertTrue(didStart)
-        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/chat/start"])
+        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/reasoning", "/api/chat/start"])
         XCTAssertEqual(streamClient.startedURLs.count, 1)
     }
 
@@ -4762,6 +4768,8 @@ final class ChatViewModelSendTests: XCTestCase {
                 XCTAssertEqual(body["profile"] as? String, "work")
                 XCTAssertEqual(body["explicit_model_pick"] as? Bool, true)
                 return apiTestJSONResponse(#"{"session_id": "session-abc", "stream_id": "stream-slash-model"}"#, for: request)
+            case "/api/reasoning":
+                return apiTestJSONResponse(#"{"reasoning_effort": "medium"}"#, for: request)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)
@@ -4776,7 +4784,7 @@ final class ChatViewModelSendTests: XCTestCase {
 
         XCTAssertEqual(result, .executed(message: nil))
         XCTAssertTrue(didStart)
-        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/chat/start"])
+        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/reasoning", "/api/chat/start"])
         XCTAssertEqual(streamClient.startedURLs.count, 1)
     }
 
@@ -4911,6 +4919,8 @@ final class ChatViewModelSendTests: XCTestCase {
                   }
                 }
                 """, for: request)
+            case "/api/reasoning":
+                return apiTestJSONResponse(#"{"reasoning_effort": "medium"}"#, for: request)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)
@@ -4926,7 +4936,157 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedModelID, customModel)
         XCTAssertEqual(viewModel.selectedModelProviderID, "openrouter")
         XCTAssertNil(viewModel.composerConfigurationErrorMessage)
-        XCTAssertEqual(requestPaths, ["/api/session/update"])
+        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/reasoning"])
+    }
+
+    @MainActor
+    func testSelectingComposerModelRefreshesEffortGatingAndSnapsUnsupportedEffort() async throws {
+        let limitedModel = "o4-mini"
+        var reasoningQueries: [[String: String?]] = []
+        let viewModel = try makeViewModel(
+            sessionSummary: makeSession(model: "gpt-5.4", modelProvider: "openai", profile: "work")
+        ) { request in
+            switch request.url?.path {
+            case "/api/reasoning" where request.httpMethod == "POST":
+                return apiTestJSONResponse(#"{"ok": true, "reasoning_effort": "xhigh"}"#, for: request)
+            case "/api/session/update":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "workspace": "/tmp/workspace",
+                    "model": "\(limitedModel)",
+                    "model_provider": "openai",
+                    "profile": "work"
+                  }
+                }
+                """, for: request)
+            case "/api/reasoning":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                reasoningQueries.append(Dictionary(
+                    uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) }
+                ))
+                return apiTestJSONResponse("""
+                {
+                  "show_reasoning": true,
+                  "reasoning_effort": "high",
+                  "supported_efforts": ["low", "medium", "high"],
+                  "supports_reasoning_effort": true
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.selectReasoningEffort("xhigh")
+        XCTAssertEqual(viewModel.selectedReasoningEffort, "xhigh")
+
+        await viewModel.selectComposerModel(ModelCatalogOption(
+            id: limitedModel,
+            displayName: limitedModel,
+            providerID: "openai"
+        ))
+
+        // The gating query is scoped to the newly selected model, never stale
+        // session state (upstream #3750 class of bug).
+        XCTAssertEqual(reasoningQueries.count, 1)
+        XCTAssertEqual(reasoningQueries[0]["model"], limitedModel)
+        XCTAssertEqual(reasoningQueries[0]["provider"], "openai")
+        XCTAssertEqual(viewModel.supportedReasoningEfforts, ["low", "medium", "high"])
+        XCTAssertEqual(viewModel.supportsReasoningEffort, true)
+        XCTAssertTrue(viewModel.showsReasoningEffortControl)
+        // "xhigh" is not supported by the new model: snap to the server's
+        // coerced reasoning_effort.
+        XCTAssertEqual(viewModel.selectedReasoningEffort, "high")
+    }
+
+    @MainActor
+    func testSelectingComposerModelHidesEffortControlWhenUnsupported() async throws {
+        let viewModel = try makeViewModel(
+            sessionSummary: makeSession(model: "gpt-5.4", modelProvider: "openai", profile: "work")
+        ) { request in
+            switch request.url?.path {
+            case "/api/session/update":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "workspace": "/tmp/workspace",
+                    "model": "no-effort-model",
+                    "model_provider": "openai",
+                    "profile": "work"
+                  }
+                }
+                """, for: request)
+            case "/api/reasoning":
+                return apiTestJSONResponse("""
+                {
+                  "show_reasoning": true,
+                  "reasoning_effort": "",
+                  "supported_efforts": [],
+                  "supports_reasoning_effort": false
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        XCTAssertTrue(viewModel.showsReasoningEffortControl)
+
+        await viewModel.selectComposerModel(ModelCatalogOption(
+            id: "no-effort-model",
+            displayName: "no-effort-model",
+            providerID: "openai"
+        ))
+
+        XCTAssertEqual(viewModel.supportedReasoningEfforts, [])
+        XCTAssertEqual(viewModel.supportsReasoningEffort, false)
+        XCTAssertFalse(viewModel.showsReasoningEffortControl)
+    }
+
+    @MainActor
+    func testEffortGatingRefreshFailureKeepsExistingGating() async throws {
+        let viewModel = try makeViewModel(
+            sessionSummary: makeSession(model: "gpt-5.4", modelProvider: "openai", profile: "work")
+        ) { request in
+            switch request.url?.path {
+            case "/api/session/update":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "workspace": "/tmp/workspace",
+                    "model": "flaky-model",
+                    "model_provider": "openai",
+                    "profile": "work"
+                  }
+                }
+                """, for: request)
+            case "/api/reasoning":
+                throw URLError(.timedOut)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didSelect = await viewModel.selectComposerModel(ModelCatalogOption(
+            id: "flaky-model",
+            displayName: "flaky-model",
+            providerID: "openai"
+        ))
+
+        // The model change still succeeds; the gating silently keeps its
+        // previous (legacy/full) state.
+        XCTAssertTrue(didSelect)
+        XCTAssertEqual(viewModel.selectedModelID, "flaky-model")
+        XCTAssertNil(viewModel.supportedReasoningEfforts)
+        XCTAssertTrue(viewModel.showsReasoningEffortControl)
+        XCTAssertNil(viewModel.composerConfigurationErrorMessage)
     }
 
     @MainActor

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -5049,7 +5049,13 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
-    func testEffortGatingRefreshFailureKeepsExistingGating() async throws {
+    func testEffortGatingRefreshFailureResetsStaleGatingToFallback() async throws {
+        // First switch lands restrictive gating (no effort support); the second
+        // switch succeeds but its gating refresh fails. The stale "hidden"
+        // gating from the first model must not stick to the new model — it
+        // resets to the unknown fallback (static list, control shown).
+        var reasoningCalls = 0
+        var sessionModel = "gpt-5.4"
         let viewModel = try makeViewModel(
             sessionSummary: makeSession(model: "gpt-5.4", modelProvider: "openai", profile: "work")
         ) { request in
@@ -5060,13 +5066,24 @@ final class ChatViewModelSendTests: XCTestCase {
                   "session": {
                     "session_id": "session-abc",
                     "workspace": "/tmp/workspace",
-                    "model": "flaky-model",
+                    "model": "\(sessionModel)",
                     "model_provider": "openai",
                     "profile": "work"
                   }
                 }
                 """, for: request)
             case "/api/reasoning":
+                reasoningCalls += 1
+                if reasoningCalls == 1 {
+                    return apiTestJSONResponse("""
+                    {
+                      "show_reasoning": true,
+                      "reasoning_effort": "",
+                      "supported_efforts": [],
+                      "supports_reasoning_effort": false
+                    }
+                    """, for: request)
+                }
                 throw URLError(.timedOut)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
@@ -5074,17 +5091,29 @@ final class ChatViewModelSendTests: XCTestCase {
             }
         }
 
+        sessionModel = "no-effort-model"
+        let didSelectFirst = await viewModel.selectComposerModel(ModelCatalogOption(
+            id: "no-effort-model",
+            displayName: "no-effort-model",
+            providerID: "openai"
+        ))
+        XCTAssertTrue(didSelectFirst)
+        XCTAssertEqual(viewModel.supportsReasoningEffort, false)
+        XCTAssertFalse(viewModel.showsReasoningEffortControl)
+
+        sessionModel = "flaky-model"
         let didSelect = await viewModel.selectComposerModel(ModelCatalogOption(
             id: "flaky-model",
             displayName: "flaky-model",
             providerID: "openai"
         ))
 
-        // The model change still succeeds; the gating silently keeps its
-        // previous (legacy/full) state.
+        // The model change still succeeds; the failed refresh drops the stale
+        // gating instead of applying it to the new model.
         XCTAssertTrue(didSelect)
         XCTAssertEqual(viewModel.selectedModelID, "flaky-model")
         XCTAssertNil(viewModel.supportedReasoningEfforts)
+        XCTAssertNil(viewModel.supportsReasoningEffort)
         XCTAssertTrue(viewModel.showsReasoningEffortControl)
         XCTAssertNil(viewModel.composerConfigurationErrorMessage)
     }


### PR DESCRIPTION
Fixes #18

## Summary

The composer's reasoning-effort menu was a static list (`none, minimal, low, medium, high, xhigh`) regardless of model. `GET /api/reasoning` now returns `supported_efforts` + `supports_reasoning_effort` and accepts `model`/`provider` query params, so the app adopts the server's vocabulary — no client-side model-name heuristics (the old I-052 constraint still holds).

- A model with limited efforts shows only those efforts in the menu (server order, unknown ids kept with capitalized titles).
- `supports_reasoning_effort == false` hides the effort control entirely.
- Older servers without the fields keep exactly today's behavior (full static menu, control visible) via tolerant optional decoding.
- Gating refreshes when the model changes (composer picker, `/model` slash command) and on every composer config load (initial load, profile switch). The refresh is token-guarded so an out-of-order response can never apply a stale model's gating (upstream #3750 class of bug), and it runs inside the `isUpdatingComposerConfiguration` window so the menu is disabled until the new model's gating lands.
- If the currently selected effort is not in `supported_efforts`, the UI snaps to the server's coerced `reasoning_effort`.

## Plan (E1, pre-approved for this unattended run)

1. `ReasoningStatusResponse`: optional `supportedEfforts` / `supportsReasoningEffort` + `normalizedSupportedEfforts` (trim/lowercase/dedupe, order preserved).
2. `Endpoint.reasoning(model:provider:)` emits `model`/`provider` query items; `APIClient.reasoning(model:provider:)` with nil defaults (POST save paths unchanged).
3. Loader scopes the reasoning query to the session's resolved model/provider and captures the gating fields into `ChatComposerConfigState`.
4. `ChatViewModel.refreshReasoningEffortGating()` — silent-failure, token-guarded; hooks after `selectComposerModel` and the `/model` slash command; snap-to-server for unsupported selections.
5. `ComposerReasoningMenu` builds options via `ReasoningEffortOption.options(forSupportedEfforts:)`; `showsEffortControl(...)` decides visibility; wiring through `MessageComposerView`/`ChatView`.
6. Tests at every layer (see below).

## Evidence

- Upstream pinned copy: `api/routes.py:11481` (GET accepts `model`/`provider`/`base_url`) and `api/config.py get_reasoning_status` (returns coerced `reasoning_effort`, `supported_efforts`, `supports_reasoning_effort = bool(supported_efforts)`) @ `312d3fab`.
- Live server verified 2026-07-02 (issue body): returns both new fields.

## Out of scope (issue non-goals)

- `SlashCommandCatalog.reasoningLevels` filtering (static `/reasoning` autocomplete list unchanged; the server still validates/coerces).
- Client-side capability inference from model/provider names (explicitly rejected in I-052).
- Passive external model changes (another client editing the session) refresh at the next composer config load rather than instantly; both in-app model-change paths refresh immediately.

## Validation

- Full XCTest suite on iPhone 17 sim (Hermex-W1): **1199 tests, 0 failures** on the head commit (`xcodebuild test -parallel-testing-enabled NO`).
- New/updated tests: response decoding with/without the new fields + normalization; endpoint query contract; loader query scoping + field capture; option filtering / hide logic (`ReasoningEffortGatingTests`); model-change refresh, snap-to-coerced-effort, hide-on-unsupported, and silent-failure behavior in `ChatViewModelSendTests`.

## Owner manual checks

1. Open a chat on a model with a limited effort set (e.g. an OpenAI reasoning model) — the composer Reasoning menu should list only the server's efforts.
2. Switch to a model that doesn't support reasoning effort — the Reasoning control should disappear (no dead menu); switch back and it returns.
3. With an effort selected that the new model doesn't support, switch models — the chip should snap to the server's effort, not keep the stale one.
4. Against an older server (if available): full static menu, identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
