### PR TITLE
Cron: delivery-options picker (replace free-text deliver) + provider field

### DIFF
--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -115,7 +115,8 @@ struct TaskDetailView: View {
                 draft: CronJobEditorDraft(job: viewModel.job),
                 saveTitle: String(localized: "Save"),
                 isSaving: viewModel.isMutating,
-                errorMessage: viewModel.actionErrorMessage
+                errorMessage: viewModel.actionErrorMessage,
+                deliveryOptions: viewModel.deliveryOptions
             ) { draft in
                 let didUpdate = await viewModel.update(from: draft)
                 handleActionResult(didUpdate)
@@ -208,6 +209,10 @@ struct TaskDetailView: View {
 
             if let model = viewModel.job.model, !model.isEmpty {
                 CronJobMetadataRow(title: String(localized: "Model"), value: model)
+            }
+
+            if let provider = viewModel.job.provider, !provider.isEmpty {
+                CronJobMetadataRow(title: String(localized: "Provider"), value: provider)
             }
 
             if let profile = viewModel.job.profile, !profile.isEmpty {

--- a/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
@@ -8,6 +8,9 @@ final class TaskDetailViewModel {
     private(set) var runningElapsed: Double?
 
     private(set) var outputs: [CronOutputItem] = []
+    /// Server-provided deliver targets; `nil` while unknown or when the
+    /// endpoint is unavailable (the editor then falls back to free text).
+    private(set) var deliveryOptions: [CronDeliveryOption]?
     private(set) var isLoading = false
     private(set) var isMutating = false
     private(set) var errorMessage: String?
@@ -34,6 +37,10 @@ final class TaskDetailViewModel {
         lastError = nil
         defer { isLoading = false }
 
+        // Optional endpoint: failure must not break the detail view, and a
+        // nil result keeps the editor's free-text deliver fallback.
+        async let deliveryOptionsResponse = try? client.cronDeliveryOptions()
+
         do {
             let response = try await client.cronOutput(jobID: jobID, limit: 5)
             outputs = response.outputs ?? []
@@ -41,6 +48,8 @@ final class TaskDetailViewModel {
             lastError = error
             errorMessage = error.localizedDescription
         }
+
+        deliveryOptions = await deliveryOptionsResponse?.platforms
     }
 
     func clearActionError() {
@@ -88,6 +97,7 @@ final class TaskDetailViewModel {
                 deliver: draft.deliver.trimmingCharacters(in: .whitespacesAndNewlines),
                 skills: draft.skills,
                 model: draft.model.trimmingCharacters(in: .whitespacesAndNewlines),
+                provider: draft.provider.trimmingCharacters(in: .whitespacesAndNewlines),
                 profile: draft.profile.trimmingCharacters(in: .whitespacesAndNewlines),
                 toastNotifications: draft.toastNotifications
             )

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -44,7 +44,8 @@ struct TasksView: View {
                     draft: CronJobEditorDraft(),
                     saveTitle: String(localized: "Create"),
                     isSaving: viewModel.isMutating,
-                    errorMessage: viewModel.actionErrorMessage
+                    errorMessage: viewModel.actionErrorMessage,
+                    deliveryOptions: viewModel.deliveryOptions
                 ) { draft in
                     let didCreate = await viewModel.create(from: draft)
                     if let lastError = viewModel.lastError {
@@ -183,6 +184,10 @@ private struct CronJobRowView: View {
                     CronJobMetadataRow(title: String(localized: "Model"), value: model)
                 }
 
+                if let provider = job.provider, !provider.isEmpty {
+                    CronJobMetadataRow(title: String(localized: "Provider"), value: provider)
+                }
+
                 if let profile = job.profile, !profile.isEmpty {
                     CronJobMetadataRow(title: String(localized: "Profile"), value: profile)
                 }
@@ -240,12 +245,18 @@ struct CronJobEditorSheet: View {
     @State private var draft: CronJobEditorDraft
     @Environment(\.dismiss) private var dismiss
 
+    /// Picker rows built once from the draft's initial deliver value, so an
+    /// unknown/legacy value keeps its custom row even after the user selects
+    /// another option. `nil` means fall back to free-text entry.
+    private let deliverPickerOptions: [CronDeliverPickerOption]?
+
     init(
         title: String,
         draft: CronJobEditorDraft,
         saveTitle: String,
         isSaving: Bool,
         errorMessage: String?,
+        deliveryOptions: [CronDeliveryOption]? = nil,
         onSave: @escaping (CronJobEditorDraft) async -> Bool
     ) {
         self.title = title
@@ -253,6 +264,10 @@ struct CronJobEditorSheet: View {
         self.isSaving = isSaving
         self.errorMessage = errorMessage
         self.onSave = onSave
+        self.deliverPickerOptions = CronDeliverPicker.options(
+            serverOptions: deliveryOptions,
+            currentValue: draft.deliver
+        )
         _draft = State(initialValue: draft)
     }
 
@@ -271,9 +286,24 @@ struct CronJobEditorSheet: View {
                 }
 
                 Section("Delivery") {
-                    TextField("Deliver", text: $draft.deliver)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
+                    if let deliverPickerOptions {
+                        Picker("Deliver", selection: $draft.deliver) {
+                            ForEach(deliverPickerOptions) { option in
+                                Group {
+                                    if option.isCustom {
+                                        Text("\(option.label) (custom)")
+                                    } else {
+                                        Text(option.label)
+                                    }
+                                }
+                                .tag(option.value)
+                            }
+                        }
+                    } else {
+                        TextField("Deliver", text: $draft.deliver)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    }
 
                     Toggle("Toast Notifications", isOn: $draft.toastNotifications)
                 }
@@ -285,6 +315,10 @@ struct CronJobEditorSheet: View {
                         .autocorrectionDisabled()
 
                     TextField("Model", text: $draft.model)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    TextField("Provider", text: $draft.provider)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
 

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -245,10 +245,25 @@ struct CronJobEditorSheet: View {
     @State private var draft: CronJobEditorDraft
     @Environment(\.dismiss) private var dismiss
 
-    /// Picker rows built once from the draft's initial deliver value, so an
+    /// Server-provided deliver targets. A plain `let` so a re-init while the
+    /// sheet is presented (options finishing their async load) swaps in the
+    /// fresh list, unlike `@State draft`, which keeps the user's edits.
+    private let serverDeliveryOptions: [CronDeliveryOption]?
+    /// The draft's deliver value when the editor opened; stable across
+    /// re-inits because callers rebuild the same draft.
+    private let initialDeliver: String
+
+    /// Picker rows recomputed from the live draft so a value typed while the
+    /// options were still loading keeps a matching row, and the initial
     /// unknown/legacy value keeps its custom row even after the user selects
     /// another option. `nil` means fall back to free-text entry.
-    private let deliverPickerOptions: [CronDeliverPickerOption]?
+    private var deliverPickerOptions: [CronDeliverPickerOption]? {
+        CronDeliverPicker.options(
+            serverOptions: serverDeliveryOptions,
+            currentValue: draft.deliver,
+            initialValue: initialDeliver
+        )
+    }
 
     init(
         title: String,
@@ -264,10 +279,8 @@ struct CronJobEditorSheet: View {
         self.isSaving = isSaving
         self.errorMessage = errorMessage
         self.onSave = onSave
-        self.deliverPickerOptions = CronDeliverPicker.options(
-            serverOptions: deliveryOptions,
-            currentValue: draft.deliver
-        )
+        self.serverDeliveryOptions = deliveryOptions
+        self.initialDeliver = draft.deliver
         _draft = State(initialValue: draft)
     }
 

--- a/HermesMobile/Features/Tasks/TasksViewModel.swift
+++ b/HermesMobile/Features/Tasks/TasksViewModel.swift
@@ -11,6 +11,9 @@ enum CronJobListMutation: Equatable {
 final class TasksViewModel {
     private(set) var jobs: [CronJob] = []
     private(set) var runningJobs: [String: Double] = [:]
+    /// Server-provided deliver targets; `nil` while unknown or when the
+    /// endpoint is unavailable (the editor then falls back to free text).
+    private(set) var deliveryOptions: [CronDeliveryOption]?
     private(set) var isLoading = false
     private(set) var isMutating = false
     private(set) var errorMessage: String?
@@ -32,10 +35,14 @@ final class TasksViewModel {
         do {
             async let jobsResponse = client.crons()
             async let statusResponse = client.cronStatus()
+            // Optional endpoint: failure must not break the task list, and a
+            // nil result keeps the editor's free-text deliver fallback.
+            async let deliveryOptionsResponse = try? client.cronDeliveryOptions()
 
             let (jobsResult, statusResult) = try await (jobsResponse, statusResponse)
             runningJobs = statusResult.runningJobs ?? [:]
             jobs = (jobsResult.jobs ?? []).sorted(by: sortJobs)
+            deliveryOptions = await deliveryOptionsResponse?.platforms
         } catch {
             lastError = error
             errorMessage = error.localizedDescription
@@ -70,6 +77,7 @@ final class TasksViewModel {
                 deliver: draft.trimmedDeliver,
                 skills: draft.skills,
                 model: draft.trimmedModel,
+                provider: draft.trimmedProvider,
                 profile: draft.trimmedProfile,
                 toastNotifications: draft.toastNotifications
             )

--- a/HermesMobile/Models/Cron.swift
+++ b/HermesMobile/Models/Cron.swift
@@ -56,6 +56,7 @@ struct CronJob: Decodable, Equatable, Identifiable {
     let deliver: String?
     let skills: [String]?
     let model: String?
+    let provider: String?
     let profile: String?
     let toastNotifications: Bool?
 
@@ -77,6 +78,7 @@ struct CronJob: Decodable, Equatable, Identifiable {
         case deliver
         case skills
         case model
+        case provider
         case profile
         case toastNotifications
     }
@@ -100,6 +102,7 @@ struct CronJob: Decodable, Equatable, Identifiable {
         deliver = container.decodeLossyStringIfPresent(forKey: .deliver)
         skills = (try? container.decodeIfPresent([String].self, forKey: .skills)) ?? nil
         model = container.decodeLossyStringIfPresent(forKey: .model)
+        provider = container.decodeLossyStringIfPresent(forKey: .provider)
         profile = container.decodeLossyStringIfPresent(forKey: .profile)
         toastNotifications = container.decodeLossyBoolIfPresent(forKey: .toastNotifications)
     }
@@ -237,6 +240,102 @@ struct CronOutputItem: Decodable, Equatable, Identifiable {
     }
 }
 
+struct CronDeliveryOptionsResponse: Decodable, Equatable {
+    let platforms: [CronDeliveryOption]?
+
+    enum CodingKeys: String, CodingKey {
+        case platforms
+    }
+
+    init(platforms: [CronDeliveryOption]?) {
+        self.platforms = platforms
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        platforms = (try? container.decodeIfPresent([CronDeliveryOption].self, forKey: .platforms)) ?? nil
+    }
+}
+
+struct CronDeliveryOption: Decodable, Equatable, Identifiable {
+    var id: String { value ?? label ?? UUID().uuidString }
+
+    let value: String?
+    let label: String?
+
+    enum CodingKeys: String, CodingKey {
+        case value
+        case label
+    }
+
+    init(value: String?, label: String?) {
+        self.value = value
+        self.label = label
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        value = container.decodeLossyStringIfPresent(forKey: .value)
+        label = container.decodeLossyStringIfPresent(forKey: .label)
+    }
+}
+
+/// One selectable row in the cron deliver picker.
+struct CronDeliverPickerOption: Equatable, Identifiable {
+    let value: String
+    let label: String
+    /// `true` when the row exists only to round-trip a draft value that the
+    /// server did not list (unknown/legacy deliver target).
+    let isCustom: Bool
+
+    var id: String { value }
+}
+
+enum CronDeliverPicker {
+    /// Builds picker rows from server-provided delivery options.
+    ///
+    /// Returns `nil` when the picker should fall back to free-text entry:
+    /// options missing/empty (endpoint failed or returned nothing usable) or
+    /// the current draft value is blank (nothing safe to select).
+    /// A current value outside the server list is preserved as an extra
+    /// custom row instead of being clobbered.
+    static func options(
+        serverOptions: [CronDeliveryOption]?,
+        currentValue: String
+    ) -> [CronDeliverPickerOption]? {
+        var seenValues = Set<String>()
+        let valid: [CronDeliverPickerOption] = (serverOptions ?? []).compactMap { option in
+            guard let value = option.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !value.isEmpty,
+                  seenValues.insert(value).inserted else {
+                return nil
+            }
+
+            let label = option.label?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return CronDeliverPickerOption(
+                value: value,
+                label: (label?.isEmpty == false ? label : nil) ?? value,
+                isCustom: false
+            )
+        }
+
+        guard !valid.isEmpty else {
+            return nil
+        }
+
+        let current = currentValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !current.isEmpty else {
+            return nil
+        }
+
+        var options = valid
+        if !valid.contains(where: { $0.value == current }) {
+            options.append(CronDeliverPickerOption(value: current, label: current, isCustom: true))
+        }
+        return options
+    }
+}
+
 enum CronJobStatus: Equatable {
     case active
     case paused
@@ -267,6 +366,7 @@ struct CronJobEditorDraft: Equatable {
     var deliver: String
     var skillsText: String
     var model: String
+    var provider: String
     var profile: String
     var toastNotifications: Bool
 
@@ -277,6 +377,7 @@ struct CronJobEditorDraft: Equatable {
         deliver: String = "local",
         skillsText: String = "",
         model: String = "",
+        provider: String = "",
         profile: String = "",
         toastNotifications: Bool = true
     ) {
@@ -286,6 +387,7 @@ struct CronJobEditorDraft: Equatable {
         self.deliver = deliver
         self.skillsText = skillsText
         self.model = model
+        self.provider = provider
         self.profile = profile
         self.toastNotifications = toastNotifications
     }
@@ -298,6 +400,7 @@ struct CronJobEditorDraft: Equatable {
             deliver: job.deliver ?? "local",
             skillsText: job.skills?.joined(separator: ", ") ?? "",
             model: job.model ?? "",
+            provider: job.provider ?? "",
             profile: job.profile ?? "",
             toastNotifications: job.toastNotifications ?? true
         )
@@ -321,6 +424,10 @@ struct CronJobEditorDraft: Equatable {
 
     var trimmedModel: String? {
         Self.nonEmpty(model)
+    }
+
+    var trimmedProvider: String? {
+        Self.nonEmpty(provider)
     }
 
     var trimmedProfile: String? {

--- a/HermesMobile/Models/Cron.swift
+++ b/HermesMobile/Models/Cron.swift
@@ -298,10 +298,13 @@ enum CronDeliverPicker {
     /// options missing/empty (endpoint failed or returned nothing usable) or
     /// the current draft value is blank (nothing safe to select).
     /// A current value outside the server list is preserved as an extra
-    /// custom row instead of being clobbered.
+    /// custom row instead of being clobbered. `initialValue` (the draft's
+    /// deliver value when the editor opened) also keeps its custom row so an
+    /// unknown/legacy value can be re-selected after choosing another option.
     static func options(
         serverOptions: [CronDeliveryOption]?,
-        currentValue: String
+        currentValue: String,
+        initialValue: String? = nil
     ) -> [CronDeliverPickerOption]? {
         var seenValues = Set<String>()
         let valid: [CronDeliverPickerOption] = (serverOptions ?? []).compactMap { option in
@@ -329,7 +332,12 @@ enum CronDeliverPicker {
         }
 
         var options = valid
-        if !valid.contains(where: { $0.value == current }) {
+        var knownValues = Set(valid.map(\.value))
+        let initial = initialValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !initial.isEmpty, knownValues.insert(initial).inserted {
+            options.append(CronDeliverPickerOption(value: initial, label: initial, isCustom: true))
+        }
+        if knownValues.insert(current).inserted {
             options.append(CronDeliverPickerOption(value: current, label: current, isCustom: true))
         }
         return options

--- a/HermesMobile/Networking/APIClient+Cron.swift
+++ b/HermesMobile/Networking/APIClient+Cron.swift
@@ -12,6 +12,7 @@ extension APIClient {
         deliver: String?,
         skills: [String],
         model: String?,
+        provider: String?,
         profile: String?,
         toastNotifications: Bool
     ) async throws -> CronMutationResponse {
@@ -25,6 +26,7 @@ extension APIClient {
                 deliver: deliver,
                 skills: skills,
                 model: model,
+                provider: provider,
                 profile: profile,
                 toastNotifications: toastNotifications
             )
@@ -39,6 +41,7 @@ extension APIClient {
         deliver: String?,
         skills: [String]?,
         model: String?,
+        provider: String?,
         profile: String?,
         toastNotifications: Bool?
     ) async throws -> CronMutationResponse {
@@ -53,10 +56,15 @@ extension APIClient {
                 deliver: deliver,
                 skills: skills,
                 model: model,
+                provider: provider,
                 profile: profile,
                 toastNotifications: toastNotifications
             )
         )
+    }
+
+    func cronDeliveryOptions() async throws -> CronDeliveryOptionsResponse {
+        try await send(endpoint: .cronDeliveryOptions, method: "GET")
     }
 
     func deleteCron(jobID: String) async throws -> CronMutationResponse {
@@ -107,6 +115,7 @@ private struct CronCreateRequest: Encodable {
     let deliver: String?
     let skills: [String]
     let model: String?
+    let provider: String?
     let profile: String?
     let toastNotifications: Bool
 }
@@ -119,6 +128,7 @@ private struct CronUpdateRequest: Encodable {
     let deliver: String?
     let skills: [String]?
     let model: String?
+    let provider: String?
     let profile: String?
     let toastNotifications: Bool?
 }

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -87,6 +87,7 @@ enum Endpoint {
     case cronResume
     case cronStatus(jobID: String?)
     case cronOutput(jobID: String, limit: Int?)
+    case cronDeliveryOptions
     case memory
     case memoryWrite
     case skills
@@ -269,6 +270,8 @@ enum Endpoint {
             return "/api/crons/status"
         case .cronOutput:
             return "/api/crons/output"
+        case .cronDeliveryOptions:
+            return "/api/crons/delivery-options"
         case .memory:
             return "/api/memory"
         case .memoryWrite:

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -2975,6 +2975,112 @@
         }
       }
     },
+    "%@ (custom)" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (مخصص)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (benutzerdefiniert)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (personalizado)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (personnalisé)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (מותאם אישית)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (personalizzato)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@（カスタム）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (사용자 지정)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (aangepast)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (niestandardowe)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (personalizado)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (пользовательское)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (özel)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ (حسبِ ضرورت)"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@（自訂）"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@（自定义）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@（自訂）"
+          }
+        }
+      }
+    },
     "%@ header logo color" : {
       "localizations" : {
         "ar" : {
@@ -54272,6 +54378,112 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "提示詞為必填項目。"
+          }
+        }
+      }
+    },
+    "Provider" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "المزوّد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anbieter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Proveedor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fournisseur"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ספק"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プロバイダ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "제공자"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dostawca"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provedor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Провайдер"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sağlayıcı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فراہم کنندہ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "供應商"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "供應商"
           }
         }
       }

--- a/HermesMobileTests/APIClientCronEndpointTests.swift
+++ b/HermesMobileTests/APIClientCronEndpointTests.swift
@@ -163,6 +163,7 @@ final class APIClientCronEndpointTests: APIClientTestCase {
             XCTAssertEqual(body?["deliver"] as? String, "local")
             XCTAssertEqual(body?["skills"] as? [String], ["summarize", "notify"])
             XCTAssertEqual(body?["model"] as? String, "@openai:gpt-5.5")
+            XCTAssertNil(body?["provider"], "Omitted provider must not be sent so the server default applies.")
             XCTAssertEqual(body?["profile"] as? String, "work")
             XCTAssertEqual(body?["toast_notifications"] as? Bool, true)
 
@@ -191,6 +192,7 @@ final class APIClientCronEndpointTests: APIClientTestCase {
             deliver: "local",
             skills: ["summarize", "notify"],
             model: "@openai:gpt-5.5",
+            provider: nil,
             profile: "work",
             toastNotifications: true
         )
@@ -216,6 +218,7 @@ final class APIClientCronEndpointTests: APIClientTestCase {
             XCTAssertEqual(body?["deliver"] as? String, "local")
             XCTAssertEqual(body?["skills"] as? [String], ["swift"])
             XCTAssertEqual(body?["model"] as? String, "@anthropic:claude")
+            XCTAssertEqual(body?["provider"] as? String, "anthropic")
             XCTAssertEqual(body?["profile"] as? String, "personal")
             XCTAssertEqual(body?["toast_notifications"] as? Bool, false)
 
@@ -230,6 +233,7 @@ final class APIClientCronEndpointTests: APIClientTestCase {
                 "enabled": true,
                 "state": "scheduled",
                 "model": "@anthropic:claude",
+                "provider": "anthropic",
                 "profile": "personal",
                 "toast_notifications": false
               }
@@ -245,6 +249,7 @@ final class APIClientCronEndpointTests: APIClientTestCase {
             deliver: "local",
             skills: ["swift"],
             model: "@anthropic:claude",
+            provider: "anthropic",
             profile: "personal",
             toastNotifications: false
         )
@@ -253,7 +258,81 @@ final class APIClientCronEndpointTests: APIClientTestCase {
         XCTAssertEqual(response.job?.displayName, "Updated digest")
         XCTAssertEqual(response.job?.scheduleText, "0 8 * * *")
         XCTAssertEqual(response.job?.model, "@anthropic:claude")
+        XCTAssertEqual(response.job?.provider, "anthropic")
         XCTAssertEqual(response.job?.toastNotifications, false)
+    }
+
+    func testCronCreateSendsProviderWhenSet() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/crons/create")
+
+            let data = try XCTUnwrap(apiTestBodyData(from: request))
+            let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertEqual(body?["provider"] as? String, "openai")
+
+            return apiTestJSONResponse("""
+            {
+              "ok": true,
+              "job": {
+                "id": "job-provider",
+                "prompt": "Run it",
+                "schedule": "0 7 * * *",
+                "provider": "openai"
+              }
+            }
+            """, for: request)
+        }
+
+        let response = try await client.createCron(
+            prompt: "Run it",
+            schedule: "0 7 * * *",
+            name: nil,
+            deliver: nil,
+            skills: [],
+            model: nil,
+            provider: "openai",
+            profile: nil,
+            toastNotifications: true
+        )
+
+        XCTAssertEqual(response.job?.provider, "openai")
+    }
+
+    func testCronDeliveryOptionsBuildsExpectedPathAndDecodesTolerantly() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/crons/delivery-options")
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertNil(request.url?.query)
+
+            return apiTestJSONResponse("""
+            {
+              "platforms": [
+                {"value": "local", "label": "Local (save output only)"},
+                {"value": "origin", "label": "Origin (reply to creator)"},
+                {"value": "slack", "label": "Slack", "unexpected_field": {"nested": true}},
+                {"value": "telegram"}
+              ],
+              "ignored_new_field": 7
+            }
+            """, for: request)
+        }
+
+        let response = try await client.cronDeliveryOptions()
+        let platforms = try XCTUnwrap(response.platforms)
+
+        XCTAssertEqual(platforms.map(\.value), ["local", "origin", "slack", "telegram"])
+        XCTAssertEqual(platforms.first?.label, "Local (save output only)")
+        XCTAssertNil(platforms.last?.label)
+    }
+
+    func testCronDeliveryOptionsToleratesUnexpectedPlatformsShape() async throws {
+        let client = makeClient { request in
+            apiTestJSONResponse(#"{"platforms": "unexpected"}"#, for: request)
+        }
+
+        let response = try await client.cronDeliveryOptions()
+
+        XCTAssertNil(response.platforms)
     }
 
     func testCronJobIDMutationsBuildExpectedPathsAndBodies() async throws {

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -213,6 +213,12 @@ final class ContractReadinessTests: XCTestCase {
                 path: "/api/crons/output",
                 query: ["job_id": "job-123", "limit": "5"]
             ),
+            .init(
+                name: "cron delivery options",
+                method: "GET",
+                endpoint: .cronDeliveryOptions,
+                path: "/api/crons/delivery-options"
+            ),
             .init(name: "memory", method: "GET", endpoint: .memory, path: "/api/memory"),
             .init(name: "memory write", method: "POST", endpoint: .memoryWrite, path: "/api/memory/write"),
             .init(name: "skills", method: "GET", endpoint: .skills, path: "/api/skills"),

--- a/HermesMobileTests/CronManagementTests.swift
+++ b/HermesMobileTests/CronManagementTests.swift
@@ -130,6 +130,59 @@ final class CronManagementModelTests: XCTestCase {
         XCTAssertFalse(knownValue.contains(where: \.isCustom))
     }
 
+    func testCronDeliverPickerPreservesInitialAndLiveCustomValues() throws {
+        let serverOptions = [
+            CronDeliveryOption(value: "local", label: "Local"),
+            CronDeliveryOption(value: "telegram", label: "Telegram")
+        ]
+
+        // The editor's initial legacy value keeps its custom row even after
+        // the user selects a server option (currentValue moved on).
+        let afterSelection = try XCTUnwrap(
+            CronDeliverPicker.options(
+                serverOptions: serverOptions,
+                currentValue: "telegram",
+                initialValue: "legacy-target"
+            )
+        )
+        XCTAssertEqual(afterSelection.map(\.value), ["local", "telegram", "legacy-target"])
+        XCTAssertEqual(afterSelection.map(\.isCustom), [false, false, true])
+
+        // A value typed into the free-text fallback while options were still
+        // loading gets its own row alongside the initial value's row, so the
+        // picker selection always has a matching tag.
+        let typedWhileLoading = try XCTUnwrap(
+            CronDeliverPicker.options(
+                serverOptions: serverOptions,
+                currentValue: "typed-target",
+                initialValue: "local"
+            )
+        )
+        XCTAssertEqual(typedWhileLoading.map(\.value), ["local", "telegram", "typed-target"])
+        XCTAssertEqual(typedWhileLoading.map(\.isCustom), [false, false, true])
+
+        // Identical initial and current custom values collapse to one row.
+        let sameCustom = try XCTUnwrap(
+            CronDeliverPicker.options(
+                serverOptions: serverOptions,
+                currentValue: "legacy-target",
+                initialValue: "legacy-target"
+            )
+        )
+        XCTAssertEqual(sameCustom.map(\.value), ["local", "telegram", "legacy-target"])
+        XCTAssertEqual(sameCustom.filter(\.isCustom).count, 1)
+
+        // A blank initial value adds no row.
+        let blankInitial = try XCTUnwrap(
+            CronDeliverPicker.options(
+                serverOptions: serverOptions,
+                currentValue: "local",
+                initialValue: "   "
+            )
+        )
+        XCTAssertEqual(blankInitial.map(\.value), ["local", "telegram"])
+    }
+
     func testCronJobEditorDraftRequiresPromptAndSchedule() {
         XCTAssertEqual(
             CronJobEditorDraft(prompt: "", schedule: "0 7 * * *").validationMessage,

--- a/HermesMobileTests/CronManagementTests.swift
+++ b/HermesMobileTests/CronManagementTests.swift
@@ -49,6 +49,7 @@ final class CronManagementModelTests: XCTestCase {
             deliver: "  local  ",
             skillsText: "summarize, notify\nswift",
             model: "  @openai:gpt-5.5  ",
+            provider: "  openai  ",
             profile: "  work  ",
             toastNotifications: true
         )
@@ -59,8 +60,74 @@ final class CronManagementModelTests: XCTestCase {
         XCTAssertEqual(draft.trimmedDeliver, "local")
         XCTAssertEqual(draft.skills, ["summarize", "notify", "swift"])
         XCTAssertEqual(draft.trimmedModel, "@openai:gpt-5.5")
+        XCTAssertEqual(draft.trimmedProvider, "openai")
         XCTAssertEqual(draft.trimmedProfile, "work")
         XCTAssertNil(draft.validationMessage)
+    }
+
+    func testCronJobEditorDraftRoundTripsUnknownDeliverAndProvider() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let job = try decoder.decode(
+            CronJob.self,
+            from: Data("""
+            {
+              "id": "job-legacy",
+              "prompt": "Run it",
+              "schedule": "0 7 * * *",
+              "deliver": "legacy-target",
+              "provider": "openai"
+            }
+            """.utf8)
+        )
+
+        let draft = CronJobEditorDraft(job: job)
+
+        XCTAssertEqual(draft.deliver, "legacy-target")
+        XCTAssertEqual(draft.trimmedDeliver, "legacy-target")
+        XCTAssertEqual(draft.provider, "openai")
+    }
+
+    func testCronDeliverPickerFallsBackWithoutUsableOptions() {
+        XCTAssertNil(CronDeliverPicker.options(serverOptions: nil, currentValue: "local"))
+        XCTAssertNil(CronDeliverPicker.options(serverOptions: [], currentValue: "local"))
+        XCTAssertNil(
+            CronDeliverPicker.options(
+                serverOptions: [CronDeliveryOption(value: "  ", label: "Blank"), CronDeliveryOption(value: nil, label: "No value")],
+                currentValue: "local"
+            )
+        )
+        XCTAssertNil(
+            CronDeliverPicker.options(
+                serverOptions: [CronDeliveryOption(value: "local", label: "Local")],
+                currentValue: "   "
+            ),
+            "A blank draft value has nothing safe to select, so free text is kept."
+        )
+    }
+
+    func testCronDeliverPickerKeepsUnknownValueAsCustomRow() throws {
+        let serverOptions = [
+            CronDeliveryOption(value: "local", label: "Local (save output only)"),
+            CronDeliveryOption(value: "origin", label: "Origin (reply to creator)"),
+            CronDeliveryOption(value: "origin", label: "Duplicate ignored"),
+            CronDeliveryOption(value: "telegram", label: nil)
+        ]
+
+        let options = try XCTUnwrap(
+            CronDeliverPicker.options(serverOptions: serverOptions, currentValue: "legacy-target")
+        )
+
+        XCTAssertEqual(options.map(\.value), ["local", "origin", "telegram", "legacy-target"])
+        XCTAssertEqual(options.map(\.isCustom), [false, false, false, true])
+        XCTAssertEqual(options.first?.label, "Local (save output only)")
+        XCTAssertEqual(options[2].label, "telegram", "Missing labels fall back to the raw value.")
+
+        let knownValue = try XCTUnwrap(
+            CronDeliverPicker.options(serverOptions: serverOptions, currentValue: "origin")
+        )
+        XCTAssertEqual(knownValue.map(\.value), ["local", "origin", "telegram"])
+        XCTAssertFalse(knownValue.contains(where: \.isCustom))
     }
 
     func testCronJobEditorDraftRequiresPromptAndSchedule() {
@@ -113,6 +180,63 @@ final class CronManagementViewModelTests: XCTestCase {
         XCTAssertTrue(didCreate)
         XCTAssertEqual(viewModel.jobs.map(\.jobId), ["job-created"])
         XCTAssertNil(viewModel.actionErrorMessage)
+    }
+
+    @MainActor
+    func testTasksViewModelLoadPopulatesDeliveryOptions() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons":
+                return apiTestJSONResponse(#"{"jobs": []}"#, for: request)
+            case "/api/crons/status":
+                return apiTestJSONResponse(#"{"running": {}}"#, for: request)
+            case "/api/crons/delivery-options":
+                return apiTestJSONResponse(
+                    #"{"platforms": [{"value": "local", "label": "Local (save output only)"}]}"#,
+                    for: request
+                )
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TasksViewModel(server: try XCTUnwrap(URL(string: "https://example.test")), client: client)
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.deliveryOptions?.count, 1)
+        XCTAssertEqual(viewModel.deliveryOptions?.first?.value, "local")
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testTasksViewModelLoadToleratesDeliveryOptionsFailure() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons":
+                return apiTestJSONResponse(#"{"jobs": [{"id": "job123", "name": "Digest"}]}"#, for: request)
+            case "/api/crons/status":
+                return apiTestJSONResponse(#"{"running": {}}"#, for: request)
+            case "/api/crons/delivery-options":
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (response, Data(#"{"error": "not found"}"#.utf8))
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TasksViewModel(server: try XCTUnwrap(URL(string: "https://example.test")), client: client)
+
+        await viewModel.load()
+
+        XCTAssertNil(viewModel.deliveryOptions, "Endpoint failure must fall back to free-text deliver entry.")
+        XCTAssertEqual(viewModel.jobs.map(\.jobId), ["job123"], "Jobs must still load when delivery options fail.")
+        XCTAssertNil(viewModel.errorMessage)
     }
 
     @MainActor

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -71,7 +71,6 @@ sub-paths of a group. Do not reorder casually.
 | `/api/git/` | roadmap | P3 | write | Git review & management — branches/diff/commit/stage/push/pull/discard/stash |
 | `/api/rollback/` | roadmap | P3 | write | Git Info & Rollback — checkpoint list/diff/restore |
 | `/api/crons/history` | roadmap | P2 | read | Cron History / Recent Runs |
-| `/api/crons/delivery-options` | roadmap | P2 | read | Cron History / Recent Runs |
 | `/api/session/usage` | roadmap | P2 | read | Session Token Usage — mostly covered by the context ring |
 | `/api/session/clear` | roadmap | P2 | write | Session Clear — destructive; needs confirmation |
 | `/api/session/export` | roadmap | P4 | — | Session Export / Share — owner-deferred |


### PR DESCRIPTION
Fixes #23

## Plan (E1, owner pre-approved for this unattended run)

1. `Endpoints.swift` + `APIClient+Cron.swift`: add `cronDeliveryOptions` (GET `/api/crons/delivery-options`), decoded tolerantly as `{platforms: [{value, label}]}`; add `provider` to the cron create/update request bodies.
2. `Cron.swift`: optional `provider` on `CronJob` and the editor draft; tolerant `CronDeliveryOption` model; pure `CronDeliverPicker.options` helper that decides picker vs free-text fallback and preserves unknown/legacy deliver values as an extra custom row.
3. View models: load delivery options tolerantly (any failure leaves them `nil`, which keeps the free-text fallback); thread `provider` through create/update.
4. `CronJobEditorSheet`: deliver picker when options exist, free-text field otherwise; new Provider text field; Provider metadata row on job list rows and the detail view.
5. Tests + `Localizable.xcstrings` strings + feature-gap-index row update.

## Summary

- **Deliver picker:** the cron editor's free-text `deliver` field becomes a picker fed by `GET /api/crons/delivery-options`. An existing job whose deliver value is not in the server list shows it as an extra "<value> (custom)" row (built from the draft's initial value, so it stays selectable even after picking another option) and saves unchanged. If the endpoint fails or returns nothing usable, the editor keeps today's free-text field — no dead editor.
- **Provider field:** `CronJob`, the editor draft, and create/update bodies now carry optional `provider`. On create it is omitted when empty (server default applies); on update an emptied field sends `""`, which the server treats as clearing the pin — identical to the existing `model` behavior. Provider shows on job rows and the detail view when set.

## API verification

- Pinned upstream `.codex-tmp/hermes-webui/api/routes.py` @ 312d3fab: `_handle_cron_delivery_options` returns `{"platforms": [{"value", "label"}, ...]}`; `_handle_cron_create` reads `body.get("provider")`; `_handle_cron_update` maps falsy `model`/`provider` to `None` (clear) and passes non-nil values through; job payloads pass persisted fields (incl. `provider`) through `_cron_job_for_api`.
- Issue #23 records the endpoint as verified live on 2026-07-02 (it is excluded from the docs site as internal; the fallback path covers a future 404).

## Validation

- `xcodebuild build` (scheme HermesMobile, sim Hermex-W0) — succeeded.
- `xcodebuild test` full suite on the same simulator — **TEST SUCCEEDED** on the head commit.
- New tests: endpoint contract row; delivery-options decode (tolerant fields + unexpected `platforms` shape); create body omits `provider` when nil / sends it when set; update body includes `provider`; draft round-trip of unknown deliver + provider; `CronDeliverPicker` fallback and custom-row behavior; `TasksViewModel.load` populates options and tolerates a 404 without breaking the job list.

## Owner manual checks

- [ ] Tasks → New Task: Deliver is a picker listing the server's options (Local / Origin / ...); create a job and confirm the chosen value shows on the row.
- [ ] Edit a job whose deliver value is not in the server list (legacy/custom): the value appears as "... (custom)", and saving without touching it keeps it unchanged.
- [ ] Set Provider on create or edit; confirm it appears on the job row/detail and the job runs with the pinned provider; clearing it on edit removes the pin.
- [ ] With the server unreachable-for-options (or an older server without the endpoint), the editor falls back to the free-text Deliver field and still saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)