### PR TITLE
feat(intents): localize app shortcut phrases

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1A2B3C4D5E6F700000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000014 /* Assets.xcassets */; };
 		10CA110C0DE000000000B001 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000B002 /* Localizable.xcstrings */; };
 		10CA110C0DE000000000B003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000B002 /* Localizable.xcstrings */; };
+		10CA110C0DE000000000B004 /* AppShortcuts.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000B005 /* AppShortcuts.xcstrings */; };
 		10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000C002 /* LocalizationCatalogTests.swift */; };
 		1A2B3C4D5E6F700000000004 /* LDSwiftEventSource in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000094 /* LDSwiftEventSource */; };
 		1A2B3C4D5E6F700000000005 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000095 /* MarkdownUI */; };
@@ -337,6 +338,7 @@
 		1A2B3C4D5E6F700000000013 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1A2B3C4D5E6F700000000014 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		10CA110C0DE000000000B002 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		10CA110C0DE000000000B005 /* AppShortcuts.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = AppShortcuts.xcstrings; sourceTree = "<group>"; };
 		10CA110C0DE000000000C002 /* LocalizationCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationCatalogTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F700000000015 /* HermesMobileTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HermesMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A2B3C4D5E6F7000000000B0 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
@@ -678,6 +680,7 @@
 			children = (
 				1A2B3C4D5E6F700000000014 /* Assets.xcassets */,
 				10CA110C0DE000000000B002 /* Localizable.xcstrings */,
+				10CA110C0DE000000000B005 /* AppShortcuts.xcstrings */,
 				1A2B3C4D5E6F700000000013 /* Info.plist */,
 				B5A100000000000000000015 /* HermesMobile.entitlements */,
 				1A2B3C4D5E6F70000000301 /* PrivacyInfo.xcprivacy */,
@@ -1286,6 +1289,7 @@
 			files = (
 				1A2B3C4D5E6F700000000003 /* Assets.xcassets in Resources */,
 				10CA110C0DE000000000B001 /* Localizable.xcstrings in Resources */,
+				10CA110C0DE000000000B004 /* AppShortcuts.xcstrings in Resources */,
 				1A2B3C4D5E6F70000000300 /* PrivacyInfo.xcprivacy in Resources */,
 				9E2A653D968A4ACDA19A8142 /* ThirdPartyNotices in Resources */,
 			);

