### PR TITLE
Sessions: export a conversation to the iOS share sheet (GET /api/session/export)

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -206,7 +206,9 @@
 		C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F105 /* APIClientTranscribeTests.swift */; };
 		C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */; };
 		C03260000000000000B101 /* APIClient+TTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F101 /* APIClient+TTS.swift */; };
+		C03270000000000000B101 /* APIClient+SessionExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03270000000000000F101 /* APIClient+SessionExport.swift */; };
 		C03260000000000000B102 /* APIClientTTSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F102 /* APIClientTTSTests.swift */; };
+		C03270000000000000B102 /* APIClientSessionExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03270000000000000F102 /* APIClientSessionExportTests.swift */; };
 		C03140000000000000B001 /* GitBranchPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03140000000000000F001 /* GitBranchPickerView.swift */; };
 		C03120000000000000B006 /* APIClientGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F006 /* APIClientGitTests.swift */; };
 		C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */; };
@@ -520,7 +522,9 @@
 		C03250000000000000F105 /* APIClientTranscribeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTranscribeTests.swift; sourceTree = "<group>"; };
 		C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorderTests.swift; sourceTree = "<group>"; };
 		C03260000000000000F101 /* APIClient+TTS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+TTS.swift"; sourceTree = "<group>"; };
+		C03270000000000000F101 /* APIClient+SessionExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+SessionExport.swift"; sourceTree = "<group>"; };
 		C03260000000000000F102 /* APIClientTTSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTTSTests.swift; sourceTree = "<group>"; };
+		C03270000000000000F102 /* APIClientSessionExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionExportTests.swift; sourceTree = "<group>"; };
 		C03140000000000000F001 /* GitBranchPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranchPickerView.swift; sourceTree = "<group>"; };
 		C03120000000000000F006 /* APIClientGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientGitTests.swift; sourceTree = "<group>"; };
 		C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceViewModelTests.swift; sourceTree = "<group>"; };
@@ -718,6 +722,7 @@
 				C0390000000000000000000D /* APIClientUploadTests.swift */,
 				C03250000000000000F105 /* APIClientTranscribeTests.swift */,
 				C03260000000000000F102 /* APIClientTTSTests.swift */,
+				C03270000000000000F102 /* APIClientSessionExportTests.swift */,
 				C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */,
 					C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */,
 					C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */,
@@ -808,6 +813,7 @@
 				1A2B3C4D5E6F7000000000B8 /* Endpoints.swift */,
 				C03250000000000000F102 /* APIClient+Transcribe.swift */,
 				C03260000000000000F101 /* APIClient+TTS.swift */,
+				C03270000000000000F101 /* APIClient+SessionExport.swift */,
 				C03250000000000000F103 /* MultipartFormData.swift */,
 				1A2B3C4D5E6F7000000000D7 /* SSEClient.swift */,
 				C0FF000000000000000000A2 /* CustomHeader.swift */,
@@ -1361,6 +1367,7 @@
 				C03250000000000000B101 /* TranscribeResponse.swift in Sources */,
 				C03250000000000000B102 /* APIClient+Transcribe.swift in Sources */,
 				C03260000000000000B101 /* APIClient+TTS.swift in Sources */,
+				C03270000000000000B101 /* APIClient+SessionExport.swift in Sources */,
 				C03250000000000000B103 /* MultipartFormData.swift in Sources */,
 				C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */,
 				1A2B3C4D5E6F7000000000A3 /* APIError.swift in Sources */,
@@ -1529,6 +1536,7 @@
 				C0391000000000000000000D /* APIClientUploadTests.swift in Sources */,
 				C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */,
 				C03260000000000000B102 /* APIClientTTSTests.swift in Sources */,
