### PR TITLE
Settings: read-only Providers status screen (#26)

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		05814DEA5DE4690F730B1E15 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931EC010A2D940B0E42287A4 /* InsightsViewModel.swift */; };
+		26AB000000000000000000B1 /* ProvidersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F1 /* ProvidersViewModel.swift */; };
+		26AB000000000000000000B2 /* ProvidersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F2 /* ProvidersView.swift */; };
+		26AB000000000000000000B3 /* APIClientProvidersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F3 /* APIClientProvidersTests.swift */; };
+		26AB000000000000000000B4 /* ProvidersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F4 /* ProvidersViewModelTests.swift */; };
 		1A2B3C4D5E6F700000000300 /* ServerAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000301 /* ServerAccount.swift */; };
 		B5A1000000000000000000A0 /* ServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A1000000000000000000A1 /* ServerRegistryTests.swift */; };
 		C0DE512E0000000000000202 /* InsightsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000201 /* InsightsModels.swift */; };
@@ -563,6 +567,10 @@
 		5DA59130ED4141049177576C /* SlashCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommand.swift; sourceTree = "<group>"; };
 		6809B8F1391248A4AA77C453 /* SlashCommandExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandExecutorTests.swift; sourceTree = "<group>"; };
 		931EC010A2D940B0E42287A4 /* InsightsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F1 /* ProvidersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersViewModel.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F2 /* ProvidersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersView.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F3 /* APIClientProvidersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientProvidersTests.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F4 /* ProvidersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersViewModelTests.swift; sourceTree = "<group>"; };
 		A710739233F64F4FA4C2B710 /* ComposerVoiceInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceInputController.swift; sourceTree = "<group>"; };
 		A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceDraftComposerTests.swift; sourceTree = "<group>"; };
 		B5A100000000000000000010 /* SharedDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDraftStore.swift; sourceTree = "<group>"; };
@@ -772,6 +780,8 @@
 				A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */,
 				C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */,
 				2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */,
+				26AB000000000000000000F3 /* APIClientProvidersTests.swift */,
+				26AB000000000000000000F4 /* ProvidersViewModelTests.swift */,
 				B5A100000000000000000016 /* SharedDraftStoreTests.swift */,
 				B5A100000000000000000019 /* ShareInputReaderTests.swift */,
 				B5A100000000000000000061 /* AuthManagerStateTests.swift */,
@@ -1022,6 +1032,8 @@
 				C23400000000000000000004 /* StreamingLabView.swift */,
 				1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */,
 				19C1150000000000000000A2 /* CliSessionsSyncModel.swift */,
+				26AB000000000000000000F2 /* ProvidersView.swift */,
+				26AB000000000000000000F1 /* ProvidersViewModel.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1506,6 +1518,8 @@
 				C0DE512E0000000000000202 /* InsightsModels.swift in Sources */,
 				C0DE512E0000000000000204 /* InsightsRows.swift in Sources */,
 				05814DEA5DE4690F730B1E15 /* InsightsViewModel.swift in Sources */,
+				26AB000000000000000000B1 /* ProvidersViewModel.swift in Sources */,
+				26AB000000000000000000B2 /* ProvidersView.swift in Sources */,
 				B5A100000000000000000001 /* SharedDraftStore.swift in Sources */,
 				B5A100000000000000000008 /* ShareInputReader.swift in Sources */,
 			);
@@ -1586,6 +1600,8 @@
 				A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */,
 				C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */,
 				2BE8F2B38F094C4C9EB18301 /* SkillsViewModelTests.swift in Sources */,
+				26AB000000000000000000B3 /* APIClientProvidersTests.swift in Sources */,
+				26AB000000000000000000B4 /* ProvidersViewModelTests.swift in Sources */,
 				B5A100000000000000000005 /* SharedDraftStoreTests.swift in Sources */,
 				B5A100000000000000000009 /* ShareInputReaderTests.swift in Sources */,
 				B5A100000000000000000060 /* AuthManagerStateTests.swift in Sources */,

--- a/HermesMobile/Features/Settings/ProvidersView.swift
+++ b/HermesMobile/Features/Settings/ProvidersView.swift
@@ -1,0 +1,253 @@
+import SwiftUI
+
+/// Read-only provider status screen (#26): which providers the server knows
+/// about, whether each has a credential (and where it came from), which one is
+/// active, and each provider's model catalog. Deliberately carries no write
+/// affordances — API-key set/delete stays a server-side operation.
+struct ProvidersView: View {
+    let server: URL
+
+    @State private var viewModel: ProvidersViewModel
+    @State private var expandedProviderIndices: Set<Int> = []
+
+    init(server: URL) {
+        self.server = server
+        _viewModel = State(initialValue: ProvidersViewModel(server: server))
+    }
+
+    var body: some View {
+        content
+            .navigationTitle("Providers")
+            .background(Color(.systemBackground))
+            .task {
+                await viewModel.load()
+            }
+            .refreshable {
+                await viewModel.load()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if viewModel.isLoading && viewModel.providers.isEmpty {
+                    ProvidersStatusRow(title: String(localized: "Loading providers…"), systemImage: "key.horizontal")
+                        .padding(.horizontal, 24)
+                } else if let errorMessage = viewModel.errorMessage, viewModel.providers.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ProvidersStatusRow(title: String(localized: "Could not load providers"), systemImage: "exclamationmark.triangle")
+
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(3)
+
+                        Button("Try Again") {
+                            Task { await viewModel.load() }
+                        }
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                    }
+                    .padding(.horizontal, 24)
+                } else if viewModel.providers.isEmpty {
+                    ProvidersStatusRow(title: String(localized: "No providers reported by this server."), systemImage: "key.horizontal")
+                        .padding(.horizontal, 24)
+                } else {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(Array(viewModel.providers.enumerated()), id: \.offset) { index, provider in
+                            ProviderRow(
+                                provider: provider,
+                                isActive: viewModel.isActive(provider),
+                                isExpanded: expandedProviderIndices.contains(index),
+                                toggleExpanded: { toggleExpanded(index) }
+                            )
+                        }
+
+                        Text("Provider keys are managed on the server. This screen is read-only.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 6)
+                            .padding(.horizontal, 4)
+                    }
+                    .padding(.horizontal, 16)
+                }
+            }
+            .padding(.top, 20)
+            .padding(.bottom, 44)
+        }
+    }
+
+    private func toggleExpanded(_ index: Int) {
+        withAnimation(.snappy(duration: 0.22)) {
+            if expandedProviderIndices.contains(index) {
+                expandedProviderIndices.remove(index)
+            } else {
+                expandedProviderIndices.insert(index)
+            }
+        }
+    }
+}
+
+private struct ProviderRow: View {
+    let provider: ProviderSummary
+    let isActive: Bool
+    let isExpanded: Bool
+    let toggleExpanded: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(ProvidersViewModel.displayName(for: provider))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+
+                if isActive {
+                    Text("Active")
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color.green.opacity(0.16)))
+                        .foregroundStyle(.green)
+                }
+
+                Spacer(minLength: 0)
+
+                if let badge = ProvidersViewModel.keySourceBadge(for: provider) {
+                    // Technical token (env / OAuth / config) — deliberately not localized.
+                    Text(verbatim: badge)
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color(.tertiarySystemFill)))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            keyStatusLine
+
+            if let authError = ProvidersViewModel.authErrorText(for: provider) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .accessibilityHidden(true)
+
+                    Text(authError)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.leading)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text("Authentication error: \(authError)"))
+            }
+
+            if let models = provider.models, !models.isEmpty {
+                modelsDisclosure(models)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    @ViewBuilder
+    private var keyStatusLine: some View {
+        if let hasKey = provider.hasKey {
+            HStack(spacing: 6) {
+                Image(systemName: hasKey ? "checkmark.seal.fill" : "key.slash")
+                    .font(.caption)
+                    .foregroundStyle(hasKey ? Color.green : Color.secondary)
+                    .accessibilityHidden(true)
+
+                Text(hasKey ? "Key configured" : "No key")
+                    .font(.footnote)
+                    .foregroundStyle(hasKey ? Color.primary : Color.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func modelsDisclosure(_ models: [ProviderModel]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button(action: toggleExpanded) {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .accessibilityHidden(true)
+
+                    Text("Models (\(ProvidersViewModel.modelCount(for: provider)))")
+                        .font(.footnote.weight(.medium))
+                }
+                .foregroundStyle(.secondary)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("Shows this provider's model list.")
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(models.enumerated()), id: \.offset) { _, model in
+                        if let title = modelTitle(model) {
+                            Text(verbatim: title)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+
+                    if let info = ProvidersViewModel.truncatedModelInfo(for: provider) {
+                        Text("Showing \(info.shown) of \(info.total) models")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .padding(.top, 2)
+                    }
+                }
+                .padding(.leading, 18)
+            }
+        }
+    }
+
+    private func modelTitle(_ model: ProviderModel) -> String? {
+        let label = model.label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let label, !label.isEmpty {
+            return label
+        }
+
+        let id = model.id?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let id, !id.isEmpty {
+            return id
+        }
+
+        return nil
+    }
+}
+
+private struct ProvidersStatusRow: View {
+    let title: String
+    let systemImage: String
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: systemImage)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+
+            Text(title)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            Spacer(minLength: 0)
+        }
+        .frame(minHeight: 42)
+    }
+}