--- a/HermesMobile/Resources/AppShortcuts.xcstrings
+++ b/HermesMobile/Resources/AppShortcuts.xcstrings
@@ -1,0 +1,1014 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "New \\(.applicationName) chat": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محادثة \\(.applicationName) جديدة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer \\(.applicationName)-Chat"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New \\(.applicationName) chat"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo chat de \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle discussion \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צ׳אט \\(.applicationName) חדש"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova chat \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規\\(.applicationName)チャット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 \\(.applicationName) 채팅"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe \\(.applicationName)-chat"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy czat \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo chat do \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новый чат \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni \\(.applicationName) sohbeti"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نئی \\(.applicationName) چیٹ"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增 \\(.applicationName) 聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 \\(.applicationName) 聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增 \\(.applicationName) 聊天"
+          }
+        }
+      }
+    },
+    "New \\(.applicationName) voice chat": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محادثة \\(.applicationName) صوتية جديدة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer \\(.applicationName)-Sprachchat"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New \\(.applicationName) voice chat"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo chat de voz de \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle discussion vocale \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צ׳אט קולי חדש של \\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova chat vocale \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規\\(.applicationName)音声チャット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 \\(.applicationName) 음성 채팅"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe \\(.applicationName)-spraakchat"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy czat głosowy \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo chat por voz do \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новый голосовой чат \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni \\(.applicationName) sesli sohbeti"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نئی \\(.applicationName) صوتی چیٹ"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增 \\(.applicationName) 語音聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 \\(.applicationName) 语音聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增 \\(.applicationName) 語音聊天"
+          }
+        }
+      }
+    },
+    "New \\(\\.$profile) chat in \\(.applicationName)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محادثة \\(\\.$profile) جديدة في \\(.applicationName)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer \\(\\.$profile)-Chat in \\(.applicationName)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New \\(\\.$profile) chat in \\(.applicationName)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo chat de \\(\\.$profile) en \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle discussion \\(\\.$profile) dans \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צ׳אט \\(\\.$profile) חדש ב-\\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova chat \\(\\.$profile) in \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)で新規\\(\\.$profile)チャット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)에서 새 \\(\\.$profile) 채팅"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe \\(\\.$profile)-chat in \\(.applicationName)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy czat \\(\\.$profile) w \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo chat de \\(\\.$profile) no \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новый чат \\(\\.$profile) в \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) içinde yeni \\(\\.$profile) sohbeti"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) میں نئی \\(\\.$profile) چیٹ"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新增 \\(\\.$profile) 聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新建 \\(\\.$profile) 聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新增 \\(\\.$profile) 聊天"
+          }
+        }
+      }
+    },
+    "New chat in \\(.applicationName)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محادثة جديدة في \\(.applicationName)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Chat in \\(.applicationName)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New chat in \\(.applicationName)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo chat en \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle discussion dans \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צ׳אט חדש ב-\\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova chat in \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)で新規チャット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)에서 새 채팅"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe chat in \\(.applicationName)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy czat w \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo chat no \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новый чат в \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) içinde yeni sohbet"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) میں نئی چیٹ"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新增聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新建聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新增聊天"
+          }
+        }
+      }
+    },
+    "New chat in \\(\\.$profile) on \\(.applicationName)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محادثة جديدة في \\(\\.$profile) على \\(.applicationName)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Chat in \\(\\.$profile) auf \\(.applicationName)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New chat in \\(\\.$profile) on \\(.applicationName)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo chat en \\(\\.$profile) en \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle discussion dans \\(\\.$profile) sur \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צ׳אט חדש ב-\\(\\.$profile) ב-\\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova chat in \\(\\.$profile) su \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)の\\(\\.$profile)で新規チャット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)의 \\(\\.$profile)에서 새 채팅"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe chat in \\(\\.$profile) op \\(.applicationName)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy czat w \\(\\.$profile) na \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo chat em \\(\\.$profile) no \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новый чат в \\(\\.$profile) в \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) üzerinde \\(\\.$profile) içinde yeni sohbet"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) پر \\(\\.$profile) میں نئی چیٹ"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 的 \\(\\.$profile) 中新增聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 的 \\(\\.$profile) 中新建聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 的 \\(\\.$profile) 中新增聊天"
+          }
+        }
+      }
+    },
+    "New voice chat in \\(.applicationName)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محادثة صوتية جديدة في \\(.applicationName)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuer Sprachchat in \\(.applicationName)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New voice chat in \\(.applicationName)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo chat de voz en \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle discussion vocale dans \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צ׳אט קולי חדש ב-\\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova chat vocale in \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)で新規音声チャット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)에서 새 음성 채팅"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieuwe spraakchat in \\(.applicationName)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy czat głosowy w \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo chat por voz no \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новый голосовой чат в \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) içinde yeni sesli sohbet"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) میں نئی صوتی چیٹ"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新增語音聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新建语音聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中新增語音聊天"
+          }
+        }
+      }
+    },
+    "Start a new \\(\\.$profile) chat in \\(.applicationName)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابدأ محادثة \\(\\.$profile) جديدة في \\(.applicationName)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte einen neuen \\(\\.$profile)-Chat in \\(.applicationName)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start a new \\(\\.$profile) chat in \\(.applicationName)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia un nuevo chat de \\(\\.$profile) en \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer une nouvelle discussion \\(\\.$profile) dans \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התחל צ׳אט \\(\\.$profile) חדש ב-\\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvia una nuova chat \\(\\.$profile) in \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)で新しい\\(\\.$profile)チャットを開始"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)에서 새 \\(\\.$profile) 채팅 시작"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start een nieuwe \\(\\.$profile)-chat in \\(.applicationName)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij nowy czat \\(\\.$profile) w \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar um novo chat de \\(\\.$profile) no \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать новый чат \\(\\.$profile) в \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) içinde yeni \\(\\.$profile) sohbeti başlat"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) میں نئی \\(\\.$profile) چیٹ شروع کریں"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中開始新的 \\(\\.$profile) 聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中开始新的 \\(\\.$profile) 聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中開始新的 \\(\\.$profile) 聊天"
+          }
+        }
+      }
+    },
+    "Start a new chat in \\(.applicationName)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابدأ محادثة جديدة في \\(.applicationName)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte einen neuen Chat in \\(.applicationName)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start a new chat in \\(.applicationName)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia un nuevo chat en \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer une nouvelle discussion dans \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התחל צ׳אט חדש ב-\\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvia una nuova chat in \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)で新しいチャットを開始"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)에서 새 채팅 시작"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start een nieuwe chat in \\(.applicationName)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij nowy czat w \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar um novo chat no \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать новый чат в \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) içinde yeni sohbet başlat"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) میں نئی چیٹ شروع کریں"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中開始新聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中开始新聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中開始新聊天"
+          }
+        }
+      }
+    },
+    "Start a voice chat in \\(.applicationName)": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابدأ محادثة صوتية في \\(.applicationName)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte einen Sprachchat in \\(.applicationName)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start a voice chat in \\(.applicationName)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia un chat de voz en \\(.applicationName)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer une discussion vocale dans \\(.applicationName)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התחל צ׳אט קולי ב-\\(.applicationName)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvia una chat vocale in \\(.applicationName)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)で音声チャットを開始"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName)에서 음성 채팅 시작"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start een spraakchat in \\(.applicationName)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij czat głosowy w \\(.applicationName)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar um chat por voz no \\(.applicationName)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать голосовой чат в \\(.applicationName)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) içinde sesli sohbet başlat"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\\(.applicationName) میں صوتی چیٹ شروع کریں"
+          }
+        },
+        "zh-HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中開始語音聊天"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中开始语音聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 \\(.applicationName) 中開始語音聊天"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/HermesMobile/Resources/AppShortcuts.xcstrings
+++ b/HermesMobile/Resources/AppShortcuts.xcstrings
@@ -1,1010 +1,1010 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "New \\(.applicationName) chat": {
+    "New ${applicationName} chat": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "محادثة \\(.applicationName) جديدة"
+            "value": "محادثة ${applicationName} جديدة"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neuer \\(.applicationName)-Chat"
+            "value": "Neuer ${applicationName}-Chat"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New \\(.applicationName) chat"
+            "value": "New ${applicationName} chat"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuevo chat de \\(.applicationName)"
+            "value": "Nuevo chat de ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nouvelle discussion \\(.applicationName)"
+            "value": "Nouvelle discussion ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "צ׳אט \\(.applicationName) חדש"
+            "value": "צ׳אט ${applicationName} חדש"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuova chat \\(.applicationName)"
+            "value": "Nuova chat ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "新規\\(.applicationName)チャット"
+            "value": "新規${applicationName}チャット"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 \\(.applicationName) 채팅"
+            "value": "새 ${applicationName} 채팅"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nieuwe \\(.applicationName)-chat"
+            "value": "Nieuwe ${applicationName}-chat"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nowy czat \\(.applicationName)"
+            "value": "Nowy czat ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Novo chat do \\(.applicationName)"
+            "value": "Novo chat do ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Новый чат \\(.applicationName)"
+            "value": "Новый чат ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Yeni \\(.applicationName) sohbeti"
+            "value": "Yeni ${applicationName} sohbeti"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "نئی \\(.applicationName) چیٹ"
+            "value": "نئی ${applicationName} چیٹ"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "新增 \\(.applicationName) 聊天"
+            "value": "新增 ${applicationName} 聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "新建 \\(.applicationName) 聊天"
+            "value": "新建 ${applicationName} 聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "新增 \\(.applicationName) 聊天"
+            "value": "新增 ${applicationName} 聊天"
           }
         }
       }
     },