+				C03270000000000000B102 /* APIClientSessionExportTests.swift in Sources */,
 				C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */,
 					C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */,
 					C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */,

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -12,6 +12,7 @@ struct SessionListRowActions {
     let move: (SessionSummary, String?) -> Void
     let createProject: (SessionSummary) -> Void
     let refreshProjects: () -> Void
+    let export: (SessionSummary, SessionExportFormat) -> Void
 }
 
 enum SessionListMotion {
@@ -539,6 +540,26 @@ struct SessionRowContextMenu: View {
         }
         .disabled(isViewingCachedData || session.sessionId == nil || isMutating)
 
+        // Export works for any session the server can see (incl. foreign/CLI
+        // ones — upstream's export handler only gates on the active profile),
+        // so it needs a server session ID and a live connection, like Rename.
+        Menu {
+            Button {
+                actions.export(session, .html)
+            } label: {
+                Label("Export as HTML", systemImage: "doc.richtext")
+            }
+
+            Button {
+                actions.export(session, .json)
+            } label: {
+                Label("Export as JSON", systemImage: "curlybraces")
+            }
+        } label: {
+            Label("Export", systemImage: "square.and.arrow.up")
+        }
+        .disabled(!canShowSessionMutationActions || isMutating)
+
         Button {
             actions.archive(session)
         } label: {
@@ -720,6 +741,29 @@ extension View {
             in: shape
         )
     }
+}
+
+/// Sheet item for a finished session export: the temp file offered to the
+/// share sheet. Identity is the file URL, which is unique per export.
+struct SessionExportShareItem: Identifiable {
+    let fileURL: URL
+
+    var id: String { fileURL.absoluteString }
+}
+
+/// Minimal `UIActivityViewController` wrapper — the app has no other share
+/// surface and `ShareLink` can't be presented programmatically after an async
+/// download finishes. Cleanup of the temp file happens in the sheet's
+/// `onDismiss`, which runs after the activity UI is gone in both the
+/// completed and cancelled paths.
+struct SessionExportShareSheet: UIViewControllerRepresentable {
+    let fileURL: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 private func hasServerSessionID(_ session: SessionSummary) -> Bool {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -668,11 +668,7 @@ struct SessionListView: View {
                 Task { await viewModel.loadProjects() }
             },
             export: { session, format in
-                Task {
-                    if let fileURL = await viewModel.export(session, format: format) {
-                        sessionExportShareItem = SessionExportShareItem(fileURL: fileURL)
-                    }
-                }
+                Task { await export(session, format: format) }
             }
         )
     }