--- a/HermesMobile/Features/Settings/ProvidersView.swift
+++ b/HermesMobile/Features/Settings/ProvidersView.swift
@@ -8,7 +8,7 @@ struct ProvidersView: View {
     let server: URL
 
     @State private var viewModel: ProvidersViewModel
-    @State private var expandedProviderIndices: Set<Int> = []
+    @State private var expandedProviderKeys: Set<String> = []
 
     init(server: URL) {
         self.server = server
@@ -56,11 +56,12 @@ struct ProvidersView: View {
                 } else {
                     VStack(alignment: .leading, spacing: 10) {
                         ForEach(Array(viewModel.providers.enumerated()), id: \.offset) { index, provider in
+                            let key = Self.expansionKey(for: provider, at: index)
                             ProviderRow(
                                 provider: provider,
                                 isActive: viewModel.isActive(provider),
-                                isExpanded: expandedProviderIndices.contains(index),
-                                toggleExpanded: { toggleExpanded(index) }
+                                isExpanded: expandedProviderKeys.contains(key),
+                                toggleExpanded: { toggleExpanded(key) }
                             )
                         }
 
@@ -78,12 +79,23 @@ struct ProvidersView: View {
         }
     }
 
-    private func toggleExpanded(_ index: Int) {
+    /// Expansion is keyed by the provider's stable id so refreshes that reorder
+    /// the list (the server sorts active-first) keep the right rows expanded;
+    /// entries without an id fall back to their position.
+    static func expansionKey(for provider: ProviderSummary, at index: Int) -> String {
+        if let id = provider.id?.trimmingCharacters(in: .whitespacesAndNewlines), !id.isEmpty {
+            return id
+        }
+
+        return "#\(index)"
+    }
+
+    private func toggleExpanded(_ key: String) {
         withAnimation(.snappy(duration: 0.22)) {
-            if expandedProviderIndices.contains(index) {
-                expandedProviderIndices.remove(index)
+            if expandedProviderKeys.contains(key) {
+                expandedProviderKeys.remove(key)
             } else {
-                expandedProviderIndices.insert(index)
+                expandedProviderKeys.insert(key)
             }
         }
     }

--- a/HermesMobile/Features/Settings/ProvidersView.swift
+++ b/HermesMobile/Features/Settings/ProvidersView.swift
@@ -55,6 +55,10 @@ struct ProvidersView: View {
                         .padding(.horizontal, 24)
                 } else {
                     VStack(alignment: .leading, spacing: 10) {
+                        if let errorMessage = viewModel.errorMessage {
+                            refreshFailureBanner(detail: errorMessage)
+                        }
+
                         ForEach(Array(viewModel.providers.enumerated()), id: \.offset) { index, provider in
                             let key = Self.expansionKey(for: provider, at: index)
                             ProviderRow(
@@ -77,6 +81,36 @@ struct ProvidersView: View {
             .padding(.top, 20)
             .padding(.bottom, 44)
         }
+    }
+
+    /// Shown above cached rows when a pull-to-refresh fails: the list would
+    /// otherwise look freshly loaded even though the request errored (#42 review).
+    private func refreshFailureBanner(detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+
+                Text("Couldn't refresh. Showing previously loaded providers.")
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+            }
+
+            Text(verbatim: detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.orange.opacity(0.14))
+        )
+        .accessibilityElement(children: .combine)
     }
 
     /// Expansion is keyed by the provider's stable id so refreshes that reorder

--- a/HermesMobile/Features/Settings/ProvidersViewModel.swift
+++ b/HermesMobile/Features/Settings/ProvidersViewModel.swift
@@ -28,6 +28,11 @@ final class ProvidersViewModel {
             let response = try await client.providers()
             providers = response.providers ?? []
             activeProviderID = Self.normalizedProviderID(response.activeProvider)
+        } catch is CancellationError {
+            // The owning view was dismissed (or the refresh gesture was torn
+            // down) mid-request — don't surface "cancelled" as a load error.
+        } catch let error as URLError where error.code == .cancelled {
+            // Same cancellation, surfaced through URLSession.
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/HermesMobile/Features/Settings/ProvidersViewModel.swift
+++ b/HermesMobile/Features/Settings/ProvidersViewModel.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Observation
+
+/// Backs the read-only Providers status screen (#26). Loads `GET /api/providers`
+/// once per appearance and exposes pure, testable presentation helpers — no
+/// write operations by design (key set/delete stays a server-side concern).
+@MainActor
+@Observable
+final class ProvidersViewModel {
+    /// Server order is preserved: upstream already sorts active-first, then
+    /// custom providers, then key-holders, then the rest.
+    private(set) var providers: [ProviderSummary] = []
+    private(set) var activeProviderID: String?
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private let client: APIClient
+
+    init(server: URL, client: APIClient? = nil) {
+        self.client = client ?? APIClient(baseURL: server)
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let response = try await client.providers()
+            providers = response.providers ?? []
+            activeProviderID = Self.normalizedProviderID(response.activeProvider)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    func isActive(_ provider: ProviderSummary) -> Bool {
+        guard let active = activeProviderID,
+              let id = Self.normalizedProviderID(provider.id)
+        else {
+            return false
+        }
+
+        return id == active
+    }
+
+    // MARK: - Presentation helpers (pure, testable)
+
+    /// `active_provider` comes from config (`model.provider`) while entry `id`s are
+    /// canonical slugs — trim and lowercase both sides so cosmetic differences
+    /// don't hide the active badge.
+    static func normalizedProviderID(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+
+        return trimmed
+    }
+
+    static func displayName(for provider: ProviderSummary) -> String {
+        if let name = trimmedNonEmpty(provider.displayName) {
+            return name
+        }
+
+        if let id = trimmedNonEmpty(provider.id) {
+            return id
+        }
+
+        return String(localized: "Unknown provider")
+    }
+
+    /// Short technical badge naming where a configured key came from. Collapses the
+    /// upstream `key_source` vocabulary (`env_file`/`env_var`/`env` → env,
+    /// `oauth`/`token` → OAuth, `config_yaml`/`config` → config); unknown future
+    /// values pass through verbatim rather than being hidden. `nil` when the
+    /// provider has no key — the badge only ever describes an existing credential.
+    static func keySourceBadge(for provider: ProviderSummary) -> String? {
+        guard provider.hasKey == true else {
+            return nil
+        }
+
+        let raw = provider.keySource?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+
+        switch raw {
+        case "", "none":
+            return nil
+        case "env_file", "env_var", "env":
+            return "env"
+        case "oauth", "token":
+            return "OAuth"
+        case "config_yaml", "config":
+            return "config"
+        default:
+            return raw
+        }
+    }
+
+    static func authErrorText(for provider: ProviderSummary) -> String? {
+        trimmedNonEmpty(provider.authError)
+    }
+
+    /// Catalog size to advertise on the models disclosure: `models_total` reflects
+    /// the complete catalog even when `models` is trimmed to a featured subset, so
+    /// prefer it whenever it is larger than the visible list.
+    static func modelCount(for provider: ProviderSummary) -> Int {
+        max(provider.modelsTotal ?? 0, provider.models?.count ?? 0)
+    }
+
+    /// Non-nil only when the server trimmed the model list (`models_total` exceeds
+    /// the entries actually sent) — drives the "Showing X of Y models" footer.
+    static func truncatedModelInfo(for provider: ProviderSummary) -> (shown: Int, total: Int)? {
+        let shown = provider.models?.count ?? 0
+
+        guard let total = provider.modelsTotal, shown > 0, total > shown else {
+            return nil
+        }
+
+        return (shown: shown, total: total)
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}

--- a/HermesMobile/Features/Settings/ProvidersViewModel.swift
+++ b/HermesMobile/Features/Settings/ProvidersViewModel.swift
@@ -16,16 +16,26 @@ final class ProvidersViewModel {
 
     private let client: APIClient
 
+    /// Monotonic token identifying the most recent `load()` call. `load()` has
+    /// three overlapping entry points (`.task`, `.refreshable`, "Try Again"), so
+    /// an older in-flight request must not overwrite a newer response or clear
+    /// `isLoading` while the newer request is still pending (#42 Codex review).
+    private var loadGeneration = 0
+
     init(server: URL, client: APIClient? = nil) {
         self.client = client ?? APIClient(baseURL: server)
     }
 
     func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
+
         isLoading = true
         errorMessage = nil
 
         do {
             let response = try await client.providers()
+            guard generation == loadGeneration else { return }
             providers = response.providers ?? []
             activeProviderID = Self.normalizedProviderID(response.activeProvider)
         } catch is CancellationError {
@@ -34,9 +44,12 @@ final class ProvidersViewModel {
         } catch let error as URLError where error.code == .cancelled {
             // Same cancellation, surfaced through URLSession.
         } catch {
+            guard generation == loadGeneration else { return }
             errorMessage = error.localizedDescription
         }
 
+        // A newer load owns the loading state now — leave it alone.
+        guard generation == loadGeneration else { return }
         isLoading = false
     }
 

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -349,6 +349,19 @@ struct SettingsView: View {
                     SettingsDivider()
 
                     NavigationLink {
+                        ProvidersView(server: server)
+                    } label: {
+                        SettingsAccessoryRow(
+                            title: String(localized: "Providers"),
+                            systemImage: "key.horizontal"
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Opens the provider status screen.")
+
+                    SettingsDivider()
+
+                    NavigationLink {
                         CustomHeadersSettingsView(authManager: authManager)
                     } label: {
                         SettingsAccessoryRow(

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -136,9 +136,146 @@ struct AgentCommand: Decodable, Equatable, Identifiable, Sendable {
     }
 }
 
+/// `GET /api/providers` — read-only provider status (#26). Shape verified against
+/// the live server (2026-07-02) and upstream `api/providers.py::get_providers()`
+/// @ `312d3fab`: standard entries carry the full field set, while entries derived
+/// from `custom_providers` in config.yaml (`is_custom == true`) omit `is_oauth`,
+/// `auth_error`, `is_self_hosted`, `base_url`, and `is_plugin_provider` — so every
+/// field stays optional and decoding never fails on a partial entry.
 struct ProvidersResponse: Decodable, Equatable {
-    let providers: [JSONValue]?
+    let providers: [ProviderSummary]?
     let activeProvider: String?
+
+    init(providers: [ProviderSummary]?, activeProvider: String?) {
+        self.providers = providers
+        self.activeProvider = activeProvider
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case providers
+        case activeProvider
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        providers = try? container.decodeIfPresent([ProviderSummary].self, forKey: .providers)
+        activeProvider = container.decodeLossyStringIfPresent(forKey: .activeProvider)
+    }
+}
+
+/// One provider entry from `GET /api/providers`. `keySource` vocabulary upstream:
+/// `env_file`, `env_var`, `config_yaml`, `oauth`, `none` — plus `env`, `config`,
+/// and `token` from the live-auth fallback probe. Unknown values are kept verbatim.
+struct ProviderSummary: Decodable, Equatable, Sendable {
+    let id: String?
+    let displayName: String?
+    let hasKey: Bool?
+    let configurable: Bool?
+    let isSelfHosted: Bool?
+    let baseUrl: String?
+    let isPluginProvider: Bool?
+    let isOauth: Bool?
+    let isCustom: Bool?
+    let keySource: String?
+    let authError: String?
+    let models: [ProviderModel]?
+    /// Size of the provider's complete catalog. May exceed `models.count` when the
+    /// server trims the list to a featured subset (e.g. large Nous Portal accounts).
+    let modelsTotal: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName
+        case hasKey
+        case configurable
+        case isSelfHosted
+        case baseUrl
+        case isPluginProvider
+        case isOauth
+        case isCustom
+        case keySource
+        case authError
+        case models
+        case modelsTotal
+    }
+
+    init(
+        id: String?,
+        displayName: String? = nil,
+        hasKey: Bool? = nil,
+        configurable: Bool? = nil,
+        isSelfHosted: Bool? = nil,
+        baseUrl: String? = nil,
+        isPluginProvider: Bool? = nil,
+        isOauth: Bool? = nil,
+        isCustom: Bool? = nil,
+        keySource: String? = nil,
+        authError: String? = nil,
+        models: [ProviderModel]? = nil,
+        modelsTotal: Int? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.hasKey = hasKey
+        self.configurable = configurable
+        self.isSelfHosted = isSelfHosted
+        self.baseUrl = baseUrl
+        self.isPluginProvider = isPluginProvider
+        self.isOauth = isOauth
+        self.isCustom = isCustom
+        self.keySource = keySource
+        self.authError = authError
+        self.models = models
+        self.modelsTotal = modelsTotal
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyStringIfPresent(forKey: .id)
+        displayName = container.decodeLossyStringIfPresent(forKey: .displayName)
+        hasKey = container.decodeLossyBoolIfPresent(forKey: .hasKey)
+        configurable = container.decodeLossyBoolIfPresent(forKey: .configurable)
+        isSelfHosted = container.decodeLossyBoolIfPresent(forKey: .isSelfHosted)
+        baseUrl = container.decodeLossyStringIfPresent(forKey: .baseUrl)
+        isPluginProvider = container.decodeLossyBoolIfPresent(forKey: .isPluginProvider)
+        isOauth = container.decodeLossyBoolIfPresent(forKey: .isOauth)
+        isCustom = container.decodeLossyBoolIfPresent(forKey: .isCustom)
+        keySource = container.decodeLossyStringIfPresent(forKey: .keySource)
+        authError = container.decodeLossyStringIfPresent(forKey: .authError)
+        models = try? container.decodeIfPresent([ProviderModel].self, forKey: .models)
+        modelsTotal = container.decodeLossyIntIfPresent(forKey: .modelsTotal)
+    }
+}
+
+/// A model entry inside a provider's `models` list. Upstream normally emits
+/// `{ "id": …, "label": … }` objects, but the docs historically described bare
+/// model-ID strings — both shapes decode.
+struct ProviderModel: Decodable, Equatable, Sendable {
+    let id: String?
+    let label: String?
+
+    init(id: String?, label: String? = nil) {
+        self.id = id
+        self.label = label
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case label
+    }
+
+    init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(),
+           let raw = try? single.decode(String.self) {
+            id = raw
+            label = raw
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyStringIfPresent(forKey: .id)
+        label = container.decodeLossyStringIfPresent(forKey: .label)
+    }
 }
 
 /// `GET /api/settings` (the saved-settings body `POST /api/settings` echoes the

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -637,6 +637,112 @@
         }
       }
     },
+    "Couldn't refresh. Showing previously loaded providers." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تعذّر التحديث. يتم عرض المزوّدين المحمّلين سابقًا."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aktualisierung fehlgeschlagen. Zuvor geladene Anbieter werden angezeigt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No se pudo actualizar. Se muestran los proveedores cargados anteriormente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossible d'actualiser. Affichage des fournisseurs chargés précédemment."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הרענון נכשל. מוצגים ספקים שנטענו קודם לכן."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossibile aggiornare. Vengono mostrati i provider caricati in precedenza."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "更新できませんでした。以前に読み込んだプロバイダを表示しています。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "새로 고칠 수 없습니다. 이전에 불러온 제공업체를 표시합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kan niet vernieuwen. Eerder geladen providers worden weergegeven."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nie udało się odświeżyć. Wyświetlani są wcześniej wczytani dostawcy."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não foi possível atualizar. Mostrando os provedores carregados anteriormente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Не удалось обновить. Показаны ранее загруженные провайдеры."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yenilenemedi. Daha önce yüklenen sağlayıcılar gösteriliyor."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ریفریش نہیں ہو سکا۔ پہلے سے لوڈ کیے گئے فراہم کنندگان دکھائے جا رہے ہیں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法重新整理。正在顯示先前載入的供應商。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法刷新。正在显示之前加载的提供商。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法重新整理。正在顯示先前載入的供應商。"
+          }
+        }
+      }
+    },
     "Diff too large to show." : {
       "localizations" : {
         "zh-Hant" : {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -107,6 +107,112 @@
         }
       }
     },
+    "Authentication error: %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "خطأ في المصادقة: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Authentifizierungsfehler: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Error de autenticación: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erreur d’authentification : %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "שגיאת אימות: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Errore di autenticazione: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "認証エラー：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "인증 오류: %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verificatiefout: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Błąd uwierzytelniania: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erro de autenticação: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ошибка аутентификации: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kimlik doğrulama hatası: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تصدیق کی خرابی: %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "驗證錯誤：%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "身份验证错误：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "驗證錯誤：%@"
+          }
+        }
+      }
+    },
     "Binary file changed" : {
       "localizations" : {
         "de" : {
@@ -421,6 +527,112 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "無法更改"
+          }
+        }
+      }
+    },
+    "Could not load providers" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تعذّر تحميل المزوّدين"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anbieter konnten nicht geladen werden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No se pudieron cargar los proveedores"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossible de charger les fournisseurs"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא ניתן לטעון ספקים"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossibile caricare i provider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プロバイダを読み込めませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "제공업체를 불러올 수 없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kan providers niet laden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nie udało się wczytać dostawców"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não foi possível carregar os provedores"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Не удалось загрузить провайдеров"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sağlayıcılar yüklenemedi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فراہم کنندگان لوڈ نہیں ہو سکے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法載入供應商"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法加载提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法載入供應商"
           }
         }
       }
