### PR TITLE
Sessions: make archived sessions reachable (include_archived) with count entry + unarchive surfacing

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -106,6 +106,8 @@ struct SessionListView: View {
                     MemoryView(server: server, onAPIError: authManager.handleAPIError)
                 case .insights:
                     InsightsView(server: server, onAPIError: authManager.handleAPIError)
+                case .archived:
+                    ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
                 }
             }
             .sheet(item: $sessionPendingRename) { session in
@@ -282,6 +284,11 @@ struct SessionListView: View {
                 showsWorkspace: showsSessionWorkspace,
                 actions: sessionRowActions
             )
+
+            if showsArchivedEntry {
+                archivedEntryRow
+                    .sessionsScreenListRow()
+            }
 
             Color.clear
                 .frame(height: 104)
@@ -497,6 +504,56 @@ struct SessionListView: View {
 
     private var automatedSessionVisibility: AutomatedSessionVisibility {
         AutomatedSessionVisibility(showsCron: showsCronSessions, showsCli: showsCliSessions)
+    }
+
+    /// Bottom-of-list entry to the Archived screen (issue #17). Hidden while
+    /// searching, offline (cached data cannot fetch archived rows), and when the
+    /// server reports zero archived sessions or omits `archived_count` (older
+    /// server) — so the list is unchanged for users with nothing archived.
+    private var showsArchivedEntry: Bool {
+        guard !isSearchingSessions, !viewModel.isViewingCachedData else { return false }
+        return (viewModel.archivedCount ?? 0) > 0
+    }
+
+    private var archivedEntryRow: some View {
+        HapticButton {
+            selectedUtilityDestination = .archived
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "archivebox")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24)
+                    .accessibilityHidden(true)
+
+                Text("Archived Sessions")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                if let archivedCount = viewModel.archivedCount {
+                    Text("\(archivedCount)")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(.thinMaterial, in: Capsule())
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.forward")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 24)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 12)
+        .accessibilityHint("Shows archived sessions.")
     }
 
     private var emptySessionsTitle: String {
@@ -975,6 +1032,8 @@ enum SessionListUtilityDestination: Hashable, Identifiable {
     case skills
     case memory
     case insights
+    /// Archived sessions screen (issue #17), also reachable from Settings.
+    case archived
 
     var id: Self { self }
 }

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -56,6 +56,10 @@ final class SessionListViewModel {
     private(set) var switchingActiveProfileName: String?
     private(set) var activeProfileErrorMessage: String?
     private(set) var mutatingSessionIDs: Set<String> = []
+    /// Total archived sessions reported by the last successful list load
+    /// (`archived_count`, issue #17). nil until a load succeeds or when an older
+    /// server omits the field — the Archived entry stays hidden then.
+    private(set) var archivedCount: Int?
 
     private(set) var remoteContentSearchSessionIDs: [String] = []
     private var activeRemoteSearchQuery: String?
@@ -151,6 +155,7 @@ final class SessionListViewModel {
             let response = try await client.sessions()
             let visibleSessions = (response.sessions ?? []).filter { $0.archived != true }
             applySessions(visibleSessions, animation: animation)
+            archivedCount = response.archivedCount
             isViewingCachedData = false
 
             if let modelContext {

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -154,8 +154,7 @@ final class SessionListViewModel {
         do {
             let response = try await client.sessions()
             let visibleSessions = (response.sessions ?? []).filter { $0.archived != true }
-            applySessions(visibleSessions, animation: animation)
-            archivedCount = response.archivedCount
+            applySessions(visibleSessions, archivedCount: response.archivedCount, animation: animation)
             isViewingCachedData = false
 
             if let modelContext {
@@ -858,14 +857,22 @@ final class SessionListViewModel {
         .joined(separator: " ")
     }
 
-    private func applySessions(_ newSessions: [SessionSummary], animation: Animation?) {
+    /// `archivedCount` is applied inside the same transaction as the rows so the
+    /// bottom Archived entry inserts/removes with the list mutation animation.
+    private func applySessions(
+        _ newSessions: [SessionSummary],
+        archivedCount newArchivedCount: Int?,
+        animation: Animation?
+    ) {
         guard let animation else {
             sessions = newSessions
+            archivedCount = newArchivedCount
             return
         }
 
         withAnimation(animation) {
             sessions = newSessions
+            archivedCount = newArchivedCount
         }
     }
 

--- a/HermesMobile/Features/Settings/ArchivedSessionsView.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsView.swift
@@ -2,25 +2,35 @@ import SwiftUI
 
 struct ArchivedSessionsView: View {
     let server: URL
+    /// Forwarded to `ChatView` and used for load/unarchive failures so a 401
+    /// here triggers the same re-login flow as everywhere else.
+    let onAPIError: (Error) -> Void
 
     @State private var viewModel: ArchivedSessionsViewModel
+    @State private var openedSession: SessionSummary?
     @AppStorage(SessionRowDisplaySettings.showMessageCountKey) private var showsSessionMessageCount = true
     @AppStorage(SessionRowDisplaySettings.showWorkspaceKey) private var showsSessionWorkspace = true
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
 
-    init(server: URL) {
+    init(server: URL, onAPIError: @escaping (Error) -> Void) {
         self.server = server
+        self.onAPIError = onAPIError
         _viewModel = State(initialValue: ArchivedSessionsViewModel(server: server))
     }
 
     var body: some View {
         content
             .navigationTitle("Archived Sessions")
+            .navigationDestination(item: $openedSession) { session in
+                // Opening an archived session reuses the normal read path —
+                // no special-casing on the chat side (issue #17).
+                ChatView(session: session, server: server, onAPIError: onAPIError)
+            }
             .task {
-                await viewModel.load()
+                await load()
             }
             .refreshable {
-                await viewModel.load()
+                await load()
             }
             .alert(
                 "Action Failed",
@@ -58,7 +68,7 @@ struct ArchivedSessionsView: View {
                             .lineLimit(3)
 
                         Button("Try Again") {
-                            Task { await viewModel.load() }
+                            Task { await load() }
                         }
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(.primary)
@@ -70,24 +80,7 @@ struct ArchivedSessionsView: View {
                 } else {
                     VStack(spacing: 2) {
                         ForEach(visibleSessions) { session in
-                            SessionRowView(
-                                session: session,
-                                showsMessageCount: showsSessionMessageCount,
-                                showsWorkspace: showsSessionWorkspace
-                            )
-                                .contextMenu {
-                                    Button {
-                                        Task {
-                                            let didUnarchive = await viewModel.unarchive(session)
-                                            if didUnarchive {
-                                                SessionHaptics.archiveStateChanged(isEnabled: isHapticsEnabled)
-                                            }
-                                        }
-                                    } label: {
-                                        Label("Unarchive", systemImage: "arrow.up.bin")
-                                    }
-                                    .disabled(viewModel.isUnarchiving(session))
-                                }
+                            archivedSessionRow(for: session)
                         }
                     }
                     .padding(.horizontal, 12)
@@ -95,6 +88,76 @@ struct ArchivedSessionsView: View {
             }
             .padding(.top, 28)
             .padding(.bottom, 44)
+        }
+    }
+
+    private func archivedSessionRow(for session: SessionSummary) -> some View {
+        HStack(spacing: 0) {
+            Button {
+                openedSession = session
+            } label: {
+                SessionRowView(
+                    session: session,
+                    showsMessageCount: showsSessionMessageCount,
+                    showsWorkspace: showsSessionWorkspace
+                )
+            }
+            .buttonStyle(.plain)
+
+            unarchiveButton(for: session)
+        }
+        .contextMenu {
+            Button {
+                unarchive(session)
+            } label: {
+                Label("Unarchive", systemImage: "arrow.up.bin")
+            }
+            .disabled(viewModel.isUnarchiving(session))
+        }
+    }
+
+    /// Always-visible unarchive affordance; the context menu keeps the same
+    /// action for discoverability parity with the main list's row menus.
+    private func unarchiveButton(for session: SessionSummary) -> some View {
+        Button {
+            unarchive(session)
+        } label: {
+            Group {
+                if viewModel.isUnarchiving(session) {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.up.bin")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.isUnarchiving(session))
+        .accessibilityLabel("Unarchive")
+    }
+
+    private func unarchive(_ session: SessionSummary) {
+        Task {
+            let didUnarchive = await viewModel.unarchive(session)
+            handleLastError()
+            if didUnarchive {
+                SessionHaptics.archiveStateChanged(isEnabled: isHapticsEnabled)
+            }
+        }
+    }
+
+    private func load() async {
+        await viewModel.load()
+        handleLastError()
+    }
+
+    private func handleLastError() {
+        if let lastError = viewModel.lastError {
+            onAPIError(lastError)
         }
     }
 

--- a/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
@@ -9,6 +9,9 @@ final class ArchivedSessionsViewModel {
     private(set) var unarchivingSessionIDs: Set<String> = []
     private(set) var errorMessage: String?
     private(set) var actionErrorMessage: String?
+    /// Last raw failure, exposed so the view can forward it to the shared
+    /// API-error handler (401 → re-login), mirroring `SessionListViewModel`.
+    private(set) var lastError: Error?
 
     private let client: APIClient
 
@@ -24,11 +27,18 @@ final class ArchivedSessionsViewModel {
         isLoading = true
         errorMessage = nil
         actionErrorMessage = nil
+        lastError = nil
 
         do {
-            let response = try await client.sessions()
+            // `include_archived=1` is required — the default response excludes
+            // archived rows entirely, which made this view permanently empty
+            // (issue #17). The merged response keeps the visible rows too; each
+            // row carries an `archived` flag (verified against upstream routes.py
+            // @312d3fab and the live server), so filter client-side.
+            let response = try await client.sessions(includeArchived: true)
             sessions = (response.sessions ?? []).filter { $0.archived == true }
         } catch {
+            lastError = error
             errorMessage = error.localizedDescription
         }
 
@@ -50,15 +60,25 @@ final class ArchivedSessionsViewModel {
 
         unarchivingSessionIDs.insert(sessionId)
         actionErrorMessage = nil
+        lastError = nil
         defer {
             unarchivingSessionIDs.remove(sessionId)
         }
 
         do {
-            _ = try await client.archiveSession(id: sessionId, archived: false)
+            let response = try await client.archiveSession(id: sessionId, archived: false)
+            // Rejections (subagent / read-only CLI sessions) arrive as HTTP 400
+            // and throw above; a 200 body with an `error` field is surfaced too
+            // so the server's own message is always shown (issue #17).
+            if let error = Self.nonEmpty(response.error) {
+                restore(removedSession)
+                actionErrorMessage = error
+                return false
+            }
             return true
         } catch {
             restore(removedSession)
+            lastError = error
             actionErrorMessage = error.localizedDescription
             return false
         }

--- a/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
@@ -38,8 +38,12 @@ final class ArchivedSessionsViewModel {
             let response = try await client.sessions(includeArchived: true)
             sessions = (response.sessions ?? []).filter { $0.archived == true }
         } catch {
-            lastError = error
-            errorMessage = error.localizedDescription
+            // A cancelled load (pull-to-refresh superseding `.task`, or the view
+            // disappearing) is not a failure — don't flash an error state.
+            if !Self.isCancellationError(error) {
+                lastError = error
+                errorMessage = error.localizedDescription
+            }
         }
 
         isLoading = false
@@ -78,8 +82,10 @@ final class ArchivedSessionsViewModel {
             return true
         } catch {
             restore(removedSession)
-            lastError = error
-            actionErrorMessage = error.localizedDescription
+            if !Self.isCancellationError(error) {
+                lastError = error
+                actionErrorMessage = error.localizedDescription
+            }
             return false
         }
     }
@@ -116,5 +122,23 @@ final class ArchivedSessionsViewModel {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Mirrors `SessionListViewModel`'s cancellation check: a `CancellationError`
+    /// or a (possibly `APIError.network`-wrapped) `URLError.cancelled`.
+    private static func isCancellationError(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+
+        let underlying: Error
+        if case APIError.network(let wrapped) = error {
+            underlying = wrapped
+        } else {
+            underlying = error
+        }
+
+        guard let urlError = underlying as? URLError else { return false }
+        return urlError.code == .cancelled
     }
 }

--- a/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
@@ -73,10 +73,18 @@ final class ArchivedSessionsViewModel {
             let response = try await client.archiveSession(id: sessionId, archived: false)
             // Rejections (subagent / read-only CLI sessions) arrive as HTTP 400
             // and throw above; a 200 body with an `error` field is surfaced too
-            // so the server's own message is always shown (issue #17).
+            // so the server's own message is always shown (issue #17). An
+            // explicit `ok: false` without an `error` string is still a failure
+            // (matching the `ok != false` guard used across the app) — only a
+            // missing `ok` is treated as success, per tolerant decoding.
             if let error = Self.nonEmpty(response.error) {
                 restore(removedSession)
                 actionErrorMessage = error
+                return false
+            }
+            if response.ok == false {
+                restore(removedSession)
+                actionErrorMessage = String(localized: "The server could not unarchive this session.")
                 return false
             }
             return true

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -88,7 +88,7 @@ struct SettingsView: View {
 
                 SettingsCard(title: String(localized: "Archived Sessions")) {
                     NavigationLink {
-                        ArchivedSessionsView(server: server)
+                        ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
                     } label: {
                         SettingsAccessoryRow(title: String(localized: "Archived Sessions"), systemImage: "archivebox")
                     }

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -3,6 +3,10 @@ import Foundation
 struct SessionsResponse: Decodable {
     let sessions: [SessionSummary]?
     let cliCount: Int?
+    /// Total archived sessions in the active profile (`archived_count`), present
+    /// on every response regardless of `include_archived` (issue #17). Optional so
+    /// older servers that omit it decode fine.
+    let archivedCount: Int?
     let serverTime: Double?
     let serverTz: String?
 }

--- a/HermesMobile/Networking/APIClient+Sessions.swift
+++ b/HermesMobile/Networking/APIClient+Sessions.swift
@@ -1,8 +1,22 @@
 import Foundation
 
 extension APIClient {
+    /// Parameterless overload kept so `InsightsDataClient` (and any other
+    /// protocol witness) still sees the exact `sessions()` signature — a method
+    /// with defaulted parameters cannot satisfy that requirement.
     func sessions() async throws -> SessionsResponse {
-        try await send(endpoint: .sessions, method: "GET")
+        try await sessions(includeArchived: false, archivedLimit: nil)
+    }
+
+    /// Fetches the session list. `includeArchived` opts in to archived rows
+    /// (merged with the visible ones; each row carries an `archived` flag) and
+    /// `archivedLimit` optionally caps how many archived rows the server appends
+    /// (issue #17). Defaults keep today's request untouched.
+    func sessions(includeArchived: Bool = false, archivedLimit: Int? = nil) async throws -> SessionsResponse {
+        try await send(
+            endpoint: .sessions(includeArchived: includeArchived, archivedLimit: archivedLimit),
+            method: "GET"
+        )
     }
 
     func searchSessions(query: String, content: Bool = true, depth: Int = 5) async throws -> SessionSearchResponse {

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -5,7 +5,7 @@ enum Endpoint {
     case authStatus
     case login
     case logout
-    case sessions
+    case sessions(includeArchived: Bool = false, archivedLimit: Int? = nil)
     case sessionsSearch(query: String, content: Bool, depth: Int)
     case session(id: String, includeMessages: Bool, messageLimit: Int?, messageBefore: Int?, expandRenderable: Bool = false)
     case sessionStatus(id: String)
@@ -288,6 +288,18 @@ enum Endpoint {
 
     var queryItems: [URLQueryItem] {
         switch self {
+        case let .sessions(includeArchived, archivedLimit):
+            // Opt-in (issue #17): the server's default response excludes archived
+            // rows, so the main list request stays byte-identical when off.
+            // `archived_limit` only means something alongside `include_archived=1`
+            // (`_query_positive_int` in upstream routes.py), so it is only sent then.
+            guard includeArchived else { return [] }
+
+            var items = [URLQueryItem(name: "include_archived", value: "1")]
+            if let archivedLimit {
+                items.append(URLQueryItem(name: "archived_limit", value: "\(archivedLimit)"))
+            }
+            return items
         case let .sessionsSearch(query, content, depth):
             return [
                 URLQueryItem(name: "q", value: query),

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -77754,6 +77754,112 @@
         }
       }
     },
+    "The server could not unarchive this session." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تعذّر على الخادم إلغاء أرشفة هذه الجلسة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Der Server konnte diese Sitzung nicht aus dem Archiv holen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "El servidor no pudo desarchivar esta sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Le serveur n'a pas pu désarchiver cette session."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "השרת לא הצליח להוציא מפגש זה מהארכיון."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Il server non è riuscito a disarchiviare questa sessione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "サーバがこのセッションのアーカイブを解除できませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "서버가 이 세션의 보관을 해제하지 못했어요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "De server kon deze sessie niet uit het archief halen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Serwer nie mógł przywrócić tej sesji z archiwum."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O servidor não conseguiu desarquivar esta sessão."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Серверу не удалось извлечь эту сессию из архива."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sunucu bu oturumu arşivden çıkaramadı."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سرور اس سیشن کو آرکائیو سے نہیں نکال سکا۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器無法取消封存此工作階段。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "服务器无法取消归档此会话。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器無法取消封存此工作階段。"
+          }
+        }
+      }
+    },
     "The server did not provide a session ID." : {
       "localizations" : {
         "ar" : {

--- a/HermesMobileTests/APIClientSessionListTests.swift
+++ b/HermesMobileTests/APIClientSessionListTests.swift
@@ -10,6 +10,9 @@ final class APIClientSessionListTests: APIClientTestCase {
     func testSessionsDecodesSnakeCaseResponse() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/sessions")
+            // The default fetch must stay parameterless so the main list request
+            // (and its server-side ordering) is unchanged (issue #17).
+            XCTAssertNil(request.url?.query)
 
             return apiTestJSONResponse("""
             {
@@ -24,6 +27,7 @@ final class APIClientSessionListTests: APIClientTestCase {
                 }
               ],
               "cli_count": 2,
+              "archived_count": 8,
               "server_time": 1770000001,
               "server_tz": "-0400"
             }
@@ -38,6 +42,44 @@ final class APIClientSessionListTests: APIClientTestCase {
         XCTAssertEqual(response.sessions?.first?.lastMessageAt, 1_770_000_000)
         XCTAssertEqual(response.sessions?.first?.pinned, true)
         XCTAssertEqual(response.cliCount, 2)
+        XCTAssertEqual(response.archivedCount, 8)
+    }
+
+    func testSessionsIncludeArchivedBuildsQueryAndDecodesMergedRows() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/sessions")
+
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+            XCTAssertEqual(query, ["include_archived": "1", "archived_limit": "50"])
+
+            // include_archived=1 merges archived rows into the visible list;
+            // each row carries an `archived` flag (upstream routes.py @312d3fab).
+            return apiTestJSONResponse("""
+            {
+              "sessions": [
+                {
+                  "session_id": "visible-1",
+                  "title": "Visible",
+                  "archived": false
+                },
+                {
+                  "session_id": "archived-1",
+                  "title": "Old research",
+                  "archived": true
+                }
+              ]
+            }
+            """, for: request)
+        }
+
+        let response = try await client.sessions(includeArchived: true, archivedLimit: 50)
+
+        XCTAssertEqual(response.sessions?.compactMap(\.sessionId), ["visible-1", "archived-1"])
+        XCTAssertEqual(response.sessions?.last?.archived, true)
+        // Tolerant decoding: an older server that omits archived_count still decodes.
+        XCTAssertNil(response.archivedCount)
     }
 
     func testSessionSearchRequestBuildsExpectedQueryAndDecodesContentMatch() async throws {

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -13,7 +13,21 @@ final class ContractReadinessTests: XCTestCase {
             .init(name: "auth status", method: "GET", endpoint: .authStatus, path: "/api/auth/status"),
             .init(name: "login", method: "POST", endpoint: .login, path: "/api/auth/login"),
             .init(name: "logout", method: "POST", endpoint: .logout, path: "/api/auth/logout"),
-            .init(name: "sessions", method: "GET", endpoint: .sessions, path: "/api/sessions"),
+            .init(name: "sessions", method: "GET", endpoint: .sessions(), path: "/api/sessions"),
+            .init(
+                name: "sessions including archived",
+                method: "GET",
+                endpoint: .sessions(includeArchived: true, archivedLimit: 3),
+                path: "/api/sessions",
+                query: ["include_archived": "1", "archived_limit": "3"]
+            ),
+            .init(
+                name: "sessions including archived without limit",
+                method: "GET",
+                endpoint: .sessions(includeArchived: true),
+                path: "/api/sessions",
+                query: ["include_archived": "1"]
+            ),
             .init(
                 name: "session search",
                 method: "GET",

--- a/HermesMobileTests/InsightsViewModelTests.swift
+++ b/HermesMobileTests/InsightsViewModelTests.swift
@@ -89,7 +89,7 @@ final class InsightsViewModelTests: XCTestCase {
         ])
         let client = StubInsightsClient(
             insightsResult: .failure(StubInsightsError()),
-            sessionsResult: .success(SessionsResponse(sessions: sessions, cliCount: nil, serverTime: nil, serverTz: nil))
+            sessionsResult: .success(SessionsResponse(sessions: sessions, cliCount: nil, archivedCount: nil, serverTime: nil, serverTz: nil))
         )
         let viewModel = InsightsViewModel(client: client)
         viewModel.selectedTimeframe = .last7Days

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -1627,6 +1627,11 @@ final class SessionListMutationTests: XCTestCase {
         let viewModel = try makeArchivedViewModel { request in
             switch request.url?.path {
             case "/api/sessions":
+                // The archived screen must opt in to archived rows — without
+                // include_archived=1 the server returns none (issue #17).
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+                XCTAssertEqual(query["include_archived"], "1")
                 return apiTestJSONResponse(self.archivedSessionListJSON(), for: request)
             case "/api/session/archive":
                 archiveRequestCount += 1
@@ -1659,6 +1664,11 @@ final class SessionListMutationTests: XCTestCase {
         let viewModel = try makeArchivedViewModel { request in
             switch request.url?.path {
             case "/api/sessions":
+                // The archived screen must opt in to archived rows — without
+                // include_archived=1 the server returns none (issue #17).
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+                XCTAssertEqual(query["include_archived"], "1")
                 return apiTestJSONResponse(self.archivedSessionListJSON(), for: request)
             case "/api/session/archive":
                 let response = HTTPURLResponse(
@@ -1682,6 +1692,93 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertEqual(viewModel.sessions, before)
         XCTAssertFalse(viewModel.isUnarchiving)
         XCTAssertNotNil(viewModel.actionErrorMessage)
+    }
+
+    @MainActor
+    func testArchivedSessionUnarchiveRejectionSurfacesServerMessage() async throws {
+        // Mirrors the live contract: subagent and read-only imported CLI sessions
+        // reject archive-state changes with HTTP 400 + an `error` message, which
+        // must reach the user verbatim rather than a generic failure (issue #17).
+        let serverMessage = "Subagent sessions are view-only and cannot be archived from WebUI"
+        let viewModel = try makeArchivedViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse(self.archivedSessionListJSON(), for: request)
+            case "/api/session/archive":
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 400,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+                return (try XCTUnwrap(response), Data(#"{"error":"\#(serverMessage)"}"#.utf8))
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        let before = viewModel.sessions
+        let didUnarchive = await viewModel.unarchive(try XCTUnwrap(viewModel.sessions.first))
+
+        XCTAssertFalse(didUnarchive)
+        XCTAssertEqual(viewModel.sessions, before)
+        let actionErrorMessage = try XCTUnwrap(viewModel.actionErrorMessage)
+        XCTAssertTrue(
+            actionErrorMessage.contains(serverMessage),
+            "Expected the server's message in: \(actionErrorMessage)"
+        )
+    }
+
+    @MainActor
+    func testArchivedSessionUnarchiveOkResponseWithErrorFieldSurfacesMessageAndRestoresRow() async throws {
+        let viewModel = try makeArchivedViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse(self.archivedSessionListJSON(), for: request)
+            case "/api/session/archive":
+                return apiTestJSONResponse(#"{"ok": false, "error": "Session not writable"}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        let before = viewModel.sessions
+        let didUnarchive = await viewModel.unarchive(try XCTUnwrap(viewModel.sessions.first))
+
+        XCTAssertFalse(didUnarchive)
+        XCTAssertEqual(viewModel.sessions, before)
+        XCTAssertEqual(viewModel.actionErrorMessage, "Session not writable")
+    }
+
+    @MainActor
+    func testLoadStoresArchivedCountFromResponseForArchivedEntry() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/sessions")
+            XCTAssertNil(request.url?.query)
+            return apiTestJSONResponse("""
+            {
+              "sessions": [
+                {
+                  "session_id": "session-abc",
+                  "title": "Planning",
+                  "archived": false
+                }
+              ],
+              "archived_count": 8
+            }
+            """, for: request)
+        }
+
+        XCTAssertNil(viewModel.archivedCount)
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.archivedCount, 8)
+        XCTAssertEqual(viewModel.sessions.compactMap(\.sessionId), ["session-abc"])
     }
 
     @MainActor

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -1755,6 +1755,33 @@ final class SessionListMutationTests: XCTestCase {
     }
 
     @MainActor
+    func testArchivedSessionUnarchiveOkFalseWithoutErrorFieldFailsAndRestoresRow() async throws {
+        // An explicit `ok: false` with no `error` string must still be treated
+        // as a failure — reporting success here would permanently drop the row
+        // from the archived list even though the server did not restore it.
+        let viewModel = try makeArchivedViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse(self.archivedSessionListJSON(), for: request)
+            case "/api/session/archive":
+                return apiTestJSONResponse(#"{"ok": false}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        let before = viewModel.sessions
+        let didUnarchive = await viewModel.unarchive(try XCTUnwrap(viewModel.sessions.first))
+
+        XCTAssertFalse(didUnarchive)
+        XCTAssertEqual(viewModel.sessions, before)
+        XCTAssertNotNil(viewModel.actionErrorMessage)
+        XCTAssertFalse(viewModel.isUnarchiving)
+    }
+
+    @MainActor
     func testLoadStoresArchivedCountFromResponseForArchivedEntry() async throws {
         let viewModel = try makeViewModel { request in
             XCTAssertEqual(request.url?.path, "/api/sessions")


### PR DESCRIPTION
## Summary

Archived sessions were a roach motel: the app can archive a session, and a Settings → Archived Sessions screen exists, but its fetch called `GET /api/sessions` **without** `include_archived=1` — and the server's default response excludes archived rows entirely, so the screen was permanently empty and archived sessions were unreachable (the live server reports 8 of them). This PR fixes the root cause and makes archived sessions discoverable.

- **API layer:** `Endpoint.sessions` gains `includeArchived` / `archivedLimit` (query `include_archived=1`, `archived_limit=<n>`); the default request stays parameterless so the main list is byte-identical.
- **Root-cause fix:** `ArchivedSessionsViewModel.load()` now opts in with `include_archived=1` and filters rows client-side on the `archived` flag.
- **Model:** `SessionsResponse` decodes `archived_count` (optional — older servers that omit it still decode).
- **Discoverability:** the session list shows an "Archived Sessions" entry with a count at the bottom when the server reports archived sessions (hidden while searching, offline, or at count 0 / missing field — the list is unchanged for users with nothing archived).
- **Archived screen:** rows now open in `ChatView` (normal read path, unchanged) and get an always-visible unarchive button next to the existing context-menu action; unarchive errors forward to the shared API-error handler (401 → re-login).
- **Error surfacing:** archive/unarchive rejections (subagent, read-only imported CLI sessions) arrive as HTTP 400 + `{"error": ...}` and surface the server's message verbatim; a 200 body carrying an `error` field is surfaced too.

## Plan (E1, pre-approved for this unattended run)

1. Verify the contract against the pinned upstream (`.codex-tmp/hermes-webui/api/routes.py` @ `312d3fab`): `include_archived`/`archived_limit` are query params; the merged response rows each carry an `archived` flag (the handler filters on `s.get("archived")`), `archived_count` is present on every response, and `POST /api/session/archive {"archived": false}` unarchives. ✔ (matches the issue's live-server verification of 2026-07-02)
2. Add opt-in `include_archived`/`archived_limit` to `Endpoint.sessions` + `APIClient.sessions` (defaults keep today's request).
3. Decode `archived_count` on `SessionsResponse`; expose it on `SessionListViewModel`.
4. Fix `ArchivedSessionsViewModel.load()` to send `include_archived=1`; keep client-side `archived == true` filtering (validated above).
5. Surface unarchive rejections (thrown HTTP 400 with server message, plus `error` field on 200) and restore the optimistically removed row on failure.
6. UI: bottom-of-list "Archived Sessions" entry with count → existing Archived screen (also still reachable from Settings); tap-to-open archived sessions; visible unarchive affordance.
7. Tests: endpoint contract matrix, query construction on/off, tolerant decode with/without `archived_count`, unarchive body shape, rejection-message surfacing, view-model filtering/count exposure.

## Decisions recorded

- **Archived row detection:** merged `include_archived=1` response + client-side `archived` filter (no separate endpoint); flag verified in the pinned handler, matching the issue's just-in-time validation ask.
- **`archived_limit`** is supported in the API layer but not sent by the archived screen (it wants all archived rows); it is only emitted alongside `include_archived=1`, mirroring upstream semantics.
- A parameterless `APIClient.sessions()` overload is kept so the `InsightsDataClient` protocol witness still matches.
- The new list-entry strings reuse the already-translated "Archived Sessions" catalog key; no new translation keys were introduced.

## Validation

- `git diff --check` clean.
- Full XCTest suite: `xcodebuild test -scheme HermesMobile -destination "id=12128609-569F-45F8-B87B-1C18E1A40068"` → **TEST SUCCEEDED** on the head commit.

## Owner manual checks

1. Session list → scroll to the bottom: an "Archived Sessions" row with a count badge (live server: 8) appears below the sessions. It is hidden while searching and when offline.
2. Tap it → the Archived screen lists the archived sessions (previously empty).
3. Tap an archived session → it opens read-only-as-usual in chat.
4. Tap the unarchive icon (or long-press → Unarchive) → the row disappears; go back → the session is in the main list again without relaunching, and the bottom count drops by one.
5. Settings → Archived Sessions still reaches the same screen.
6. Archive a subagent/read-only imported CLI session (or unarchive one) → the alert shows the server's own message, not a generic error.

Fixes #17