-    "New \\(.applicationName) voice chat": {
+    "New ${applicationName} voice chat": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "محادثة \\(.applicationName) صوتية جديدة"
+            "value": "محادثة ${applicationName} صوتية جديدة"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neuer \\(.applicationName)-Sprachchat"
+            "value": "Neuer ${applicationName}-Sprachchat"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New \\(.applicationName) voice chat"
+            "value": "New ${applicationName} voice chat"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuevo chat de voz de \\(.applicationName)"
+            "value": "Nuevo chat de voz de ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nouvelle discussion vocale \\(.applicationName)"
+            "value": "Nouvelle discussion vocale ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "צ׳אט קולי חדש של \\(.applicationName)"
+            "value": "צ׳אט קולי חדש של ${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuova chat vocale \\(.applicationName)"
+            "value": "Nuova chat vocale ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "新規\\(.applicationName)音声チャット"
+            "value": "新規${applicationName}音声チャット"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 \\(.applicationName) 음성 채팅"
+            "value": "새 ${applicationName} 음성 채팅"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nieuwe \\(.applicationName)-spraakchat"
+            "value": "Nieuwe ${applicationName}-spraakchat"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nowy czat głosowy \\(.applicationName)"
+            "value": "Nowy czat głosowy ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Novo chat por voz do \\(.applicationName)"
+            "value": "Novo chat por voz do ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Новый голосовой чат \\(.applicationName)"
+            "value": "Новый голосовой чат ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Yeni \\(.applicationName) sesli sohbeti"
+            "value": "Yeni ${applicationName} sesli sohbeti"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "نئی \\(.applicationName) صوتی چیٹ"
+            "value": "نئی ${applicationName} صوتی چیٹ"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "新增 \\(.applicationName) 語音聊天"
+            "value": "新增 ${applicationName} 語音聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "新建 \\(.applicationName) 语音聊天"
+            "value": "新建 ${applicationName} 语音聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "新增 \\(.applicationName) 語音聊天"
+            "value": "新增 ${applicationName} 語音聊天"
           }
         }
       }
     },