@@ -849,6 +1061,218 @@
         }
       }
     },
+    "Key configured" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم إعداد المفتاح"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Schlüssel konfiguriert"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Clave configurada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Clé configurée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "המפתח מוגדר"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chiave configurata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "キー設定済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "키 구성됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sleutel geconfigureerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Klucz skonfigurowany"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chave configurada"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ключ настроен"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anahtar yapılandırıldı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کلید ترتیب دی گئی"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已設定金鑰"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已配置密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已設定金鑰"
+          }
+        }
+      }
+    },
+    "Loading providers…" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "جارٍ تحميل المزوّدين…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anbieter werden geladen…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cargando proveedores…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chargement des fournisseurs…"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "טוען ספקים…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Caricamento dei provider…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プロバイダを読み込み中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "제공업체 불러오는 중…"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Providers laden…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wczytywanie dostawców…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando provedores…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загрузка провайдеров…"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sağlayıcılar yükleniyor…"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فراہم کنندگان لوڈ ہو رہے ہیں…"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在載入供應商…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在加载提供商…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在載入供應商…"
+          }
+        }
+      }
+    },
     "Local and remote branches diverged" : {
       "localizations" : {
         "de" : {
@@ -1273,6 +1697,112 @@
         }
       }
     },
+    "Models (%lld)" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "النماذج (%lld)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modelle (%lld)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modelos (%lld)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modèles (%lld)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מודלים (%lld)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modelli (%lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "モデル（%lld）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모델 (%lld)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modellen (%lld)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modele (%lld)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modelos (%lld)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Модели (%lld)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modeller (%lld)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ماڈلز (%lld)"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "模型（%lld）"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "模型（%lld）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "模型（%lld）"
+          }
+        }
+      }
+    },
     "No changes" : {
       "localizations" : {
         "de" : {
@@ -1375,6 +1905,536 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "沒有變化"
+          }
+        }
+      }
+    },
+    "No key" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لا يوجد مفتاح"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kein Schlüssel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sin clave"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aucune clé"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "אין מפתח"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nessuna chiave"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "キーなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "키 없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geen sleutel"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brak klucza"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sem chave"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Нет ключа"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anahtar yok"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کوئی کلید نہیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無金鑰"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無金鑰"
+          }
+        }
+      }
+    },
+    "No providers reported by this server." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لم يُبلغ هذا الخادم عن أي مزوّدين."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dieser Server meldet keine Anbieter."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este servidor no informa de ningún proveedor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ce serveur ne signale aucun fournisseur."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "השרת הזה לא דיווח על ספקים."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Questo server non riporta alcun provider."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "このサーバーからプロバイダは報告されていません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 서버에서 보고된 제공업체가 없습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deze server meldt geen providers."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ten serwer nie zgłasza żadnych dostawców."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este servidor não relata nenhum provedor."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сервер не сообщил ни об одном провайдере."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu sunucu herhangi bir sağlayıcı bildirmedi."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اس سرور نے کوئی فراہم کنندہ رپورٹ نہیں کیا۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此伺服器未回報任何供應商。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此服务器未报告任何提供商。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此伺服器未回報任何供應商。"
+          }
+        }
+      }
+    },
+    "Opens the provider status screen." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يفتح شاشة حالة المزوّدين."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Öffnet die Anbieter-Statusansicht."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abre la pantalla de estado de los proveedores."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ouvre l’écran d’état des fournisseurs."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פותח את מסך מצב הספקים."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apre la schermata di stato dei provider."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プロバイダの状態画面を開きます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "제공업체 상태 화면을 엽니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opent het providerstatusscherm."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Otwiera ekran stanu dostawców."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abre a tela de status dos provedores."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Открывает экран состояния провайдеров."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sağlayıcı durumu ekranını açar."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فراہم کنندہ کی صورتحال کی اسکرین کھولتا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "開啟供應商狀態畫面。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "打开提供商状态界面。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "開啟供應商狀態畫面。"
+          }
+        }
+      }
+    },
+    "Provider keys are managed on the server. This screen is read-only." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تُدار مفاتيح المزوّدين على الخادم. هذه الشاشة للقراءة فقط."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anbieter-Schlüssel werden auf dem Server verwaltet. Diese Ansicht ist schreibgeschützt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Las claves de los proveedores se gestionan en el servidor. Esta pantalla es de solo lectura."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Les clés des fournisseurs sont gérées sur le serveur. Cet écran est en lecture seule."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מפתחות הספקים מנוהלים בשרת. מסך זה הוא לקריאה בלבד."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Le chiavi dei provider sono gestite sul server. Questa schermata è di sola lettura."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プロバイダのキーはサーバー側で管理されます。この画面は読み取り専用です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "제공업체 키는 서버에서 관리됩니다. 이 화면은 읽기 전용입니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Providersleutels worden op de server beheerd. Dit scherm is alleen-lezen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Klucze dostawców są zarządzane na serwerze. Ten ekran jest tylko do odczytu."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "As chaves dos provedores são gerenciadas no servidor. Esta tela é somente leitura."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ключи провайдеров управляются на сервере. Этот экран доступен только для чтения."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sağlayıcı anahtarları sunucuda yönetilir. Bu ekran salt okunurdur."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فراہم کنندگان کی کلیدیں سرور پر منظم کی جاتی ہیں۔ یہ اسکرین صرف پڑھنے کے لیے ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "供應商金鑰在伺服器上管理。此畫面為唯讀。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "提供商密钥在服务器上管理。此界面为只读。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "供應商金鑰在伺服器上管理。此畫面為唯讀。"
+          }
+        }
+      }
+    },
+    "Providers" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "المزوّدون"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anbieter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Proveedores"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fournisseurs"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ספקים"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プロバイダ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "제공업체"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Providers"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dostawcy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provedores"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Провайдеры"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sağlayıcılar"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فراہم کنندگان"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "供應商"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "供應商"
           }
         }
       }
