### PR TITLE
Memory: surface the read-only project-context document

### DIFF
--- a/HermesMobile/Features/Memory/MemoryView.swift
+++ b/HermesMobile/Features/Memory/MemoryView.swift
@@ -85,6 +85,20 @@ struct MemoryView: View {
                         }
                     }
                 }
+
+                if viewModel.showsProjectContext {
+                    Section {
+                        MarkdownRenderer(content: viewModel.projectContextText ?? "")
+                            .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+                    } header: {
+                        ProjectContextSectionHeader(modifiedAt: viewModel.projectContextMtime)
+                    } footer: {
+                        ProjectContextSectionFooter(
+                            detail: viewModel.projectContextDetail,
+                            isShadowed: viewModel.isProjectContextShadowed
+                        )
+                    }
+                }
             }
             .refreshable {
                 await loadMemory()
@@ -122,6 +136,43 @@ private struct MemorySectionHeader: View {
             }
             .disabled(isEditingDisabled)
             .buttonStyle(.borderless)
+        }
+    }
+}
+
+/// Header for the read-only project-context document: no edit affordance — the
+/// server has no write path for this section — so a lock icon marks it read-only.
+private struct ProjectContextSectionHeader: View {
+    let modifiedAt: Date?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Label("Project Context", systemImage: "folder.badge.gearshape")
+            Spacer()
+            if let modifiedAt {
+                Text("Modified \(modifiedAt, style: .relative) ago")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Image(systemName: "lock.fill")
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(Text("Read-only"))
+        }
+    }
+}
+
+private struct ProjectContextSectionFooter: View {
+    let detail: String?
+    let isShadowed: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let detail {
+                Text(verbatim: detail)
+            }
+            if isShadowed {
+                Text("A workspace-local file is overriding the global project context.")
+            }
         }
     }
 }

--- a/HermesMobile/Features/Memory/MemoryViewModel.swift
+++ b/HermesMobile/Features/Memory/MemoryViewModel.swift
@@ -10,6 +10,12 @@ final class MemoryViewModel {
     private(set) var memoryMtime: Date?
     private(set) var userMtime: Date?
     private(set) var soulMtime: Date?
+    private(set) var projectContextText: String?
+    private(set) var projectContextName: String?
+    private(set) var projectContextWorkspace: String?
+    private(set) var projectContextMtime: Date?
+    private(set) var isProjectContextShadowed = false
+    private(set) var isExternalNotesEnabled: Bool?
     private(set) var hasLoaded = false
     private(set) var isLoading = false
     private(set) var isSaving = false
@@ -40,6 +46,23 @@ final class MemoryViewModel {
 
     func clearActionError() {
         actionErrorMessage = nil
+    }
+
+    /// The read-only project-context section only appears when the server sent a
+    /// non-empty document. Servers without the field (or with an empty/blank one,
+    /// which is what upstream returns when no readable context file exists) render
+    /// the screen exactly as before.
+    var showsProjectContext: Bool {
+        guard let text = projectContextText else { return false }
+        return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Non-localized "name — workspace" detail line for the project-context section.
+    var projectContextDetail: String? {
+        let parts = [projectContextName, projectContextWorkspace]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: " — ")
     }
 
     func content(for section: MemorySection) -> String {
@@ -94,6 +117,12 @@ final class MemoryViewModel {
         memoryMtime = response.memoryMtime.map { Date(timeIntervalSince1970: $0) }
         userMtime = response.userMtime.map { Date(timeIntervalSince1970: $0) }
         soulMtime = response.soulMtime.map { Date(timeIntervalSince1970: $0) }
+        projectContextText = response.projectContext
+        projectContextName = response.projectContextName
+        projectContextWorkspace = response.projectContextWorkspace
+        projectContextMtime = response.projectContextMtime.map { Date(timeIntervalSince1970: $0) }
+        isProjectContextShadowed = response.projectContextShadowed ?? false
+        isExternalNotesEnabled = response.externalNotesEnabled
         hasLoaded = true
     }
 }

--- a/HermesMobile/Models/Memory.swift
+++ b/HermesMobile/Models/Memory.swift
@@ -18,6 +18,13 @@ struct MemoryResponse: Decodable, Equatable {
     let memoryMtime: Double?
     let userMtime: Double?
     let soulMtime: Double?
+    let projectContext: String?
+    let projectContextName: String?
+    let projectContextPath: String?
+    let projectContextWorkspace: String?
+    let projectContextMtime: Double?
+    let projectContextShadowed: Bool?
+    let externalNotesEnabled: Bool?
 
     enum CodingKeys: String, CodingKey {
         case memory
@@ -29,6 +36,13 @@ struct MemoryResponse: Decodable, Equatable {
         case memoryMtime
         case userMtime
         case soulMtime
+        case projectContext
+        case projectContextName
+        case projectContextPath
+        case projectContextWorkspace
+        case projectContextMtime
+        case projectContextShadowed
+        case externalNotesEnabled
     }
 
     init(from decoder: Decoder) throws {
@@ -42,6 +56,25 @@ struct MemoryResponse: Decodable, Equatable {
         memoryMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .memoryMtime)
         userMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .userMtime)
         soulMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .soulMtime)
+        projectContext = try container.decodeIfPresent(String.self, forKey: .projectContext)
+        projectContextName = try container.decodeIfPresent(String.self, forKey: .projectContextName)
+        projectContextPath = try container.decodeIfPresent(String.self, forKey: .projectContextPath)
+        projectContextWorkspace = try container.decodeIfPresent(
+            String.self,
+            forKey: .projectContextWorkspace
+        )
+        projectContextMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .projectContextMtime)
+        // Upstream (routes.py @ 312d3fab, verified live 2026-07-03) returns a *list* of
+        // shadowed-file objects here; the API docs describe a boolean flag. Accept both:
+        // `true` or a non-empty list means the active document shadows another file.
+        if let flag = try? container.decode(Bool.self, forKey: .projectContextShadowed) {
+            projectContextShadowed = flag
+        } else if let list = try? container.nestedUnkeyedContainer(forKey: .projectContextShadowed) {
+            projectContextShadowed = (list.count ?? 0) > 0
+        } else {
+            projectContextShadowed = nil
+        }
+        externalNotesEnabled = (try? container.decodeIfPresent(Bool.self, forKey: .externalNotesEnabled)) ?? nil
     }
 }
 

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -53746,6 +53746,218 @@
         }
       }
     },
