### PR TITLE
feat(memory): surface project context

### DIFF
--- a/HermesMobile/Features/Memory/MemoryView.swift
+++ b/HermesMobile/Features/Memory/MemoryView.swift
@@ -210,11 +210,17 @@ private struct ProjectContextContent: View {
         }
     }
 
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter
+    }()
+
     private var metadataText: String? {
         let parts = [
             nonEmpty(name),
             nonEmpty(workspace).map { String(localized: "Workspace: \($0)") },
-            modifiedAt.map { String(localized: "Modified \($0, style: .relative) ago") },
+            modifiedAt.map { String(localized: "Modified \(Self.relativeFormatter.localizedString(for: $0, relativeTo: Date()))") },
             nonEmpty(path)
         ].compactMap { $0 }
 

--- a/HermesMobile/Features/Memory/MemoryView.swift
+++ b/HermesMobile/Features/Memory/MemoryView.swift
@@ -93,6 +93,7 @@ struct MemoryView: View {
                             name: viewModel.projectContextName,
                             path: viewModel.projectContextPath,
                             workspace: viewModel.projectContextWorkspace,
+                            modifiedAt: viewModel.projectContextMtime,
                             isShadowed: viewModel.isProjectContextShadowed,
                             externalNotesEnabled: viewModel.isExternalNotesEnabled
                         )
@@ -174,6 +175,7 @@ private struct ProjectContextContent: View {
     let name: String?
     let path: String?
     let workspace: String?
+    let modifiedAt: Date?
     let isShadowed: Bool
     let externalNotesEnabled: Bool
 
@@ -211,7 +213,8 @@ private struct ProjectContextContent: View {
     private var metadataText: String? {
         let parts = [
             nonEmpty(name),
-            nonEmpty(workspace).map { "Workspace: \($0)" },
+            nonEmpty(workspace).map { String(localized: "Workspace: \($0)") },
+            modifiedAt.map { String(localized: "Modified \($0, style: .relative) ago") },
             nonEmpty(path)
         ].compactMap { $0 }
 

--- a/HermesMobile/Features/Memory/MemoryView.swift
+++ b/HermesMobile/Features/Memory/MemoryView.swift
@@ -85,6 +85,22 @@ struct MemoryView: View {
                         }
                     }
                 }
+
+                if viewModel.projectContextText != nil || viewModel.isExternalNotesEnabled {
+                    Section {
+                        ProjectContextContent(
+                            content: viewModel.projectContextText ?? "",
+                            name: viewModel.projectContextName,
+                            path: viewModel.projectContextPath,
+                            workspace: viewModel.projectContextWorkspace,
+                            isShadowed: viewModel.isProjectContextShadowed,
+                            externalNotesEnabled: viewModel.isExternalNotesEnabled
+                        )
+                        .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+                    } header: {
+                        ProjectContextHeader()
+                    }
+                }
             }
             .refreshable {
                 await loadMemory()
@@ -138,6 +154,73 @@ private struct MemorySectionContent: View {
         } else {
             MarkdownRenderer(content: content)
         }
+    }
+}
+
+private struct ProjectContextHeader: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            Label("Project Context", systemImage: "doc.text.magnifyingglass")
+            Spacer()
+            Label("Read only", systemImage: "lock")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct ProjectContextContent: View {
+    let content: String
+    let name: String?
+    let path: String?
+    let workspace: String?
+    let isShadowed: Bool
+    let externalNotesEnabled: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let metadataText {
+                Text(metadataText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            if isShadowed {
+                Label("A workspace-local file is overriding the global project context.", systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            if externalNotesEnabled {
+                Label("External notes are enabled on this server.", systemImage: "note.text")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text("No project context is active.")
+                    .foregroundStyle(.secondary)
+                    .italic()
+            } else {
+                MarkdownRenderer(content: content)
+            }
+        }
+    }
+
+    private var metadataText: String? {
+        let parts = [
+            nonEmpty(name),
+            nonEmpty(workspace).map { "Workspace: \($0)" },
+            nonEmpty(path)
+        ].compactMap { $0 }
+
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 }
 

--- a/HermesMobile/Features/Memory/MemoryViewModel.swift
+++ b/HermesMobile/Features/Memory/MemoryViewModel.swift
@@ -11,6 +11,7 @@ final class MemoryViewModel {
     private(set) var projectContextName: String?
     private(set) var projectContextPath: String?
     private(set) var projectContextWorkspace: String?
+    private(set) var projectContextMtime: Date?
     private(set) var isProjectContextShadowed = false
     private(set) var isExternalNotesEnabled = false
     private(set) var memoryMtime: Date?
@@ -101,6 +102,7 @@ final class MemoryViewModel {
         projectContextName = response.projectContextName
         projectContextPath = response.projectContextPath
         projectContextWorkspace = response.projectContextWorkspace
+        projectContextMtime = response.projectContextMtime.map { Date(timeIntervalSince1970: $0) }
         isProjectContextShadowed = response.projectContextShadowed == true
         isExternalNotesEnabled = response.externalNotesEnabled == true
         memoryMtime = response.memoryMtime.map { Date(timeIntervalSince1970: $0) }

--- a/HermesMobile/Features/Memory/MemoryViewModel.swift
+++ b/HermesMobile/Features/Memory/MemoryViewModel.swift
@@ -7,6 +7,12 @@ final class MemoryViewModel {
     private(set) var memoryText: String?
     private(set) var userText: String?
     private(set) var soulText: String?
+    private(set) var projectContextText: String?
+    private(set) var projectContextName: String?
+    private(set) var projectContextPath: String?
+    private(set) var projectContextWorkspace: String?
+    private(set) var isProjectContextShadowed = false
+    private(set) var isExternalNotesEnabled = false
     private(set) var memoryMtime: Date?
     private(set) var userMtime: Date?
     private(set) var soulMtime: Date?
@@ -91,6 +97,12 @@ final class MemoryViewModel {
         memoryText = response.memory
         userText = response.user
         soulText = response.soul
+        projectContextText = response.projectContext
+        projectContextName = response.projectContextName
+        projectContextPath = response.projectContextPath
+        projectContextWorkspace = response.projectContextWorkspace
+        isProjectContextShadowed = response.projectContextShadowed == true
+        isExternalNotesEnabled = response.externalNotesEnabled == true
         memoryMtime = response.memoryMtime.map { Date(timeIntervalSince1970: $0) }
         userMtime = response.userMtime.map { Date(timeIntervalSince1970: $0) }
         soulMtime = response.soulMtime.map { Date(timeIntervalSince1970: $0) }

--- a/HermesMobile/Models/Memory.swift
+++ b/HermesMobile/Models/Memory.swift
@@ -18,6 +18,13 @@ struct MemoryResponse: Decodable, Equatable {
     let memoryMtime: Double?
     let userMtime: Double?
     let soulMtime: Double?
+    let projectContext: String?
+    let projectContextName: String?
+    let projectContextPath: String?
+    let projectContextWorkspace: String?
+    let projectContextShadowed: Bool?
+    let projectContextMtime: Double?
+    let externalNotesEnabled: Bool?
 
     enum CodingKeys: String, CodingKey {
         case memory
@@ -29,6 +36,13 @@ struct MemoryResponse: Decodable, Equatable {
         case memoryMtime
         case userMtime
         case soulMtime
+        case projectContext
+        case projectContextName
+        case projectContextPath
+        case projectContextWorkspace
+        case projectContextShadowed
+        case projectContextMtime
+        case externalNotesEnabled
     }
 
     init(from decoder: Decoder) throws {
@@ -42,6 +56,13 @@ struct MemoryResponse: Decodable, Equatable {
         memoryMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .memoryMtime)
         userMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .userMtime)
         soulMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .soulMtime)
+        projectContext = try container.decodeIfPresent(String.self, forKey: .projectContext)
+        projectContextName = try container.decodeIfPresent(String.self, forKey: .projectContextName)
+        projectContextPath = try container.decodeIfPresent(String.self, forKey: .projectContextPath)
+        projectContextWorkspace = try container.decodeIfPresent(String.self, forKey: .projectContextWorkspace)
+        projectContextShadowed = try container.decodeIfPresent(Bool.self, forKey: .projectContextShadowed)
+        projectContextMtime = try container.decodeFlexibleDoubleIfPresent(forKey: .projectContextMtime)
+        externalNotesEnabled = try container.decodeIfPresent(Bool.self, forKey: .externalNotesEnabled)
     }
 }
 

--- a/HermesMobileTests/MemoryViewModelTests.swift
+++ b/HermesMobileTests/MemoryViewModelTests.swift
@@ -7,6 +7,36 @@ import UniformTypeIdentifiers
 @testable import HermesMobile
 
 final class MemoryViewModelTests: XCTestCase {
+    func testMemoryResponseDecodesProjectContextFields() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(
+            MemoryResponse.self,
+            from: Data("""
+            {
+              "memory": "# Notes",
+              "user": "# User",
+              "soul": "# Soul",
+              "project_context": "# Project",
+              "project_context_name": "AGENTS.md",
+              "project_context_path": "/work/app/AGENTS.md",
+              "project_context_workspace": "/work/app",
+              "project_context_shadowed": true,
+              "project_context_mtime": "1770000300",
+              "external_notes_enabled": true
+            }
+            """.utf8)
+        )
+
+        XCTAssertEqual(response.projectContext, "# Project")
+        XCTAssertEqual(response.projectContextName, "AGENTS.md")
+        XCTAssertEqual(response.projectContextPath, "/work/app/AGENTS.md")
+        XCTAssertEqual(response.projectContextWorkspace, "/work/app")
+        XCTAssertEqual(response.projectContextShadowed, true)
+        XCTAssertEqual(response.projectContextMtime, 1_770_000_300)
+        XCTAssertEqual(response.externalNotesEnabled, true)
+    }
+
     override func tearDown() {
         MockURLProtocol.requestHandler = nil
         super.tearDown()

--- a/HermesMobileTests/MemoryViewModelTests.swift
+++ b/HermesMobileTests/MemoryViewModelTests.swift
@@ -37,6 +37,62 @@ final class MemoryViewModelTests: XCTestCase {
         XCTAssertEqual(response.externalNotesEnabled, true)
     }
 
+
+    func testMemoryResponseToleratesAbsentProjectContextFields() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(
+            MemoryResponse.self,
+            from: Data("""
+            {
+              "memory": "# Notes"
+            }
+            """.utf8)
+        )
+
+        XCTAssertEqual(response.memory, "# Notes")
+        XCTAssertNil(response.projectContext)
+        XCTAssertNil(response.projectContextName)
+        XCTAssertNil(response.projectContextPath)
+        XCTAssertNil(response.projectContextWorkspace)
+        XCTAssertNil(response.projectContextShadowed)
+        XCTAssertNil(response.projectContextMtime)
+        XCTAssertNil(response.externalNotesEnabled)
+    }
+
+    @MainActor
+    func testLoadMapsProjectContextFieldsToViewModel() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/memory")
+            return apiTestJSONResponse("""
+            {
+              "project_context": "# Project",
+              "project_context_name": "AGENTS.md",
+              "project_context_path": "/work/app/AGENTS.md",
+              "project_context_workspace": "/work/app",
+              "project_context_shadowed": true,
+              "project_context_mtime": 1770000300,
+              "external_notes_enabled": true
+            }
+            """, for: request)
+        }
+        let viewModel = MemoryViewModel(
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.projectContextText, "# Project")
+        XCTAssertEqual(viewModel.projectContextName, "AGENTS.md")
+        XCTAssertEqual(viewModel.projectContextPath, "/work/app/AGENTS.md")
+        XCTAssertEqual(viewModel.projectContextWorkspace, "/work/app")
+        XCTAssertEqual(viewModel.projectContextMtime, Date(timeIntervalSince1970: 1_770_000_300))
+        XCTAssertTrue(viewModel.isProjectContextShadowed)
+        XCTAssertTrue(viewModel.isExternalNotesEnabled)
+        XCTAssertTrue(viewModel.hasLoaded)
+    }
+
     override func tearDown() {
         MockURLProtocol.requestHandler = nil
         super.tearDown()


### PR DESCRIPTION
## Summary
- Decode project_context and related metadata from /api/memory
- Show a read-only Project Context section on the Memory screen
- Surface shadowing and external-notes state without adding unsupported edit affordances

## Test Plan
- [x] Added decode coverage for project-context fields
- [x] git diff --check
- [x] Static delimiter balance check for touched Swift files
- [ ] Full XCTest suite (pending GitHub CI / Mac runner; Linux host has no xcodebuild or swift)

Closes #20