@@ -1697,6 +2757,112 @@
         }
       }
     },
+    "Showing %lld of %lld models" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "عرض %1$lld من %2$lld نموذجًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$lld von %2$lld Modellen angezeigt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrando %1$lld de %2$lld modelos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$lld modèles affichés sur %2$lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מוצגים %1$lld מתוך %2$lld מודלים"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Visualizzati %1$lld modelli su %2$lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%2$lld件中%1$lld件のモデルを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모델 %2$lld개 중 %1$lld개 표시"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$lld van %2$lld modellen weergegeven"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wyświetlanie %1$lld z %2$lld modeli"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrando %1$lld de %2$lld modelos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показано %1$lld из %2$lld моделей"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%2$lld modelden %1$lld tanesi gösteriliyor"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%2$lld میں سے %1$lld ماڈلز دکھائے جا رہے ہیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示 %2$lld 個模型中的 %1$lld 個"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "显示 %2$lld 个模型中的 %1$lld 个"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示 %2$lld 個模型中的 %1$lld 個"
+          }
+        }
+      }
+    },
     "Showing first 500 changed files." : {
       "localizations" : {
         "de" : {
@@ -1799,6 +2965,218 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "顯示前 500 個已更改的檔案。"
+          }
+        }
+      }
+    },
+    "Shows this provider's model list." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يعرض قائمة نماذج هذا المزوّد."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zeigt die Modellliste dieses Anbieters an."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Muestra la lista de modelos de este proveedor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Affiche la liste des modèles de ce fournisseur."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מציג את רשימת המודלים של ספק זה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra l'elenco dei modelli di questo provider."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "このプロバイダのモデル一覧を表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 제공업체의 모델 목록을 표시합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toont de modellenlijst van deze provider."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pokazuje listę modeli tego dostawcy."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra a lista de modelos deste provedor."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показывает список моделей этого провайдера."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu sağlayıcının model listesini gösterir."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اس فراہم کنندہ کے ماڈلز کی فہرست دکھاتا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示此供應商的模型列表。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "显示此提供商的模型列表。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示此供應商的模型列表。"
+          }
+        }
+      }
+    },
+    "Unknown provider" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مزوّد غير معروف"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Unbekannter Anbieter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Proveedor desconocido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fournisseur inconnu"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ספק לא ידוע"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider sconosciuto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "不明なプロバイダ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "알 수 없는 제공업체"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Onbekende provider"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nieznany dostawca"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provedor desconhecido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Неизвестный провайдер"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bilinmeyen sağlayıcı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نامعلوم فراہم کنندہ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未知供應商"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未知提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未知供應商"
           }
         }
       }