-    "New \\(\\.$profile) chat in \\(.applicationName)": {
+    "New ${profile} chat in ${applicationName}": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "محادثة \\(\\.$profile) جديدة في \\(.applicationName)"
+            "value": "محادثة ${profile} جديدة في ${applicationName}"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neuer \\(\\.$profile)-Chat in \\(.applicationName)"
+            "value": "Neuer ${profile}-Chat in ${applicationName}"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New \\(\\.$profile) chat in \\(.applicationName)"
+            "value": "New ${profile} chat in ${applicationName}"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuevo chat de \\(\\.$profile) en \\(.applicationName)"
+            "value": "Nuevo chat de ${profile} en ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nouvelle discussion \\(\\.$profile) dans \\(.applicationName)"
+            "value": "Nouvelle discussion ${profile} dans ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "צ׳אט \\(\\.$profile) חדש ב-\\(.applicationName)"
+            "value": "צ׳אט ${profile} חדש ב-${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuova chat \\(\\.$profile) in \\(.applicationName)"
+            "value": "Nuova chat ${profile} in ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)で新規\\(\\.$profile)チャット"
+            "value": "${applicationName}で新規${profile}チャット"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)에서 새 \\(\\.$profile) 채팅"
+            "value": "${applicationName}에서 새 ${profile} 채팅"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nieuwe \\(\\.$profile)-chat in \\(.applicationName)"
+            "value": "Nieuwe ${profile}-chat in ${applicationName}"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nowy czat \\(\\.$profile) w \\(.applicationName)"
+            "value": "Nowy czat ${profile} w ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Novo chat de \\(\\.$profile) no \\(.applicationName)"
+            "value": "Novo chat de ${profile} no ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Новый чат \\(\\.$profile) в \\(.applicationName)"
+            "value": "Новый чат ${profile} в ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) içinde yeni \\(\\.$profile) sohbeti"
+            "value": "${applicationName} içinde yeni ${profile} sohbeti"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) میں نئی \\(\\.$profile) چیٹ"
+            "value": "${applicationName} میں نئی ${profile} چیٹ"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新增 \\(\\.$profile) 聊天"
+            "value": "在 ${applicationName} 中新增 ${profile} 聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新建 \\(\\.$profile) 聊天"
+            "value": "在 ${applicationName} 中新建 ${profile} 聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新增 \\(\\.$profile) 聊天"
+            "value": "在 ${applicationName} 中新增 ${profile} 聊天"
           }
         }
       }
     },
-    "New chat in \\(.applicationName)": {
+    "New chat in ${applicationName}": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "محادثة جديدة في \\(.applicationName)"
+            "value": "محادثة جديدة في ${applicationName}"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neuer Chat in \\(.applicationName)"
+            "value": "Neuer Chat in ${applicationName}"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New chat in \\(.applicationName)"
+            "value": "New chat in ${applicationName}"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuevo chat en \\(.applicationName)"
+            "value": "Nuevo chat en ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nouvelle discussion dans \\(.applicationName)"
+            "value": "Nouvelle discussion dans ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "צ׳אט חדש ב-\\(.applicationName)"
+            "value": "צ׳אט חדש ב-${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuova chat in \\(.applicationName)"
+            "value": "Nuova chat in ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)で新規チャット"
+            "value": "${applicationName}で新規チャット"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)에서 새 채팅"
+            "value": "${applicationName}에서 새 채팅"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nieuwe chat in \\(.applicationName)"
+            "value": "Nieuwe chat in ${applicationName}"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nowy czat w \\(.applicationName)"
+            "value": "Nowy czat w ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Novo chat no \\(.applicationName)"
+            "value": "Novo chat no ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Новый чат в \\(.applicationName)"
+            "value": "Новый чат в ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) içinde yeni sohbet"
+            "value": "${applicationName} içinde yeni sohbet"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) میں نئی چیٹ"
+            "value": "${applicationName} میں نئی چیٹ"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新增聊天"
+            "value": "在 ${applicationName} 中新增聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新建聊天"
+            "value": "在 ${applicationName} 中新建聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新增聊天"
+            "value": "在 ${applicationName} 中新增聊天"
           }
         }
       }
     },