+    "A workspace-local file is overriding the global project context." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملف محلي في مساحة العمل يتجاوز سياق المشروع العام."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eine lokale Datei im Arbeitsbereich überschreibt den globalen Projektkontext."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un archivo local del espacio de trabajo está anulando el contexto global del proyecto."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un fichier local de l'espace de travail remplace le contexte de projet global."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "קובץ מקומי בסביבת העבודה עוקף את הקשר הפרויקט הגלובלי."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un file locale dello spazio di lavoro sta sostituendo il contesto globale del progetto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークスペース内のローカルファイルがグローバルなプロジェクトコンテキストを上書きしています。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 공간의 로컬 파일이 전역 프로젝트 컨텍스트를 재정의하고 있습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Een lokaal bestand in de werkruimte overschrijft de globale projectcontext."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lokalny plik obszaru roboczego zastępuje globalny kontekst projektu."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Um arquivo local do espaço de trabalho está substituindo o contexto global do projeto."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Локальный файл рабочей области переопределяет глобальный контекст проекта."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışma alanına özgü bir dosya genel proje bağlamını geçersiz kılıyor."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورک اسپیس کی ایک مقامی فائل عالمی پروجیکٹ سیاق و سباق کو زیر کر رہی ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作區本機檔案正在覆寫全域專案上下文。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作区本地文件正在覆盖全局项目上下文。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作區本機檔案正在覆寫全域專案上下文。"
+          }
+        }
+      }
+    },
+    "Project Context" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سياق المشروع"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Projektkontext"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contexto del proyecto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contexte du projet"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הקשר הפרויקט"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contesto del progetto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロジェクトコンテキスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프로젝트 컨텍스트"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Projectcontext"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontekst projektu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contexto do projeto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Контекст проекта"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proje Bağlamı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پروجیکٹ سیاق و سباق"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專案上下文"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "项目上下文"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專案上下文"
+          }
+        }
+      }
+    },
     "Project actions for %@" : {
       "localizations" : {
         "ar" : {
@@ -54696,6 +54908,112 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "已排入佇列，下一輪傳送（#%lld）。"
+          }
+        }
+      }
+    },
+    "Read-only" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "للقراءة فقط"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schreibgeschützt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo lectura"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture seule"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "לקריאה בלבד"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sola lettura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み取り専用"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 전용"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alleen-lezen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tylko do odczytu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Somente leitura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Только для чтения"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salt okunur"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "صرف پڑھنے کے لیے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "唯讀"
           }
         }
       }

