### PR TITLE
feat(settings): add read-only providers status

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		1A2B3C4D5E6F70000000112 /* ArchivedSessionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */; };
 		1A2B3C4D5E6F70000000114 /* DefaultModelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000115 /* DefaultModelPickerView.swift */; };
 		103200000000000000000002 /* DefaultProfilePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103200000000000000000001 /* DefaultProfilePickerView.swift */; };
+		C02600000000000000000001 /* ProvidersStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02600000000000000000002 /* ProvidersStatusView.swift */; };
 		1A2B3C4D5E6F70000000130 /* ContextWindowSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000120 /* ContextWindowSnapshot.swift */; };
 		1A2B3C4D5E6F70000000131 /* ContextWindowIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000121 /* ContextWindowIndicatorView.swift */; };
 		1A2B3C4D5E6F70000000132 /* ContextWindowIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000122 /* ContextWindowIndicatorTests.swift */; };
@@ -524,6 +525,7 @@
 		1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedSessionsViewModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000115 /* DefaultModelPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultModelPickerView.swift; sourceTree = "<group>"; };
 		103200000000000000000001 /* DefaultProfilePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProfilePickerView.swift; sourceTree = "<group>"; };
+		C02600000000000000000002 /* ProvidersStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersStatusView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000120 /* ContextWindowSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextWindowSnapshot.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000121 /* ContextWindowIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextWindowIndicatorView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000122 /* ContextWindowIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextWindowIndicatorTests.swift; sourceTree = "<group>"; };
@@ -1000,6 +1002,7 @@
 				C012400000000000000003 /* AppIconSettingsSection.swift */,
 				1A2B3C4D5E6F70000000115 /* DefaultModelPickerView.swift */,
 				103200000000000000000001 /* DefaultProfilePickerView.swift */,
+				C02600000000000000000002 /* ProvidersStatusView.swift */,
 				1A2B3C4D5E6F70000000111 /* ArchivedSessionsView.swift */,
 				C23400000000000000000002 /* StreamingLabReplay.swift */,
 				C23400000000000000000004 /* StreamingLabView.swift */,
@@ -1377,6 +1380,7 @@
 				C012400000000000000004 /* AppIconSettingsSection.swift in Sources */,
 				1A2B3C4D5E6F70000000114 /* DefaultModelPickerView.swift in Sources */,
 				103200000000000000000002 /* DefaultProfilePickerView.swift in Sources */,
+				C02600000000000000000001 /* ProvidersStatusView.swift in Sources */,
 				1A2B3C4D5E6F70000000110 /* ArchivedSessionsView.swift in Sources */,
 				C23400000000000000000001 /* StreamingLabReplay.swift in Sources */,
 				C23400000000000000000003 /* StreamingLabView.swift in Sources */,

