### PR TITLE
Workspace: manage the registry from the app (add/remove/rename/reorder)

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -191,6 +191,8 @@
 		C03120000000000000B001 /* GitWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F001 /* GitWorkspace.swift */; };
 		C03120000000000000B002 /* APIClient+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F002 /* APIClient+Git.swift */; };
 		C03120000000000000B003 /* GitWorkspaceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F003 /* GitWorkspaceViewModel.swift */; };
+		22AB000000000000000000B1 /* WorkspaceRegistryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */; };
+		22AB000000000000000000B2 /* WorkspaceManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F2 /* WorkspaceManagerView.swift */; };
 		C03120000000000000B004 /* GitWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F004 /* GitWorkspaceView.swift */; };
 		C03120000000000000B005 /* GitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F005 /* GitDiffView.swift */; };
 		C03180000000000000B001 /* GitActionsMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F001 /* GitActionsMenuButton.swift */; };
@@ -273,6 +275,7 @@
 		A04500000000000000000007 /* HermesLiveActivityWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A04500000000000000000017 /* HermesLiveActivityWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A04500000000000000000008 /* LiveActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000018 /* LiveActivityTests.swift */; };
 		2BE8F2B38F094C4C9EB18301 /* SkillsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */; };
+		22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */; };
 		36CD9EF0B0734E5F8C28BB92 /* SlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA59130ED4141049177576C /* SlashCommand.swift */; };
 		3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01011 /* Cron.swift */; };
 		3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01012 /* TasksView.swift */; };
@@ -507,6 +510,8 @@
 		C03120000000000000F001 /* GitWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspace.swift; sourceTree = "<group>"; };
 		C03120000000000000F002 /* APIClient+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Git.swift"; sourceTree = "<group>"; };
 		C03120000000000000F003 /* GitWorkspaceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceViewModel.swift; sourceTree = "<group>"; };
+		22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModel.swift; sourceTree = "<group>"; };
+		22AB000000000000000000F2 /* WorkspaceManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManagerView.swift; sourceTree = "<group>"; };
 		C03120000000000000F004 /* GitWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceView.swift; sourceTree = "<group>"; };
 		C03120000000000000F005 /* GitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitDiffView.swift; sourceTree = "<group>"; };
 		C03180000000000000F001 /* GitActionsMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitActionsMenuButton.swift; sourceTree = "<group>"; };
@@ -555,6 +560,7 @@
 		1A2B3C4D5E6F70000000215 /* SkillsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsViewModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000301 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsViewModelTests.swift; sourceTree = "<group>"; };
+		22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModelTests.swift; sourceTree = "<group>"; };
 		1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandCatalog.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01011 /* Cron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cron.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01012 /* TasksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksView.swift; sourceTree = "<group>"; };
@@ -782,6 +788,7 @@
 				2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */,
 				26AB000000000000000000F3 /* APIClientProvidersTests.swift */,
 				26AB000000000000000000F4 /* ProvidersViewModelTests.swift */,
+				22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */,
 				B5A100000000000000000016 /* SharedDraftStoreTests.swift */,
 				B5A100000000000000000019 /* ShareInputReaderTests.swift */,
 				B5A100000000000000000061 /* AuthManagerStateTests.swift */,
@@ -1006,6 +1013,8 @@
 				C03180000000000000F004 /* GitCommitView.swift */,
 				C03180000000000000F007 /* GitTurnChangesCard.swift */,
 				C03140000000000000F001 /* GitBranchPickerView.swift */,
+				22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */,
+				22AB000000000000000000F2 /* WorkspaceManagerView.swift */,
 			);
 			path = Workspace;
 			sourceTree = "<group>";
@@ -1361,6 +1370,8 @@
 				C03120000000000000B001 /* GitWorkspace.swift in Sources */,
 				C03120000000000000B002 /* APIClient+Git.swift in Sources */,
 				C03120000000000000B003 /* GitWorkspaceViewModel.swift in Sources */,
+				22AB000000000000000000B1 /* WorkspaceRegistryViewModel.swift in Sources */,
+				22AB000000000000000000B2 /* WorkspaceManagerView.swift in Sources */,
 				C03120000000000000B004 /* GitWorkspaceView.swift in Sources */,
 				C03120000000000000B005 /* GitDiffView.swift in Sources */,
 				C03180000000000000B001 /* GitActionsMenuButton.swift in Sources */,
@@ -1602,6 +1613,7 @@
 				2BE8F2B38F094C4C9EB18301 /* SkillsViewModelTests.swift in Sources */,
 				26AB000000000000000000B3 /* APIClientProvidersTests.swift in Sources */,
 				26AB000000000000000000B4 /* ProvidersViewModelTests.swift in Sources */,