--- a/HermesMobileTests/APIClientMemoryEndpointTests.swift
+++ b/HermesMobileTests/APIClientMemoryEndpointTests.swift
@@ -22,7 +22,20 @@ final class APIClientMemoryEndpointTests: APIClientTestCase {
               "soul_path": "/Users/test/.hermes/SOUL.md",
               "memory_mtime": 1770000000,
               "user_mtime": 1770000100,
-              "soul_mtime": "1770000200"
+              "soul_mtime": "1770000200",
+              "project_context": "# Project\\n\\n- Ship it",
+              "project_context_name": "AGENTS.md",
+              "project_context_path": "/Users/test/workspace/AGENTS.md",
+              "project_context_workspace": "/Users/test/workspace",
+              "project_context_mtime": 1770000300,
+              "project_context_shadowed": [
+                {
+                  "name": "PROJECT.md",
+                  "path": "/Users/test/PROJECT.md",
+                  "shadowed_by": "AGENTS.md"
+                }
+              ],
+              "external_notes_enabled": true
             }
             """, for: request)
         }
@@ -38,6 +51,13 @@ final class APIClientMemoryEndpointTests: APIClientTestCase {
         XCTAssertEqual(response.memoryMtime, 1_770_000_000)
         XCTAssertEqual(response.userMtime, 1_770_000_100)
         XCTAssertEqual(response.soulMtime, 1_770_000_200)
+        XCTAssertEqual(response.projectContext, "# Project\n\n- Ship it")
+        XCTAssertEqual(response.projectContextName, "AGENTS.md")
+        XCTAssertEqual(response.projectContextPath, "/Users/test/workspace/AGENTS.md")
+        XCTAssertEqual(response.projectContextWorkspace, "/Users/test/workspace")
+        XCTAssertEqual(response.projectContextMtime, 1_770_000_300)
+        XCTAssertEqual(response.projectContextShadowed, true)
+        XCTAssertEqual(response.externalNotesEnabled, true)
     }
 
     func testMemoryToleratesMissingFields() async throws {
@@ -60,6 +80,69 @@ final class APIClientMemoryEndpointTests: APIClientTestCase {
         XCTAssertNil(response.memoryMtime)
         XCTAssertNil(response.userMtime)
         XCTAssertNil(response.soulMtime)
+        XCTAssertNil(response.projectContext)
+        XCTAssertNil(response.projectContextName)
+        XCTAssertNil(response.projectContextPath)
+        XCTAssertNil(response.projectContextWorkspace)
+        XCTAssertNil(response.projectContextMtime)
+        XCTAssertNil(response.projectContextShadowed)
+        XCTAssertNil(response.externalNotesEnabled)
+    }
+
+    func testMemoryDecodesProjectContextShadowedBooleanShape() async throws {
+        // The API docs describe project_context_shadowed as a boolean flag even though
+        // upstream currently sends a list; both shapes must decode.
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/memory")
+
+            return apiTestJSONResponse("""
+            {
+              "project_context": "# Project",
+              "project_context_shadowed": true
+            }
+            """, for: request)
+        }
+
+        let response = try await client.memory()
+
+        XCTAssertEqual(response.projectContext, "# Project")
+        XCTAssertEqual(response.projectContextShadowed, true)
+    }
+
+    func testMemoryDecodesEmptyShadowedListAsNotShadowed() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/memory")
+
+            return apiTestJSONResponse("""
+            {
+              "project_context": "# Project",
+              "project_context_shadowed": []
+            }
+            """, for: request)
+        }
+
+        let response = try await client.memory()
+
+        XCTAssertEqual(response.projectContextShadowed, false)
+    }
+
+    func testMemoryToleratesNullAndUnexpectedShadowedShapes() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/memory")
+
+            return apiTestJSONResponse("""
+            {
+              "project_context": "# Project",
+              "project_context_shadowed": null,
+              "external_notes_enabled": "yes"
+            }
+            """, for: request)
+        }
+
+        let response = try await client.memory()
+
+        XCTAssertNil(response.projectContextShadowed)
+        XCTAssertNil(response.externalNotesEnabled)
     }
 
     func testMemoryWriteBuildsExpectedPathBodyAndDecodesResponse() async throws {

--- a/HermesMobileTests/MemoryViewModelTests.swift
+++ b/HermesMobileTests/MemoryViewModelTests.swift
@@ -89,6 +89,102 @@ final class MemoryViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasLoaded)
     }
 
+    @MainActor
+    func testLoadSurfacesProjectContextDocument() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/memory")
+
+            return apiTestJSONResponse("""
+            {
+              "memory": "# Notes",
+              "user": "# Profile",
+              "soul": "# Soul",
+              "project_context": "# Project rules",
+              "project_context_name": "AGENTS.md",
+              "project_context_workspace": "/Users/test/workspace",
+              "project_context_mtime": 1770000300,
+              "project_context_shadowed": [
+                {
+                  "name": "PROJECT.md",
+                  "path": "/Users/test/PROJECT.md"
+                }
+              ],
+              "external_notes_enabled": true
+            }
+            """, for: request)
+        }
+        let viewModel = MemoryViewModel(
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertTrue(viewModel.showsProjectContext)
+        XCTAssertEqual(viewModel.projectContextText, "# Project rules")
+        XCTAssertEqual(viewModel.projectContextName, "AGENTS.md")
+        XCTAssertEqual(viewModel.projectContextWorkspace, "/Users/test/workspace")
+        XCTAssertEqual(viewModel.projectContextMtime, Date(timeIntervalSince1970: 1_770_000_300))
+        XCTAssertTrue(viewModel.isProjectContextShadowed)
+        XCTAssertEqual(viewModel.isExternalNotesEnabled, true)
+        XCTAssertEqual(viewModel.projectContextDetail, "AGENTS.md — /Users/test/workspace")
+    }
+
+    @MainActor
+    func testProjectContextSectionHiddenWithoutFields() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/memory")
+
+            return apiTestJSONResponse("""
+            {
+              "memory": "# Notes",
+              "user": "# Profile",
+              "soul": "# Soul"
+            }
+            """, for: request)
+        }
+        let viewModel = MemoryViewModel(
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertTrue(viewModel.hasLoaded)
+        XCTAssertFalse(viewModel.showsProjectContext)
+        XCTAssertFalse(viewModel.isProjectContextShadowed)
+        XCTAssertNil(viewModel.projectContextDetail)
+        XCTAssertNil(viewModel.isExternalNotesEnabled)
+    }
+
+    @MainActor
+    func testProjectContextSectionHiddenForBlankDocumentAndDetailOmitsEmptyParts() async throws {
+        // Upstream returns "" (not null) when no readable project-context file exists.
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/memory")
+
+            return apiTestJSONResponse("""
+            {
+              "memory": "# Notes",
+              "project_context": "  \\n ",
+              "project_context_name": "",
+              "project_context_workspace": "/Users/test/workspace",
+              "project_context_shadowed": []
+            }
+            """, for: request)
+        }
+        let viewModel = MemoryViewModel(
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.showsProjectContext)
+        XCTAssertFalse(viewModel.isProjectContextShadowed)
+        XCTAssertEqual(viewModel.projectContextDetail, "/Users/test/workspace")
+    }
+
     private func makeClient(
         handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
     ) -> APIClient {


### PR DESCRIPTION
Fixes #20

## Plan (E1 — pre-approved for this unattended run)

1. `MemoryResponse`: add tolerant optionals `projectContext`, `projectContextName`, `projectContextPath`, `projectContextWorkspace`, `projectContextMtime`, `projectContextShadowed`, `externalNotesEnabled`.
2. `MemoryViewModel`: expose the new fields plus `showsProjectContext` (hides section when the document is absent/blank) and a non-localized `projectContextDetail` ("name — workspace") line.
3. `MemoryView`: read-only "Project Context" section after the three editable documents — same Markdown rendering, lock icon instead of an edit button, footer caption when shadowed. Existing sections untouched.
4. `external_notes_enabled`: decoded and exposed, no UI (does not fit the screen naturally — deferred).
5. Localization: 3 new keys added to `Localizable.xcstrings` in all 17 shipped languages (catalog parity test enforces this).
6. Tests: tolerant decode (present/absent/null/both shadowed shapes), section-visibility and shadowed-caption view-model logic.

## Shape verification (hard rule #1)

Verified against the **live server** (final arbiter, 2026-07-03) and the pinned upstream (`_handle_memory_read`, routes.py @ `312d3fab`): `project_context_shadowed` is a **JSON list** of shadowed-file objects, not the boolean the issue text assumed (the API docs describe a flag). The decoder accepts **both** shapes: `true` or a non-empty list ⇒ shadowed; empty list ⇒ not shadowed; null/unknown shape ⇒ nil (never throws). Live server also confirmed `project_context` comes back as `""` (not null) when no context file exists, so section visibility trims and checks for emptiness.

## Behavior

- With a project context on the server: a read-only "Project Context" section appears below Agent Soul, rendered as Markdown, with modified-ago timestamp, a lock (read-only) icon, the file name + workspace in the footer, and — when shadowed — the caption "A workspace-local file is overriding the global project context."
- No edit affordance for it; the three editable documents' editing paths are byte-for-byte untouched.
- Servers without the fields (or with a blank document) render the screen exactly as today.

## Validation

- `xcodebuild test` (full HermesMobileTests suite) on iPhone 17 sim `12128609-…`: **TEST SUCCEEDED** on head commit.
- `git diff --check` clean.

## Owner manual checks

- [ ] Memory screen against your server: Project Context section shows the workspace AGENTS.md/context document (your live server currently has an empty project context for the default workspace, so the section should be hidden — point a session at a workspace with an AGENTS.md to see it).
- [ ] No pencil/edit icon on the Project Context header; lock icon shown.
- [ ] The three existing documents still edit and save normally.
- [ ] German (or any non-English) locale shows the new strings translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
