### PR TITLE
Settings: expand SettingsResponse decode, drop phantom version, sync the CLI-sessions toggle with the server

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		C15210000000000000000006 /* OnboardingConnectPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000006 /* OnboardingConnectPage.swift */; };
 		C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000007 /* OnboardingFlowTests.swift */; };
 		C0391000000000000000000F /* SessionListMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000F /* SessionListMutationTests.swift */; };
+		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
 		C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000010 /* APIEndpointContractTests.swift */; };
 		C03910000000000000000011 /* CronManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000011 /* CronManagementTests.swift */; };
 		C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000012 /* MemoryViewModelTests.swift */; };
@@ -212,6 +213,7 @@
 		C012400000000000000006 /* AppIconChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C012400000000000000005 /* AppIconChoiceTests.swift */; };
 		1A2B3C4D5E6F70000000110 /* ArchivedSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000111 /* ArchivedSessionsView.swift */; };
 		1A2B3C4D5E6F70000000112 /* ArchivedSessionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */; };
+		19C1150000000000000000A1 /* CliSessionsSyncModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A2 /* CliSessionsSyncModel.swift */; };
 		1A2B3C4D5E6F70000000114 /* DefaultModelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000115 /* DefaultModelPickerView.swift */; };
 		103200000000000000000002 /* DefaultProfilePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103200000000000000000001 /* DefaultProfilePickerView.swift */; };
 		1A2B3C4D5E6F70000000130 /* ContextWindowSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000120 /* ContextWindowSnapshot.swift */; };
@@ -390,6 +392,7 @@
 		C15200000000000000000006 /* OnboardingConnectPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConnectPage.swift; sourceTree = "<group>"; };
 		C15200000000000000000007 /* OnboardingFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowTests.swift; sourceTree = "<group>"; };
 		C0390000000000000000000F /* SessionListMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListMutationTests.swift; sourceTree = "<group>"; };
+		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000010 /* APIEndpointContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointContractTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000011 /* CronManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronManagementTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000012 /* MemoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewModelTests.swift; sourceTree = "<group>"; };
@@ -522,6 +525,7 @@
 		C012400000000000000005 /* AppIconChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconChoiceTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000111 /* ArchivedSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedSessionsView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedSessionsViewModel.swift; sourceTree = "<group>"; };
+		19C1150000000000000000A2 /* CliSessionsSyncModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000115 /* DefaultModelPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultModelPickerView.swift; sourceTree = "<group>"; };
 		103200000000000000000001 /* DefaultProfilePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProfilePickerView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000120 /* ContextWindowSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextWindowSnapshot.swift; sourceTree = "<group>"; };
@@ -718,6 +722,7 @@
 					C14600000000000000000001 /* ChatToolbarHeaderTests.swift */,
 					C15200000000000000000007 /* OnboardingFlowTests.swift */,
 				C0390000000000000000000F /* SessionListMutationTests.swift */,
+				19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */,
 				C03900000000000000000010 /* APIEndpointContractTests.swift */,
 				C03900000000000000000011 /* CronManagementTests.swift */,
 				C03900000000000000000012 /* MemoryViewModelTests.swift */,
@@ -1004,6 +1009,7 @@
 				C23400000000000000000002 /* StreamingLabReplay.swift */,
 				C23400000000000000000004 /* StreamingLabView.swift */,
 				1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */,
+				19C1150000000000000000A2 /* CliSessionsSyncModel.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1381,6 +1387,7 @@
 				C23400000000000000000001 /* StreamingLabReplay.swift in Sources */,
 				C23400000000000000000003 /* StreamingLabView.swift in Sources */,
 				1A2B3C4D5E6F70000000112 /* ArchivedSessionsViewModel.swift in Sources */,
+				19C1150000000000000000A1 /* CliSessionsSyncModel.swift in Sources */,
 				1A2B3C4D5E6F7000000000F8 /* AppConfig.swift in Sources */,
 				C09200000000000000000001 /* AppFont.swift in Sources */,
 				1A2B3C4D5E6F700000000100 /* AppTheme.swift in Sources */,
@@ -1523,6 +1530,7 @@
 					C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */,
 					C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */,
 				C0391000000000000000000F /* SessionListMutationTests.swift in Sources */,
