### PR TITLE
feat: render transcript audio media as voice bubbles

### DIFF
--- a/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
@@ -167,6 +167,19 @@ final class ChatAttachmentCoordinator {
         }
     }
 
+    /// Raw `MEDIA:` bytes for transcript audio. Unlike thumbnails, this must not
+    /// downsample or re-encode the data because `AVAudioPlayer` needs the
+    /// original container/codec bytes.
+    func transcriptMediaRawData(for reference: TranscriptMediaReference) async -> Data? {
+        guard reference.isAudioCandidate else { return nil }
+
+        do {
+            return try await client.transcriptMediaData(for: reference)
+        } catch {
+            return nil
+        }
+    }
+
     func prepareForSend(localMessageID: String) -> ChatAttachmentSendPreparation {
         let attachmentsForSend = pendingAttachments
         let messageAttachments = attachmentsForSend.map { pending in

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -47,6 +47,7 @@ struct ChatTranscriptView: View {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let loadTranscriptMediaData: (TranscriptMediaReference) async -> Data?
     let actionContext: (ChatMessage, Int) -> MessageActionContext?
     let shouldRenderMessageRow: (ChatMessage) -> Bool
     let onLoadMessages: () async -> Void
@@ -233,6 +234,7 @@ struct ChatTranscriptView: View {
                     loadAttachmentImage: loadAttachmentImage,
                     loadAttachmentData: loadAttachmentData,
                     loadTranscriptMediaImage: loadTranscriptMediaImage,
+                    loadTranscriptMediaData: loadTranscriptMediaData,
                     actionContext: actionContext,
                     shouldRenderMessageRow: shouldRenderMessageRow,
                     onPreviewAttachment: onPreviewAttachment,
@@ -452,6 +454,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let loadTranscriptMediaData: (TranscriptMediaReference) async -> Data?
     let actionContext: (ChatMessage, Int) -> MessageActionContext?
     let shouldRenderMessageRow: (ChatMessage) -> Bool
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
@@ -516,6 +519,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                     loadAttachmentImage: loadAttachmentImage,
                     loadAttachmentData: loadAttachmentData,
                     loadTranscriptMediaImage: loadTranscriptMediaImage,
+                    loadTranscriptMediaData: loadTranscriptMediaData,
                     onPreviewAttachment: onPreviewAttachment,
                     onPreviewTranscriptMedia: onPreviewTranscriptMedia,
                     onToggleListening: onToggleListening,
@@ -596,6 +600,7 @@ private struct ChatTranscriptMessageRow: View {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let loadTranscriptMediaData: (TranscriptMediaReference) async -> Data?
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
     let onPreviewTranscriptMedia: (TranscriptMediaReference) -> Void
     let onToggleListening: (MessageActionContext) -> Void
@@ -641,6 +646,7 @@ private struct ChatTranscriptMessageRow: View {
             loadAttachmentImage: loadAttachmentImage,
             loadAttachmentData: loadAttachmentData,
             loadTranscriptMediaImage: loadTranscriptMediaImage,
+            loadTranscriptMediaData: loadTranscriptMediaData,
             localAttachmentPreviews: localAttachmentPreviews,
             onPreviewAttachment: onPreviewAttachment,
             onPreviewTranscriptMedia: onPreviewTranscriptMedia,

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -859,6 +859,9 @@ struct ChatView: View {
             loadTranscriptMediaImage: { reference in
                 await viewModel.transcriptMediaThumbnailData(for: reference)
             },
+            loadTranscriptMediaData: { reference in
+                await viewModel.transcriptMediaRawData(for: reference)
+            },
             actionContext: { message, visibleIndex in
                 viewModel.actionContext(for: message, visibleIndex: visibleIndex)
             },

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -883,6 +883,10 @@ final class ChatViewModel {
         await attachmentCoordinator.transcriptMediaThumbnailData(for: reference)
     }
 
+    func transcriptMediaRawData(for reference: TranscriptMediaReference) async -> Data? {
+        await attachmentCoordinator.transcriptMediaRawData(for: reference)
+    }
+
     func loadMessages(modelContext: ModelContext? = nil) async {
         guard let sessionID else {
             errorMessage = String(localized: "The server did not provide a session ID.")

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -11,6 +11,7 @@ struct MessageBubbleView: View {
     let loadAttachmentImage: ((String) async -> Data?)?
     let loadAttachmentData: ((String) async -> Data?)?
     let loadTranscriptMediaImage: ((TranscriptMediaReference) async -> Data?)?
+    let loadTranscriptMediaData: ((TranscriptMediaReference) async -> Data?)?
     let localAttachmentPreviews: [String: Data]?
     let onPreviewAttachment: ((MessageAttachment, Data?) -> Void)?
     let onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)?
@@ -21,6 +22,7 @@ struct MessageBubbleView: View {
         loadAttachmentImage: ((String) async -> Data?)? = nil,
         loadAttachmentData: ((String) async -> Data?)? = nil,
         loadTranscriptMediaImage: ((TranscriptMediaReference) async -> Data?)? = nil,
+        loadTranscriptMediaData: ((TranscriptMediaReference) async -> Data?)? = nil,
         localAttachmentPreviews: [String: Data]? = nil,
         onPreviewAttachment: ((MessageAttachment, Data?) -> Void)? = nil,
         onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)? = nil,
@@ -30,6 +32,7 @@ struct MessageBubbleView: View {
         self.loadAttachmentImage = loadAttachmentImage
         self.loadAttachmentData = loadAttachmentData
         self.loadTranscriptMediaImage = loadTranscriptMediaImage
+        self.loadTranscriptMediaData = loadTranscriptMediaData
         self.localAttachmentPreviews = localAttachmentPreviews
         self.onPreviewAttachment = onPreviewAttachment
         self.onPreviewTranscriptMedia = onPreviewTranscriptMedia
@@ -85,6 +88,7 @@ struct MessageBubbleView: View {
                 TranscriptMediaContentView(
                     segments: segments,
                     loadMediaImage: loadTranscriptMediaImage,
+                    loadMediaData: loadTranscriptMediaData,
                     onPreviewMedia: onPreviewTranscriptMedia,
                     isStreaming: isStreaming
                 )

--- a/HermesMobile/Features/Chat/TranscriptMedia.swift
+++ b/HermesMobile/Features/Chat/TranscriptMedia.swift
@@ -51,6 +51,14 @@ struct TranscriptMediaReference: Equatable, Identifiable {
         return false
     }
 
+    /// `MEDIA:` transcript tokens do not carry server MIME metadata, so detect
+    /// audio by the resolved URL/path extension. These render with the same
+    /// inline player as uploaded voice-note attachments instead of falling back
+    /// to the generic unavailable chip.
+    var isAudioCandidate: Bool {
+        AttachmentAudioDetection.audioExtensions.contains(pathExtension)
+    }
+
     private var pathExtension: String {
         switch source {
         case let .remoteURL(url):

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -12,17 +12,20 @@ struct TranscriptMediaPreviewItem: Identifiable, Equatable {
 struct TranscriptMediaContentView: View {
     let segments: [TranscriptMediaSegment]
     let loadMediaImage: ((TranscriptMediaReference) async -> Data?)?
+    let loadMediaData: ((TranscriptMediaReference) async -> Data?)?
     let onPreviewMedia: ((TranscriptMediaReference) -> Void)?
     let isStreaming: Bool
 
     init(
         segments: [TranscriptMediaSegment],
         loadMediaImage: ((TranscriptMediaReference) async -> Data?)?,
+        loadMediaData: ((TranscriptMediaReference) async -> Data?)? = nil,
         onPreviewMedia: ((TranscriptMediaReference) -> Void)?,
         isStreaming: Bool = false
     ) {
         self.segments = segments
         self.loadMediaImage = loadMediaImage
+        self.loadMediaData = loadMediaData
         self.onPreviewMedia = onPreviewMedia
         self.isStreaming = isStreaming
     }
@@ -39,6 +42,7 @@ struct TranscriptMediaContentView: View {
                     TranscriptMediaThumbnailView(
                         reference: reference,
                         loadMediaImage: loadMediaImage,
+                        loadMediaData: loadMediaData,
                         onPreviewMedia: onPreviewMedia
                     )
                     // Pin the image container LTR so media keeps its leading-edge
@@ -54,6 +58,7 @@ struct TranscriptMediaContentView: View {
 private struct TranscriptMediaThumbnailView: View {
     let reference: TranscriptMediaReference
     let loadMediaImage: ((TranscriptMediaReference) async -> Data?)?
+    let loadMediaData: ((TranscriptMediaReference) async -> Data?)?
     let onPreviewMedia: ((TranscriptMediaReference) -> Void)?
 
     @State private var image: UIImage?
@@ -63,7 +68,18 @@ private struct TranscriptMediaThumbnailView: View {
     private let thumbnailHeight: CGFloat = 132
 
     var body: some View {
-        if reference.isRasterImageCandidate, let loadMediaImage {
+        if reference.isAudioCandidate, let loadMediaData {
+            InlineAudioPlayerView(
+                title: reference.displayName,
+                load: { await loadMediaData(reference) }
+            )
+            // Keep the player's state tied to the `MEDIA:` token. Without this,
+            // SwiftUI row reuse can leave a scrolled transcript bubble holding
+            // audio bytes for a previous clip.
+            .id(reference.id)
+            .frame(maxWidth: 300, alignment: .leading)
+            .accessibilityLabel(String(localized: "Voice message \(reference.displayName)"))
+        } else if reference.isRasterImageCandidate, let loadMediaImage {
             Button {
                 onPreviewMedia?(reference)
             } label: {
@@ -150,7 +166,9 @@ private struct TranscriptMediaUnavailableChip: View {
     }
 
     private var iconName: String {
-        reference.isRasterImageCandidate ? "photo" : "doc"
+        if reference.isRasterImageCandidate { return "photo" }
+        if reference.isAudioCandidate { return "waveform" }
+        return "doc"
     }
 }
 

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -78,7 +78,6 @@ private struct TranscriptMediaThumbnailView: View {
             // audio bytes for a previous clip.
             .id(reference.id)
             .frame(maxWidth: 300, alignment: .leading)
-            .accessibilityLabel(String(localized: "Voice message \(reference.displayName)"))
         } else if reference.isRasterImageCandidate, let loadMediaImage {
             Button {
                 onPreviewMedia?(reference)

--- a/HermesMobile/Models/AttachmentAudioDetection.swift
+++ b/HermesMobile/Models/AttachmentAudioDetection.swift
@@ -5,11 +5,11 @@ import Foundation
 /// `GridAttachmentCell.inferredIsImage` / `ChatAttachmentPreviewItem.inferredIsImage`.
 enum AttachmentAudioDetection {
     /// File extensions we treat as audio. `AVAudioPlayer` natively decodes the
-    /// first group (m4a/mp3/wav/aac/caf); ogg/oga/opus/flac are still detected
+    /// first group (m4a/mp3/wav/aac/caf); ogg/oga/opus/flac/webm/weba are still detected
     /// as audio so they surface an audio player with a graceful "can't play"
     /// state instead of a dead file chip.
     static let audioExtensions: Set<String> = [
-        "m4a", "mp3", "wav", "aac", "caf", "ogg", "oga", "opus", "flac"
+        "m4a", "mp3", "wav", "aac", "caf", "ogg", "oga", "opus", "flac", "webm", "weba"
     ]
 
     /// Audio when the attachment is *not* an image and either its MIME type

--- a/HermesMobileTests/AttachmentAudioDetectionTests.swift
+++ b/HermesMobileTests/AttachmentAudioDetectionTests.swift
@@ -20,7 +20,7 @@ final class AttachmentAudioDetectionTests: XCTestCase {
     // MARK: - Extension detection
 
     func testKnownAudioExtensionsAreAudio() {
-        for ext in ["m4a", "mp3", "wav", "aac", "caf", "ogg", "oga", "opus", "flac"] {
+        for ext in ["m4a", "mp3", "wav", "aac", "caf", "ogg", "oga", "opus", "flac", "webm", "weba"] {
             XCTAssertTrue(
                 AttachmentAudioDetection.isAudio(isImage: nil, mime: nil, name: "clip.\(ext)", path: nil),
                 "Expected .\(ext) to be detected as audio"

--- a/HermesMobileTests/ChatAttachmentCoordinatorTests.swift
+++ b/HermesMobileTests/ChatAttachmentCoordinatorTests.swift
@@ -195,6 +195,29 @@ final class ChatAttachmentCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(thumbnail, mediaData)
     }
 
+    func testTranscriptAudioMediaReturnsRawBytesWithoutDownsampling() async throws {
+        let audioData = Data("raw-audio-bytes".utf8)
+        let remoteURL = try XCTUnwrap(URL(string: "https://example.test/generated/media/voice-note.m4a"))
+        let client = makeAuthenticatedMediaClient { request in
+            XCTAssertEqual(request.url, remoteURL)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Hermes-Test-Session"), "authenticated")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mp4"]
+            )!
+            return (response, audioData)
+        }
+        let coordinator = makeCoordinator(client: client)
+
+        let rawData = await coordinator.transcriptMediaRawData(
+            for: TranscriptMediaReference(rawReference: remoteURL.absoluteString)
+        )
+
+        XCTAssertEqual(rawData, audioData)
+    }
+
     private func makeCoordinator(client: APIClient) -> ChatAttachmentCoordinator {
         let coordinator = ChatAttachmentCoordinator(client: client)
         let delegate = ChatAttachmentCoordinatorDelegateSpy()

--- a/HermesMobileTests/TranscriptMediaParserTests.swift
+++ b/HermesMobileTests/TranscriptMediaParserTests.swift
@@ -95,6 +95,17 @@ final class TranscriptMediaParserTests: XCTestCase {
         XCTAssertEqual(media?.isRasterImageCandidate, false)
     }
 
+    func testTranscriptAudioMediaReferenceIsAudioCandidate() throws {
+        let local = TranscriptMediaReference(rawReference: "/tmp/voice-note.m4a")
+        XCTAssertTrue(local.isAudioCandidate)
+        XCTAssertFalse(local.isRasterImageCandidate)
+
+        let remote = TranscriptMediaReference(rawReference: "https://cdn.example.test/audio/reply.OPUS?download=1")
+        XCTAssertEqual(remote.source, .remoteURL(try XCTUnwrap(URL(string: remote.rawReference))))
+        XCTAssertTrue(remote.isAudioCandidate)
+        XCTAssertFalse(remote.isRasterImageCandidate)
+    }
+
     func testEmptyReferenceDisplayNameFallsBackToMedia() {
         XCTAssertEqual(TranscriptMediaReference(rawReference: "").displayName, "Media")
     }


### PR DESCRIPTION
## Summary

- Render `MEDIA:` transcript audio references as inline voice/audio bubbles using the existing `InlineAudioPlayerView`.
- Add a raw transcript-media data path so audio bytes are fetched without image downsampling or re-encoding.
- Extend shared audio extension detection to include `webm` and `weba` and cover transcript audio references with regression tests.

## Details

Assistant messages can already include `MEDIA:` tokens for generated/attached media. Before this change, non-image media such as `MEDIA:/path/to/voice.m4a` fell through to the generic unavailable chip. This adds `TranscriptMediaReference.isAudioCandidate` and routes audio references to the same compact player used for uploaded voice-note attachments.

The data path is intentionally separate from the image thumbnail loader:

`ChatView → ChatViewModel.transcriptMediaRawData → ChatAttachmentCoordinator.transcriptMediaRawData → APIClient.transcriptMediaData`

That preserves the original encoded bytes for `AVAudioPlayer`.

## Verification

- `git diff --check` ✅
- Static call-site check confirmed every new `loadTranscriptMediaData` parameter is passed through all SwiftUI layers ✅
- Delimiter balance check across edited Swift files ✅

Not run locally:

- `xcodebuild test ...` — unavailable on this Linux host (`xcodebuild: command not found`, `swift: command not found`).

## Manual validation suggestion

On a Mac/Xcode host, open a chat containing an assistant response like:

```text
MEDIA:/tmp/voice-note.m4a
```

or a same-origin/remote audio URL ending in `.m4a`, `.mp3`, `.opus`, `.webm`, etc. The transcript should render a playable inline audio bubble instead of a “Media unavailable” chip.