+				22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */,
 				B5A100000000000000000005 /* SharedDraftStoreTests.swift in Sources */,
 				B5A100000000000000000009 /* ShareInputReaderTests.swift in Sources */,
 				B5A100000000000000000060 /* AuthManagerStateTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatComposerSelectorSheets.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSelectorSheets.swift
@@ -412,12 +412,19 @@ struct ComposerWorkspacePickerSheet: View {
     let workspaceRoots: [WorkspaceRoot]
     let selectedWorkspacePath: String?
     let suggestions: [String]
+    /// Server base URL used to open the registry manager; nil hides the
+    /// Manage affordance (e.g. offline cached mode).
+    var managementServer: URL?
     let onLoadSuggestions: (String) async -> Void
     let onSelect: (String) async -> Void
+    /// Called after the registry manager closes having changed the registry,
+    /// so the owner can refetch `workspaceRoots`.
+    var onRegistryChanged: () async -> Void = {}
 
     @Environment(\.dismiss) private var dismiss
     @State private var prefix = ""
     @State private var acceptedWorkspacePath: String?
+    @State private var showsManagerSheet = false
 
     var body: some View {
         NavigationStack {
@@ -463,6 +470,14 @@ struct ComposerWorkspacePickerSheet: View {
             .navigationTitle("Choose Workspace")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                if managementServer != nil {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Manage") {
+                            showsManagerSheet = true
+                        }
+                    }
+                }
+
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") {
                         dismiss()
@@ -475,6 +490,13 @@ struct ComposerWorkspacePickerSheet: View {
                     guard !Task.isCancelled else { return }
                 }
                 await onLoadSuggestions(prefix)
+            }
+            .sheet(isPresented: $showsManagerSheet) {
+                if let managementServer {
+                    WorkspaceManagerView(server: managementServer) {
+                        await onRegistryChanged()
+                    }
+                }
             }
         }
     }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -84,6 +84,9 @@ struct MessageComposerView: View {
     let workspaceRoots: [WorkspaceRoot]
     let selectedWorkspacePath: String?
     let workspaceSuggestions: [String]
+    /// Server base URL for the workspace-registry manager; nil hides the
+    /// Manage affordance in the workspace picker.
+    let workspaceManagementServer: URL?
     let personalitySuggestions: [String]
     let skillSuggestions: [SkillSlashSuggestion]
     let agentCommands: [AgentCommand]
@@ -111,6 +114,7 @@ struct MessageComposerView: View {
     let onSelectModel: (ModelCatalogOption) -> Void
     let onModelPickerOpen: () async -> Void
     let onLoadWorkspaceSuggestions: (String) async -> Void
+    let onWorkspaceRegistryChanged: () async -> Void
     let onLoadPersonalitySuggestions: () async -> Void
     let onLoadSkillSuggestions: () async -> Void
     let onSelectWorkspace: (String) async -> Void
@@ -429,12 +433,14 @@ struct MessageComposerView: View {
                 workspaceRoots: workspaceRoots,
                 selectedWorkspacePath: displayedWorkspacePath,
                 suggestions: workspaceSuggestions,
+                managementServer: isOfflineReadOnly ? nil : workspaceManagementServer,
                 onLoadSuggestions: onLoadWorkspaceSuggestions,
                 onSelect: { path in
                     optimisticWorkspacePath = path
                     showsWorkspaceSheet = false
                     await onSelectWorkspace(path)
-                }
+                },
+                onRegistryChanged: onWorkspaceRegistryChanged
             )
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -159,6 +159,7 @@ struct ChatView: View {
             workspaceRoots: viewModel.workspaceRoots,
             selectedWorkspacePath: viewModel.selectedWorkspacePath,
             workspaceSuggestions: viewModel.workspaceSuggestions,
+            workspaceManagementServer: server,
             personalitySuggestions: viewModel.personalitySuggestions,
             skillSuggestions: viewModel.skillSlashSuggestions,
             agentCommands: viewModel.agentCommands,
@@ -198,6 +199,9 @@ struct ChatView: View {
             },
             onLoadWorkspaceSuggestions: { prefix in
                 await viewModel.loadWorkspaceSuggestions(prefix: prefix)
+            },
+            onWorkspaceRegistryChanged: {
+                await viewModel.refreshWorkspaceRoots()
             },
             onLoadPersonalitySuggestions: {
                 await viewModel.loadPersonalitySuggestions()

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -729,6 +729,17 @@ final class ChatViewModel {
            !supported.contains(selected),
            let serverEffort = Self.nonEmpty(response.effectiveEffort) {
             selectedReasoningEffort = serverEffort
+    /// Refetches the workspace registry after the manager sheet mutated it
+    /// (issue #22), so the picker reflects adds/removes/renames/reorders.
+    func refreshWorkspaceRoots() async {
+        guard !isViewingCachedData else { return }
+
+        do {
+            let response = try await client.workspaces()
+            workspaceRoots = response.workspaces ?? []
+            workspaceSuggestions = workspaceRoots.compactMap(\.path)
+        } catch {
+            lastError = error
         }
     }
 

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -729,6 +729,9 @@ final class ChatViewModel {
            !supported.contains(selected),
            let serverEffort = Self.nonEmpty(response.effectiveEffort) {
             selectedReasoningEffort = serverEffort
+        }
+    }
+
     /// Refetches the workspace registry after the manager sheet mutated it
     /// (issue #22), so the picker reflects adds/removes/renames/reorders.
     func refreshWorkspaceRoots() async {

--- a/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
@@ -1,0 +1,301 @@
+import SwiftUI
+
+/// Workspace-registry management sheet (issue #22): add, rename, reorder, and
+/// remove registered workspaces. Removal only unregisters a path from the
+/// server's list — it never deletes files — and is confirmation-gated.
+struct WorkspaceManagerView: View {
+    @State private var viewModel: WorkspaceRegistryViewModel
+
+    /// Called when the sheet disappears after at least one successful mutation,
+    /// so the presenting surface can refresh its own copy of the registry.
+    private let onRegistryChanged: () async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showsAddSheet = false
+    @State private var renameTargetPath: String?
+    @State private var renameText = ""
+
+    init(server: URL, onRegistryChanged: @escaping () async -> Void) {
+        _viewModel = State(initialValue: WorkspaceRegistryViewModel(server: server))
+        self.onRegistryChanged = onRegistryChanged
+    }
+
+    init(viewModel: WorkspaceRegistryViewModel, onRegistryChanged: @escaping () async -> Void) {
+        _viewModel = State(initialValue: viewModel)
+        self.onRegistryChanged = onRegistryChanged
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                if viewModel.managementUnavailable {
+                    Section {
+                        Text("Workspace management isn't available on this server.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if !viewModel.rows.isEmpty {
+                    Section {
+                        ForEach(viewModel.rows, id: \.path) { workspace in
+                            workspaceRow(workspace)
+                        }
+                        .onMove { source, destination in
+                            Task {
+                                await viewModel.moveWorkspaces(fromOffsets: source, toOffset: destination)
+                            }
+                        }
+                        .onDelete { offsets in
+                            guard let index = offsets.first, viewModel.rows.indices.contains(index) else { return }
+                            viewModel.requestRemoval(of: viewModel.rows[index])
+                        }
+                    } footer: {
+                        Text("Removing a workspace only unregisters its path from the server's list. No files are deleted.")
+                    }
+                } else if !viewModel.isLoading {
+                    ContentUnavailableView {
+                        Label("No Workspaces", systemImage: "folder")
+                    } description: {
+                        Text("Add a workspace to make it available when starting sessions.")
+                    }
+                }
+            }
+            .navigationTitle("Manage Workspaces")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    EditButton()
+                        .disabled(viewModel.rows.isEmpty)
+
+                    Button {
+                        showsAddSheet = true
+                    } label: {
+                        Label("Add Workspace", systemImage: "plus")
+                    }
+                    .disabled(viewModel.isMutating)
+                }
+            }
+            .overlay {
+                if viewModel.isLoading && viewModel.rows.isEmpty {
+                    ProgressView()
+                }
+            }
+            .task {
+                await viewModel.load()
+            }
+            .sheet(isPresented: $showsAddSheet) {
+                WorkspaceAddSheet(viewModel: viewModel)
+            }
+            .alert(
+                "Rename Workspace",
+                isPresented: renameAlertBinding
+            ) {
+                TextField("Workspace name", text: $renameText)
+                Button("Cancel", role: .cancel) {
+                    renameTargetPath = nil
+                }
+                Button("Save") {
+                    let path = renameTargetPath
+                    let name = renameText
+                    renameTargetPath = nil
+                    guard let path else { return }
+                    Task {
+                        await viewModel.renameWorkspace(path: path, to: name)
+                    }
+                }
+            }
+            .confirmationDialog(
+                "Remove Workspace?",
+                isPresented: removalDialogBinding,
+                titleVisibility: .visible
+            ) {
+                Button("Remove", role: .destructive) {
+                    Task {
+                        await viewModel.confirmPendingRemoval()
+                    }
+                }
+                Button("Cancel", role: .cancel) {
+                    viewModel.cancelPendingRemoval()
+                }
+            } message: {
+                Text("Removing a workspace only unregisters its path from the server's list. No files are deleted.")
+            }
+            .onDisappear {
+                guard viewModel.didMutateRegistry else { return }
+                Task {
+                    await onRegistryChanged()
+                }
+            }
+        }
+    }
+
+    private func workspaceRow(_ workspace: WorkspaceRoot) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(displayName(for: workspace))
+                .font(.body)
+
+            if let path = workspace.path {
+                Text(path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        }
+        .swipeActions(edge: .leading) {
+            Button {
+                renameText = workspace.name ?? ""
+                renameTargetPath = workspace.path
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            .tint(.blue)
+        }
+    }
+
+    private func displayName(for workspace: WorkspaceRoot) -> String {
+        if let name = workspace.name, !name.isEmpty {
+            return name
+        }
+        return workspace.path?.lastPathComponentFallback ?? ""
+    }
+
+    private var renameAlertBinding: Binding<Bool> {
+        Binding(
+            get: { renameTargetPath != nil },
+            set: { isPresented in
+                if !isPresented {
+                    renameTargetPath = nil
+                }
+            }
+        )
+    }
+
+    private var removalDialogBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.pendingRemoval != nil },
+            set: { isPresented in
+                if !isPresented {
+                    viewModel.cancelPendingRemoval()
+                }
+            }
+        )
+    }
+}
+
+/// Add-workspace form: path (with server suggestions), optional display name,
+/// and an opt-in "create the folder" flag mirroring the web UI's Add Space.
+private struct WorkspaceAddSheet: View {
+    let viewModel: WorkspaceRegistryViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var path = ""
+    @State private var name = ""
+    @State private var createIfMissing = false
+    @State private var suggestions: [String] = []
+    @State private var isSubmitting = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    TextField("Workspace path", text: $path)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    TextField("Name (optional)", text: $name)
+
+                    Toggle("Create the folder if it doesn't exist", isOn: $createIfMissing)
+                } footer: {
+                    Text("Suggestions are limited to trusted workspace roots from the server.")
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                if !filteredSuggestions.isEmpty {
+                    Section("Suggestions") {
+                        ForEach(filteredSuggestions, id: \.self) { suggestion in
+                            Button {
+                                path = suggestion
+                            } label: {
+                                HStack(spacing: 12) {
+                                    Image(systemName: "folder")
+                                        .foregroundStyle(Color(.secondaryLabel))
+                                    Text(suggestion)
+                                        .font(.callout)
+                                        .foregroundStyle(.primary)
+                                        .lineLimit(2)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Add Workspace")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Add") {
+                        submit()
+                    }
+                    .disabled(trimmedPath.isEmpty || isSubmitting)
+                }
+            }
+            .task(id: path) {
+                if !path.isEmpty {
+                    try? await Task.sleep(for: .milliseconds(250))
+                    guard !Task.isCancelled else { return }
+                }
+                suggestions = await viewModel.loadSuggestions(prefix: path)
+            }
+        }
+    }
+
+    private var trimmedPath: String {
+        path.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var filteredSuggestions: [String] {
+        var seen = Set<String>()
+        return suggestions.filter { !$0.isEmpty && $0 != trimmedPath && seen.insert($0).inserted }
+    }
+
+    private func submit() {
+        guard !trimmedPath.isEmpty, !isSubmitting else { return }
+        isSubmitting = true
+        Task { @MainActor in
+            let succeeded = await viewModel.addWorkspace(path: trimmedPath, name: name, create: createIfMissing)
+            isSubmitting = false
+            if succeeded {
+                dismiss()
+            }
+        }
+    }
+}

--- a/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
@@ -47,7 +47,13 @@ struct WorkspaceManagerView: View {
                 if !viewModel.rows.isEmpty {
                     Section {
                         ForEach(viewModel.rows, id: \.path) { workspace in
+                            // moveDisabled blocks new drags while a mutation is
+                            // in flight: actor reentrancy across the network
+                            // await would otherwise let overlapping reorders
+                            // race (the view model's generation guard is the
+                            // second line of defense).
                             workspaceRow(workspace)
+                                .moveDisabled(viewModel.isMutating)
                         }
                         .onMove { source, destination in
                             Task {

--- a/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
@@ -47,13 +47,15 @@ struct WorkspaceManagerView: View {
                 if !viewModel.rows.isEmpty {
                     Section {
                         ForEach(viewModel.rows, id: \.path) { workspace in
-                            // moveDisabled blocks new drags while a mutation is
-                            // in flight: actor reentrancy across the network
-                            // await would otherwise let overlapping reorders
-                            // race (the view model's generation guard is the
-                            // second line of defense).
+                            // moveDisabled/deleteDisabled block new drags and
+                            // swipe-deletes while a mutation is in flight:
+                            // actor reentrancy across the network await would
+                            // otherwise let overlapping mutations race (the
+                            // view model's generation guard is the second
+                            // line of defense).
                             workspaceRow(workspace)
                                 .moveDisabled(viewModel.isMutating)
+                                .deleteDisabled(viewModel.isMutating)
                         }
                         .onMove { source, destination in
                             Task {
@@ -175,6 +177,7 @@ struct WorkspaceManagerView: View {
                 Label("Rename", systemImage: "pencil")
             }
             .tint(.blue)
+            .disabled(viewModel.isMutating)
         }
     }
 

--- a/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
@@ -122,17 +122,22 @@ struct WorkspaceManagerView: View {
             .confirmationDialog(
                 "Remove Workspace?",
                 isPresented: removalDialogBinding,
-                titleVisibility: .visible
-            ) {
+                titleVisibility: .visible,
+                presenting: viewModel.pendingRemoval
+            ) { workspace in
+                // `presenting:` hands the staged workspace to this closure at
+                // presentation time — the dismissal binding clears
+                // `pendingRemoval` before this async task runs, so the target
+                // must not be re-read from the view model here.
                 Button("Remove", role: .destructive) {
-                    Task {
-                        await viewModel.confirmPendingRemoval()
+                    Task { @MainActor in
+                        await viewModel.confirmRemoval(of: workspace)
                     }
                 }
                 Button("Cancel", role: .cancel) {
                     viewModel.cancelPendingRemoval()
                 }
-            } message: {
+            } message: { _ in
                 Text("Removing a workspace only unregisters its path from the server's list. No files are deleted.")
             }
             .onDisappear {

--- a/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Observation
+
+/// Drives the workspace-registry management sheet (issue #22): add, remove,
+/// rename, and reorder entries via the undocumented `/api/workspaces/*`
+/// mutation routes. Every mutation prefers the `workspaces` echo the server
+/// returns; when it is missing (tolerant decoding — these routes carry no
+/// stability promise) the list is refetched from `GET /api/workspaces`.
+@MainActor
+@Observable
+final class WorkspaceRegistryViewModel {
+    private(set) var workspaces: [WorkspaceRoot] = []
+    private(set) var isLoading = false
+    private(set) var isMutating = false
+    private(set) var errorMessage: String?
+    private(set) var lastError: Error?
+
+    /// Set when a management route returns 404 — a future server release may
+    /// drop these undocumented routes; the UI then explains instead of crashing.
+    private(set) var managementUnavailable = false
+
+    /// True once any mutation succeeded, so the presenting picker knows to
+    /// refresh its own copy of the registry on dismiss.
+    private(set) var didMutateRegistry = false
+
+    /// Removal is confirmation-gated (write-safety rule): a swipe-to-delete only
+    /// stages the entry here; the API call happens in `confirmPendingRemoval()`.
+    private(set) var pendingRemoval: WorkspaceRoot?
+
+    private let client: APIClient
+
+    init(server: URL) {
+        client = APIClient(baseURL: server)
+    }
+
+    init(client: APIClient) {
+        self.client = client
+    }
+
+    var rows: [WorkspaceRoot] {
+        workspaces.filter { $0.path?.isEmpty == false }
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        lastError = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await client.workspaces()
+            workspaces = response.workspaces ?? []
+        } catch {
+            record(error)
+        }
+    }
+
+    func loadSuggestions(prefix: String) async -> [String] {
+        (try? await client.workspaceSuggestions(prefix: prefix))?.suggestions ?? []
+    }
+
+    @discardableResult
+    func addWorkspace(path: String, name: String?, create: Bool) async -> Bool {
+        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else { return false }
+        let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return await performMutation {
+            try await self.client.addWorkspace(
+                path: trimmedPath,
+                name: trimmedName?.isEmpty == false ? trimmedName : nil,
+                create: create ? true : nil
+            )
+        }
+    }
+
+    @discardableResult
+    func renameWorkspace(path: String, to name: String) async -> Bool {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty, !trimmedName.isEmpty else { return false }
+
+        return await performMutation {
+            try await self.client.renameWorkspace(path: path, name: trimmedName)
+        }
+    }
+
+    // MARK: Removal (confirmation-gated)
+
+    func requestRemoval(of workspace: WorkspaceRoot) {
+        pendingRemoval = workspace
+    }
+
+    func cancelPendingRemoval() {
+        pendingRemoval = nil
+    }
+
+    @discardableResult
+    func confirmPendingRemoval() async -> Bool {
+        guard let path = pendingRemoval?.path, !path.isEmpty else {
+            pendingRemoval = nil
+            return false
+        }
+        pendingRemoval = nil
+
+        return await performMutation {
+            try await self.client.removeWorkspace(path: path)
+        }
+    }
+
+    // MARK: Reorder
+
+    /// Applies the move locally (trivial optimistic step so the row lands where
+    /// the user dropped it), then asks the server to persist the full order.
+    /// On failure the list is refetched so local order never drifts from the server.
+    @discardableResult
+    func moveWorkspaces(fromOffsets source: IndexSet, toOffset destination: Int) async -> Bool {
+        var reordered = workspaces
+        reordered.move(fromOffsets: source, toOffset: destination)
+        guard reordered != workspaces else { return true }
+        workspaces = reordered
+
+        let paths = reordered.compactMap { workspace -> String? in
+            guard let path = workspace.path, !path.isEmpty else { return nil }
+            return path
+        }
+        guard !paths.isEmpty else { return false }
+
+        let succeeded = await performMutation {
+            try await self.client.reorderWorkspaces(paths: paths)
+        }
+        if !succeeded {
+            // Refetch so local order never drifts from the server, but keep the
+            // reorder failure visible (load() clears error state on entry).
+            let failureMessage = errorMessage
+            let failure = lastError
+            await load()
+            if errorMessage == nil {
+                errorMessage = failureMessage
+                lastError = failure
+            }
+        }
+        return succeeded
+    }
+
+    // MARK: - Helpers
+
+    private func performMutation(_ operation: @escaping () async throws -> WorkspaceMutationResponse) async -> Bool {
+        isMutating = true
+        errorMessage = nil
+        lastError = nil
+        defer { isMutating = false }
+
+        do {
+            let response = try await operation()
+            didMutateRegistry = true
+            if let updated = response.workspaces {
+                workspaces = updated
+            } else {
+                await load()
+            }
+            return true
+        } catch {
+            record(error)
+            return false
+        }
+    }
+
+    private func record(_ error: Error) {
+        lastError = error
+        errorMessage = error.localizedDescription
+        if case APIError.http(let statusCode, _) = error, statusCode == 404 {
+            managementUnavailable = true
+        }
+    }
+}

--- a/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
@@ -94,13 +94,14 @@ final class WorkspaceRegistryViewModel {
         pendingRemoval = nil
     }
 
+    /// Performs the removal for a workspace the user already confirmed in the
+    /// dialog. Takes the workspace explicitly (rather than reading
+    /// `pendingRemoval`) because SwiftUI clears the presentation binding —
+    /// and with it the staged state — before the confirm action's task runs.
     @discardableResult
-    func confirmPendingRemoval() async -> Bool {
-        guard let path = pendingRemoval?.path, !path.isEmpty else {
-            pendingRemoval = nil
-            return false
-        }
+    func confirmRemoval(of workspace: WorkspaceRoot) async -> Bool {
         pendingRemoval = nil
+        guard let path = workspace.path, !path.isEmpty else { return false }
 
         return await performMutation {
             try await self.client.removeWorkspace(path: path)
@@ -112,14 +113,22 @@ final class WorkspaceRegistryViewModel {
     /// Applies the move locally (trivial optimistic step so the row lands where
     /// the user dropped it), then asks the server to persist the full order.
     /// On failure the list is refetched so local order never drifts from the server.
+    ///
+    /// Offsets are relative to `rows` (what the list renders), not `workspaces`:
+    /// tolerant decoding can leave pathless entries that the UI filters out, so
+    /// the move is applied to the visible rows and any hidden entries are kept
+    /// at the end — mirroring the server, which appends omitted entries.
     @discardableResult
     func moveWorkspaces(fromOffsets source: IndexSet, toOffset destination: Int) async -> Bool {
-        var reordered = workspaces
-        reordered.move(fromOffsets: source, toOffset: destination)
-        guard reordered != workspaces else { return true }
-        workspaces = reordered
+        let originalRows = rows
+        var reorderedRows = originalRows
+        reorderedRows.move(fromOffsets: source, toOffset: destination)
+        guard reorderedRows != originalRows else { return true }
 
-        let paths = reordered.compactMap { workspace -> String? in
+        let hiddenEntries = workspaces.filter { !($0.path?.isEmpty == false) }
+        workspaces = reorderedRows + hiddenEntries
+
+        let paths = reorderedRows.compactMap { workspace -> String? in
             guard let path = workspace.path, !path.isEmpty else { return nil }
             return path
         }

--- a/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
@@ -29,11 +29,12 @@ final class WorkspaceRegistryViewModel {
 
     private let client: APIClient
 
-    /// Monotonic token for reorder requests: because `@MainActor` methods are
-    /// reentrant across network awaits, a slow older reorder response could
-    /// land after a newer one and overwrite the user's latest ordering. Each
-    /// reorder bumps this; only the most recent one may apply its result.
-    private var reorderGeneration = 0
+    /// Monotonic token for mutation requests: because `@MainActor` methods are
+    /// reentrant across network awaits, a slow older mutation response (add,
+    /// rename, remove, or reorder) could land after a newer one and overwrite
+    /// the newer result with a stale registry echo. Every mutation bumps this;
+    /// only the most recent one may apply its echo, refetch, or record errors.
+    private var mutationGeneration = 0
 
     /// Count of in-flight mutations, so `isMutating` stays true until the last
     /// overlapping mutation settles instead of flipping off when the first does.
@@ -81,7 +82,7 @@ final class WorkspaceRegistryViewModel {
                 name: trimmedName?.isEmpty == false ? trimmedName : nil,
                 create: create ? true : nil
             )
-        }
+        }.succeeded
     }
 
     @discardableResult
@@ -91,7 +92,7 @@ final class WorkspaceRegistryViewModel {
 
         return await performMutation {
             try await self.client.renameWorkspace(path: path, name: trimmedName)
-        }
+        }.succeeded
     }
 
     // MARK: Removal (confirmation-gated)
@@ -115,7 +116,7 @@ final class WorkspaceRegistryViewModel {
 
         return await performMutation {
             try await self.client.removeWorkspace(path: path)
-        }
+        }.succeeded
     }
 
     // MARK: Reorder
@@ -144,13 +145,10 @@ final class WorkspaceRegistryViewModel {
         }
         guard !paths.isEmpty else { return false }
 
-        reorderGeneration += 1
-        let generation = reorderGeneration
-
-        let succeeded = await performMutation(isStale: { generation != self.reorderGeneration }) {
+        let outcome = await performMutation {
             try await self.client.reorderWorkspaces(paths: paths)
         }
-        if !succeeded, generation == reorderGeneration {
+        if !outcome.succeeded, !outcome.superseded {
             // Refetch so local order never drifts from the server, but keep the
             // reorder failure visible (load() clears error state on entry).
             let failureMessage = errorMessage
@@ -161,18 +159,29 @@ final class WorkspaceRegistryViewModel {
                 lastError = failure
             }
         }
-        return succeeded
+        return outcome.succeeded
     }
 
     // MARK: - Helpers
 
-    /// Runs one mutation call and applies its outcome. `isStale` is checked
-    /// after the await: a stale mutation (a newer reorder superseded it) must
-    /// not apply its echo, refetch, or overwrite error state.
+    /// Outcome of one mutation call. `superseded` means a newer mutation
+    /// started while this one was awaiting its response, so this one applied
+    /// nothing locally (its echo would be stale) — the caller must not
+    /// refetch or surface errors for a superseded mutation either.
+    private struct MutationOutcome {
+        let succeeded: Bool
+        let superseded: Bool
+    }
+
+    /// Runs one mutation call and applies its outcome. Staleness is checked
+    /// after the await: a mutation superseded by a newer one (any kind — the
+    /// UI leaves swipe rename/delete reachable while another mutation is in
+    /// flight) must not apply its echo, refetch, or overwrite error state.
     private func performMutation(
-        isStale: @escaping () -> Bool = { false },
         _ operation: @escaping () async throws -> WorkspaceMutationResponse
-    ) async -> Bool {
+    ) async -> MutationOutcome {
+        mutationGeneration += 1
+        let generation = mutationGeneration
         inFlightMutations += 1
         isMutating = true
         errorMessage = nil
@@ -184,28 +193,32 @@ final class WorkspaceRegistryViewModel {
 
         do {
             let response = try await operation()
+            let superseded = generation != mutationGeneration
             // These undocumented routes signal failure via non-2xx today, but
             // the body explicitly carries `ok`/`error` — honor a 2xx that
             // reports `ok: false` as a failure instead of a success.
             if response.ok == false {
-                if !isStale() {
+                if !superseded {
                     record(WorkspaceMutationRejection(serverMessage: response.error))
                 }
-                return false
+                return MutationOutcome(succeeded: false, superseded: superseded)
             }
             didMutateRegistry = true
-            guard !isStale() else { return true }
+            guard !superseded else {
+                return MutationOutcome(succeeded: true, superseded: true)
+            }
             if let updated = response.workspaces {
                 workspaces = updated
             } else {
                 await load()
             }
-            return true
+            return MutationOutcome(succeeded: true, superseded: false)
         } catch {
-            if !isStale() {
+            let superseded = generation != mutationGeneration
+            if !superseded {
                 record(error)
             }
-            return false
+            return MutationOutcome(succeeded: false, superseded: superseded)
         }
     }
 

--- a/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceRegistryViewModel.swift
@@ -29,6 +29,16 @@ final class WorkspaceRegistryViewModel {
 
     private let client: APIClient
 
+    /// Monotonic token for reorder requests: because `@MainActor` methods are
+    /// reentrant across network awaits, a slow older reorder response could
+    /// land after a newer one and overwrite the user's latest ordering. Each
+    /// reorder bumps this; only the most recent one may apply its result.
+    private var reorderGeneration = 0
+
+    /// Count of in-flight mutations, so `isMutating` stays true until the last
+    /// overlapping mutation settles instead of flipping off when the first does.
+    private var inFlightMutations = 0
+
     init(server: URL) {
         client = APIClient(baseURL: server)
     }
@@ -134,10 +144,13 @@ final class WorkspaceRegistryViewModel {
         }
         guard !paths.isEmpty else { return false }
 
-        let succeeded = await performMutation {
+        reorderGeneration += 1
+        let generation = reorderGeneration
+
+        let succeeded = await performMutation(isStale: { generation != self.reorderGeneration }) {
             try await self.client.reorderWorkspaces(paths: paths)
         }
-        if !succeeded {
+        if !succeeded, generation == reorderGeneration {
             // Refetch so local order never drifts from the server, but keep the
             // reorder failure visible (load() clears error state on entry).
             let failureMessage = errorMessage
@@ -153,15 +166,35 @@ final class WorkspaceRegistryViewModel {
 
     // MARK: - Helpers
 
-    private func performMutation(_ operation: @escaping () async throws -> WorkspaceMutationResponse) async -> Bool {
+    /// Runs one mutation call and applies its outcome. `isStale` is checked
+    /// after the await: a stale mutation (a newer reorder superseded it) must
+    /// not apply its echo, refetch, or overwrite error state.
+    private func performMutation(
+        isStale: @escaping () -> Bool = { false },
+        _ operation: @escaping () async throws -> WorkspaceMutationResponse
+    ) async -> Bool {
+        inFlightMutations += 1
         isMutating = true
         errorMessage = nil
         lastError = nil
-        defer { isMutating = false }
+        defer {
+            inFlightMutations -= 1
+            isMutating = inFlightMutations > 0
+        }
 
         do {
             let response = try await operation()
+            // These undocumented routes signal failure via non-2xx today, but
+            // the body explicitly carries `ok`/`error` — honor a 2xx that
+            // reports `ok: false` as a failure instead of a success.
+            if response.ok == false {
+                if !isStale() {
+                    record(WorkspaceMutationRejection(serverMessage: response.error))
+                }
+                return false
+            }
             didMutateRegistry = true
+            guard !isStale() else { return true }
             if let updated = response.workspaces {
                 workspaces = updated
             } else {
@@ -169,7 +202,9 @@ final class WorkspaceRegistryViewModel {
             }
             return true
         } catch {
-            record(error)
+            if !isStale() {
+                record(error)
+            }
             return false
         }
     }

--- a/HermesMobile/Models/Workspace.swift
+++ b/HermesMobile/Models/Workspace.swift
@@ -32,6 +32,36 @@ struct WorkspaceRoot: Decodable, Equatable, Sendable {
     }
 }
 
+/// Response shape shared by the four workspace-registry mutation routes
+/// (`/api/workspaces/add|remove|rename|reorder`). Verified against upstream
+/// `_handle_workspace_*` handlers: `{"ok": true, "workspaces": [...]}` on success.
+/// These routes are undocumented (not on the official docs site), so every field
+/// stays optional and callers must tolerate a missing `workspaces` echo.
+struct WorkspaceMutationResponse: Decodable, Equatable {
+    let ok: Bool?
+    let workspaces: [WorkspaceRoot]?
+    let error: String?
+}
+
+struct AddWorkspaceRequest: Encodable, Equatable {
+    let path: String
+    let name: String?
+    let create: Bool?
+}
+
+struct RemoveWorkspaceRequest: Encodable, Equatable {
+    let path: String
+}
+
+struct RenameWorkspaceRequest: Encodable, Equatable {
+    let path: String
+    let name: String
+}
+
+struct ReorderWorkspacesRequest: Encodable, Equatable {
+    let paths: [String]
+}
+
 struct DirectoryListResponse: Decodable, Equatable {
     let entries: [WorkspaceEntry]?
     let path: String?

--- a/HermesMobile/Models/Workspace.swift
+++ b/HermesMobile/Models/Workspace.swift
@@ -43,6 +43,22 @@ struct WorkspaceMutationResponse: Decodable, Equatable {
     let error: String?
 }
 
+/// Surfaced when a mutation route answers with HTTP success but reports
+/// `ok: false` in the body. Upstream signals failure via non-2xx today, but
+/// these routes are undocumented, so an explicit body-level failure must not
+/// be presented as a success. Reuses the phrasing (and localization keys) of
+/// `APIError`'s 400 handling.
+struct WorkspaceMutationRejection: LocalizedError, Equatable {
+    let serverMessage: String?
+
+    var errorDescription: String? {
+        if let serverMessage, !serverMessage.isEmpty {
+            return String(localized: "The server rejected the request: \(serverMessage)")
+        }
+        return String(localized: "The server rejected the request.")
+    }
+}
+
 struct AddWorkspaceRequest: Encodable, Equatable {
     let path: String
     let name: String?

--- a/HermesMobile/Networking/APIClient+Workspace.swift
+++ b/HermesMobile/Networking/APIClient+Workspace.swift
@@ -9,6 +9,38 @@ extension APIClient {
         try await send(endpoint: .workspaceSuggestions(prefix: prefix), method: "GET")
     }
 
+    func addWorkspace(path: String, name: String? = nil, create: Bool? = nil) async throws -> WorkspaceMutationResponse {
+        try await send(
+            endpoint: .workspaceAdd,
+            method: "POST",
+            body: AddWorkspaceRequest(path: path, name: name, create: create)
+        )
+    }
+
+    func removeWorkspace(path: String) async throws -> WorkspaceMutationResponse {
+        try await send(
+            endpoint: .workspaceRemove,
+            method: "POST",
+            body: RemoveWorkspaceRequest(path: path)
+        )
+    }
+
+    func renameWorkspace(path: String, name: String) async throws -> WorkspaceMutationResponse {
+        try await send(
+            endpoint: .workspaceRename,
+            method: "POST",
+            body: RenameWorkspaceRequest(path: path, name: name)
+        )
+    }
+
+    func reorderWorkspaces(paths: [String]) async throws -> WorkspaceMutationResponse {
+        try await send(
+            endpoint: .workspaceReorder,
+            method: "POST",
+            body: ReorderWorkspacesRequest(paths: paths)
+        )
+    }
+
     func directoryList(sessionID: String, path: String? = nil) async throws -> DirectoryListResponse {
         try await send(
             endpoint: .directoryList(sessionID: sessionID, path: path),

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -44,6 +44,10 @@ enum Endpoint {
     case backgroundStatus(sessionID: String)
     case workspaces
     case workspaceSuggestions(prefix: String)
+    case workspaceAdd
+    case workspaceRemove
+    case workspaceRename
+    case workspaceReorder
     case directoryList(sessionID: String, path: String?)
     case file(sessionID: String, path: String)
     case rawFile(sessionID: String, path: String)
@@ -186,6 +190,14 @@ enum Endpoint {
             return "/api/workspaces"
         case .workspaceSuggestions:
             return "/api/workspaces/suggest"
+        case .workspaceAdd:
+            return "/api/workspaces/add"
+        case .workspaceRemove:
+            return "/api/workspaces/remove"
+        case .workspaceRename:
+            return "/api/workspaces/rename"
+        case .workspaceReorder:
+            return "/api/workspaces/reorder"
         case .directoryList:
             return "/api/list"
         case .file:

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -108221,6 +108221,1278 @@
           }
         }
       }
+    },
+    "Manage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwalten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestisci"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zarządzaj"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerenciar"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beheren"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yönet"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управлять"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "관리"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إدارة"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ניהול"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انتظام"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理"
+          }
+        }
+      }
+    },
+    "Manage Workspaces" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arbeitsbereiche verwalten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionar espacios de trabajo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérer les espaces de travail"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestisci workspace"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zarządzaj obszarami roboczymi"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerenciar espaços de trabalho"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werkruimtes beheren"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışma Alanlarını Yönet"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление рабочими пространствами"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークスペースを管理"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理工作区"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 공간 관리"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إدارة مساحات العمل"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ניהול סביבות עבודה"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورک اسپیسز کا انتظام"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理工作區"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理工作區"
+          }
+        }
+      }
+    },
+    "Add Workspace" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arbeitsbereich hinzufügen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir espacio de trabajo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un espace de travail"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi workspace"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodaj obszar roboczy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar espaço de trabalho"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werkruimte toevoegen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışma Alanı Ekle"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить рабочее пространство"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークスペースを追加"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加工作区"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 공간 추가"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إضافة مساحة عمل"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הוספת סביבת עבודה"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورک اسپیس شامل کریں"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增工作區"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增工作區"
+          }
+        }
+      }
+    },
+    "Rename Workspace" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arbeitsbereich umbenennen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renombrar espacio de trabajo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer l'espace de travail"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rinomina workspace"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zmień nazwę obszaru roboczego"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renomear espaço de trabalho"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werkruimte hernoemen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışma Alanını Yeniden Adlandır"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переименовать рабочее пространство"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークスペースの名前を変更"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名工作区"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 공간 이름 변경"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة تسمية مساحة العمل"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שינוי שם סביבת העבודה"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورک اسپیس کا نام تبدیل کریں"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新命名工作區"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新命名工作區"
+          }
+        }
+      }
+    },
+    "Workspace name" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name des Arbeitsbereichs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre del espacio de trabajo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom de l'espace de travail"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome del workspace"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nazwa obszaru roboczego"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome do espaço de trabalho"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naam van werkruimte"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışma alanı adı"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название рабочего пространства"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークスペース名"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作区名称"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 공간 이름"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اسم مساحة العمل"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שם סביבת העבודה"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورک اسپیس کا نام"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作區名稱"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作區名稱"
+          }
+        }
+      }
+    },
+    "Remove Workspace?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arbeitsbereich entfernen?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Quitar espacio de trabajo?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer l'espace de travail ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovere il workspace?"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usunąć obszar roboczy?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover espaço de trabalho?"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werkruimte verwijderen?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalışma Alanı Kaldırılsın mı?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убрать рабочее пространство?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークスペースを削除しますか？"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除工作区？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 공간을 제거하시겠습니까?"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هل تريد إزالة مساحة العمل؟"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "להסיר את סביבת העבודה?"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورک اسپیس ہٹائیں؟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除工作區？"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除工作區？"
+          }
+        }
+      }
+    },
+    "Remove" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuń"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwijderen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaldır"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убрать"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제거"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إزالة"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הסרה"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ہٹائیں"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
+        }
+      }
+    },
+    "Removing a workspace only unregisters its path from the server's list. No files are deleted." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Entfernen eines Arbeitsbereichs wird nur sein Pfad aus der Liste des Servers ausgetragen. Es werden keine Dateien gelöscht."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar un espacio de trabajo solo elimina su ruta de la lista del servidor. No se borra ningún archivo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer un espace de travail supprime uniquement son chemin de la liste du serveur. Aucun fichier n'est supprimé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La rimozione di un workspace elimina solo il suo percorso dall'elenco del server. Nessun file viene eliminato."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usunięcie obszaru roboczego jedynie wyrejestrowuje jego ścieżkę z listy serwera. Żadne pliki nie są usuwane."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover um espaço de trabalho apenas retira o caminho da lista do servidor. Nenhum arquivo é excluído."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bij het verwijderen van een werkruimte wordt alleen het pad uit de lijst van de server gehaald. Er worden geen bestanden verwijderd."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bir çalışma alanını kaldırmak yalnızca yolunu sunucunun listesinden çıkarır. Hiçbir dosya silinmez."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удаление рабочего пространства лишь убирает его путь из списка сервера. Файлы не удаляются."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワークスペースを削除しても、サーバーのリストからパスが登録解除されるだけです。ファイルは削除されません。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除工作区仅会将其路径从服务器列表中注销，不会删除任何文件。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 공간을 제거하면 서버 목록에서 경로만 등록 해제됩니다. 파일은 삭제되지 않습니다."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إزالة مساحة العمل تلغي تسجيل مسارها من قائمة الخادم فقط. لن يتم حذف أي ملفات."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הסרת סביבת עבודה רק מבטלת את רישום הנתיב מרשימת השרת. שום קובץ לא נמחק."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورک اسپیس ہٹانے سے صرف اس کا راستہ سرور کی فہرست سے خارج ہوتا ہے۔ کوئی فائل حذف نہیں ہوتی۔"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除工作區只會將其路徑從伺服器清單中取消註冊，不會刪除任何檔案。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除工作區只會將其路徑從伺服器清單中取消註冊，不會刪除任何檔案。"
+          }
+        }
+      }
+    },
+    "Workspace management isn't available on this server." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Arbeitsbereich-Verwaltung ist auf diesem Server nicht verfügbar."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La gestión de espacios de trabajo no está disponible en este servidor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La gestion des espaces de travail n'est pas disponible sur ce serveur."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La gestione dei workspace non è disponibile su questo server."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zarządzanie obszarami roboczymi nie jest dostępne na tym serwerze."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O gerenciamento de espaços de trabalho não está disponível neste servidor."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werkruimtebeheer is niet beschikbaar op deze server."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sunucuda çalışma alanı yönetimi kullanılamıyor."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление рабочими пространствами недоступно на этом сервере."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このサーバーではワークスペース管理を利用できません。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此服务器不支持工作区管理。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 서버에서는 작업 공간 관리를 사용할 수 없습니다."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إدارة مساحات العمل غير متاحة على هذا الخادم."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ניהול סביבות עבודה אינו זמין בשרת זה."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اس سرور پر ورک اسپیس کا انتظام دستیاب نہیں ہے۔"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此伺服器不支援工作區管理。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此伺服器不支援工作區管理。"
+          }
+        }
+      }
+    },
+    "Name (optional)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name (optional)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre (opcional)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom (facultatif)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome (facoltativo)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nazwa (opcjonalnie)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome (opcional)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naam (optioneel)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ad (isteğe bağlı)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название (необязательно)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前（任意）"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名称（可选）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이름(선택 사항)"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الاسم (اختياري)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "שם (אופציונלי)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نام (اختیاری)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱（選填）"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱（選填）"
+          }
+        }
+      }
+    },
+    "Create the folder if it doesn't exist" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordner erstellen, falls er nicht existiert"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear la carpeta si no existe"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer le dossier s'il n'existe pas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea la cartella se non esiste"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utwórz folder, jeśli nie istnieje"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criar a pasta se ela não existir"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Map aanmaken als deze niet bestaat"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasör yoksa oluştur"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать папку, если она не существует"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダが存在しない場合は作成"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如文件夹不存在则创建"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "폴더가 없으면 생성"
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنشاء المجلد إذا لم يكن موجودًا"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "צור את התיקייה אם היא לא קיימת"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اگر فولڈر موجود نہ ہو تو بنائیں"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "若資料夾不存在則建立"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "若資料夾不存在則建立"
+          }
+        }
+      }
+    },
+    "Add a workspace to make it available when starting sessions." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füge einen Arbeitsbereich hinzu, damit er beim Starten von Sitzungen verfügbar ist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añade un espacio de trabajo para que esté disponible al iniciar sesiones."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoutez un espace de travail pour le rendre disponible au démarrage des sessions."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi un workspace per renderlo disponibile all'avvio delle sessioni."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodaj obszar roboczy, aby był dostępny podczas rozpoczynania sesji."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicione um espaço de trabalho para disponibilizá-lo ao iniciar sessões."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voeg een werkruimte toe zodat deze beschikbaar is bij het starten van sessies."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oturum başlatırken kullanılabilmesi için bir çalışma alanı ekleyin."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавьте рабочее пространство, чтобы оно было доступно при запуске сессий."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッション開始時に使えるようにワークスペースを追加してください。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加工作区，以便在开始会话时使用。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세션을 시작할 때 사용할 수 있도록 작업 공간을 추가하세요."
+          }
+        },
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أضف مساحة عمل لتصبح متاحة عند بدء الجلسات."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "הוסף סביבת עבודה כדי שתהיה זמינה בעת התחלת שיחות."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سیشن شروع کرتے وقت دستیاب بنانے کے لیے ورک اسپیس شامل کریں۔"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增工作區，以便開始工作階段時使用。"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增工作區，以便開始工作階段時使用。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/APIClientWorkspaceFileTests.swift
+++ b/HermesMobileTests/APIClientWorkspaceFileTests.swift
@@ -241,6 +241,154 @@ final class APIClientWorkspaceFileTests: APIClientTestCase {
         XCTAssertEqual(response.suggestions, ["/Users/test/project", "/Users/test/prototypes"])
     }
 
+    func testAddWorkspaceBuildsExpectedBodyAndDecodesUpdatedList() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/workspaces/add")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let json = try apiTestJSONBody(from: request)
+            XCTAssertEqual(json["path"] as? String, "/Users/test/newproject")
+            XCTAssertEqual(json["name"] as? String, "New Project")
+            XCTAssertEqual(json["create"] as? Bool, true)
+
+            return apiTestJSONResponse("""
+            {
+              "ok": true,
+              "workspaces": [
+                {"path": "/Users/test/project", "name": "Project"},
+                {"path": "/Users/test/newproject", "name": "New Project"}
+              ]
+            }
+            """, for: request)
+        }
+
+        let response = try await client.addWorkspace(path: "/Users/test/newproject", name: "New Project", create: true)
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.workspaces?.count, 2)
+        XCTAssertEqual(response.workspaces?.last?.path, "/Users/test/newproject")
+        XCTAssertEqual(response.workspaces?.last?.name, "New Project")
+    }
+
+    func testAddWorkspaceOmitsOptionalFieldsWhenNil() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/workspaces/add")
+
+            let json = try apiTestJSONBody(from: request)
+            XCTAssertEqual(json["path"] as? String, "/Users/test/newproject")
+            XCTAssertNil(json["name"])
+            XCTAssertNil(json["create"])
+
+            return apiTestJSONResponse("""
+            {"ok": true, "workspaces": [{"path": "/Users/test/newproject", "name": "newproject"}]}
+            """, for: request)
+        }
+
+        let response = try await client.addWorkspace(path: "/Users/test/newproject")
+
+        XCTAssertEqual(response.ok, true)
+    }
+
+    func testAddWorkspaceSurfacesServerErrorString() async throws {
+        let client = makeClient { request in
+            let (_, data) = apiTestJSONResponse("""
+            {"error": "Workspace already in list"}
+            """, for: request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, data)
+        }
+
+        do {
+            _ = try await client.addWorkspace(path: "/Users/test/project")
+            XCTFail("Expected APIError.http")
+        } catch let error as APIError {
+            XCTAssertEqual(error.serverMessage, "Workspace already in list")
+            XCTAssertTrue(error.localizedDescription.contains("Workspace already in list"))
+        }
+    }
+
+    func testRemoveWorkspaceBuildsExpectedBodyAndDecodesUpdatedList() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/workspaces/remove")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let json = try apiTestJSONBody(from: request)
+            XCTAssertEqual(json["path"] as? String, "/Users/test/oldproject")
+
+            return apiTestJSONResponse("""
+            {"ok": true, "workspaces": [{"path": "/Users/test/project", "name": "Project"}]}
+            """, for: request)
+        }
+
+        let response = try await client.removeWorkspace(path: "/Users/test/oldproject")
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.workspaces?.map(\.path), ["/Users/test/project"])
+    }
+
+    func testRenameWorkspaceBuildsExpectedBodyAndDecodesUpdatedList() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/workspaces/rename")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let json = try apiTestJSONBody(from: request)
+            XCTAssertEqual(json["path"] as? String, "/Users/test/project")
+            XCTAssertEqual(json["name"] as? String, "Renamed")
+
+            return apiTestJSONResponse("""
+            {"ok": true, "workspaces": [{"path": "/Users/test/project", "name": "Renamed"}]}
+            """, for: request)
+        }
+
+        let response = try await client.renameWorkspace(path: "/Users/test/project", name: "Renamed")
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.workspaces?.first?.name, "Renamed")
+    }
+
+    func testReorderWorkspacesBuildsExpectedBodyAndDecodesUpdatedList() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/workspaces/reorder")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let json = try apiTestJSONBody(from: request)
+            XCTAssertEqual(json["paths"] as? [String], ["/Users/test/b", "/Users/test/a"])
+
+            return apiTestJSONResponse("""
+            {
+              "ok": true,
+              "workspaces": [
+                {"path": "/Users/test/b", "name": "B"},
+                {"path": "/Users/test/a", "name": "A"}
+              ]
+            }
+            """, for: request)
+        }
+
+        let response = try await client.reorderWorkspaces(paths: ["/Users/test/b", "/Users/test/a"])
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.workspaces?.compactMap(\.path), ["/Users/test/b", "/Users/test/a"])
+    }
+
+    func testWorkspaceMutationToleratesMissingWorkspacesEcho() async throws {
+        let client = makeClient { request in
+            apiTestJSONResponse("""
+            {"ok": true, "unexpected_new_field": {"nested": 1}}
+            """, for: request)
+        }
+
+        let response = try await client.removeWorkspace(path: "/Users/test/project")
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertNil(response.workspaces)
+    }
+
     func testDirectoryListDecodesUpstreamEntries() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/list")

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -150,6 +150,10 @@ final class ContractReadinessTests: XCTestCase {
                 path: "/api/workspaces/suggest",
                 query: ["prefix": "/Users/uzair"]
             ),
+            .init(name: "workspace add", method: "POST", endpoint: .workspaceAdd, path: "/api/workspaces/add"),
+            .init(name: "workspace remove", method: "POST", endpoint: .workspaceRemove, path: "/api/workspaces/remove"),
+            .init(name: "workspace rename", method: "POST", endpoint: .workspaceRename, path: "/api/workspaces/rename"),
+            .init(name: "workspace reorder", method: "POST", endpoint: .workspaceReorder, path: "/api/workspaces/reorder"),
             .init(
                 name: "directory list root",
                 method: "GET",

--- a/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
+++ b/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import HermesMobile
+
+final class WorkspaceRegistryViewModelTests: APIClientTestCase {
+    private static let twoWorkspacesJSON = """
+    {
+      "workspaces": [
+        {"path": "/Users/test/alpha", "name": "Alpha"},
+        {"path": "/Users/test/beta", "name": "Beta"}
+      ],
+      "last": "/Users/test/alpha"
+    }
+    """
+
+    @MainActor
+    func testLoadFetchesWorkspaces() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/workspaces")
+            return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+
+        await model.load()
+
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/alpha", "/Users/test/beta"])
+        XCTAssertNil(model.errorMessage)
+        XCTAssertFalse(model.isLoading)
+    }
+
+    @MainActor
+    func testLoadFailureSurfacesError() async throws {
+        let client = makeClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil
+            )!
+            return (response, Data("{}".utf8))
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+
+        await model.load()
+
+        XCTAssertNotNil(model.errorMessage)
+        XCTAssertTrue(model.rows.isEmpty)
+        XCTAssertFalse(model.managementUnavailable)
+    }
+
+    @MainActor
+    func testAddWorkspaceTrimsInputAndUsesReturnedList() async throws {
+        var addBody: [String: Any] = [:]
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces/add":
+                addBody = try apiTestJSONBody(from: request)
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "workspaces": [
+                    {"path": "/Users/test/alpha", "name": "Alpha"},
+                    {"path": "/Users/test/gamma", "name": "Gamma"}
+                  ]
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+
+        let succeeded = await model.addWorkspace(path: "  /Users/test/gamma  ", name: "   ", create: false)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(addBody["path"] as? String, "/Users/test/gamma")
+        XCTAssertNil(addBody["name"], "Blank names must be omitted so the server derives one from the path.")
+        XCTAssertNil(addBody["create"], "create is opt-in and omitted when false.")
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/alpha", "/Users/test/gamma"])
+        XCTAssertTrue(model.didMutateRegistry)
+    }
+
+    @MainActor
+    func testAddWorkspaceFailureSurfacesServerErrorString() async throws {
+        let client = makeClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"error": "Path points to a system directory: /etc"}"#.utf8))
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+
+        let succeeded = await model.addWorkspace(path: "/etc", name: nil, create: false)
+
+        XCTAssertFalse(succeeded)
+        XCTAssertTrue(model.errorMessage?.contains("Path points to a system directory: /etc") == true)
+        XCTAssertFalse(model.didMutateRegistry)
+    }
+
+    @MainActor
+    func testRemovalIsConfirmationGated() async throws {
+        var removeCallCount = 0
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/remove":
+                removeCallCount += 1
+                let body = try apiTestJSONBody(from: request)
+                XCTAssertEqual(body["path"] as? String, "/Users/test/beta")
+                return apiTestJSONResponse("""
+                {"ok": true, "workspaces": [{"path": "/Users/test/alpha", "name": "Alpha"}]}
+                """, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+        let beta = try XCTUnwrap(model.rows.last)
+
+        // Staging then cancelling must never hit the network.
+        model.requestRemoval(of: beta)
+        XCTAssertEqual(model.pendingRemoval?.path, "/Users/test/beta")
+        model.cancelPendingRemoval()
+        XCTAssertNil(model.pendingRemoval)
+        XCTAssertEqual(removeCallCount, 0)
+        XCTAssertEqual(model.rows.count, 2)
+
+        // Confirming with nothing staged is a no-op.
+        let noPending = await model.confirmPendingRemoval()
+        XCTAssertFalse(noPending)
+        XCTAssertEqual(removeCallCount, 0)
+
+        // Only stage + confirm performs the removal.
+        model.requestRemoval(of: beta)
+        let succeeded = await model.confirmPendingRemoval()
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(removeCallCount, 1)
+        XCTAssertNil(model.pendingRemoval)
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/alpha"])
+    }
+
+    @MainActor
+    func testRenameWorkspaceUpdatesListFromResponse() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/rename":
+                let body = try apiTestJSONBody(from: request)
+                XCTAssertEqual(body["path"] as? String, "/Users/test/beta")
+                XCTAssertEqual(body["name"] as? String, "Beta Renamed")
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "workspaces": [
+                    {"path": "/Users/test/alpha", "name": "Alpha"},
+                    {"path": "/Users/test/beta", "name": "Beta Renamed"}
+                  ]
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        let succeeded = await model.renameWorkspace(path: "/Users/test/beta", to: "  Beta Renamed  ")
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(model.rows.last?.name, "Beta Renamed")
+    }
+
+    @MainActor
+    func testRenameRejectsBlankNameWithoutNetworkCall() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/workspaces")
+            return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        let succeeded = await model.renameWorkspace(path: "/Users/test/beta", to: "   ")
+
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(model.rows.last?.name, "Beta")
+    }
+
+    @MainActor
+    func testMoveWorkspacesSendsFullOrder() async throws {
+        var reorderBody: [String: Any] = [:]
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/reorder":
+                reorderBody = try apiTestJSONBody(from: request)
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "workspaces": [
+                    {"path": "/Users/test/beta", "name": "Beta"},
+                    {"path": "/Users/test/alpha", "name": "Alpha"}
+                  ]
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        let succeeded = await model.moveWorkspaces(fromOffsets: IndexSet(integer: 1), toOffset: 0)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(reorderBody["paths"] as? [String], ["/Users/test/beta", "/Users/test/alpha"])
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/beta", "/Users/test/alpha"])
+    }
+
+    @MainActor
+    func testMoveWorkspacesRefetchesOnFailure() async throws {
+        var workspacesLoadCount = 0
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                workspacesLoadCount += 1
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/reorder":
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil
+                )!
+                return (response, Data("{}".utf8))
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        let succeeded = await model.moveWorkspaces(fromOffsets: IndexSet(integer: 1), toOffset: 0)
+
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(workspacesLoadCount, 2, "A failed reorder must refetch so local order matches the server.")
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/alpha", "/Users/test/beta"])
+        XCTAssertNotNil(model.errorMessage)
+    }
+
+    @MainActor
+    func testMutationWithoutWorkspacesEchoRefetchesList() async throws {
+        var workspacesLoadCount = 0
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                workspacesLoadCount += 1
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/remove":
+                return apiTestJSONResponse(#"{"ok": true}"#, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        model.requestRemoval(of: try XCTUnwrap(model.rows.first))
+        let succeeded = await model.confirmPendingRemoval()
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(workspacesLoadCount, 2, "A mutation response without a workspaces echo must refetch.")
+    }
+
+    @MainActor
+    func testMutation404MarksManagementUnavailable() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/add":
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil
+                )!
+                return (response, Data("Not Found".utf8))
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        let succeeded = await model.addWorkspace(path: "/Users/test/gamma", name: nil, create: false)
+
+        XCTAssertFalse(succeeded)
+        XCTAssertTrue(model.managementUnavailable)
+        XCTAssertNotNil(model.errorMessage)
+        // The registry list itself must keep working.
+        XCTAssertEqual(model.rows.count, 2)
+    }
+}

--- a/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
+++ b/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
@@ -128,14 +128,19 @@ final class WorkspaceRegistryViewModelTests: APIClientTestCase {
         XCTAssertEqual(removeCallCount, 0)
         XCTAssertEqual(model.rows.count, 2)
 
-        // Confirming with nothing staged is a no-op.
-        let noPending = await model.confirmPendingRemoval()
-        XCTAssertFalse(noPending)
+        // Confirming a pathless workspace is a no-op.
+        let pathless = try JSONDecoder().decode(WorkspaceRoot.self, from: Data("{}".utf8))
+        let noPath = await model.confirmRemoval(of: pathless)
+        XCTAssertFalse(noPath)
         XCTAssertEqual(removeCallCount, 0)
 
-        // Only stage + confirm performs the removal.
+        // Confirm performs the removal even after the presentation binding
+        // already cleared the staged state (the dialog-dismissal race the
+        // first review round caught): the confirmed workspace is passed
+        // explicitly, so removal must not depend on `pendingRemoval`.
         model.requestRemoval(of: beta)
-        let succeeded = await model.confirmPendingRemoval()
+        model.cancelPendingRemoval()
+        let succeeded = await model.confirmRemoval(of: beta)
         XCTAssertTrue(succeeded)
         XCTAssertEqual(removeCallCount, 1)
         XCTAssertNil(model.pendingRemoval)
@@ -224,6 +229,43 @@ final class WorkspaceRegistryViewModelTests: APIClientTestCase {
     }
 
     @MainActor
+    func testMoveWorkspacesAppliesOffsetsToVisibleRowsWhenPathlessEntriesExist() async throws {
+        var reorderBody: [String: Any] = [:]
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                // A pathless entry (tolerant decoding) is hidden from the UI,
+                // so move offsets are relative to the two visible rows.
+                return apiTestJSONResponse("""
+                {
+                  "workspaces": [
+                    {"path": "/Users/test/alpha", "name": "Alpha"},
+                    {"name": "Ghost"},
+                    {"path": "/Users/test/beta", "name": "Beta"}
+                  ]
+                }
+                """, for: request)
+            case "/api/workspaces/reorder":
+                reorderBody = try apiTestJSONBody(from: request)
+                return apiTestJSONResponse(#"{"ok": true}"#, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/alpha", "/Users/test/beta"])
+
+        // Move the second *visible* row (beta) to the front. With offsets
+        // applied to the raw list this would move the pathless ghost instead.
+        let succeeded = await model.moveWorkspaces(fromOffsets: IndexSet(integer: 1), toOffset: 0)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(reorderBody["paths"] as? [String], ["/Users/test/beta", "/Users/test/alpha"])
+    }
+
+    @MainActor
     func testMoveWorkspacesRefetchesOnFailure() async throws {
         var workspacesLoadCount = 0
         let client = makeClient { request in
@@ -270,8 +312,9 @@ final class WorkspaceRegistryViewModelTests: APIClientTestCase {
         let model = WorkspaceRegistryViewModel(client: client)
         await model.load()
 
-        model.requestRemoval(of: try XCTUnwrap(model.rows.first))
-        let succeeded = await model.confirmPendingRemoval()
+        let target = try XCTUnwrap(model.rows.first)
+        model.requestRemoval(of: target)
+        let succeeded = await model.confirmRemoval(of: target)
 
         XCTAssertTrue(succeeded)
         XCTAssertEqual(workspacesLoadCount, 2, "A mutation response without a workspaces echo must refetch.")

--- a/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
+++ b/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
@@ -414,6 +414,74 @@ final class WorkspaceRegistryViewModelTests: APIClientTestCase {
     }
 
     @MainActor
+    func testStaleRenameResponseDoesNotResurrectRemovedWorkspace() async throws {
+        // The rename of alpha is held back so an overlapping removal of beta
+        // supersedes it. The stale rename echo still contains beta; the
+        // generation guard must ignore it instead of resurrecting the removed
+        // row. (As above: whether the hold ends via the signal or the bounded
+        // timeout, the stale echo is always processed after the removal began.)
+        let renameStarted = expectation(description: "rename request in flight")
+        let releaseRename = DispatchSemaphore(value: 0)
+
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/rename":
+                renameStarted.fulfill()
+                _ = releaseRename.wait(timeout: .now() + 2)
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "workspaces": [
+                    {"path": "/Users/test/alpha", "name": "Renamed Alpha"},
+                    {"path": "/Users/test/beta", "name": "Beta"}
+                  ]
+                }
+                """, for: request)
+            case "/api/workspaces/remove":
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "workspaces": [
+                    {"path": "/Users/test/alpha", "name": "Renamed Alpha"}
+                  ]
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        // Rename alpha; the response is held while the removal overlaps it.
+        let renameTask = Task { @MainActor in
+            await model.renameWorkspace(path: "/Users/test/alpha", to: "Renamed Alpha")
+        }
+        await fulfillment(of: [renameStarted], timeout: 2)
+        XCTAssertTrue(model.isMutating)
+
+        let beta = try XCTUnwrap(model.rows.first { $0.path == "/Users/test/beta" })
+        let removalSucceeded = await model.confirmRemoval(of: beta)
+        XCTAssertTrue(removalSucceeded)
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/alpha"])
+
+        // Release the stale rename response; it must not restore beta.
+        releaseRename.signal()
+        let renameSucceeded = await renameTask.value
+        XCTAssertTrue(renameSucceeded)
+        XCTAssertEqual(
+            model.rows.map(\.path),
+            ["/Users/test/alpha"],
+            "A stale rename echo must not resurrect a removed workspace."
+        )
+        XCTAssertFalse(model.isMutating)
+        XCTAssertTrue(model.didMutateRegistry)
+    }
+
+    @MainActor
     func testMutationWithoutWorkspacesEchoRefetchesList() async throws {
         var workspacesLoadCount = 0
         let client = makeClient { request in

--- a/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
+++ b/HermesMobileTests/WorkspaceRegistryViewModelTests.swift
@@ -295,6 +295,125 @@ final class WorkspaceRegistryViewModelTests: APIClientTestCase {
     }
 
     @MainActor
+    func testMutationOkFalseIsTreatedAsFailure() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse(Self.twoWorkspacesJSON, for: request)
+            case "/api/workspaces/add":
+                // HTTP 200, but the body reports failure. Upstream uses non-2xx
+                // for failures today, yet the routes are undocumented — an
+                // explicit `ok: false` must never be presented as a success.
+                return apiTestJSONResponse(
+                    #"{"ok": false, "error": "Workspace already in list"}"#,
+                    for: request
+                )
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        let succeeded = await model.addWorkspace(path: "/Users/test/alpha", name: nil, create: false)
+
+        XCTAssertFalse(succeeded)
+        XCTAssertFalse(model.didMutateRegistry)
+        XCTAssertTrue(model.errorMessage?.contains("Workspace already in list") == true)
+        XCTAssertEqual(model.rows.map(\.path), ["/Users/test/alpha", "/Users/test/beta"])
+        XCTAssertFalse(model.isMutating)
+    }
+
+    @MainActor
+    func testStaleReorderResponseDoesNotClobberNewerOrder() async throws {
+        let threeWorkspacesJSON = """
+        {
+          "workspaces": [
+            {"path": "/Users/test/alpha", "name": "Alpha"},
+            {"path": "/Users/test/beta", "name": "Beta"},
+            {"path": "/Users/test/gamma", "name": "Gamma"}
+          ]
+        }
+        """
+        // First reorder ([beta, gamma, alpha]) is held back so the second one
+        // ([gamma, alpha, beta]) supersedes it before its stale echo lands.
+        // Whether the hold ends via the signal or the bounded timeout (the mock
+        // URL loading may serialize the two requests), the stale echo is always
+        // processed after the newer reorder began — the generation guard must
+        // ignore it.
+        let firstReorderStarted = expectation(description: "first reorder request in flight")
+        let releaseFirstReorder = DispatchSemaphore(value: 0)
+        var reorderCallCount = 0
+
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse(threeWorkspacesJSON, for: request)
+            case "/api/workspaces/reorder":
+                reorderCallCount += 1
+                if reorderCallCount == 1 {
+                    firstReorderStarted.fulfill()
+                    _ = releaseFirstReorder.wait(timeout: .now() + 2)
+                    return apiTestJSONResponse("""
+                    {
+                      "ok": true,
+                      "workspaces": [
+                        {"path": "/Users/test/beta", "name": "Beta"},
+                        {"path": "/Users/test/gamma", "name": "Gamma"},
+                        {"path": "/Users/test/alpha", "name": "Alpha"}
+                      ]
+                    }
+                    """, for: request)
+                }
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "workspaces": [
+                    {"path": "/Users/test/gamma", "name": "Gamma"},
+                    {"path": "/Users/test/alpha", "name": "Alpha"},
+                    {"path": "/Users/test/beta", "name": "Beta"}
+                  ]
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected path: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let model = WorkspaceRegistryViewModel(client: client)
+        await model.load()
+
+        // Move 1: alpha to the end → [beta, gamma, alpha]; response is held.
+        let firstMove = Task { @MainActor in
+            await model.moveWorkspaces(fromOffsets: IndexSet(integer: 0), toOffset: 3)
+        }
+        await fulfillment(of: [firstReorderStarted], timeout: 2)
+        XCTAssertTrue(model.isMutating)
+
+        // Move 2 (overlapping): beta to the end → [gamma, alpha, beta];
+        // completes while move 1 is still awaiting its response.
+        let secondSucceeded = await model.moveWorkspaces(fromOffsets: IndexSet(integer: 0), toOffset: 3)
+        XCTAssertTrue(secondSucceeded)
+        XCTAssertEqual(
+            model.rows.map(\.path),
+            ["/Users/test/gamma", "/Users/test/alpha", "/Users/test/beta"]
+        )
+
+        // Release the stale first response; it must not overwrite the order.
+        releaseFirstReorder.signal()
+        let firstSucceeded = await firstMove.value
+        XCTAssertTrue(firstSucceeded)
+        XCTAssertEqual(
+            model.rows.map(\.path),
+            ["/Users/test/gamma", "/Users/test/alpha", "/Users/test/beta"],
+            "A stale reorder echo must not clobber a newer ordering."
+        )
+        XCTAssertFalse(model.isMutating, "isMutating must stay true until the last overlapping mutation settles, then clear.")
+        XCTAssertTrue(model.didMutateRegistry)
+    }
+
+    @MainActor
     func testMutationWithoutWorkspacesEchoRefetchesList() async throws {
         var workspacesLoadCount = 0
         let client = makeClient { request in

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -93,7 +93,7 @@ sub-paths of a group. Do not reorder casually.
 | `/api/profile/` | roadmap | P3 | write | Profile Management — active/create/delete |
 | `/api/skills/` | roadmap | P3 | write | Skill Management — toggle shipped; save/delete remain roadmap |
 | `/api/transcribe` | roadmap | P3 | privacy | Audio Transcription — server-side; audio leaves the device |
-| `/api/workspaces/` | roadmap | P3 | write | Workspace Management — add/remove/rename/reorder |
+| `/api/workspaces/` | roadmap | P3 | write | Workspace Management — add/remove/rename/reorder shipped (#22); list + `/suggest` were already shipped |
 | `/api/workspace/` | roadmap | P3 | write | Workspace Management |
 | `/api/file/` | roadmap | P4 | write | File Editing / Management — owner-deferred |
 | `/api/folder/` | roadmap | P4 | write | File Editing / Management — owner-deferred |


### PR DESCRIPTION
## Summary

Adds workspace-registry management to the app (issue #22): the composer workspace picker gains a **Manage** button opening a Manage Workspaces sheet where you can add, rename, drag-to-reorder, and remove registered workspaces. The picker refreshes automatically after the sheet closes with changes.

Fixes #22

## Plan (E1, pre-approved for this unattended run)

1. `Endpoints.swift` + `APIClient+Workspace.swift`: four new POST routes — `/api/workspaces/add|remove|rename|reorder` — with request/response models in `Models/Workspace.swift` (tolerant decoding, every field optional).
2. New `WorkspaceRegistryViewModel` (`@MainActor @Observable`): load/add/rename/reorder plus **confirmation-gated removal** (`requestRemoval` stages, only `confirmPendingRemoval` calls the API). Mutations prefer the server's `workspaces` echo; when it is missing the list is refetched. A 404 on any management route sets `managementUnavailable` so future upstream drift degrades gracefully (these routes are undocumented and carry no stability promise).
3. New `WorkspaceManagerView` + add sheet (path field with `/api/workspaces/suggest` autocomplete, optional name, opt-in "create the folder" flag mirroring the web UI's Add Space).
4. Wiring: `ComposerWorkspacePickerSheet` toolbar → manager sheet; `ChatViewModel.refreshWorkspaceRoots()` refetches roots + suggestions after mutations; Manage is hidden in offline read-only mode.
5. i18n: 12 new keys translated into all 17 shipped languages.
6. `docs/agents/feature-gap-index.md`: `/api/workspaces/` row marked shipped.

## API verification (hard rule #1)

- Pinned upstream `.codex-tmp/hermes-webui/api/routes.py` @ `312d3fab`: `_handle_workspace_add` (path/name/create; rejects system roots; duplicate → 400 `"Workspace already in list"`), `_handle_workspace_remove` (**filters the list only — never touches files**, confirming the non-destructive remove copy), `_handle_workspace_rename` (404 `"Workspace not found"` when path unknown), `_handle_workspace_reorder` (`{"paths": [...]}`, omitted entries appended). All four return `{"ok": true, "workspaces": [...]}`; errors are `{"error": "..."}` which `APIError` already surfaces.
- Live server verified 2026-07-02 in the issue (400 + required-field errors on empty-body probes confirm the routes exist).
- Routes are absent from the official docs site (internal/undocumented) → tolerant decoding + 404 fallback per the issue's stability caveat.

## Validation

- `xcodebuild test -scheme HermesMobile -destination "id=359CB4A0-3F01-40E0-95DC-957C98C7B4EC"` (iPhone 17 sim): **1207 passed, 0 failed** on the head commit.
- New tests: endpoint contract entries for all four routes; APIClient body-construction/decoding/error-surfacing tests; `WorkspaceRegistryViewModelTests` covering load, add (trim/omission/error), confirmation-gated remove, rename, reorder full-order body, refetch-on-reorder-failure, refetch-when-echo-missing, and 404 → management-unavailable.

## Owner manual checks

- [ ] Composer → workspace picker → **Manage**: registered workspaces listed with names + paths.
- [ ] Add: suggestions appear while typing; adding a valid path updates the list and the picker after Done.
- [ ] Add an invalid path (e.g. `/etc`) → server error string shown inline, no crash.
- [ ] Rename via leading swipe → name updates in list and picker.
- [ ] Edit mode drag-to-reorder → order persists after closing/reopening the manager (server order).
- [ ] Swipe-to-delete shows the confirmation dialog with "no files are deleted" copy; Cancel keeps the workspace; Remove unregisters it (files remain on the Mac).
- [ ] Spot-check one non-English language (e.g. German) for the new strings.