+				19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */,
 				C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */,
 				C03910000000000000000011 /* CronManagementTests.swift in Sources */,
 				C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */,

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -42,7 +42,10 @@ struct SessionListView: View {
     @AppStorage(SessionRowDisplaySettings.showMessageCountKey) private var showsSessionMessageCount = true
     @AppStorage(SessionRowDisplaySettings.showWorkspaceKey) private var showsSessionWorkspace = true
     @AppStorage(SessionRowDisplaySettings.showCronSessionsKey) private var showsCronSessions = true
-    @AppStorage(SessionRowDisplaySettings.showCliSessionsKey) private var showsCliSessions = true
+    // Per-server key (#19): the CLI toggle mirrors the active server's
+    // `show_cli_sessions`, so its cached value must not leak across servers.
+    // Configured in `init`, where the server URL is known.
+    @AppStorage private var showsCliSessions: Bool
     @AppStorage(HeaderLogoColor.storageKey) private var headerLogoColorHex = HeaderLogoColor.defaultHex
     @AppStorage(PrimaryActionTintSettings.isEnabledKey) private var tintsPrimaryActions = false
     @AppStorage(GlassPreference.isEnabledKey) private var isGlassEnabled = GlassPreference.defaultIsEnabled
@@ -63,6 +66,10 @@ struct SessionListView: View {
         _pendingDeepLinkedSessionID = pendingDeepLinkedSessionID
         _requestedNewChat = requestedNewChat
         _viewModel = State(initialValue: SessionListViewModel(server: server))
+        _showsCliSessions = AppStorage(
+            wrappedValue: SessionRowDisplaySettings.showsCliSessions(for: server),
+            SessionRowDisplaySettings.showCliSessionsKey(for: server)
+        )
     }
 
     var body: some View {

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -365,7 +365,32 @@ enum SessionRowDisplaySettings {
     // Cron and CLI sessions are controlled independently (#256); both default to
     // shown, and their toggles let users hide each kind separately.
     static let showCronSessionsKey = "sessionRow.showCronSessions"
+    // Legacy global CLI-sessions key. Since #19 the CLI toggle is stored
+    // per-server (it mirrors the server's own `show_cli_sessions` setting, and a
+    // value adopted from server A must not leak to server B); this key survives
+    // only as the migration seed for servers with no per-server value yet.
     static let showCliSessionsKey = "sessionRow.showCliSessions"
+
+    /// Per-server storage key for the CLI-sessions toggle (#19). Keyed by the
+    /// active server's absolute URL, matching how the offline cache scopes rows.
+    static func showCliSessionsKey(for server: URL) -> String {
+        "\(showCliSessionsKey)|\(server.absoluteString)"
+    }
+
+    /// Effective CLI-sessions visibility for `server`: the per-server value if
+    /// one was ever stored, else the pre-#19 global value, else shown-by-default
+    /// like every other session-row toggle.
+    static func showsCliSessions(for server: URL, in defaults: UserDefaults = .standard) -> Bool {
+        if let perServer = defaults.object(forKey: showCliSessionsKey(for: server)) as? Bool {
+            return perServer
+        }
+
+        if let legacy = defaults.object(forKey: showCliSessionsKey) as? Bool {
+            return legacy
+        }
+
+        return true
+    }
 }
 
 enum SessionSidebarDisclosureSettings {

--- a/HermesMobile/Features/Settings/CliSessionsSyncModel.swift
+++ b/HermesMobile/Features/Settings/CliSessionsSyncModel.swift
@@ -71,6 +71,10 @@ final class CliSessionsSyncModel {
 
         writeGeneration += 1
         let generation = writeGeneration
+        // Cancel the superseded write so rapid re-toggles don't race each other
+        // at the server; its failure path is additionally ignored via the
+        // generation guard below.
+        pendingWrite?.cancel()
         pendingWrite = Task { [weak self] in
             guard let self else { return }
             do {

--- a/HermesMobile/Features/Settings/CliSessionsSyncModel.swift
+++ b/HermesMobile/Features/Settings/CliSessionsSyncModel.swift
@@ -71,12 +71,17 @@ final class CliSessionsSyncModel {
 
         writeGeneration += 1
         let generation = writeGeneration
-        // Cancel the superseded write so rapid re-toggles don't race each other
-        // at the server; its failure path is additionally ignored via the
-        // generation guard below.
-        pendingWrite?.cancel()
+        // Serialize behind the in-flight write: cancelling a Task does not
+        // un-send a POST that already left the device, so the previous request
+        // could land at the server *after* a newer one and flip the stored
+        // value against the UI. Holding the next request until the previous
+        // response arrives guarantees the server applies toggles in UI order;
+        // a superseded write skips its POST entirely (the newest queued write
+        // carries the final value), so a long chain collapses to one request.
+        let predecessor = pendingWrite
         pendingWrite = Task { [weak self] in
-            guard let self else { return }
+            await predecessor?.value
+            guard let self, self.writeGeneration == generation else { return }
             do {
                 try await self.writeToServer(newValue)
             } catch {

--- a/HermesMobile/Features/Settings/CliSessionsSyncModel.swift
+++ b/HermesMobile/Features/Settings/CliSessionsSyncModel.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Observation
+
+/// Server-synced "Show CLI sessions" toggle (#19).
+///
+/// The server's `show_cli_sessions` setting is the cross-device source of
+/// truth: on every Settings load the server value is adopted into the
+/// per-server local cache (server wins on conflict), and flipping the toggle
+/// writes `POST /api/settings {"show_cli_sessions": <bool>}` back. The local
+/// value doubles as an offline cache — servers that never report the key keep
+/// today's purely local behavior (no adoption, no write). On a failed write
+/// the toggle reverts and the error is surfaced.
+///
+/// Storage is per-server (`SessionRowDisplaySettings.showCliSessionsKey(for:)`)
+/// so an adopted value on server A can never leak into server B
+/// (docs/agents/multi-server-state-isolation.md).
+@MainActor
+@Observable
+final class CliSessionsSyncModel {
+    private(set) var showsCliSessions: Bool
+    /// True once the active server has reported `show_cli_sessions` — only then
+    /// do toggle changes write back. Older servers stay local-only.
+    private(set) var serverSyncsCliSessions = false
+    private(set) var syncErrorMessage: String?
+    /// The in-flight write, exposed so callers (and tests) can await it.
+    private(set) var pendingWrite: Task<Void, Never>?
+
+    private let server: URL
+    private let defaults: UserDefaults
+    private let writeToServer: @MainActor (Bool) async throws -> Void
+    /// Invalidates stale write completions: only the latest toggle change may
+    /// revert the value or publish an error.
+    private var writeGeneration = 0
+
+    init(
+        server: URL,
+        defaults: UserDefaults = .standard,
+        writeToServer: @escaping @MainActor (Bool) async throws -> Void
+    ) {
+        self.server = server
+        self.defaults = defaults
+        self.writeToServer = writeToServer
+        showsCliSessions = SessionRowDisplaySettings.showsCliSessions(for: server, in: defaults)
+    }
+
+    /// Adopts the server-reported value on settings load. `nil` (server omitted
+    /// the key) leaves the local toggle exactly as it was and disables
+    /// write-back. Adoption never writes back to the server.
+    func adopt(serverValue: Bool?) {
+        guard let serverValue else {
+            serverSyncsCliSessions = false
+            return
+        }
+
+        serverSyncsCliSessions = true
+        syncErrorMessage = nil
+        persist(serverValue)
+    }
+
+    /// Applies a user toggle: optimistic local update, then the server write.
+    /// On write failure the toggle reverts (unless the user has already toggled
+    /// again) and `syncErrorMessage` is set.
+    func setShowsCliSessions(_ newValue: Bool) {
+        guard newValue != showsCliSessions else { return }
+
+        let previousValue = showsCliSessions
+        persist(newValue)
+        syncErrorMessage = nil
+
+        guard serverSyncsCliSessions else { return }
+
+        writeGeneration += 1
+        let generation = writeGeneration
+        pendingWrite = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.writeToServer(newValue)
+            } catch {
+                guard self.writeGeneration == generation else { return }
+                self.persist(previousValue)
+                self.syncErrorMessage = String(
+                    localized: "Could not save to the server. The toggle was reverted."
+                )
+            }
+        }
+    }
+
+    private func persist(_ value: Bool) {
+        showsCliSessions = value
+        defaults.set(value, forKey: SessionRowDisplaySettings.showCliSessionsKey(for: server))
+    }
+}

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -19,6 +19,13 @@ struct SettingsView: View {
         self.authManager = authManager
         self.server = server
         self.initialScrollTarget = initialScrollTarget
+        // The CLI-sessions toggle is server-synced (#19): loads adopt the
+        // server's `show_cli_sessions`, toggles POST it back, failures revert.
+        // Stored per-server so one server's value never leaks into another.
+        _cliSessionsSync = State(initialValue: CliSessionsSyncModel(server: server) { value in
+            let client = APIClient(baseURL: server)
+            _ = try await client.updateSettings(showCliSessions: value)
+        })
     }
 
     @ScaledMetric(relativeTo: .body) private var settingsCardSpacing: CGFloat = 18
@@ -55,7 +62,7 @@ struct SettingsView: View {
     @AppStorage(SessionRowDisplaySettings.showMessageCountKey) private var showsSessionMessageCount = true
     @AppStorage(SessionRowDisplaySettings.showWorkspaceKey) private var showsSessionWorkspace = true
     @AppStorage(SessionRowDisplaySettings.showCronSessionsKey) private var showsCronSessions = true
-    @AppStorage(SessionRowDisplaySettings.showCliSessionsKey) private var showsCliSessions = true
+    @State private var cliSessionsSync: CliSessionsSyncModel
     @AppStorage(StreamingSendBehavior.storageKey) private var streamingSendBehaviorRawValue = StreamingSendBehavior.steer.rawValue
     @AppStorage(ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey) private var showsThinkingAndToolCards = true
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var thinkingCardsStartExpanded = false
@@ -274,8 +281,17 @@ struct SettingsView: View {
                     SettingsToggleRow(
                         title: String(localized: "CLI Sessions"),
                         systemImage: "terminal",
-                        isOn: $showsCliSessions
+                        isOn: Binding(
+                            get: { cliSessionsSync.showsCliSessions },
+                            set: { cliSessionsSync.setShowsCliSessions($0) }
+                        )
                     )
+
+                    if let syncError = cliSessionsSync.syncErrorMessage {
+                        SettingsErrorFootnote(syncError)
+                    } else if cliSessionsSync.serverSyncsCliSessions {
+                        SettingsFootnote(String(localized: "CLI session visibility is synced with this server, so the WebUI follows it too."))
+                    }
                 }
 
                 SettingsCard(title: String(localized: "Siri & Shortcuts")) {
@@ -865,7 +881,10 @@ struct SettingsView: View {
 
         do {
             let settings = try await client.settings()
-            serverVersion = settings.webuiVersion ?? settings.version
+            serverVersion = settings.webuiVersion
+            // Server wins on conflict: `show_cli_sessions` is the cross-device
+            // truth, the local value is just its offline cache (#19).
+            cliSessionsSync.adopt(serverValue: settings.showCliSessions)
             if serverVersion == nil {
                 serverSettingsError = String(localized: "Unknown")
             }
@@ -1012,7 +1031,7 @@ struct SettingsView: View {
                 continue
             }
 
-            let newVersion = settings.webuiVersion ?? settings.version
+            let newVersion = settings.webuiVersion
             let updateState = (try? await client.updatesCheck())?.webuiUpdateState ?? .unavailable
             let restartConfirmed = (newVersion != nil && newVersion != previousVersion)
                 || updateState == .upToDate
@@ -1463,6 +1482,30 @@ private struct SettingsFootnote: View {
             .font(AppFont.caption())
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// A footnote for inline failures (e.g. the CLI-sessions server write): same
+/// footprint as `SettingsFootnote`, plus a warning icon so it reads as an error.
+private struct SettingsErrorFootnote: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(AppFont.caption())
+                .foregroundStyle(.orange)
+
+            Text(text)
+                .font(AppFont.caption())
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -141,11 +141,54 @@ struct ProvidersResponse: Decodable, Equatable {
     let activeProvider: String?
 }
 
+/// `GET /api/settings` (the saved-settings body `POST /api/settings` echoes the
+/// same shape back). The server returns ~75 keys; we decode only the ones with
+/// a consumer or near-term use (#19). Every field is optional and lossy-decoded
+/// — servers omit keys freely and we never crash on an unexpected shape.
 struct SettingsResponse: Decodable, Equatable {
     let botName: String?
     let webuiVersion: String?
-    let version: String?
+    let agentVersion: String?
     let theme: String?
+    let checkForUpdates: Bool?
+    let showCliSessions: Bool?
+    let maxTokens: Int?
+    let maxTokensEffective: Int?
+    let authEnabled: Bool?
+    let passwordAuthEnabled: Bool?
+    let passkeysEnabled: Bool?
+    let passwordlessEnabled: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case botName
+        case webuiVersion
+        case agentVersion
+        case theme
+        case checkForUpdates
+        case showCliSessions
+        case maxTokens
+        case maxTokensEffective
+        case authEnabled
+        case passwordAuthEnabled
+        case passkeysEnabled
+        case passwordlessEnabled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        botName = container.decodeLossyStringIfPresent(forKey: .botName)
+        webuiVersion = container.decodeLossyStringIfPresent(forKey: .webuiVersion)
+        agentVersion = container.decodeLossyStringIfPresent(forKey: .agentVersion)
+        theme = container.decodeLossyStringIfPresent(forKey: .theme)
+        checkForUpdates = container.decodeLossyBoolIfPresent(forKey: .checkForUpdates)
+        showCliSessions = container.decodeLossyBoolIfPresent(forKey: .showCliSessions)
+        maxTokens = container.decodeLossyIntIfPresent(forKey: .maxTokens)
+        maxTokensEffective = container.decodeLossyIntIfPresent(forKey: .maxTokensEffective)
+        authEnabled = container.decodeLossyBoolIfPresent(forKey: .authEnabled)
+        passwordAuthEnabled = container.decodeLossyBoolIfPresent(forKey: .passwordAuthEnabled)
+        passkeysEnabled = container.decodeLossyBoolIfPresent(forKey: .passkeysEnabled)
+        passwordlessEnabled = container.decodeLossyBoolIfPresent(forKey: .passwordlessEnabled)
+    }
 }
 
 struct DefaultModelResponse: Decodable, Equatable {

--- a/HermesMobile/Networking/APIClient+ServerPanels.swift
+++ b/HermesMobile/Networking/APIClient+ServerPanels.swift
@@ -102,6 +102,20 @@ extension APIClient {
         try await send(endpoint: .settings, method: "GET")
     }
 
+    /// Writes the single server-synced session-visibility key (#19):
+    /// `POST /api/settings {"show_cli_sessions": <bool>}`. Upstream
+    /// `save_settings(body)` merges exactly the keys sent — nothing else is
+    /// touched — and responds with the full saved settings dict, so the
+    /// response reuses `SettingsResponse`. A general settings editor stays
+    /// out of scope.
+    func updateSettings(showCliSessions: Bool) async throws -> SettingsResponse {
+        try await send(
+            endpoint: .settings,
+            method: "POST",
+            body: ShowCliSessionsUpdateRequest(showCliSessions: showCliSessions)
+        )
+    }
+
     func updatesCheck() async throws -> UpdatesCheckResponse {
         try await send(endpoint: .updatesCheck, method: "GET")
     }
@@ -173,3 +187,7 @@ private struct UpdatesCheckForceRequest: Encodable {
     let force: Bool
 }
 
+private struct ShowCliSessionsUpdateRequest: Encodable {
+    // Encoded as `show_cli_sessions` via the client's convertToSnakeCase strategy.
+    let showCliSessions: Bool
+}

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -12030,6 +12030,112 @@
         }
       }
     },
+    "CLI session visibility is synced with this server, so the WebUI follows it too." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تتم مزامنة إظهار جلسات CLI مع هذا الخادم، لذا يتبعها WebUI أيضًا."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Die Sichtbarkeit von CLI-Sitzungen wird mit diesem Server synchronisiert, sodass auch die WebUI ihr folgt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La visibilidad de las sesiones CLI se sincroniza con este servidor, así que la WebUI también la sigue."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La visibilité des sessions CLI est synchronisée avec ce serveur ; la WebUI la suit donc aussi."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הצגת מפגשי CLI מסונכרנת עם שרת זה, ולכן גם ה-WebUI עוקב אחריה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La visibilità delle sessioni CLI è sincronizzata con questo server, quindi anche la WebUI la segue."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "CLI セッションの表示はこのサーバーと同期されるため、WebUI にも反映されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "CLI 세션 표시 여부는 이 서버와 동기화되므로 WebUI도 이를 따릅니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "De zichtbaarheid van CLI-sessies wordt gesynchroniseerd met deze server, dus de WebUI volgt deze ook."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Widoczność sesji CLI jest synchronizowana z tym serwerem, więc WebUI również ją odzwierciedla."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A visibilidade das sessões CLI é sincronizada com este servidor, então a WebUI também a acompanha."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Видимость сессий CLI синхронизируется с этим сервером, поэтому WebUI также следует ей."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "CLI oturumlarının görünürlüğü bu sunucuyla eşitlenir, bu yüzden WebUI de bunu izler."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "CLI سیشنز کی نمائش اس سرور کے ساتھ ہم آہنگ رہتی ہے، اس لیے WebUI بھی اسی کی پیروی کرتا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "CLI 工作階段的顯示會與此伺服器同步，因此 WebUI 也會跟隨。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "CLI 会话的显示与此服务器同步，因此 WebUI 也会跟随。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "CLI 工作階段的顯示會與此伺服器同步，因此 WebUI 也會跟隨。"
+          }
+        }
+      }
+    },
     "Cached" : {
       "localizations" : {
         "ar" : {
@@ -22944,6 +23050,112 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "無法儲存記憶。"
+          }
+        }
+      }
+    },
+    "Could not save to the server. The toggle was reverted." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تعذّر الحفظ على الخادم. تمت إعادة المفتاح إلى حالته السابقة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Konnte nicht auf dem Server gespeichert werden. Der Schalter wurde zurückgesetzt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No se pudo guardar en el servidor. El interruptor se revirtió."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossible d'enregistrer sur le serveur. Le réglage a été rétabli."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא ניתן היה לשמור בשרת. המתג הוחזר למצבו הקודם."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossibile salvare sul server. L'interruttore è stato ripristinato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "サーバーに保存できませんでした。トグルは元に戻されました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "서버에 저장하지 못했습니다. 토글이 되돌려졌습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kon niet opslaan op de server. De schakelaar is teruggezet."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nie udało się zapisać na serwerze. Przełącznik został przywrócony."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não foi possível salvar no servidor. O botão foi revertido."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Не удалось сохранить на сервере. Переключатель был возвращён."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sunucuya kaydedilemedi. Anahtar geri alındı."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سرور پر محفوظ نہیں ہو سکا۔ ٹوگل واپس پلٹا دیا گیا۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法儲存到伺服器。開關已還原。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法保存到服务器。开关已恢复。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法儲存到伺服器。開關已還原。"
           }
         }
       }

--- a/HermesMobileTests/CliSessionsSyncModelTests.swift
+++ b/HermesMobileTests/CliSessionsSyncModelTests.swift
@@ -183,6 +183,33 @@ final class CliSessionsSyncModelTests: APIClientTestCase {
         )
     }
 