@@ -835,6 +831,15 @@ struct SessionListView: View {
     private func move(_ session: SessionSummary, to projectID: String?) async {
         await viewModel.move(session, to: projectID, modelContext: modelContext)
         handleLastError()
+    }
+
+    private func export(_ session: SessionSummary, format: SessionExportFormat) async {
+        let fileURL = await viewModel.export(session, format: format)
+        handleLastError()
+
+        if let fileURL {
+            sessionExportShareItem = SessionExportShareItem(fileURL: fileURL)
+        }
     }
 
     private func delete(_ project: ProjectSummary) async {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -24,6 +24,7 @@ struct SessionListView: View {
     @State private var sessionPendingRename: SessionSummary?
     @State private var sessionPendingDeletion: SessionSummary?
     @State private var sessionPendingProjectCreation: SessionSummary?
+    @State private var sessionExportShareItem: SessionExportShareItem?
     @State private var isPresentingProjectCreation = false
     @State private var isPresentingAddServer = false
     @State private var projectPendingDeletion: ProjectSummary?
@@ -114,6 +115,19 @@ struct SessionListView: View {
                 case .insights:
                     InsightsView(server: server, onAPIError: authManager.handleAPIError)
                 }
+            }
+            .sheet(item: $sessionExportShareItem) { item in
+                SessionExportShareSheet(fileURL: item.fileURL)
+                    .presentationDetents([.medium, .large])
+                    .ignoresSafeArea()
+                    // The temp file lives in its own UUID directory (see
+                    // SessionListViewModel.export); remove the directory once
+                    // the share sheet is gone, shared and cancelled alike.
+                    .onDisappear {
+                        try? FileManager.default.removeItem(
+                            at: item.fileURL.deletingLastPathComponent()
+                        )
+                    }
             }
             .sheet(item: $sessionPendingRename) { session in
                 SessionRenameSheet(
@@ -652,6 +666,13 @@ struct SessionListView: View {
             },
             refreshProjects: {
                 Task { await viewModel.loadProjects() }
+            },
+            export: { session, format in
+                Task {
+                    if let fileURL = await viewModel.export(session, format: format) {
+                        sessionExportShareItem = SessionExportShareItem(fileURL: fileURL)
+                    }
+                }
             }
         )
     }

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -577,6 +577,14 @@ final class SessionListViewModel {
         actionErrorMessage = nil
         lastError = nil
 
+        // Sweep exports leaked by earlier runs (e.g. the view was dismissed
+        // while a download was in flight, so the share sheet — and its
+        // cleanup — never appeared). Safe here: starting a new export means
+        // no share sheet is currently presenting a previous file.
+        let exportsRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("session-exports", isDirectory: true)
+        try? FileManager.default.removeItem(at: exportsRoot)
+
         do {
             let file = try await client.exportSession(
                 id: sessionId,
@@ -584,9 +592,7 @@ final class SessionListViewModel {
                 fallbackTitle: session.title
             )
 
-            let directory = FileManager.default.temporaryDirectory
-                .appendingPathComponent("session-exports", isDirectory: true)
-                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            let directory = exportsRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
             let fileURL = directory.appendingPathComponent(file.filename)

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -552,6 +552,55 @@ final class SessionListViewModel {
         }
     }
 
+    /// Downloads the session transcript (`GET /api/session/export`) and writes
+    /// it to a unique temp directory so the share sheet can offer it as a file
+    /// with a real filename. Returns the file URL, or nil after surfacing the
+    /// failure through the standard action-error alert. The caller owns
+    /// cleanup of the returned file's parent directory after sharing.
+    func export(_ session: SessionSummary, format: SessionExportFormat) async -> URL? {
+        guard !isViewingCachedData else {
+            actionErrorMessage = String(localized: "Reconnect to the server to export a session.")
+            return nil
+        }
+
+        guard let sessionId = Self.nonEmpty(session.sessionId) else {
+            actionErrorMessage = String(localized: "The server did not provide a session ID.")
+            return nil
+        }
+
+        // Reuses the per-session mutation gate: it disables the row's other
+        // actions while the download runs (the "progress state") and blocks a
+        // double-tap from firing two exports.
+        guard beginSessionMutation(sessionId) else { return nil }
+        defer { endSessionMutation(sessionId) }
+
+        actionErrorMessage = nil
+        lastError = nil
+
+        do {
+            let file = try await client.exportSession(
+                id: sessionId,
+                format: format,
+                fallbackTitle: session.title
+            )
+
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("session-exports", isDirectory: true)
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            let fileURL = directory.appendingPathComponent(file.filename)
+            try file.data.write(to: fileURL, options: .atomic)
+            return fileURL
+        } catch {
+            guard !isCancellationError(error) else { return nil }
+
+            lastError = error
+            actionErrorMessage = error.localizedDescription
+            return nil
+        }
+    }
+
     func loadProjects() async {
         isLoadingProjects = true
         actionErrorMessage = nil

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -69,6 +69,27 @@ final class SessionListViewModel {
         let resolvedClient = client ?? APIClient(baseURL: server)
         self.client = resolvedClient
         self.sessionMutator = SessionMutator(client: resolvedClient)
+
+        // Sweep exports leaked by a previous run (view dismissed while a
+        // download was in flight, so the share sheet — and its on-dismiss
+        // cleanup — never appeared). Done at init, not per export: no export
+        // from this instance can be in flight yet, and a previous view's
+        // share sheet was already dismissed when that view went away, so
+        // nothing being shared can be deleted.
+        Task.detached(priority: .utility) {
+            Self.sweepLeakedExports()
+        }
+    }
+
+    /// Root temp directory holding one UUID subdirectory per export
+    /// (see `export(_:format:)`).
+    nonisolated static var exportsRootDirectory: URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("session-exports", isDirectory: true)
+    }
+
+    nonisolated private static func sweepLeakedExports() {
+        try? FileManager.default.removeItem(at: exportsRootDirectory)
     }
 
     var sections: [SessionListSection] {
@@ -577,14 +598,6 @@ final class SessionListViewModel {
         actionErrorMessage = nil
         lastError = nil
 
-        // Sweep exports leaked by earlier runs (e.g. the view was dismissed
-        // while a download was in flight, so the share sheet — and its
-        // cleanup — never appeared). Safe here: starting a new export means
-        // no share sheet is currently presenting a previous file.
-        let exportsRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent("session-exports", isDirectory: true)
-        try? FileManager.default.removeItem(at: exportsRoot)
-
         do {
             let file = try await client.exportSession(
                 id: sessionId,
@@ -592,7 +605,8 @@ final class SessionListViewModel {
                 fallbackTitle: session.title
             )
 
-            let directory = exportsRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+            let directory = Self.exportsRootDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
             let fileURL = directory.appendingPathComponent(file.filename)

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -70,15 +70,14 @@ final class SessionListViewModel {
         self.client = resolvedClient
         self.sessionMutator = SessionMutator(client: resolvedClient)
 
-        // Sweep exports leaked by a previous run (view dismissed while a
+        // Sweep exports leaked by a previous app run (view dismissed while a
         // download was in flight, so the share sheet — and its on-dismiss
-        // cleanup — never appeared). Done at init, not per export: no export
-        // from this instance can be in flight yet, and a previous view's
-        // share sheet was already dismissed when that view went away, so
-        // nothing being shared can be deleted.
-        Task.detached(priority: .utility) {
-            Self.sweepLeakedExports()
-        }
+        // cleanup — never appeared). `State(initialValue:)` re-runs this init
+        // on every parent redraw, so the sweep must be once-per-process (the
+        // lazy static below), or it would delete a file an active share sheet
+        // is presenting. The first-ever init always precedes the first export,
+        // so the single sweep can never race an in-flight export.
+        _ = Self.sweepLeakedExportsOnce
     }
 
     /// Root temp directory holding one UUID subdirectory per export
@@ -88,9 +87,10 @@ final class SessionListViewModel {
             .appendingPathComponent("session-exports", isDirectory: true)
     }
 
-    nonisolated private static func sweepLeakedExports() {
+    /// Lazy static ⇒ runs exactly once per process, on first access.
+    nonisolated private static let sweepLeakedExportsOnce: Void = {
         try? FileManager.default.removeItem(at: exportsRootDirectory)
-    }
+    }()
 
     var sections: [SessionListSection] {
         let sortedSessions = sessions.sorted { left, right in

--- a/HermesMobile/Networking/APIClient+SessionExport.swift
+++ b/HermesMobile/Networking/APIClient+SessionExport.swift
@@ -38,7 +38,10 @@ extension APIClient {
         let (data, response) = try await sendDataReturningResponse(
             endpoint: .exportSession(sessionID: id, format: format),
             method: "GET",
-            encodedBody: nil
+            encodedBody: nil,
+            // The 2xx response is a file download (text/html or
+            // application/json), so don't claim we only accept JSON.
+            accept: "*/*"
         )
 
         let filename = SessionExportFile.filename(

--- a/HermesMobile/Networking/APIClient+SessionExport.swift
+++ b/HermesMobile/Networking/APIClient+SessionExport.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// Formats accepted by `GET /api/session/export?format=…`. The server defaults
+/// to JSON when the param is absent, but the app always sends it explicitly.
+/// HTML is the self-contained human-readable transcript (best for sharing);
+/// JSON is the machine-readable session dump (pairs with a future import).
+enum SessionExportFormat: String, CaseIterable {
+    case html
+    case json
+
+    var fileExtension: String { rawValue }
+}
+
+/// A downloaded session export: the raw file bytes plus the filename the share
+/// sheet should offer (never "download.bin").
+struct SessionExportFile: Equatable {
+    let data: Data
+    let filename: String
+}
+
+extension APIClient {
+    /// Downloads a session transcript via `GET /api/session/export`
+    /// (`session_id` + `format` query params). The response is a file download
+    /// (`text/html` or `application/json`), not a JSON envelope, so this
+    /// bypasses the decoding `send()` helper like transcribe/TTS do.
+    ///
+    /// The filename comes from the server's `Content-Disposition` header
+    /// (upstream sends `attachment; filename="hermes-<sid>.<ext>"`); if that
+    /// header is missing or unparsable, it falls back to a sanitized
+    /// `<title-or-id>.<ext>`. Errors reuse `sendData`'s mapping: 401 →
+    /// `.unauthorized`, other non-2xx (400 missing param, 404 unknown/foreign-
+    /// profile session) → `.http` carrying the server's error body.
+    func exportSession(
+        id: String,
+        format: SessionExportFormat,
+        fallbackTitle: String? = nil
+    ) async throws -> SessionExportFile {
+        let (data, response) = try await sendDataReturningResponse(
+            endpoint: .exportSession(sessionID: id, format: format),
+            method: "GET",
+            encodedBody: nil
+        )
+
+        let filename = SessionExportFile.filename(
+            contentDisposition: response.value(forHTTPHeaderField: "Content-Disposition"),
+            fallbackTitle: fallbackTitle,
+            sessionID: id,
+            format: format
+        )
+
+        return SessionExportFile(data: data, filename: filename)
+    }
+}
+
+extension SessionExportFile {
+    /// Derives the filename to offer in the share sheet.
+    ///
+    /// Preference order:
+    /// 1. `filename="…"` (or unquoted `filename=…`) from `Content-Disposition`.
+    /// 2. Sanitized session title + the format's extension.
+    /// 3. `hermes-<session-id>.<ext>` (mirrors the upstream server's own name).
+    static func filename(
+        contentDisposition: String?,
+        fallbackTitle: String?,
+        sessionID: String,
+        format: SessionExportFormat
+    ) -> String {
+        if let headerName = filenameParameter(in: contentDisposition),
+           let sanitized = sanitizedFilename(headerName) {
+            return sanitized
+        }
+
+        if let title = fallbackTitle,
+           let sanitizedTitle = sanitizedFilenameStem(title) {
+            return "\(sanitizedTitle).\(format.fileExtension)"
+        }
+
+        let sanitizedID = sanitizedFilenameStem(sessionID) ?? "session"
+        return "hermes-\(sanitizedID).\(format.fileExtension)"
+    }
+
+    /// Extracts the `filename` parameter value from a `Content-Disposition`
+    /// header (quoted or bare token). Intentionally does not implement the
+    /// RFC 5987 `filename*=` extended form — upstream never sends it, and the
+    /// sanitized fallback covers any server that does.
+    private static func filenameParameter(in contentDisposition: String?) -> String? {
+        guard let contentDisposition else { return nil }
+
+        for parameter in contentDisposition.split(separator: ";").dropFirst() {
+            let trimmed = parameter.trimmingCharacters(in: .whitespaces)
+            guard let separatorIndex = trimmed.firstIndex(of: "=") else { continue }
+
+            let key = trimmed[..<separatorIndex].trimmingCharacters(in: .whitespaces).lowercased()
+            guard key == "filename" else { continue }
+
+            var value = trimmed[trimmed.index(after: separatorIndex)...]
+                .trimmingCharacters(in: .whitespaces)
+            if value.hasPrefix("\""), value.hasSuffix("\""), value.count >= 2 {
+                value = String(value.dropFirst().dropLast())
+            }
+            return value.isEmpty ? nil : value
+        }
+
+        return nil
+    }
+
+    /// Keeps only the last path component and strips characters that are
+    /// unsafe in filenames, so a hostile/buggy header can't escape the temp
+    /// directory or produce an unusable name.
+    private static func sanitizedFilename(_ raw: String) -> String? {
+        let lastComponent = raw
+            .replacingOccurrences(of: "\\", with: "/")
+            .split(separator: "/")
+            .last
+            .map(String.init) ?? raw
+
+        let cleaned = replacingUnsafeFilenameCharacters(in: lastComponent)
+        guard !cleaned.isEmpty, cleaned != "." , cleaned != ".." else { return nil }
+        return cleaned
+    }
+
+    /// Sanitizes free text (session title / ID) into a filename stem, or nil
+    /// when nothing usable remains.
+    private static func sanitizedFilenameStem(_ raw: String) -> String? {
+        let cleaned = replacingUnsafeFilenameCharacters(in: raw)
+        guard !cleaned.isEmpty else { return nil }
+        return String(cleaned.prefix(80))
+    }
+
+    private static func replacingUnsafeFilenameCharacters(in raw: String) -> String {
+        var unsafe = CharacterSet(charactersIn: "/\\:")
+        unsafe.formUnion(.controlCharacters)
+        unsafe.formUnion(.newlines)
+        unsafe.formUnion(.illegalCharacters)
+
+        let replaced = raw.unicodeScalars
+            .map { unsafe.contains($0) ? " " : Character($0) }
+            .reduce(into: "") { $0.append($1) }
+
+        // Collapse whitespace runs and trim so titles like "  a  /  b  " come
+        // out as "a b" rather than "a    b".
+        return replaced
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+    }
+}

--- a/HermesMobile/Networking/APIClient.swift
+++ b/HermesMobile/Networking/APIClient.swift
@@ -139,6 +139,23 @@ actor APIClient {
         encodedBody: Data?,
         timeout: TimeInterval? = nil
     ) async throws -> Data {
+        try await sendDataReturningResponse(
+            endpoint: endpoint,
+            method: method,
+            encodedBody: encodedBody,
+            timeout: timeout
+        ).0
+    }
+
+    /// Same request/error contract as `sendData`, but also returns the
+    /// `HTTPURLResponse` so callers can read response headers (e.g. the
+    /// `Content-Disposition` filename on `GET /api/session/export`).
+    func sendDataReturningResponse(
+        endpoint: Endpoint,
+        method: String,
+        encodedBody: Data?,
+        timeout: TimeInterval? = nil
+    ) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: endpoint.url(relativeTo: baseURL))
         request.httpMethod = method
         request.cachePolicy = .reloadIgnoringLocalCacheData
@@ -177,7 +194,7 @@ actor APIClient {
             )
         }
 
-        return data
+        return (data, httpResponse)
     }
 
     func downloadData(

--- a/HermesMobile/Networking/APIClient.swift
+++ b/HermesMobile/Networking/APIClient.swift
@@ -150,11 +150,15 @@ actor APIClient {
     /// Same request/error contract as `sendData`, but also returns the
     /// `HTTPURLResponse` so callers can read response headers (e.g. the
     /// `Content-Disposition` filename on `GET /api/session/export`).
+    ///
+    /// `accept` overrides the default `application/json` Accept header for
+    /// endpoints whose 2xx response is a file download rather than JSON.
     func sendDataReturningResponse(
         endpoint: Endpoint,
         method: String,
         encodedBody: Data?,
-        timeout: TimeInterval? = nil
+        timeout: TimeInterval? = nil,
+        accept: String = "application/json"
     ) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: endpoint.url(relativeTo: baseURL))
         request.httpMethod = method
@@ -164,7 +168,7 @@ actor APIClient {
         if let timeout { request.timeoutInterval = timeout }
         // Custom headers first, then built-ins so Accept/Content-Type always win.
         customHeaderProvider().apply(to: &request)
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(accept, forHTTPHeaderField: "Accept")
 
         if let encodedBody {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -22,6 +22,7 @@ enum Endpoint {
     case updateSession
     case moveSession
     case sessionYolo(sessionID: String?)
+    case exportSession(sessionID: String, format: SessionExportFormat)
     case projects
     case createProject
     case renameProject
@@ -140,6 +141,8 @@ enum Endpoint {
             return "/api/session/move"
         case .sessionYolo:
             return "/api/session/yolo"
+        case .exportSession:
+            return "/api/session/export"
         case .projects:
             return "/api/projects"
         case .createProject:
@@ -328,6 +331,11 @@ enum Endpoint {
         case let .sessionYolo(sessionID):
             guard let sessionID else { return [] }
             return [URLQueryItem(name: "session_id", value: sessionID)]
+        case let .exportSession(sessionID, format):
+            return [
+                URLQueryItem(name: "session_id", value: sessionID),
+                URLQueryItem(name: "format", value: format.rawValue)
+            ]
         case let .approvalPending(sessionID),
             let .approvalStream(sessionID),
             let .clarifyPending(sessionID),

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -31044,6 +31044,112 @@
         }
       }
     },
+    "Export" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تصدير"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exporter"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ייצוא"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esporta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "エクスポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "내보내기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exporteren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eksportuj"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Экспорт"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dışa Aktar"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "برآمد کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匯出"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "导出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匯出"
+          }
+        }
+      }
+    },
     "Export Failed" : {
       "localizations" : {
         "ar" : {
@@ -31146,6 +31252,218 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "匯出失敗"
+          }
+        }
+      }
+    },
+    "Export as HTML" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تصدير بتنسيق HTML"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Als HTML exportieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportar como HTML"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exporter en HTML"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ייצוא כ־HTML"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esporta come HTML"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "HTMLとしてエクスポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "HTML로 내보내기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exporteren als HTML"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eksportuj jako HTML"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportar como HTML"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Экспортировать как HTML"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "HTML olarak dışa aktar"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "HTML کے طور پر برآمد کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匯出為 HTML"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "导出为 HTML"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匯出為 HTML"
+          }
+        }
+      }
+    },
+    "Export as JSON" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تصدير بتنسيق JSON"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Als JSON exportieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportar como JSON"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exporter en JSON"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ייצוא כ־JSON"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esporta come JSON"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "JSONとしてエクスポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "JSON으로 내보내기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exporteren als JSON"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eksportuj jako JSON"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportar como JSON"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Экспортировать как JSON"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "JSON olarak dışa aktar"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "JSON کے طور پر برآمد کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匯出為 JSON"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "导出为 JSON"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匯出為 JSON"
           }
         }
       }