--- a/HermesMobileTests/APIClientProvidersTests.swift
+++ b/HermesMobileTests/APIClientProvidersTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import HermesMobile
+
+/// Decoding contract for `GET /api/providers` (#26). The primary fixture mirrors
+/// the live server shape captured 2026-07-02 plus upstream
+/// `api/providers.py::get_providers()` @ `312d3fab`, including a
+/// `custom_providers`-derived entry that omits most fields.
+final class APIClientProvidersTests: APIClientTestCase {
+    func testProvidersRequestDecodesLiveShape() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/providers")
+
+            return apiTestJSONResponse("""
+            {
+              "active_provider": "openai-codex",
+              "providers": [
+                {
+                  "id": "openai-codex",
+                  "display_name": "OpenAI Codex",
+                  "has_key": true,
+                  "configurable": false,
+                  "is_self_hosted": false,
+                  "base_url": null,
+                  "is_plugin_provider": false,
+                  "is_oauth": true,
+                  "key_source": "oauth",
+                  "auth_error": null,
+                  "models": [
+                    { "id": "gpt-5.5", "label": "GPT 5.5" },
+                    { "id": "gpt-5.5-codex", "label": "GPT 5.5 Codex" }
+                  ],
+                  "models_total": 5
+                },
+                {
+                  "id": "anthropic",
+                  "display_name": "Anthropic",
+                  "has_key": false,
+                  "configurable": true,
+                  "is_self_hosted": false,
+                  "base_url": null,
+                  "is_plugin_provider": false,
+                  "is_oauth": true,
+                  "key_source": "oauth",
+                  "auth_error": "OAuth token expired — run hermes auth login anthropic",
+                  "models": [],
+                  "models_total": 0
+                },
+                {
+                  "id": "custom:glmcode",
+                  "display_name": "glmcode",
+                  "has_key": true,
+                  "configurable": false,
+                  "is_custom": true,
+                  "key_source": "config_yaml",
+                  "models": [ "glm-4.7" ],
+                  "models_total": 1
+                }
+              ]
+            }
+            """, for: request)
+        }
+
+        let response = try await client.providers()
+
+        XCTAssertEqual(response.activeProvider, "openai-codex")
+        let providers = try XCTUnwrap(response.providers)
+        XCTAssertEqual(providers.count, 3)
+
+        let codex = providers[0]
+        XCTAssertEqual(codex.id, "openai-codex")
+        XCTAssertEqual(codex.displayName, "OpenAI Codex")
+        XCTAssertEqual(codex.hasKey, true)
+        XCTAssertEqual(codex.configurable, false)
+        XCTAssertEqual(codex.isSelfHosted, false)
+        XCTAssertNil(codex.baseUrl)
+        XCTAssertEqual(codex.isPluginProvider, false)
+        XCTAssertEqual(codex.isOauth, true)
+        XCTAssertEqual(codex.keySource, "oauth")
+        XCTAssertNil(codex.authError)
+        XCTAssertEqual(codex.models?.count, 2)
+        XCTAssertEqual(codex.models?.first?.id, "gpt-5.5")
+        XCTAssertEqual(codex.models?.first?.label, "GPT 5.5")
+        XCTAssertEqual(codex.modelsTotal, 5)
+
+        let anthropic = providers[1]
+        XCTAssertEqual(anthropic.hasKey, false)
+        XCTAssertEqual(anthropic.authError, "OAuth token expired — run hermes auth login anthropic")
+        XCTAssertEqual(anthropic.models, [])
+
+        // Custom-provider entries omit is_oauth / auth_error / is_self_hosted /
+        // base_url / is_plugin_provider, and may carry bare-string model IDs.
+        let custom = providers[2]
+        XCTAssertEqual(custom.id, "custom:glmcode")
+        XCTAssertEqual(custom.isCustom, true)
+        XCTAssertNil(custom.isOauth)
+        XCTAssertNil(custom.authError)
+        XCTAssertEqual(custom.keySource, "config_yaml")
+        XCTAssertEqual(custom.models?.first?.id, "glm-4.7")
+        XCTAssertEqual(custom.models?.first?.label, "glm-4.7")
+    }
+
+    func testProvidersDecodingToleratesAbsentAndUnknownFields() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let empty = try decoder.decode(ProvidersResponse.self, from: Data("{}".utf8))
+        XCTAssertNil(empty.providers)
+        XCTAssertNil(empty.activeProvider)
+
+        let sparse = try decoder.decode(ProvidersResponse.self, from: Data("""
+        {
+          "active_provider": null,
+          "providers": [
+            {},
+            {
+              "id": "mystery",
+              "key_source": "keychain",
+              "future_field": { "nested": true },
+              "models": [ { "id": "m-1" }, "m-2" ],
+              "models_total": "7"
+            }
+          ]
+        }
+        """.utf8))
+
+        XCTAssertNil(sparse.activeProvider)
+        let providers = try XCTUnwrap(sparse.providers)
+        XCTAssertEqual(providers.count, 2)
+        XCTAssertNil(providers[0].id)
+        XCTAssertNil(providers[0].hasKey)
+        XCTAssertNil(providers[0].models)
+
+        let mystery = providers[1]
+        XCTAssertEqual(mystery.id, "mystery")
+        XCTAssertEqual(mystery.keySource, "keychain")
+        XCTAssertEqual(mystery.models?.count, 2)
+        XCTAssertEqual(mystery.models?[0].id, "m-1")
+        XCTAssertNil(mystery.models?[0].label)
+        XCTAssertEqual(mystery.models?[1].id, "m-2")
+        XCTAssertEqual(mystery.models?[1].label, "m-2")
+        XCTAssertEqual(mystery.modelsTotal, 7)
+    }
+
+    func testProvidersDecodingSurvivesUnexpectedProvidersShape() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let response = try decoder.decode(ProvidersResponse.self, from: Data("""
+        { "providers": "unexpected", "active_provider": 7 }
+        """.utf8))
+
+        XCTAssertNil(response.providers)
+        XCTAssertEqual(response.activeProvider, "7")
+    }
+}