--- a/HermesMobile/Features/Settings/ProvidersStatusView.swift
+++ b/HermesMobile/Features/Settings/ProvidersStatusView.swift
@@ -119,6 +119,7 @@ struct ProvidersStatusView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityValue(isExpanded(provider) ? String(localized: "Expanded") : String(localized: "Collapsed"))
             .accessibilityHint("Shows this provider's models.")
 
             if let authError = provider.authErrorText {
@@ -171,12 +172,15 @@ struct ProvidersStatusView: View {
 
         do {
             let response = try await APIClient(baseURL: server).providers()
+            guard !Task.isCancelled else { return }
             activeProvider = response.activeProvider
             providers = response.providers ?? []
         } catch {
+            guard !Task.isCancelled else { return }
             errorMessage = error.localizedDescription
         }
 
+        guard !Task.isCancelled else { return }
         isLoading = false
     }
 
@@ -187,10 +191,12 @@ struct ProvidersStatusView: View {
 
     private func toggleExpanded(_ provider: ProviderSummary) {
         guard let id = provider.providerID else { return }
-        if expandedProviderIDs.contains(id) {
-            expandedProviderIDs.remove(id)
-        } else {
-            expandedProviderIDs.insert(id)
+        withAnimation(.easeInOut(duration: 0.18)) {
+            if expandedProviderIDs.contains(id) {
+                expandedProviderIDs.remove(id)
+            } else {
+                expandedProviderIDs.insert(id)
+            }
         }
     }
 }

--- a/HermesMobile/Features/Settings/ProvidersStatusView.swift
+++ b/HermesMobile/Features/Settings/ProvidersStatusView.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+
+struct ProvidersStatusView: View {
+    let server: URL
+
+    @State private var isLoading = false
+    @State private var providers: [ProviderSummary] = []
+    @State private var activeProvider: String?
+    @State private var errorMessage: String?
+    @State private var expandedProviderIDs: Set<String> = []
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                ProvidersStatusCard(title: String(localized: "Providers")) {
+                    providerListContent
+                }
+
+                ProvidersStatusCard(title: String(localized: "Read Only")) {
+                    Label("API key management is not available here.", systemImage: "lock")
+                        .font(.subheadline.weight(.medium))
+
+                    Text("This screen only shows provider status reported by the server.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding()
+        }
+        .background(Color(.systemBackground))
+        .navigationTitle("Providers")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await loadProviders()
+        }
+        .refreshable {
+            await loadProviders()
+        }
+    }
+
+    @ViewBuilder
+    private var providerListContent: some View {
+        if isLoading && providers.isEmpty {
+            HStack(spacing: 8) {
+                ProgressView()
+                Text("Loading providers...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else if let errorMessage, providers.isEmpty {
+            Label("Could Not Load Providers", systemImage: "exclamationmark.triangle")
+                .font(.subheadline.weight(.semibold))
+
+            Text(errorMessage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else if providers.isEmpty {
+            Label("No Providers", systemImage: "tray")
+                .font(.subheadline.weight(.semibold))
+
+            Text("The server did not report any configured providers.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(providers.enumerated()), id: \.offset) { index, provider in
+                    providerRow(provider)
+
+                    if index < providers.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+
+    private func providerRow(_ provider: ProviderSummary) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                toggleExpanded(provider)
+            } label: {
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        HStack(spacing: 6) {
+                            Text(provider.displayTitle)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(.primary)
+                                .lineLimit(2)
+
+                            if provider.isActive(activeProvider: activeProvider) {
+                                ProviderStatusBadge(title: String(localized: "Active"), tint: .accentColor)
+                            }
+                        }
+
+                        HStack(spacing: 6) {
+                            ProviderStatusBadge(
+                                title: provider.keyStatusText,
+                                tint: provider.hasKey == true ? .green : .secondary
+                            )
+
+                            if let keySourceBadge = provider.keySourceBadge {
+                                ProviderStatusBadge(title: keySourceBadge, tint: .secondary)
+                            }
+                        }
+
+                        Text(provider.modelCountText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 12)
+
+                    Image(systemName: isExpanded(provider) ? "chevron.down" : "chevron.forward")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("Shows this provider's models.")
+
+            if let authError = provider.authErrorText {
+                Label(authError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if isExpanded(provider) {
+                providerModels(provider)
+            }
+        }
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private func providerModels(_ provider: ProviderSummary) -> some View {
+        let models = provider.visibleModels
+        if models.isEmpty {
+            Text("No models reported for this provider.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, 2)
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(models.enumerated()), id: \.offset) { _, model in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(model.label ?? model.id ?? String(localized: "Model"))
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.primary)
+
+                        if let id = model.id, id != model.label {
+                            Text(id)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(.leading, 2)
+        }
+    }
+
+    private func loadProviders() async {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let response = try await APIClient(baseURL: server).providers()
+            activeProvider = response.activeProvider
+            providers = response.providers ?? []
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    private func isExpanded(_ provider: ProviderSummary) -> Bool {
+        guard let id = provider.providerID else { return false }
+        return expandedProviderIDs.contains(id)
+    }
+
+    private func toggleExpanded(_ provider: ProviderSummary) {
+        guard let id = provider.providerID else { return }
+        if expandedProviderIDs.contains(id) {
+            expandedProviderIDs.remove(id)
+        } else {
+            expandedProviderIDs.insert(id)
+        }
+    }
+}
+
+private struct ProvidersStatusCard<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .textCase(.uppercase)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 4)
+                .padding(.bottom, 8)
+
+            VStack(alignment: .leading, spacing: 12) {
+                content
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.tertiarySystemFill).opacity(0.5), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        }
+    }
+}
+
+private struct ProviderStatusBadge: View {
+    let title: String
+    var tint: Color = .secondary
+
+    var body: some View {
+        Text(title)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .foregroundStyle(tint)
+            .background(tint.opacity(0.12), in: Capsule())
+    }
+}

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -326,6 +326,19 @@ struct SettingsView: View {
 
                     SettingsDivider()
 
+                    NavigationLink {
+                        ProvidersStatusView(server: server)
+                    } label: {
+                        SettingsAccessoryRow(
+                            title: String(localized: "Providers"),
+                            systemImage: "server.rack"
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Opens read-only provider status.")
+
+                    SettingsDivider()
+
                     SettingsValueRow(title: String(localized: "Status")) {
                         serverStatusPill
                     }

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -137,8 +137,176 @@ struct AgentCommand: Decodable, Equatable, Identifiable, Sendable {
 }
 
 struct ProvidersResponse: Decodable, Equatable {
-    let providers: [JSONValue]?
+    let providers: [ProviderSummary]?
     let activeProvider: String?
+}
+
+struct ProviderSummary: Decodable, Equatable, Identifiable, Sendable {
+    var id: String? { providerID }
+
+    let providerID: String?
+    let displayName: String?
+    let hasKey: Bool?
+    let configurable: Bool?
+    let isPluginProvider: Bool?
+    let isSelfHosted: Bool?
+    let baseUrl: String?
+    let isOauth: Bool?
+    let keySource: String?
+    let authError: String?
+    let models: [ProviderModel]?
+    let modelsTotal: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case providerID = "id"
+        case displayName
+        case hasKey
+        case configurable
+        case isPluginProvider
+        case isSelfHosted
+        case baseUrl
+        case isOauth
+        case keySource
+        case authError
+        case models
+        case modelsTotal
+    }
+
+    init(
+        id: String?,
+        displayName: String? = nil,
+        hasKey: Bool? = nil,
+        configurable: Bool? = nil,
+        isPluginProvider: Bool? = nil,
+        isSelfHosted: Bool? = nil,
+        baseUrl: String? = nil,
+        isOauth: Bool? = nil,
+        keySource: String? = nil,
+        authError: String? = nil,
+        models: [ProviderModel]? = nil,
+        modelsTotal: Int? = nil
+    ) {
+        self.providerID = id
+        self.displayName = displayName
+        self.hasKey = hasKey
+        self.configurable = configurable
+        self.isPluginProvider = isPluginProvider
+        self.isSelfHosted = isSelfHosted
+        self.baseUrl = baseUrl
+        self.isOauth = isOauth
+        self.keySource = keySource
+        self.authError = authError
+        self.models = models
+        self.modelsTotal = modelsTotal
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        providerID = container.decodeLossyStringIfPresent(forKey: .providerID)
+        displayName = container.decodeLossyStringIfPresent(forKey: .displayName)
+        hasKey = container.decodeLossyBoolIfPresent(forKey: .hasKey)
+        configurable = container.decodeLossyBoolIfPresent(forKey: .configurable)
+        isPluginProvider = container.decodeLossyBoolIfPresent(forKey: .isPluginProvider)
+        isSelfHosted = container.decodeLossyBoolIfPresent(forKey: .isSelfHosted)
+        baseUrl = container.decodeLossyStringIfPresent(forKey: .baseUrl)
+        isOauth = container.decodeLossyBoolIfPresent(forKey: .isOauth)
+        keySource = container.decodeLossyStringIfPresent(forKey: .keySource)
+        authError = container.decodeLossyStringIfPresent(forKey: .authError)
+        models = try? container.decodeIfPresent([ProviderModel].self, forKey: .models)
+        modelsTotal = container.decodeLossyIntIfPresent(forKey: .modelsTotal)
+    }
+}
+
+struct ProviderModel: Decodable, Equatable, Identifiable, Sendable {
+    let id: String?
+    let label: String?
+
+    init(id: String?, label: String? = nil) {
+        self.id = id
+        self.label = label
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case label
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyStringIfPresent(forKey: .id)
+        label = container.decodeLossyStringIfPresent(forKey: .label)
+    }
+}
+
+extension ProviderSummary {
+    var displayTitle: String {
+        normalized(displayName) ?? normalized(providerID) ?? String(localized: "Provider")
+    }
+
+    var keyStatusText: String {
+        hasKey == true ? String(localized: "Has key") : String(localized: "No key")
+    }
+
+    var keySourceBadge: String? {
+        if isSelfHosted == true {
+            return String(localized: "self-hosted")
+        }
+
+        if isOauth == true {
+            return String(localized: "oauth")
+        }
+
+        guard let source = normalized(keySource), source != "none" else { return nil }
+        switch source {
+        case "env_var":
+            return String(localized: "env var")
+        case "env_file":
+            return String(localized: "env file")
+        case "config_yaml":
+            return String(localized: "config")
+        default:
+            return source.replacingOccurrences(of: "_", with: " ")
+        }
+    }
+
+    var authErrorText: String? {
+        normalized(authError)
+    }
+
+    var visibleModels: [ProviderModel] {
+        (models ?? []).filter { normalized($0.id) != nil }
+    }
+
+    var modelCountText: String {
+        let shown = visibleModels.count
+        if let modelsTotal {
+            if shown > 0, modelsTotal > shown {
+                return String(localized: "\(shown) shown · \(modelsTotal) total")
+            }
+            return String(localized: "\(modelsTotal) models")
+        }
+
+        if shown > 0 {
+            return String(localized: "\(shown) models")
+        }
+
+        return String(localized: "No models listed")
+    }
+
+    func isActive(activeProvider: String?) -> Bool {
+        guard let providerID = normalized(providerID),
+              let activeProvider = normalized(activeProvider)
+        else {
+            return false
+        }
+
+        return providerID == activeProvider
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
 }
 
 struct SettingsResponse: Decodable, Equatable {

--- a/HermesMobileTests/ModelCatalogTests.swift
+++ b/HermesMobileTests/ModelCatalogTests.swift
@@ -222,6 +222,121 @@ final class ModelCatalogTests: XCTestCase {
             groups
         )
     }
+
+    // MARK: - /api/providers (issue #26)
+
+    func testProvidersResponseDecodesLiveStatusShape() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(
+            ProvidersResponse.self,
+            from: Data("""
+            {
+              "active_provider": "openai-codex",
+              "providers": [
+                {
+                  "id": "openai-codex",
+                  "display_name": "OpenAI Codex",
+                  "has_key": true,
+                  "configurable": false,
+                  "is_plugin_provider": false,
+                  "is_self_hosted": false,
+                  "base_url": null,
+                  "is_oauth": true,
+                  "key_source": "oauth",
+                  "auth_error": null,
+                  "models": [
+                    {"id": "gpt-5.5", "label": "GPT 5.5"}
+                  ],
+                  "models_total": 5
+                }
+              ]
+            }
+            """.utf8)
+        )
+
+        XCTAssertEqual(response.activeProvider, "openai-codex")
+        let provider = try XCTUnwrap(response.providers?.first)
+        XCTAssertEqual(provider.id, "openai-codex")
+        XCTAssertEqual(provider.displayName, "OpenAI Codex")
+        XCTAssertEqual(provider.hasKey, true)
+        XCTAssertEqual(provider.configurable, false)
+        XCTAssertEqual(provider.isPluginProvider, false)
+        XCTAssertEqual(provider.isSelfHosted, false)
+        XCTAssertEqual(provider.isOauth, true)
+        XCTAssertEqual(provider.keySource, "oauth")
+        XCTAssertNil(provider.authError)
+        XCTAssertEqual(provider.modelsTotal, 5)
+        XCTAssertEqual(provider.models?.first?.id, "gpt-5.5")
+        XCTAssertEqual(provider.models?.first?.label, "GPT 5.5")
+    }
+
+    func testProvidersResponseToleratesMissingFields() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(
+            ProvidersResponse.self,
+            from: Data("""
+            {
+              "providers": [
+                {"id": "bare-provider"},
+                {}
+              ]
+            }
+            """.utf8)
+        )
+
+        XCTAssertNil(response.activeProvider)
+        XCTAssertEqual(response.providers?.count, 2)
+        XCTAssertEqual(response.providers?.first?.displayTitle, "bare-provider")
+        XCTAssertEqual(response.providers?.last?.displayTitle, "Provider")
+    }
+
+    func testProviderPresentationHelpersExposeActiveErrorAndKeyStatus() {
+        let keyed = ProviderSummary(
+            id: "openrouter",
+            displayName: "OpenRouter",
+            hasKey: true,
+            configurable: true,
+            isPluginProvider: false,
+            isSelfHosted: false,
+            baseUrl: nil,
+            isOauth: false,
+            keySource: "env_var",
+            authError: "token expired",
+            models: [ProviderModel(id: "anthropic/claude-sonnet", label: "Claude Sonnet")],
+            modelsTotal: 12
+        )
+
+        XCTAssertTrue(keyed.isActive(activeProvider: "openrouter"))
+        XCTAssertEqual(keyed.displayTitle, "OpenRouter")
+        XCTAssertEqual(keyed.keyStatusText, "Has key")
+        XCTAssertEqual(keyed.keySourceBadge, "env var")
+        XCTAssertEqual(keyed.modelCountText, "1 shown · 12 total")
+        XCTAssertEqual(keyed.authErrorText, "token expired")
+
+        let unkeyed = ProviderSummary(
+            id: "local",
+            displayName: nil,
+            hasKey: false,
+            configurable: nil,
+            isPluginProvider: nil,
+            isSelfHosted: true,
+            baseUrl: "http://localhost:11434",
+            isOauth: nil,
+            keySource: "none",
+            authError: nil,
+            models: nil,
+            modelsTotal: nil
+        )
+
+        XCTAssertFalse(unkeyed.isActive(activeProvider: "openrouter"))
+        XCTAssertEqual(unkeyed.displayTitle, "local")
+        XCTAssertEqual(unkeyed.keyStatusText, "No key")
+        XCTAssertEqual(unkeyed.keySourceBadge, "self-hosted")
+        XCTAssertEqual(unkeyed.modelCountText, "No models listed")
+        XCTAssertNil(unkeyed.authErrorText)
+    }
 }
 
 final class PersonalityAutocompleteTests: XCTestCase {

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -87,7 +87,7 @@ sub-paths of a group. Do not reorder casually.
 | `/api/session/recovery/` | roadmap | P4 | write | Advanced Session Maintenance |
 | `/api/sessions/cleanup` | roadmap | P4 | write | Advanced Session Maintenance — bulk cleanup |
 | `/api/provider/` | roadmap | P3 | secret | Provider Management — quota/cost history |
-| `/api/providers` | roadmap | P3 | secret | Provider Management — set/delete API keys |
+| `/api/providers` | partial | P3 | secret | Provider Management — read status shipped; key set/delete remains roadmap |
 | `/api/models/refresh` | roadmap | P3 | — | Provider / Model Management |
 | `/api/models/live` | roadmap | P3 | — | Provider / Model Management — live model fetch |
 | `/api/model/` | roadmap | P3 | — | Provider / Model Management |


### PR DESCRIPTION
## Summary
- Decode /api/providers into tolerant provider status models
- Add Settings → Providers read-only status screen with active/key/source/error/model details
- Mark provider status as shipped while key management remains roadmap

## Test Plan
- [x] git diff --check
- [x] Static delimiter balance check for touched Swift files
- [ ] Full XCTest suite (pending GitHub CI / Mac runner; Linux host has no xcodebuild or swift)

Closes #26