-    "New chat in \\(\\.$profile) on \\(.applicationName)": {
+    "New chat in ${profile} on ${applicationName}": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "محادثة جديدة في \\(\\.$profile) على \\(.applicationName)"
+            "value": "محادثة جديدة في ${profile} على ${applicationName}"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neuer Chat in \\(\\.$profile) auf \\(.applicationName)"
+            "value": "Neuer Chat in ${profile} auf ${applicationName}"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New chat in \\(\\.$profile) on \\(.applicationName)"
+            "value": "New chat in ${profile} on ${applicationName}"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuevo chat en \\(\\.$profile) en \\(.applicationName)"
+            "value": "Nuevo chat en ${profile} en ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nouvelle discussion dans \\(\\.$profile) sur \\(.applicationName)"
+            "value": "Nouvelle discussion dans ${profile} sur ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "צ׳אט חדש ב-\\(\\.$profile) ב-\\(.applicationName)"
+            "value": "צ׳אט חדש ב-${profile} ב-${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuova chat in \\(\\.$profile) su \\(.applicationName)"
+            "value": "Nuova chat in ${profile} su ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)の\\(\\.$profile)で新規チャット"
+            "value": "${applicationName}の${profile}で新規チャット"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)의 \\(\\.$profile)에서 새 채팅"
+            "value": "${applicationName}의 ${profile}에서 새 채팅"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nieuwe chat in \\(\\.$profile) op \\(.applicationName)"
+            "value": "Nieuwe chat in ${profile} op ${applicationName}"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nowy czat w \\(\\.$profile) na \\(.applicationName)"
+            "value": "Nowy czat w ${profile} na ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Novo chat em \\(\\.$profile) no \\(.applicationName)"
+            "value": "Novo chat em ${profile} no ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Новый чат в \\(\\.$profile) в \\(.applicationName)"
+            "value": "Новый чат в ${profile} в ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) üzerinde \\(\\.$profile) içinde yeni sohbet"
+            "value": "${applicationName} üzerinde ${profile} içinde yeni sohbet"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) پر \\(\\.$profile) میں نئی چیٹ"
+            "value": "${applicationName} پر ${profile} میں نئی چیٹ"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 的 \\(\\.$profile) 中新增聊天"
+            "value": "在 ${applicationName} 的 ${profile} 中新增聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 的 \\(\\.$profile) 中新建聊天"
+            "value": "在 ${applicationName} 的 ${profile} 中新建聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 的 \\(\\.$profile) 中新增聊天"
+            "value": "在 ${applicationName} 的 ${profile} 中新增聊天"
           }
         }
       }
     },
-    "New voice chat in \\(.applicationName)": {
+    "New voice chat in ${applicationName}": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "محادثة صوتية جديدة في \\(.applicationName)"
+            "value": "محادثة صوتية جديدة في ${applicationName}"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neuer Sprachchat in \\(.applicationName)"
+            "value": "Neuer Sprachchat in ${applicationName}"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New voice chat in \\(.applicationName)"
+            "value": "New voice chat in ${applicationName}"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuevo chat de voz en \\(.applicationName)"
+            "value": "Nuevo chat de voz en ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nouvelle discussion vocale dans \\(.applicationName)"
+            "value": "Nouvelle discussion vocale dans ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "צ׳אט קולי חדש ב-\\(.applicationName)"
+            "value": "צ׳אט קולי חדש ב-${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nuova chat vocale in \\(.applicationName)"
+            "value": "Nuova chat vocale in ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)で新規音声チャット"
+            "value": "${applicationName}で新規音声チャット"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)에서 새 음성 채팅"
+            "value": "${applicationName}에서 새 음성 채팅"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nieuwe spraakchat in \\(.applicationName)"
+            "value": "Nieuwe spraakchat in ${applicationName}"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nowy czat głosowy w \\(.applicationName)"
+            "value": "Nowy czat głosowy w ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Novo chat por voz no \\(.applicationName)"
+            "value": "Novo chat por voz no ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Новый голосовой чат в \\(.applicationName)"
+            "value": "Новый голосовой чат в ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) içinde yeni sesli sohbet"
+            "value": "${applicationName} içinde yeni sesli sohbet"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) میں نئی صوتی چیٹ"
+            "value": "${applicationName} میں نئی صوتی چیٹ"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新增語音聊天"
+            "value": "在 ${applicationName} 中新增語音聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新建语音聊天"
+            "value": "在 ${applicationName} 中新建语音聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中新增語音聊天"
+            "value": "在 ${applicationName} 中新增語音聊天"
           }
         }
       }
     },