--- a/HermesMobileTests/ProvidersViewModelTests.swift
+++ b/HermesMobileTests/ProvidersViewModelTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import HermesMobile
+
+final class ProvidersViewModelTests: APIClientTestCase {
+    private static let serverURL = URL(string: "https://example.test")!
+
+    @MainActor
+    func testLoadPopulatesProvidersPreservingServerOrder() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/providers")
+            return apiTestJSONResponse("""
+            {
+              "active_provider": "openai-codex",
+              "providers": [
+                { "id": "openai-codex", "display_name": "OpenAI Codex", "has_key": true },
+                { "id": "anthropic", "display_name": "Anthropic", "has_key": false },
+                { "id": "custom:glmcode", "display_name": "glmcode", "has_key": true }
+              ]
+            }
+            """, for: request)
+        }
+        let model = ProvidersViewModel(server: Self.serverURL, client: client)
+
+        await model.load()
+
+        XCTAssertNil(model.errorMessage)
+        XCTAssertFalse(model.isLoading)
+        XCTAssertEqual(model.providers.map(\.id), ["openai-codex", "anthropic", "custom:glmcode"])
+        XCTAssertEqual(model.activeProviderID, "openai-codex")
+        XCTAssertTrue(model.isActive(model.providers[0]))
+        XCTAssertFalse(model.isActive(model.providers[1]))
+    }
+
+    @MainActor
+    func testLoadFailureSetsErrorMessageAndKeepsEmptyList() async {
+        let client = makeClient { request in
+            (HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!, Data())
+        }
+        let model = ProvidersViewModel(server: Self.serverURL, client: client)
+
+        await model.load()
+
+        XCTAssertNotNil(model.errorMessage)
+        XCTAssertTrue(model.providers.isEmpty)
+        XCTAssertFalse(model.isLoading)
+    }
+
+    @MainActor
+    func testActiveProviderMatchingIsTrimmedAndCaseInsensitive() {
+        XCTAssertEqual(ProvidersViewModel.normalizedProviderID("  OpenAI-Codex \n"), "openai-codex")
+        XCTAssertNil(ProvidersViewModel.normalizedProviderID("   "))
+        XCTAssertNil(ProvidersViewModel.normalizedProviderID(nil))
+    }
+
+    func testDisplayNameFallsBackFromDisplayNameToIDToPlaceholder() {
+        XCTAssertEqual(
+            ProvidersViewModel.displayName(for: ProviderSummary(id: "openai", displayName: "OpenAI")),
+            "OpenAI"
+        )
+        XCTAssertEqual(
+            ProvidersViewModel.displayName(for: ProviderSummary(id: "openai", displayName: "  ")),
+            "openai"
+        )
+        XCTAssertEqual(
+            ProvidersViewModel.displayName(for: ProviderSummary(id: nil)),
+            String(localized: "Unknown provider")
+        )
+    }
+
+    func testKeySourceBadgeCollapsesUpstreamVocabulary() {
+        func badge(_ keySource: String?, hasKey: Bool? = true) -> String? {
+            ProvidersViewModel.keySourceBadge(
+                for: ProviderSummary(id: "p", hasKey: hasKey, keySource: keySource)
+            )
+        }
+
+        XCTAssertEqual(badge("env_file"), "env")
+        XCTAssertEqual(badge("env_var"), "env")
+        XCTAssertEqual(badge("env"), "env")
+        XCTAssertEqual(badge("oauth"), "OAuth")
+        XCTAssertEqual(badge("token"), "OAuth")
+        XCTAssertEqual(badge("config_yaml"), "config")
+        XCTAssertEqual(badge("config"), "config")
+        XCTAssertEqual(badge(" OAuth "), "OAuth")
+
+        // Unknown future sources pass through instead of being hidden.
+        XCTAssertEqual(badge("keychain"), "keychain")
+
+        // No badge without a key, or when the source is missing/none.
+        XCTAssertNil(badge("none"))
+        XCTAssertNil(badge(nil))
+        XCTAssertNil(badge("oauth", hasKey: false))
+        XCTAssertNil(badge("oauth", hasKey: nil))
+    }
+
+    func testAuthErrorTextTrimsAndDropsEmptyValues() {
+        XCTAssertEqual(
+            ProvidersViewModel.authErrorText(
+                for: ProviderSummary(id: "p", authError: "  token expired \n")
+            ),
+            "token expired"
+        )
+        XCTAssertNil(ProvidersViewModel.authErrorText(for: ProviderSummary(id: "p", authError: "   ")))
+        XCTAssertNil(ProvidersViewModel.authErrorText(for: ProviderSummary(id: "p", authError: nil)))
+    }
+
+    func testModelCountPrefersModelsTotalWhenListIsTrimmed() {
+        let trimmed = ProviderSummary(
+            id: "nous",
+            models: [ProviderModel(id: "a"), ProviderModel(id: "b")],
+            modelsTotal: 396
+        )
+        XCTAssertEqual(ProvidersViewModel.modelCount(for: trimmed), 396)
+        let info = ProvidersViewModel.truncatedModelInfo(for: trimmed)
+        XCTAssertEqual(info?.shown, 2)
+        XCTAssertEqual(info?.total, 396)
+
+        let complete = ProviderSummary(
+            id: "openai",
+            models: [ProviderModel(id: "a"), ProviderModel(id: "b")],
+            modelsTotal: 2
+        )
+        XCTAssertEqual(ProvidersViewModel.modelCount(for: complete), 2)
+        XCTAssertNil(ProvidersViewModel.truncatedModelInfo(for: complete))
+
+        // No visible models -> no truncation footer even if a total is reported.
+        let hidden = ProviderSummary(id: "p", models: [], modelsTotal: 4)
+        XCTAssertNil(ProvidersViewModel.truncatedModelInfo(for: hidden))
+
+        let bare = ProviderSummary(id: "p")
+        XCTAssertEqual(ProvidersViewModel.modelCount(for: bare), 0)
+        XCTAssertNil(ProvidersViewModel.truncatedModelInfo(for: bare))
+    }
+}

