### PR TITLE
feat(settings): sync CLI session visibility

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -63,6 +63,7 @@ struct SessionListView: View {
         _pendingDeepLinkedSessionID = pendingDeepLinkedSessionID
         _requestedNewChat = requestedNewChat
         _viewModel = State(initialValue: SessionListViewModel(server: server))
+        _showsCliSessions = AppStorage(wrappedValue: true, SessionRowDisplaySettings.showCliSessionsKey(for: server))
     }
 
     var body: some View {

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -366,6 +366,11 @@ enum SessionRowDisplaySettings {
     // shown, and their toggles let users hide each kind separately.
     static let showCronSessionsKey = "sessionRow.showCronSessions"
     static let showCliSessionsKey = "sessionRow.showCliSessions"
+
+    static func showCliSessionsKey(for server: URL) -> String {
+        let normalizedServer = server.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return "\(showCliSessionsKey).\(normalizedServer)"
+    }
 }
 
 enum SessionSidebarDisclosureSettings {

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -56,6 +56,8 @@ struct SettingsView: View {
     @AppStorage(SessionRowDisplaySettings.showWorkspaceKey) private var showsSessionWorkspace = true
     @AppStorage(SessionRowDisplaySettings.showCronSessionsKey) private var showsCronSessions = true
     @AppStorage(SessionRowDisplaySettings.showCliSessionsKey) private var showsCliSessions = true
+    @State private var isSavingCliSessionsVisibility = false
+    @State private var cliSessionsVisibilityError: String?
     @AppStorage(StreamingSendBehavior.storageKey) private var streamingSendBehaviorRawValue = StreamingSendBehavior.steer.rawValue
     @AppStorage(ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey) private var showsThinkingAndToolCards = true
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var thinkingCardsStartExpanded = false
@@ -274,8 +276,14 @@ struct SettingsView: View {
                     SettingsToggleRow(
                         title: String(localized: "CLI Sessions"),
                         systemImage: "terminal",
-                        isOn: $showsCliSessions
+                        isOn: cliSessionsVisibilityBinding
                     )
+                    .disabled(isSavingCliSessionsVisibility)
+
+                    if let cliSessionsVisibilityError {
+                        SettingsFootnote(cliSessionsVisibilityError)
+                            .foregroundStyle(.red)
+                    }
                 }
 
                 SettingsCard(title: String(localized: "Siri & Shortcuts")) {
@@ -651,6 +659,20 @@ struct SettingsView: View {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? String(localized: "Unknown")
     }
 
+    private var cliSessionsVisibilityBinding: Binding<Bool> {
+        Binding(
+            get: { showsCliSessions },
+            set: { newValue in
+                let previousValue = showsCliSessions
+                showsCliSessions = newValue
+                cliSessionsVisibilityError = nil
+                Task {
+                    await saveCliSessionsVisibility(newValue, fallback: previousValue)
+                }
+            }
+        )
+    }
+
     private var responseCompletionNotificationBinding: Binding<Bool> {
         Binding(
             get: { isResponseCompletionNotificationsEnabled },
@@ -865,7 +887,10 @@ struct SettingsView: View {
 
         do {
             let settings = try await client.settings()
-            serverVersion = settings.webuiVersion ?? settings.version
+            serverVersion = settings.webuiVersion
+            if let serverShowsCliSessions = settings.showCliSessions {
+                showsCliSessions = serverShowsCliSessions
+            }
             if serverVersion == nil {
                 serverSettingsError = String(localized: "Unknown")
             }
@@ -906,6 +931,22 @@ struct SettingsView: View {
         }
 
         isLoadingDefaultProfile = false
+    }
+
+    private func saveCliSessionsVisibility(_ isVisible: Bool, fallback previousValue: Bool) async {
+        guard !isSavingCliSessionsVisibility else { return }
+        isSavingCliSessionsVisibility = true
+        defer { isSavingCliSessionsVisibility = false }
+
+        do {
+            let response = try await APIClient(baseURL: server).saveSettings(showCliSessions: isVisible)
+            showsCliSessions = response.showCliSessions ?? isVisible
+            cliSessionsVisibilityError = nil
+        } catch {
+            showsCliSessions = previousValue
+            cliSessionsVisibilityError = String(localized: "Could not sync CLI session visibility with the server.")
+            authManager.handleAPIError(error)
+        }
     }
 
     private func checkForUpdatesManually() async {
@@ -1012,7 +1053,7 @@ struct SettingsView: View {
                 continue
             }
 
-            let newVersion = settings.webuiVersion ?? settings.version
+            let newVersion = settings.webuiVersion
             let updateState = (try? await client.updatesCheck())?.webuiUpdateState ?? .unavailable
             let restartConfirmed = (newVersion != nil && newVersion != previousVersion)
                 || updateState == .upToDate

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -19,9 +19,15 @@ struct SettingsView: View {
         self.authManager = authManager
         self.server = server
         self.initialScrollTarget = initialScrollTarget
+        _showsCliSessions = AppStorage(wrappedValue: true, Self.showCliSessionsStorageKey(for: server))
     }
 
     @ScaledMetric(relativeTo: .body) private var settingsCardSpacing: CGFloat = 18
+
+    static func showCliSessionsStorageKey(for server: URL) -> String {
+        let normalizedServer = server.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return "\(SessionRowDisplaySettings.showCliSessionsKey).\(normalizedServer)"
+    }
     @State private var isConfirmingReconfigure = false
     @State private var didScrollToInitialTarget = false
     @State private var isPresentingAddServer = false
@@ -667,7 +673,7 @@ struct SettingsView: View {
                 showsCliSessions = newValue
                 cliSessionsVisibilityError = nil
                 Task {
-                    await saveCliSessionsVisibility(newValue, fallback: previousValue)
+                    await saveCliSessionsVisibility(newValue, fallback: previousValue, server: server)
                 }
             }
         )
@@ -933,16 +939,18 @@ struct SettingsView: View {
         isLoadingDefaultProfile = false
     }
 
-    private func saveCliSessionsVisibility(_ isVisible: Bool, fallback previousValue: Bool) async {
+    private func saveCliSessionsVisibility(_ isVisible: Bool, fallback previousValue: Bool, server expectedServer: URL) async {
         guard !isSavingCliSessionsVisibility else { return }
         isSavingCliSessionsVisibility = true
         defer { isSavingCliSessionsVisibility = false }
 
         do {
-            let response = try await APIClient(baseURL: server).saveSettings(showCliSessions: isVisible)
+            let response = try await APIClient(baseURL: expectedServer).saveSettings(showCliSessions: isVisible)
+            guard !Task.isCancelled, server == expectedServer else { return }
             showsCliSessions = response.showCliSessions ?? isVisible
             cliSessionsVisibilityError = nil
         } catch {
+            guard !Task.isCancelled, server == expectedServer else { return }
             showsCliSessions = previousValue
             cliSessionsVisibilityError = String(localized: "Could not sync CLI session visibility with the server.")
             authManager.handleAPIError(error)

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -60,6 +60,7 @@ struct SettingsView: View {
     @AppStorage(SessionRowDisplaySettings.showCliSessionsKey) private var showsCliSessions = true
     @State private var isSavingCliSessionsVisibility = false
     @State private var cliSessionsVisibilityError: String?
+    @State private var cliSessionsVisibilityTask: Task<Void, Never>?
     @AppStorage(StreamingSendBehavior.storageKey) private var streamingSendBehaviorRawValue = StreamingSendBehavior.steer.rawValue
     @AppStorage(ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey) private var showsThinkingAndToolCards = true
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var thinkingCardsStartExpanded = false
@@ -431,6 +432,10 @@ struct SettingsView: View {
             await loadServerSettings()
             await refreshNotificationPermissionStatus()
         }
+        .onDisappear {
+            cliSessionsVisibilityTask?.cancel()
+            cliSessionsVisibilityTask = nil
+        }
         .alert("Clear this server's cache?", isPresented: $isConfirmingClearCache) {
             Button("Cancel", role: .cancel) {}
             Button("Clear Cache", role: .destructive) {
@@ -668,7 +673,8 @@ struct SettingsView: View {
                 let previousValue = showsCliSessions
                 showsCliSessions = newValue
                 cliSessionsVisibilityError = nil
-                Task {
+                cliSessionsVisibilityTask?.cancel()
+                cliSessionsVisibilityTask = Task {
                     await saveCliSessionsVisibility(newValue, fallback: previousValue, server: server)
                 }
             }

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -19,15 +19,11 @@ struct SettingsView: View {
         self.authManager = authManager
         self.server = server
         self.initialScrollTarget = initialScrollTarget
-        _showsCliSessions = AppStorage(wrappedValue: true, Self.showCliSessionsStorageKey(for: server))
+        _showsCliSessions = AppStorage(wrappedValue: true, SessionRowDisplaySettings.showCliSessionsKey(for: server))
     }
 
     @ScaledMetric(relativeTo: .body) private var settingsCardSpacing: CGFloat = 18
 
-    static func showCliSessionsStorageKey(for server: URL) -> String {
-        let normalizedServer = server.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        return "\(SessionRowDisplaySettings.showCliSessionsKey).\(normalizedServer)"
-    }
     @State private var isConfirmingReconfigure = false
     @State private var didScrollToInitialTarget = false
     @State private var isPresentingAddServer = false

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -144,8 +144,16 @@ struct ProvidersResponse: Decodable, Equatable {
 struct SettingsResponse: Decodable, Equatable {
     let botName: String?
     let webuiVersion: String?
-    let version: String?
+    let agentVersion: String?
     let theme: String?
+    let showCliSessions: Bool?
+    let checkForUpdates: Bool?
+    let maxTokens: Int?
+    let maxTokensEffective: Int?
+    let authEnabled: Bool?
+    let passwordAuthEnabled: Bool?
+    let passkeysEnabled: Bool?
+    let passwordlessEnabled: Bool?
 }
 
 struct DefaultModelResponse: Decodable, Equatable {

--- a/HermesMobile/Networking/APIClient+ServerPanels.swift
+++ b/HermesMobile/Networking/APIClient+ServerPanels.swift
@@ -102,6 +102,14 @@ extension APIClient {
         try await send(endpoint: .settings, method: "GET")
     }
 
+    func saveSettings(showCliSessions: Bool) async throws -> SettingsResponse {
+        try await send(
+            endpoint: .settings,
+            method: "POST",
+            body: SettingsUpdateRequest(showCliSessions: showCliSessions)
+        )
+    }
+
     func updatesCheck() async throws -> UpdatesCheckResponse {
         try await send(endpoint: .updatesCheck, method: "GET")
     }
@@ -167,6 +175,10 @@ private struct ProfileCreateRequest: Encodable {
 
 private struct UpdatesApplyRequest: Encodable {
     let target: String
+}
+
+private struct SettingsUpdateRequest: Encodable {
+    let showCliSessions: Bool
 }
 
 private struct UpdatesCheckForceRequest: Encodable {

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -662,6 +662,21 @@ final class APIClientConfigurationTests: APIClientTestCase {
         XCTAssertEqual(response.showCliSessions, false)
     }
 
+
+    func testCliSessionVisibilityStorageKeyIsServerScoped() throws {
+        let first = try XCTUnwrap(URL(string: "https://one.example.test/"))
+        let second = try XCTUnwrap(URL(string: "https://two.example.test"))
+
+        XCTAssertNotEqual(
+            SettingsView.showCliSessionsStorageKey(for: first),
+            SettingsView.showCliSessionsStorageKey(for: second)
+        )
+        XCTAssertEqual(
+            SettingsView.showCliSessionsStorageKey(for: first),
+            "\(SessionRowDisplaySettings.showCliSessionsKey).https://one.example.test"
+        )
+    }
+
     func testSaveSettingsPostsCliSessionVisibility() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/settings")

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -646,7 +646,9 @@ final class APIClientConfigurationTests: APIClientTestCase {
             {
               "bot_name": "Hermes",
               "webui_version": "v0.50.253",
-              "theme": "system"
+              "agent_version": "v0.17.0",
+              "theme": "system",
+              "show_cli_sessions": false
             }
             """, for: request)
         }
@@ -655,6 +657,31 @@ final class APIClientConfigurationTests: APIClientTestCase {
 
         XCTAssertEqual(response.botName, "Hermes")
         XCTAssertEqual(response.webuiVersion, "v0.50.253")
+        XCTAssertEqual(response.agentVersion, "v0.17.0")
         XCTAssertEqual(response.theme, "system")
+        XCTAssertEqual(response.showCliSessions, false)
+    }
+
+    func testSaveSettingsPostsCliSessionVisibility() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/settings")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let data = try XCTUnwrap(apiTestBodyData(from: request))
+            let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertEqual(body?["show_cli_sessions"] as? Bool, true)
+            XCTAssertEqual(body?.count, 1)
+
+            return apiTestJSONResponse("""
+            {
+              "bot_name": "Hermes",
+              "webui_version": "v0.50.253",
+              "show_cli_sessions": true
+            }
+            """, for: request)
+        }
+
+        let response = try await client.saveSettings(showCliSessions: true)
+
+        XCTAssertEqual(response.showCliSessions, true)
     }
 }

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -668,11 +668,11 @@ final class APIClientConfigurationTests: APIClientTestCase {
         let second = try XCTUnwrap(URL(string: "https://two.example.test"))
 
         XCTAssertNotEqual(
-            SettingsView.showCliSessionsStorageKey(for: first),
-            SettingsView.showCliSessionsStorageKey(for: second)
+            SessionRowDisplaySettings.showCliSessionsKey(for: first),
+            SessionRowDisplaySettings.showCliSessionsKey(for: second)
         )
         XCTAssertEqual(
-            SettingsView.showCliSessionsStorageKey(for: first),
+            SessionRowDisplaySettings.showCliSessionsKey(for: first),
             "\(SessionRowDisplaySettings.showCliSessionsKey).https://one.example.test"
         )
     }


### PR DESCRIPTION
## Summary
- Expand SettingsResponse for documented settings fields and remove the phantom version field
- Adopt server show_cli_sessions on Settings load
- Persist the CLI Sessions toggle with POST /api/settings and roll back on failure

## Test Plan
- [x] Added decode/request coverage for show_cli_sessions
- [x] git diff --check
- [x] Static delimiter balance check for touched Swift files
- [ ] Full XCTest suite (pending GitHub CI / Mac runner; Linux host has no xcodebuild or swift)

Closes #19