-    "Start a new \\(\\.$profile) chat in \\(.applicationName)": {
+    "Start a new ${profile} chat in ${applicationName}": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ابدأ محادثة \\(\\.$profile) جديدة في \\(.applicationName)"
+            "value": "ابدأ محادثة ${profile} جديدة في ${applicationName}"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Starte einen neuen \\(\\.$profile)-Chat in \\(.applicationName)"
+            "value": "Starte einen neuen ${profile}-Chat in ${applicationName}"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start a new \\(\\.$profile) chat in \\(.applicationName)"
+            "value": "Start a new ${profile} chat in ${applicationName}"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Inicia un nuevo chat de \\(\\.$profile) en \\(.applicationName)"
+            "value": "Inicia un nuevo chat de ${profile} en ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Démarrer une nouvelle discussion \\(\\.$profile) dans \\(.applicationName)"
+            "value": "Démarrer une nouvelle discussion ${profile} dans ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "התחל צ׳אט \\(\\.$profile) חדש ב-\\(.applicationName)"
+            "value": "התחל צ׳אט ${profile} חדש ב-${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Avvia una nuova chat \\(\\.$profile) in \\(.applicationName)"
+            "value": "Avvia una nuova chat ${profile} in ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)で新しい\\(\\.$profile)チャットを開始"
+            "value": "${applicationName}で新しい${profile}チャットを開始"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)에서 새 \\(\\.$profile) 채팅 시작"
+            "value": "${applicationName}에서 새 ${profile} 채팅 시작"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start een nieuwe \\(\\.$profile)-chat in \\(.applicationName)"
+            "value": "Start een nieuwe ${profile}-chat in ${applicationName}"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rozpocznij nowy czat \\(\\.$profile) w \\(.applicationName)"
+            "value": "Rozpocznij nowy czat ${profile} w ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar um novo chat de \\(\\.$profile) no \\(.applicationName)"
+            "value": "Iniciar um novo chat de ${profile} no ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Начать новый чат \\(\\.$profile) в \\(.applicationName)"
+            "value": "Начать новый чат ${profile} в ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) içinde yeni \\(\\.$profile) sohbeti başlat"
+            "value": "${applicationName} içinde yeni ${profile} sohbeti başlat"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) میں نئی \\(\\.$profile) چیٹ شروع کریں"
+            "value": "${applicationName} میں نئی ${profile} چیٹ شروع کریں"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中開始新的 \\(\\.$profile) 聊天"
+            "value": "在 ${applicationName} 中開始新的 ${profile} 聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中开始新的 \\(\\.$profile) 聊天"
+            "value": "在 ${applicationName} 中开始新的 ${profile} 聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中開始新的 \\(\\.$profile) 聊天"
+            "value": "在 ${applicationName} 中開始新的 ${profile} 聊天"
           }
         }
       }
     },
-    "Start a new chat in \\(.applicationName)": {
+    "Start a new chat in ${applicationName}": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ابدأ محادثة جديدة في \\(.applicationName)"
+            "value": "ابدأ محادثة جديدة في ${applicationName}"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Starte einen neuen Chat in \\(.applicationName)"
+            "value": "Starte einen neuen Chat in ${applicationName}"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start a new chat in \\(.applicationName)"
+            "value": "Start a new chat in ${applicationName}"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Inicia un nuevo chat en \\(.applicationName)"
+            "value": "Inicia un nuevo chat en ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Démarrer une nouvelle discussion dans \\(.applicationName)"
+            "value": "Démarrer une nouvelle discussion dans ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "התחל צ׳אט חדש ב-\\(.applicationName)"
+            "value": "התחל צ׳אט חדש ב-${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Avvia una nuova chat in \\(.applicationName)"
+            "value": "Avvia una nuova chat in ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)で新しいチャットを開始"
+            "value": "${applicationName}で新しいチャットを開始"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)에서 새 채팅 시작"
+            "value": "${applicationName}에서 새 채팅 시작"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start een nieuwe chat in \\(.applicationName)"
+            "value": "Start een nieuwe chat in ${applicationName}"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rozpocznij nowy czat w \\(.applicationName)"
+            "value": "Rozpocznij nowy czat w ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar um novo chat no \\(.applicationName)"
+            "value": "Iniciar um novo chat no ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Начать новый чат в \\(.applicationName)"
+            "value": "Начать новый чат в ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) içinde yeni sohbet başlat"
+            "value": "${applicationName} içinde yeni sohbet başlat"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) میں نئی چیٹ شروع کریں"
+            "value": "${applicationName} میں نئی چیٹ شروع کریں"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中開始新聊天"
+            "value": "在 ${applicationName} 中開始新聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中开始新聊天"
+            "value": "在 ${applicationName} 中开始新聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中開始新聊天"
+            "value": "在 ${applicationName} 中開始新聊天"
           }
         }
       }
     },