@@ -57240,6 +57558,112 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "重新連線至伺服器以編輯訊息。"
+          }
+        }
+      }
+    },
+    "Reconnect to the server to export a session." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "أعد الاتصال بالخادم لتصدير جلسة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verbinde dich erneut mit dem Server, um eine Sitzung zu exportieren."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconéctate al servidor para exportar una sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconnectez-vous au serveur pour exporter une session."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "התחבר מחדש לשרת כדי לייצא מפגש."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Riconnettiti al server per esportare una sessione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "セッションをエクスポートするには、サーバに再接続してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "세션을 내보내려면 서버에 다시 연결하세요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Maak opnieuw verbinding met de server om een sessie te exporteren."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Połącz ponownie z serwerem, aby wyeksportować sesję."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconecte-se ao servidor para exportar uma sessão."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Переподключитесь к серверу, чтобы экспортировать сессию."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bir oturumu dışa aktarmak için sunucuya yeniden bağlanın."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سیشن برآمد کرنے کے لیے سرور سے دوبارہ منسلک ہوں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "重新連線伺服器以匯出工作階段。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "重新连接服务器以导出会话。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "重新連線至伺服器以匯出工作階段。"
           }
         }
       }

--- a/HermesMobileTests/APIClientSessionExportTests.swift
+++ b/HermesMobileTests/APIClientSessionExportTests.swift
@@ -37,6 +37,9 @@ final class APIClientSessionExportTests: APIClientTestCase {
             XCTAssertEqual(request.url?.path, "/api/session/export")
             XCTAssertEqual(request.httpMethod, "GET")
             XCTAssertNil(request.httpBody)
+            // The response is a file download, so the export request must not
+            // claim it only accepts JSON.
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "*/*")
 
             let response = HTTPURLResponse(
                 url: request.url!,

--- a/HermesMobileTests/APIClientSessionExportTests.swift
+++ b/HermesMobileTests/APIClientSessionExportTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import HermesMobile
+
+final class APIClientSessionExportTests: APIClientTestCase {
+    // MARK: - Endpoint construction
+
+    func testExportEndpointBuildsPathAndQuery() {
+        let url = Endpoint.exportSession(sessionID: "abc-123", format: .html)
+            .url(relativeTo: URL(string: "https://example.test")!)
+
+        XCTAssertEqual(url.path, "/api/session/export")
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        XCTAssertEqual(
+            components?.queryItems,
+            [
+                URLQueryItem(name: "session_id", value: "abc-123"),
+                URLQueryItem(name: "format", value: "html")
+            ]
+        )
+    }
+
+    func testExportEndpointEncodesJSONFormat() {
+        let url = Endpoint.exportSession(sessionID: "abc 123", format: .json)
+            .url(relativeTo: URL(string: "https://example.test")!)
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        XCTAssertEqual(components?.queryItems?.last, URLQueryItem(name: "format", value: "json"))
+        // Session IDs with spaces must be percent-encoded, not dropped.
+        XCTAssertEqual(components?.queryItems?.first?.value, "abc 123")
+    }
+
+    // MARK: - Download
+
+    func testExportSessionReturnsBytesAndHeaderDerivedFilename() async throws {
+        let html = Data("<html><body>hi</body></html>".utf8)
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/session/export")
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertNil(request.httpBody)
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "text/html; charset=utf-8",
+                    "Content-Disposition": "attachment; filename=\"hermes-abc-123.html\""
+                ]
+            )!
+            return (response, html)
+        }
+
+        let file = try await client.exportSession(id: "abc-123", format: .html, fallbackTitle: "Planning")
+
+        XCTAssertEqual(file.data, html)
+        XCTAssertEqual(file.filename, "hermes-abc-123.html")
+    }
+
+    func testExportSessionFallsBackToTitleWhenHeaderMissing() async throws {
+        let json = Data("{}".utf8)
+        let client = makeClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json; charset=utf-8"]
+            )!
+            return (response, json)
+        }
+
+        let file = try await client.exportSession(id: "abc-123", format: .json, fallbackTitle: "Planning notes")
+
+        XCTAssertEqual(file.data, json)
+        XCTAssertEqual(file.filename, "Planning notes.json")
+    }
+
+    func testExportSessionMapsBadRequestToHTTPErrorWithBody() async {
+        let client = makeClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"error": "Session not found"}"#.utf8))
+        }
+
+        do {
+            _ = try await client.exportSession(id: "missing", format: .html)
+            XCTFail("Expected APIError.http")
+        } catch let APIError.http(statusCode, body) {
+            XCTAssertEqual(statusCode, 404)
+            XCTAssertEqual(body, #"{"error": "Session not found"}"#)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Filename derivation
+
+    func testFilenamePrefersQuotedContentDisposition() {
+        let filename = SessionExportFile.filename(
+            contentDisposition: "attachment; filename=\"hermes-s1.html\"",
+            fallbackTitle: "Ignored",
+            sessionID: "s1",
+            format: .html
+        )
+        XCTAssertEqual(filename, "hermes-s1.html")
+    }
+
+    func testFilenameParsesUnquotedToken() {
+        let filename = SessionExportFile.filename(
+            contentDisposition: "attachment; filename=export.json",
+            fallbackTitle: nil,
+            sessionID: "s1",
+            format: .json
+        )
+        XCTAssertEqual(filename, "export.json")
+    }
+
+    func testFilenameStripsPathComponentsFromHeader() {
+        let filename = SessionExportFile.filename(
+            contentDisposition: "attachment; filename=\"../../etc/passwd\"",
+            fallbackTitle: nil,
+            sessionID: "s1",
+            format: .html
+        )
+        // Only the last path component survives; traversal segments are gone.
+        XCTAssertEqual(filename, "passwd")
+    }
+
+    func testFilenameSanitizesTitleFallback() {
+        let filename = SessionExportFile.filename(
+            contentDisposition: nil,
+            fallbackTitle: "  Fix: build/CI \n pipeline  ",
+            sessionID: "s1",
+            format: .html
+        )
+        XCTAssertEqual(filename, "Fix build CI pipeline.html")
+    }
+
+    func testFilenameUsesSessionIDWhenTitleUnusable() {
+        let filename = SessionExportFile.filename(
+            contentDisposition: "inline",
+            fallbackTitle: "   ",
+            sessionID: "abc-123",
+            format: .json
+        )
+        XCTAssertEqual(filename, "hermes-abc-123.json")
+    }
+
+    func testFilenameTruncatesVeryLongTitles() {
+        let longTitle = String(repeating: "a", count: 200)
+        let filename = SessionExportFile.filename(
+            contentDisposition: nil,
+            fallbackTitle: longTitle,
+            sessionID: "s1",
+            format: .json
+        )
+        XCTAssertEqual(filename, String(repeating: "a", count: 80) + ".json")
+    }
+}

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -74,7 +74,6 @@ sub-paths of a group. Do not reorder casually.
 | `/api/crons/delivery-options` | roadmap | P2 | read | Cron History / Recent Runs |
 | `/api/session/usage` | roadmap | P2 | read | Session Token Usage — mostly covered by the context ring |
 | `/api/session/clear` | roadmap | P2 | write | Session Clear — destructive; needs confirmation |
-| `/api/session/export` | roadmap | P4 | — | Session Export / Share — owner-deferred |
 | `/api/session/import` | roadmap | P3 | — | Session Import (JSON / CLI) |
 | `/api/session/duplicate` | roadmap | P4 | — | Session Duplicate — branch-based duplicate already covers the need |
 | `/api/session/toolsets` | roadmap | P4 | write | Advanced Session Maintenance |


### PR DESCRIPTION
Fixes #21

> **Stacked PR:** this branch is based on `issue/15-read-aloud-tts` (PR for #15) and must merge **after** it. The PR base is intentionally `issue/15-read-aloud-tts`, not `master` — after #15 merges, retarget/merge this one.

## Plan (E1, pre-approved for the unattended batch run)

1. `Endpoints.swift`: `case exportSession(sessionID:format:)` → `GET /api/session/export?session_id=…&format=html|json`.
2. `APIClient`: split the core of `sendData` into `sendDataReturningResponse` (same request/error contract, also returns the `HTTPURLResponse`) so the export call can read `Content-Disposition`. Reuses the raw-`Data` infrastructure introduced by #15 (`sendData`) rather than re-implementing it.
3. New `APIClient+SessionExport.swift`: `SessionExportFormat` (html/json), `SessionExportFile` (bytes + filename), filename derivation: `Content-Disposition` `filename=` param (quoted or bare, path components stripped) → sanitized session title → `hermes-<sid>.<ext>`.
4. Session list UI: "Export" submenu (Export as HTML / Export as JSON) in the row context menu, gated exactly like Rename/Archive (server session ID + live connection); download writes to a per-export UUID temp dir; `UIActivityViewController` sheet; temp dir removed on dismiss; errors reuse the "Session Action Failed" alert; the per-session mutation gate provides the progress/disabled state and double-tap protection.
5. `docs/agents/feature-gap-index.md`: removed the `/api/session/export` roadmap row (the index derives `implemented` live from `Endpoints.swift`).
6. Tests: endpoint path/query construction, filename derivation (header quoted/unquoted, traversal stripping, title sanitization, truncation, ID fallback), download success + 404 error mapping.

## Upstream verification (hard rule 1)

Validated against the pinned `hermes-webui` copy @ `312d3fab`, `api/routes.py` `_handle_session_export`:

- Query params: `session_id` (required, else 400 `session_id is required`), `format` (`html`/anything-else→json; app always sends it explicitly). `theme`/`palette` exist for HTML but are server-defaulted and out of scope.
- Missing/foreign-profile session → 404 `Session not found`.
- Response is a raw file download with `Content-Disposition: attachment; filename="hermes-<sid>.<ext>"`, `Content-Length` set (fully buffered — single-shot `Data` download is correct).
- No foreign/CLI-session restriction in the handler beyond the active-profile gate, so the action is shown for any row with a server session ID (same gate as Rename).

## Localization

The four new user-facing strings ship with `needs_review` translations for all 17 catalog languages, following the convention of the merged decode-gap batch (#28).

## Validation

- Full XCTest suite: `xcodebuild test -scheme HermesMobile -destination "id=359CB4A0-3F01-40E0-95DC-957C98C7B4EC"` → **TEST SUCCEEDED** on the head commit.
- `git diff --check` clean.

## Owner manual checks

- [ ] Long-press a session row → Export → Export as HTML: share sheet appears with `hermes-<sid>.html`; AirDrop/Save-to-Files works and the file opens in Safari.
- [ ] Export as JSON: file is valid JSON when opened from Files.
- [ ] Filename is sensible (not `download.bin`).
- [ ] While offline / viewing cached data, Export is disabled (menu greyed out).
- [ ] Export a bogus/foreign-profile session (if reproducible) → "Session Action Failed" alert with the server message, no silent no-op.
- [ ] Cancel the share sheet: no crash; temp file cleaned up (no visible effect, sanity only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