--- a/HermesMobileTests/ProvidersViewModelTests.swift
+++ b/HermesMobileTests/ProvidersViewModelTests.swift
@@ -57,6 +57,7 @@ final class ProvidersViewModelTests: APIClientTestCase {
         XCTAssertNil(ProvidersViewModel.normalizedProviderID(nil))
     }
 
+    @MainActor
     func testDisplayNameFallsBackFromDisplayNameToIDToPlaceholder() {
         XCTAssertEqual(
             ProvidersViewModel.displayName(for: ProviderSummary(id: "openai", displayName: "OpenAI")),
@@ -72,6 +73,7 @@ final class ProvidersViewModelTests: APIClientTestCase {
         )
     }
 
+    @MainActor
     func testKeySourceBadgeCollapsesUpstreamVocabulary() {
         func badge(_ keySource: String?, hasKey: Bool? = true) -> String? {
             ProvidersViewModel.keySourceBadge(
@@ -98,6 +100,7 @@ final class ProvidersViewModelTests: APIClientTestCase {
         XCTAssertNil(badge("oauth", hasKey: nil))
     }
 
+    @MainActor
     func testAuthErrorTextTrimsAndDropsEmptyValues() {
         XCTAssertEqual(
             ProvidersViewModel.authErrorText(
@@ -109,6 +112,7 @@ final class ProvidersViewModelTests: APIClientTestCase {
         XCTAssertNil(ProvidersViewModel.authErrorText(for: ProviderSummary(id: "p", authError: nil)))
     }
 
+    @MainActor
     func testModelCountPrefersModelsTotalWhenListIsTrimmed() {
         let trimmed = ProviderSummary(
             id: "nous",

--- a/HermesMobileTests/ProvidersViewModelTests.swift
+++ b/HermesMobileTests/ProvidersViewModelTests.swift
@@ -113,6 +113,13 @@ final class ProvidersViewModelTests: APIClientTestCase {
     }
 
     @MainActor
+    func testExpansionKeyPrefersStableProviderIDWithIndexFallback() {
+        XCTAssertEqual(ProvidersView.expansionKey(for: ProviderSummary(id: " openai "), at: 3), "openai")
+        XCTAssertEqual(ProvidersView.expansionKey(for: ProviderSummary(id: "   "), at: 3), "#3")
+        XCTAssertEqual(ProvidersView.expansionKey(for: ProviderSummary(id: nil), at: 0), "#0")
+    }
+
+    @MainActor
     func testModelCountPrefersModelsTotalWhenListIsTrimmed() {
         let trimmed = ProviderSummary(
             id: "nous",

--- a/HermesMobileTests/ProvidersViewModelTests.swift
+++ b/HermesMobileTests/ProvidersViewModelTests.swift
@@ -50,6 +50,42 @@ final class ProvidersViewModelTests: APIClientTestCase {
         XCTAssertFalse(model.isLoading)
     }
 
+    /// A failed pull-to-refresh must keep the cached providers *and* surface the
+    /// error — the view shows a refresh-failure banner above the stale rows.
+    @MainActor
+    func testRefreshFailureKeepsCachedProvidersAndSetsErrorMessage() async {
+        let client = makeClient { request in
+            apiTestJSONResponse("""
+            {
+              "active_provider": "anthropic",
+              "providers": [
+                { "id": "anthropic", "display_name": "Anthropic", "has_key": true }
+              ]
+            }
+            """, for: request)
+        }
+        let model = ProvidersViewModel(server: Self.serverURL, client: client)
+
+        await model.load()
+        XCTAssertEqual(model.providers.map(\.id), ["anthropic"])
+        XCTAssertNil(model.errorMessage)
+
+        MockURLProtocol.requestHandler = { request in
+            (HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!, Data())
+        }
+
+        await model.load()
+
+        XCTAssertEqual(model.providers.map(\.id), ["anthropic"], "cached providers must survive a failed refresh")
+        XCTAssertNotNil(model.errorMessage, "the failed refresh must be surfaced")
+        XCTAssertFalse(model.isLoading)
+    }
+
     @MainActor
     func testActiveProviderMatchingIsTrimmedAndCaseInsensitive() {
         XCTAssertEqual(ProvidersViewModel.normalizedProviderID("  OpenAI-Codex \n"), "openai-codex")

--- a/HermesMobileTests/ProvidersViewModelTests.swift
+++ b/HermesMobileTests/ProvidersViewModelTests.swift
@@ -86,6 +86,57 @@ final class ProvidersViewModelTests: APIClientTestCase {
         XCTAssertFalse(model.isLoading)
     }
 
+    /// `load()` has three overlapping entry points (`.task`, `.refreshable`,
+    /// "Try Again"). When two loads race and their responses land out of order,
+    /// the older response must be discarded: it may not overwrite newer provider
+    /// data or the newer load's state (#42 Codex review).
+    @MainActor
+    func testStaleOverlappingLoadDoesNotOverwriteNewerResponse() async throws {
+        let firstRequestArrived = expectation(description: "stale request arrived")
+        let secondRequestArrived = expectation(description: "fresh request arrived")
+        let requests = DeferredProvidersRequests()
+
+        DeferredProvidersMockURLProtocol.onRequest = { pendingRequest in
+            switch requests.append(pendingRequest) {
+            case 1: firstRequestArrived.fulfill()
+            case 2: secondRequestArrived.fulfill()
+            default: XCTFail("unexpected extra providers request")
+            }
+        }
+        defer { DeferredProvidersMockURLProtocol.onRequest = nil }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DeferredProvidersMockURLProtocol.self]
+        let client = APIClient(baseURL: Self.serverURL, session: URLSession(configuration: configuration))
+        let model = ProvidersViewModel(server: Self.serverURL, client: client)
+
+        let staleLoad = Task { await model.load() }
+        await fulfillment(of: [firstRequestArrived], timeout: 5)
+
+        // A newer load starts while the first request is still in flight …
+        let freshLoad = Task { await model.load() }
+        await fulfillment(of: [secondRequestArrived], timeout: 5)
+
+        // … and its response lands first.
+        requests.request(at: 1).complete(withJSON: """
+        { "active_provider": "fresh", "providers": [ { "id": "fresh" } ] }
+        """)
+        await freshLoad.value
+        XCTAssertEqual(model.providers.map(\.id), ["fresh"])
+        XCTAssertFalse(model.isLoading)
+
+        // The stale response lands afterwards — it must be discarded.
+        requests.request(at: 0).complete(withJSON: """
+        { "active_provider": "stale", "providers": [ { "id": "stale" } ] }
+        """)
+        await staleLoad.value
+
+        XCTAssertEqual(model.providers.map(\.id), ["fresh"], "a stale response must not overwrite newer data")
+        XCTAssertEqual(model.activeProviderID, "fresh")
+        XCTAssertFalse(model.isLoading)
+        XCTAssertNil(model.errorMessage)
+    }
+
     @MainActor
     func testActiveProviderMatchingIsTrimmedAndCaseInsensitive() {
         XCTAssertEqual(ProvidersViewModel.normalizedProviderID("  OpenAI-Codex \n"), "openai-codex")
@@ -182,5 +233,67 @@ final class ProvidersViewModelTests: APIClientTestCase {
         let bare = ProviderSummary(id: "p")
         XCTAssertEqual(ProvidersViewModel.modelCount(for: bare), 0)
         XCTAssertNil(ProvidersViewModel.truncatedModelInfo(for: bare))
+    }
+}
+
+/// URLProtocol whose responses are completed manually by the test, so two
+/// in-flight requests can be answered out of order (the shared
+/// `MockURLProtocol` answers synchronously inside `startLoading`, which
+/// serializes responses in request order).
+private final class DeferredProvidersMockURLProtocol: URLProtocol {
+    /// Called (on a URLSession worker thread) whenever a request starts loading.
+    static var onRequest: ((DeferredProvidersMockURLProtocol) -> Void)?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let onRequest = Self.onRequest else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        onRequest(self)
+    }
+
+    override func stopLoading() {}
+
+    func complete(withJSON json: String) {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(json.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}
+
+/// Thread-safe collector for the deferred requests above (`onRequest` fires on
+/// URLSession worker threads).
+private final class DeferredProvidersRequests: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pending: [DeferredProvidersMockURLProtocol] = []
+
+    /// Appends the request and returns its 1-based arrival order.
+    func append(_ request: DeferredProvidersMockURLProtocol) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        pending.append(request)
+        return pending.count
+    }
+
+    func request(at index: Int) -> DeferredProvidersMockURLProtocol {
+        lock.lock()
+        defer { lock.unlock() }
+        return pending[index]
     }
 }

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -86,7 +86,7 @@ sub-paths of a group. Do not reorder casually.
 | `/api/session/recovery/` | roadmap | P4 | write | Advanced Session Maintenance |
 | `/api/sessions/cleanup` | roadmap | P4 | write | Advanced Session Maintenance — bulk cleanup |
 | `/api/provider/` | roadmap | P3 | secret | Provider Management — quota/cost history |
-| `/api/providers` | roadmap | P3 | secret | Provider Management — set/delete API keys |
+| `/api/providers` | roadmap | P3 | secret | Provider Management — read-only status screen shipped (#26); key set/delete remains roadmap |
 | `/api/models/refresh` | roadmap | P3 | — | Provider / Model Management |
 | `/api/models/live` | roadmap | P3 | — | Provider / Model Management — live model fetch |
 | `/api/model/` | roadmap | P3 | — | Provider / Model Management |


### PR DESCRIPTION
## Summary
- Replaces the dead `ProvidersResponse` stub (`[JSONValue]?`) with real tolerant models: `ProviderSummary` + `ProviderModel` (every field optional; model entries decode from `{id,label}` objects **or** bare strings; `custom_providers`-derived entries that omit `is_oauth`/`auth_error`/`is_self_hosted`/`base_url`/`is_plugin_provider` decode fine).
- Wires up the previously-uncalled `APIClient.providers()` behind a new **read-only** Providers status screen: Settings → Active Server → Providers.
- Each provider row shows: display name, **Active** pill (matched against `active_provider`, trimmed + case-insensitive), key status (✓ Key configured / No key), a key-source badge (`env_file`/`env_var`→env, `oauth`/`token`→OAuth, `config_yaml`/`config`→config, unknown values pass through verbatim), a prominent red `auth_error` line, and an expandable model list with a "Showing X of Y models" footer when the server trims the catalog (`models_total` > `models.count`).
- Loading / error (+ Try Again) / empty states follow the existing Settings-panel pattern (ArchivedSessionsView).
- No write affordances anywhere — key set/delete stays a server-side operation per the issue's scope decision.
- New strings localized in all 17 shipped languages; `LocalizationCatalogTests` still passes.
- Feature-gap index row for `/api/providers` updated: read status shipped; key set/delete remains roadmap.

Fixes #26

## Plan (E1, pre-approved for this unattended run)
1. Tolerant `ProviderSummary`/`ProviderModel` models replacing the stub in `ServerCatalog.swift`.
2. `ProvidersViewModel` (+ pure presentation helpers) and `ProvidersView` under `Features/Settings/`.
3. `SettingsView` NavigationLink in the Active Server card.
4. Localization for new strings (17 languages).
5. Feature-gap-index note update.
6. Tests: decode contract + view-model presentation logic.

## API shape validation (hard rule #1)
- Field set re-validated just-in-time against the pinned upstream `api/providers.py::get_providers()` @ `312d3fab`: standard entries emit `id`, `display_name`, `has_key`, `configurable`, `is_self_hosted`, `base_url`, `is_plugin_provider`, `is_oauth`, `key_source`, `auth_error`, `models` (`{id,label}`), `models_total`; **custom** entries (from `config.yaml custom_providers`) emit only `id`, `display_name`, `has_key`, `configurable`, `is_custom`, `key_source`, `models`, `models_total`. `key_source` vocabulary: `env_file`, `env_var`, `config_yaml`, `oauth`, `none` + fallback-probe values `env`, `config`, `token`. Response envelope: `{ "providers": [...], "active_provider": ... }`, server-sorted active-first.
- Matches the issue's live-server capture from 2026-07-02 (docs: https://get-hermes.ai/api-docs/reference/models-providers/).

## Validation
- `xcodebuild build` (scheme HermesMobile, iPhone 17 sim) — succeeded.
- Full `xcodebuild test` suite on the final head commit — **TEST SUCCEEDED**.
- `git diff --check` clean.

## Owner manual checks
- Settings → Active Server → Providers: list shows your server's providers; the active provider (openai-codex) carries the green Active pill and OAuth badge.
- A provider with a broken credential shows its `auth_error` text in red.
- Tap "Models (N)" to expand a provider's model list; a trimmed catalog (e.g. large Nous account) shows "Showing X of Y models".
- Pull to refresh reloads; airplane mode shows the error state with Try Again.
- Confirm there is no way to edit or delete keys anywhere on the screen.
- Spot-check one non-English language (e.g. German) for the new strings.