-    "Start a voice chat in \\(.applicationName)": {
+    "Start a voice chat in ${applicationName}": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ابدأ محادثة صوتية في \\(.applicationName)"
+            "value": "ابدأ محادثة صوتية في ${applicationName}"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Starte einen Sprachchat in \\(.applicationName)"
+            "value": "Starte einen Sprachchat in ${applicationName}"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start a voice chat in \\(.applicationName)"
+            "value": "Start a voice chat in ${applicationName}"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Inicia un chat de voz en \\(.applicationName)"
+            "value": "Inicia un chat de voz en ${applicationName}"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Démarrer une discussion vocale dans \\(.applicationName)"
+            "value": "Démarrer une discussion vocale dans ${applicationName}"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "התחל צ׳אט קולי ב-\\(.applicationName)"
+            "value": "התחל צ׳אט קולי ב-${applicationName}"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Avvia una chat vocale in \\(.applicationName)"
+            "value": "Avvia una chat vocale in ${applicationName}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)で音声チャットを開始"
+            "value": "${applicationName}で音声チャットを開始"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName)에서 음성 채팅 시작"
+            "value": "${applicationName}에서 음성 채팅 시작"
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start een spraakchat in \\(.applicationName)"
+            "value": "Start een spraakchat in ${applicationName}"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rozpocznij czat głosowy w \\(.applicationName)"
+            "value": "Rozpocznij czat głosowy w ${applicationName}"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iniciar um chat por voz no \\(.applicationName)"
+            "value": "Iniciar um chat por voz no ${applicationName}"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Начать голосовой чат в \\(.applicationName)"
+            "value": "Начать голосовой чат в ${applicationName}"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) içinde sesli sohbet başlat"
+            "value": "${applicationName} içinde sesli sohbet başlat"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "\\(.applicationName) میں صوتی چیٹ شروع کریں"
+            "value": "${applicationName} میں صوتی چیٹ شروع کریں"
           }
         },
         "zh-HK": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中開始語音聊天"
+            "value": "在 ${applicationName} 中開始語音聊天"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中开始语音聊天"
+            "value": "在 ${applicationName} 中开始语音聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在 \\(.applicationName) 中開始語音聊天"
+            "value": "在 ${applicationName} 中開始語音聊天"
           }
         }
       }