+    @MainActor
+    func testRapidReToggleCancelsTheStaleWriteAndIgnoresItsFailure() async {
+        // The write for `false` fails; the follow-up write for `true` succeeds.
+        // The stale failure must neither revert the newer value nor surface an
+        // error, and the superseded task must be cancelled.
+        let model = makeModel(server: serverA) { value in
+            if value == false { throw URLError(.timedOut) }
+        }
+        model.adopt(serverValue: true)
+
+        model.setShowsCliSessions(false)
+        let staleWrite = model.pendingWrite
+        model.setShowsCliSessions(true)
+
+        XCTAssertEqual(staleWrite?.isCancelled, true)
+
+        await staleWrite?.value
+        await model.pendingWrite?.value
+
+        XCTAssertTrue(model.showsCliSessions)
+        XCTAssertNil(model.syncErrorMessage)
+        XCTAssertEqual(
+            defaults.object(forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA)) as? Bool,
+            true
+        )
+    }
+
     // MARK: - Per-server isolation
 
     @MainActor

--- a/HermesMobileTests/CliSessionsSyncModelTests.swift
+++ b/HermesMobileTests/CliSessionsSyncModelTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+@testable import HermesMobile
+
+/// Issue #19: expanded `/api/settings` decode, the `show_cli_sessions`
+/// server-sync model, and its per-server storage isolation.
+final class CliSessionsSyncModelTests: APIClientTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "CliSessionsSyncModelTests"
+    private let serverA = URL(string: "https://alpha.example.test")!
+    private let serverB = URL(string: "https://beta.example.test")!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - SettingsResponse decode
+
+    func testSettingsDecodesExpandedFieldsAndIgnoresUnknownKeys() async throws {
+        let client = makeClient { request in
+            apiTestJSONResponse("""
+            {
+              "bot_name": "Hermes",
+              "webui_version": "v0.50.253",
+              "agent_version": "v0.9.1",
+              "theme": "system",
+              "check_for_updates": true,
+              "show_cli_sessions": false,
+              "max_tokens": 4096,
+              "max_tokens_effective": 4096,
+              "auth_enabled": true,
+              "password_auth_enabled": true,
+              "passkeys_enabled": false,
+              "passwordless_enabled": false,
+              "some_future_key": {"nested": [1, 2, 3]}
+            }
+            """, for: request)
+        }
+
+        let response = try await client.settings()
+
+        XCTAssertEqual(response.botName, "Hermes")
+        XCTAssertEqual(response.webuiVersion, "v0.50.253")
+        XCTAssertEqual(response.agentVersion, "v0.9.1")
+        XCTAssertEqual(response.theme, "system")
+        XCTAssertEqual(response.checkForUpdates, true)
+        XCTAssertEqual(response.showCliSessions, false)
+        XCTAssertEqual(response.maxTokens, 4096)
+        XCTAssertEqual(response.maxTokensEffective, 4096)
+        XCTAssertEqual(response.authEnabled, true)
+        XCTAssertEqual(response.passwordAuthEnabled, true)
+        XCTAssertEqual(response.passkeysEnabled, false)
+        XCTAssertEqual(response.passwordlessEnabled, false)
+    }
+
+    func testSettingsDecodesAllFieldsAsNilWhenAbsent() async throws {
+        let client = makeClient { request in
+            apiTestJSONResponse("{}", for: request)
+        }
+
+        let response = try await client.settings()
+
+        XCTAssertNil(response.botName)
+        XCTAssertNil(response.webuiVersion)
+        XCTAssertNil(response.agentVersion)
+        XCTAssertNil(response.theme)
+        XCTAssertNil(response.checkForUpdates)
+        XCTAssertNil(response.showCliSessions)
+        XCTAssertNil(response.maxTokens)
+        XCTAssertNil(response.maxTokensEffective)
+        XCTAssertNil(response.authEnabled)
+        XCTAssertNil(response.passwordAuthEnabled)
+        XCTAssertNil(response.passkeysEnabled)
+        XCTAssertNil(response.passwordlessEnabled)
+    }
+
+    // MARK: - POST /api/settings write
+
+    func testUpdateSettingsPostsExactlyTheShowCliSessionsKey() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/settings")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let body = try XCTUnwrap(Self.jsonBody(from: request))
+            XCTAssertEqual(body.count, 1, "The write must touch only show_cli_sessions")
+            XCTAssertEqual(body["show_cli_sessions"] as? Bool, false)
+
+            // The server echoes the full saved settings dict back.
+            return apiTestJSONResponse("""
+            {
+              "bot_name": "Hermes",
+              "show_cli_sessions": false,
+              "auth_enabled": true
+            }
+            """, for: request)
+        }
+
+        let response = try await client.updateSettings(showCliSessions: false)
+
+        XCTAssertEqual(response.showCliSessions, false)
+    }
+
+    // MARK: - Adopt on load
+
+    @MainActor
+    func testAdoptServerValueWinsOverLocalAndPersistsPerServer() {
+        defaults.set(true, forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA))
+        let model = makeModel(server: serverA)
+        XCTAssertTrue(model.showsCliSessions)
+
+        model.adopt(serverValue: false)
+
+        XCTAssertFalse(model.showsCliSessions)
+        XCTAssertTrue(model.serverSyncsCliSessions)
+        XCTAssertEqual(
+            defaults.object(forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA)) as? Bool,
+            false
+        )
+    }
+
+    @MainActor
+    func testAdoptNilLeavesLocalValueAndKeepsToggleLocalOnly() async {
+        defaults.set(false, forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA))
+        var writtenValues: [Bool] = []
+        let model = makeModel(server: serverA) { writtenValues.append($0) }
+
+        model.adopt(serverValue: nil)
+
+        XCTAssertFalse(model.showsCliSessions)
+        XCTAssertFalse(model.serverSyncsCliSessions)
+
+        // Toggling still works locally but never writes to the server.
+        model.setShowsCliSessions(true)
+        await model.pendingWrite?.value
+
+        XCTAssertTrue(model.showsCliSessions)
+        XCTAssertEqual(writtenValues, [])
+        XCTAssertEqual(
+            defaults.object(forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA)) as? Bool,
+            true
+        )
+    }
+
+    // MARK: - Toggle write + revert on failure
+
+    @MainActor
+    func testToggleWritesTheNewValueToTheServer() async {
+        var writtenValues: [Bool] = []
+        let model = makeModel(server: serverA) { writtenValues.append($0) }
+        model.adopt(serverValue: true)
+
+        model.setShowsCliSessions(false)
+        await model.pendingWrite?.value
+
+        XCTAssertEqual(writtenValues, [false])
+        XCTAssertFalse(model.showsCliSessions)
+        XCTAssertNil(model.syncErrorMessage)
+    }
+
+    @MainActor
+    func testFailedWriteRevertsTheToggleAndSurfacesAnError() async {
+        let model = makeModel(server: serverA) { _ in throw URLError(.notConnectedToInternet) }
+        model.adopt(serverValue: true)
+
+        model.setShowsCliSessions(false)
+        XCTAssertFalse(model.showsCliSessions, "Optimistic update applies immediately")
+
+        await model.pendingWrite?.value
+
+        XCTAssertTrue(model.showsCliSessions, "Failed write must revert the toggle")
+        XCTAssertNotNil(model.syncErrorMessage)
+        XCTAssertEqual(
+            defaults.object(forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA)) as? Bool,
+            true,
+            "The revert must also restore the persisted per-server value"
+        )
+    }
+
+    // MARK: - Per-server isolation
+
+    @MainActor
+    func testAdoptedValueDoesNotLeakToAnotherServer() {
+        defaults.set(true, forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverB))
+        let model = makeModel(server: serverA)
+
+        model.adopt(serverValue: false)
+
+        XCTAssertFalse(SessionRowDisplaySettings.showsCliSessions(for: serverA, in: defaults))
+        XCTAssertTrue(
+            SessionRowDisplaySettings.showsCliSessions(for: serverB, in: defaults),
+            "Server A's adopted value must not change server B's toggle"
+        )
+    }
+
+    func testShowsCliSessionsFallsBackToLegacyGlobalValueThenDefault() {
+        // No per-server or legacy value: shown by default, exactly as today.
+        XCTAssertTrue(SessionRowDisplaySettings.showsCliSessions(for: serverA, in: defaults))
+
+        // A pre-#19 global value seeds servers that have no per-server value yet.
+        defaults.set(false, forKey: SessionRowDisplaySettings.showCliSessionsKey)
+        XCTAssertFalse(SessionRowDisplaySettings.showsCliSessions(for: serverA, in: defaults))
+
+        // A per-server value always wins over the legacy seed.
+        defaults.set(true, forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA))
+        XCTAssertTrue(SessionRowDisplaySettings.showsCliSessions(for: serverA, in: defaults))
+        XCTAssertFalse(
+            SessionRowDisplaySettings.showsCliSessions(for: serverB, in: defaults),
+            "Another server still reads the legacy seed until it stores its own value"
+        )
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeModel(
+        server: URL,
+        writeToServer: @escaping @MainActor (Bool) async throws -> Void = { _ in }
+    ) -> CliSessionsSyncModel {
+        CliSessionsSyncModel(server: server, defaults: defaults, writeToServer: writeToServer)
+    }
+
+    private static func jsonBody(from request: URLRequest) -> [String: Any]? {
+        guard let data = bodyData(from: request) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: bufferSize)
+            if count <= 0 {
+                break
+            }
+            data.append(buffer, count: count)
+        }
+
+        return data
+    }
+}

--- a/HermesMobileTests/CliSessionsSyncModelTests.swift
+++ b/HermesMobileTests/CliSessionsSyncModelTests.swift
@@ -184,10 +184,10 @@ final class CliSessionsSyncModelTests: APIClientTestCase {
     }
 
     @MainActor
-    func testRapidReToggleCancelsTheStaleWriteAndIgnoresItsFailure() async {
+    func testRapidReToggleIgnoresTheStaleFailureAndWritesTheFinalValue() async {
         // The write for `false` fails; the follow-up write for `true` succeeds.
         // The stale failure must neither revert the newer value nor surface an
-        // error, and the superseded task must be cancelled.
+        // error.
         let model = makeModel(server: serverA) { value in
             if value == false { throw URLError(.timedOut) }
         }
@@ -197,8 +197,6 @@ final class CliSessionsSyncModelTests: APIClientTestCase {
         let staleWrite = model.pendingWrite
         model.setShowsCliSessions(true)
 
-        XCTAssertEqual(staleWrite?.isCancelled, true)
-
         await staleWrite?.value
         await model.pendingWrite?.value
 
@@ -207,6 +205,54 @@ final class CliSessionsSyncModelTests: APIClientTestCase {
         XCTAssertEqual(
             defaults.object(forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA)) as? Bool,
             true
+        )
+    }
+
+    @MainActor
+    func testRapidReTogglesSerializeWritesAndCoalesceToTheFinalValue() async {
+        // Cancelling a Task cannot un-send an in-flight POST, so the model must
+        // instead hold the next write until the previous response lands and
+        // skip superseded writes. Here the first write is suspended while the
+        // user toggles twice more: no second request may be sent while the
+        // first is in flight, and after it completes only the *final* value is
+        // written (the intermediate toggle is coalesced away).
+        var writtenValues: [Bool] = []
+        var releaseFirstWrite: CheckedContinuation<Void, Never>?
+        let model = makeModel(server: serverA) { value in
+            writtenValues.append(value)
+            if writtenValues.count == 1 {
+                await withCheckedContinuation { releaseFirstWrite = $0 }
+            }
+        }
+        model.adopt(serverValue: true)
+
+        model.setShowsCliSessions(false) // write 1 — held in flight below
+
+        // Let write 1 start and suspend inside writeToServer, so it is truly
+        // in flight when the user keeps toggling.
+        while releaseFirstWrite == nil { await Task.yield() }
+
+        model.setShowsCliSessions(true)  // superseded before it can send
+        model.setShowsCliSessions(false) // final desired value
+
+        await Task.yield()
+        XCTAssertEqual(
+            writtenValues, [false],
+            "No follow-up POST may be sent while the first is still in flight"
+        )
+
+        releaseFirstWrite?.resume()
+        await model.pendingWrite?.value
+
+        XCTAssertEqual(
+            writtenValues, [false, false],
+            "The superseded intermediate write must be skipped; only the final value is sent"
+        )
+        XCTAssertFalse(model.showsCliSessions)
+        XCTAssertNil(model.syncErrorMessage)
+        XCTAssertEqual(
+            defaults.object(forKey: SessionRowDisplaySettings.showCliSessionsKey(for: serverA)) as? Bool,
+            false
         )
     }
 

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -91,7 +91,7 @@ sub-paths of a group. Do not reorder casually.
 | `/api/models/refresh` | roadmap | P3 | — | Provider / Model Management |
 | `/api/models/live` | roadmap | P3 | — | Provider / Model Management — live model fetch |
 | `/api/model/` | roadmap | P3 | — | Provider / Model Management |
-| `/api/settings` | roadmap | P3 | secret | Settings Write — bot name + password operations |
+| `/api/settings` | roadmap | P3 | secret | Settings Write — single-key `show_cli_sessions` write shipped (#19); full Settings Write (bot name + password operations) remains roadmap |
 | `/api/profile/` | roadmap | P3 | write | Profile Management — active/create/delete |
 | `/api/skills/` | roadmap | P3 | write | Skill Management — toggle shipped; save/delete remain roadmap |
 | `/api/transcribe` | roadmap | P3 | privacy | Audio Transcription — server-side; audio leaves the device |

--- a/docs/agents/multi-server-state-isolation.md
+++ b/docs/agents/multi-server-state-isolation.md
@@ -42,6 +42,7 @@ to `CacheStore`. Two consequences:
 | Offline session/message cache | SwiftData (`CachedSession`, `CachedMessage`) | Keyed by `serverURLString` (the active server URL's `absoluteString`) on the unique `cacheKey` and on every read/write predicate. See below. |
 | Default model / profile | Not persisted locally | Held in transient `@State` in `SettingsView` and re-fetched from the **active** server's API client each time Settings opens. There is no cross-server storage to leak. New sessions use the server's current default. |
 | Active project / session selection | View-local `@State` only | Not persisted. Destroyed and rebuilt on switch via `.id(server)`. |
+| "Show CLI sessions" toggle | UserDefaults, per-server key (`SessionRowDisplaySettings.showCliSessionsKey(for:)` = `sessionRow.showCliSessions|<server absoluteString>`) | Per-server since #19: the toggle mirrors the server's own `show_cli_sessions` setting (adopted on Settings load, written back via `POST /api/settings`), so an adopted value on one server cannot leak to another. Reads fall back to the pre-#19 global key as a migration seed, then to shown-by-default. Tested in `CliSessionsSyncModelTests`. |
 
 ### Offline cache keying (`Persistence/CacheStore.swift`)
 
@@ -69,7 +70,7 @@ per-server:
 - Haptics (`AppHaptics`)
 - Response-completion notifications + permission flag (`ResponseCompletionNotifications`)
 - Live Activity response-excerpt privacy (`AgentRunLiveActivityPrivacy`)
-- Session-row display toggles (`SessionRowDisplaySettings`: message count, workspace, cron, CLI)
+- Session-row display toggles (`SessionRowDisplaySettings`: message count, workspace, cron — the CLI toggle moved to per-server storage in #19, see the per-server table above)
 - Sidebar disclosure state (`sessionSidebar.profilesAreExpanded` / `projectsAreExpanded`)
 - Chat transcript display toggles (`ChatTranscriptDisplaySettings`: thinking/tool cards, attachment paths, timestamps, code-block wrap)
 - Streamed-text animation (`StreamedTextAnimationSettings`)


### PR DESCRIPTION
Fixes #19

## Summary

1. **`SettingsResponse` expanded, phantom `version` dropped.** The `version` field is not in the docs and (verified live 2026-07-02, issue evidence) not in the server response — removed, along with its two `settings.webuiVersion ?? settings.version` fallbacks in `SettingsView`. Added 9 optional fields: `agentVersion`, `checkForUpdates`, `showCliSessions`, `maxTokens`, `maxTokensEffective`, `authEnabled`, `passwordAuthEnabled`, `passkeysEnabled`, `passwordlessEnabled`. All lossy-decoded (string/int/bool tolerated) via the shared `decodeLossy*IfPresent` helpers — unknown/missing keys never crash.
2. **CLI-sessions toggle is now server-truth.** New `CliSessionsSyncModel`:
   - On Settings load, a server-provided `show_cli_sessions` is adopted into the local value (server wins on conflict — it is the cross-device truth).
   - Flipping the toggle updates locally (optimistic) and writes `POST /api/settings {"show_cli_sessions": <bool>}`. On write failure the toggle reverts and an inline error footnote appears. A generation counter keeps rapid re-toggles from being clobbered by stale failures.
   - Servers that never report the key keep today's purely local behavior (no adoption, no write).
3. **Per-server isolation** (docs/agents/multi-server-state-isolation.md): the toggle now lives under a per-server UserDefaults key (`sessionRow.showCliSessions|<server URL>`). The pre-existing global key survives only as a migration seed. `SessionListView` reads the per-server key, so an adopted value on server A cannot leak into server B's session list.
4. **Localization:** the 2 new user-facing strings are translated for all 17 shipped languages (keeps `LocalizationCatalogTests` green).
5. **Docs:** feature-gap-index `/api/settings` row records the single-key write shipped (full Settings Write remains roadmap); isolation doc gains the per-server row.

## Plan (E1, pre-approved for this unattended run)

- `HermesMobile/Models/ServerCatalog.swift` — `SettingsResponse` rewrite (drop `version`, add 9 lossy optionals).
- `HermesMobile/Networking/APIClient+ServerPanels.swift` — `updateSettings(showCliSessions:)` + private request struct.
- `HermesMobile/Features/Settings/CliSessionsSyncModel.swift` (new) — adopt/write/revert state machine, per-server persistence.
- `HermesMobile/Features/Settings/SettingsView.swift` — model wiring, toggle binding, error/sync footnotes, drop `version` fallbacks.
- `HermesMobile/Features/SessionList/SessionRowView.swift` — per-server key helpers + legacy fallback on `SessionRowDisplaySettings`.
- `HermesMobile/Features/SessionList/SessionListView.swift` — per-server `@AppStorage` key configured in `init`.
- Tests: `HermesMobileTests/CliSessionsSyncModelTests.swift` (new) — decode present/absent, exact write body, adopt-on-load, revert-on-failure, per-server isolation, legacy fallback.
- Docs + string catalog + pbxproj registration.

## API verification (hard rule 1)

Validated just-in-time against the pinned upstream `.codex-tmp/hermes-webui/api/routes.py` @ `312d3fab`:

- `GET /api/settings` (routes.py ~L11432): returns the full settings dict; injects `max_tokens`/`max_tokens_effective`, `auth_enabled`, `password_auth_enabled`, `passkeys_enabled`/`passwordless_enabled`, `webui_version`/`agent_version`. No `version` key anywhere.
- `POST /api/settings` (routes.py ~L14212): `save_settings(body)` merges exactly the keys sent — a `{"show_cli_sessions": <bool>}` body touches nothing else and needs none of the password/auth `_`-prefixed control keys. The response is the saved settings dict (plus auth-state fields), so it decodes as `SettingsResponse`. Upstream also explicitly invalidates its session-list cache when `show_cli_sessions` is in the body, confirming the key is the WebUI's own toggle.
- Live-server key list (incl. `show_cli_sessions`, no `version`) was verified 2026-07-02 and recorded in the issue.

## Validation

- Full XCTest suite on the head commit: **TEST SUCCEEDED — 1,197 passed / 0 failed** (sim "Hermex-W1", iPhone 17).
- `git diff --check` clean.

## Owner manual checks

1. Settings → Session Rows → toggle "CLI Sessions" off; in the WebUI (same server) reload Settings — `show_cli_sessions` should now be off and CLI sessions hidden from the WebUI sidebar.
2. Flip the setting in the WebUI, then reopen the phone's Settings screen — the phone toggle should follow the server.
3. Session list hides/shows CLI sessions immediately when the toggle changes.
4. With the server unreachable (e.g. tunnel down), flip the toggle — it should revert and show the inline warning footnote.
5. Two-server check (if configured): toggling on server A must not change server B's toggle or session list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)