--- a/HermesMobileTests/LocalizationCatalogTests.swift
+++ b/HermesMobileTests/LocalizationCatalogTests.swift
@@ -87,15 +87,15 @@ final class LocalizationCatalogTests: XCTestCase {
         XCTAssertEqual(root["sourceLanguage"] as? String, "en")
         let strings = try XCTUnwrap(root["strings"] as? [String: Any])
         let expectedPhrases = [
-            "New chat in \\(.applicationName)",
-            "New \\(.applicationName) chat",
-            "Start a new chat in \\(.applicationName)",
-            "New voice chat in \\(.applicationName)",
-            "New \\(.applicationName) voice chat",
-            "Start a voice chat in \\(.applicationName)",
-            "New \\(\\.$profile) chat in \\(.applicationName)",
-            "Start a new \\(\\.$profile) chat in \\(.applicationName)",
-            "New chat in \\(\\.$profile) on \\(.applicationName)"
+            "New chat in ${applicationName}",
+            "New ${applicationName} chat",
+            "Start a new chat in ${applicationName}",
+            "New voice chat in ${applicationName}",
+            "New ${applicationName} voice chat",
+            "Start a voice chat in ${applicationName}",
+            "New ${profile} chat in ${applicationName}",
+            "Start a new ${profile} chat in ${applicationName}",
+            "New chat in ${profile} on ${applicationName}"
         ]
 
         XCTAssertEqual(Set(strings.keys), Set(expectedPhrases))

--- a/HermesMobileTests/LocalizationCatalogTests.swift
+++ b/HermesMobileTests/LocalizationCatalogTests.swift
@@ -79,9 +79,7 @@ final class LocalizationCatalogTests: XCTestCase {
 
     func testAppShortcutPhrasesHaveDedicatedCatalogEntries() throws {
         let url = resourceURL("HermesMobile/Resources/AppShortcuts.xcstrings")
-        guard let data = try? Data(contentsOf: url) else {
-            throw XCTSkip("Could not read App Shortcuts String Catalog at \(url.path).")
-        }
+        let data = try Data(contentsOf: url)
 
         let root = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(root["sourceLanguage"] as? String, "en")

--- a/HermesMobileTests/LocalizationCatalogTests.swift
+++ b/HermesMobileTests/LocalizationCatalogTests.swift
@@ -18,13 +18,17 @@ final class LocalizationCatalogTests: XCTestCase {
     /// project file and the languages present in `Localizable.xcstrings`.
     private static let shippedLanguages = ["de", "es", "fr", "it", "pl", "pt-BR", "nl", "tr", "ru", "ja", "zh-Hans", "ko", "ar", "he", "ur", "zh-Hant", "zh-HK"]
 
-    private func catalogURL() -> URL {
-        // .../HermesMobileTests/LocalizationCatalogTests.swift
-        //   -> repo root -> HermesMobile/Resources/Localizable.xcstrings
+    private func resourceURL(_ relativePath: String) -> URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()   // HermesMobileTests
             .deletingLastPathComponent()   // repo root
-            .appendingPathComponent("HermesMobile/Resources/Localizable.xcstrings")
+            .appendingPathComponent(relativePath)
+    }
+
+    private func catalogURL() -> URL {
+        // .../HermesMobileTests/LocalizationCatalogTests.swift
+        //   -> repo root -> HermesMobile/Resources/Localizable.xcstrings
+        resourceURL("HermesMobile/Resources/Localizable.xcstrings")
     }
 
     /// True iff the language entry holds a non-empty value — either a plain `stringUnit` or
@@ -70,6 +74,39 @@ final class LocalizationCatalogTests: XCTestCase {
             XCTAssertTrue(missing.isEmpty,
                           "[\(language)] \(missing.count) translatable key(s) have no value: \(missing.sorted())")
             XCTAssertGreaterThan(translated, 200, "[\(language)] Far fewer translations than expected — something dropped.")
+        }
+    }
+
+    func testAppShortcutPhrasesHaveDedicatedCatalogEntries() throws {
+        let url = resourceURL("HermesMobile/Resources/AppShortcuts.xcstrings")
+        guard let data = try? Data(contentsOf: url) else {
+            throw XCTSkip("Could not read App Shortcuts String Catalog at \(url.path).")
+        }
+
+        let root = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(root["sourceLanguage"] as? String, "en")
+        let strings = try XCTUnwrap(root["strings"] as? [String: Any])
+        let expectedPhrases = [
+            "New chat in \\(.applicationName)",
+            "New \\(.applicationName) chat",
+            "Start a new chat in \\(.applicationName)",
+            "New voice chat in \\(.applicationName)",
+            "New \\(.applicationName) voice chat",
+            "Start a voice chat in \\(.applicationName)",
+            "New \\(\\.$profile) chat in \\(.applicationName)",
+            "Start a new \\(\\.$profile) chat in \\(.applicationName)",
+            "New chat in \\(\\.$profile) on \\(.applicationName)"
+        ]
+
+        XCTAssertEqual(Set(strings.keys), Set(expectedPhrases))
+
+        for phrase in expectedPhrases {
+            let entry = try XCTUnwrap(strings[phrase] as? [String: Any], phrase)
+            let localizations = try XCTUnwrap(entry["localizations"] as? [String: Any], phrase)
+            for language in Self.shippedLanguages + ["en"] {
+                let localization = try XCTUnwrap(localizations[language] as? [String: Any], "[\(language)] \(phrase)")
+                XCTAssertTrue(hasNonEmptyValue(localization), "[\(language)] \(phrase) is empty")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add dedicated AppShortcuts.xcstrings catalog for the nine New Chat shortcut phrases
- Populate all shipped locales plus English
- Add a catalog guard test so App Shortcut phrase localizations cannot silently disappear

## Test Plan
- [x] AppShortcuts.xcstrings JSON validation
- [x] git diff --check
- [ ] Full XCTest suite (pending GitHub CI / Mac runner; Linux host has no xcodebuild or swift)

Closes #2