### PR TITLE
fix(errors): surface terminal and stale server errors

### DIFF
--- a/HermesMobile/Features/Chat/ApprovalRequestOverlay.swift
+++ b/HermesMobile/Features/Chat/ApprovalRequestOverlay.swift
@@ -7,6 +7,7 @@ struct ApprovalRequestOverlay: View {
     let errorMessage: String?
     let onChoice: (ApprovalChoice) -> Void
     let onSkipAll: () -> Void
+    let onDismissExpired: () -> Void
 
     var body: some View {
         ZStack {
@@ -101,6 +102,16 @@ struct ApprovalRequestOverlay: View {
 
     private var actions: some View {
         VStack(spacing: 8) {
+            if prompt.isExpired {
+                Button {
+                    onDismissExpired()
+                } label: {
+                    Label("Dismiss expired request", systemImage: "xmark.circle")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.chatDecision(.secondary))
+            }
+
             HStack(spacing: 8) {
                 approvalButton("Allow once", systemImage: "checkmark.circle.fill", choice: .once, prominent: true)
                 approvalButton("Allow session", systemImage: "lock.open", choice: .session, prominent: false)

--- a/HermesMobile/Features/Chat/ApprovalRequestOverlay.swift
+++ b/HermesMobile/Features/Chat/ApprovalRequestOverlay.swift
@@ -118,7 +118,7 @@ struct ApprovalRequestOverlay: View {
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.chatDecision(.secondary))
-            .disabled(isResponding)
+            .disabled(isResponding || prompt.isExpired)
         }
     }
 
@@ -138,7 +138,7 @@ struct ApprovalRequestOverlay: View {
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.chatDecision(.primary))
-            .disabled(isResponding)
+            .disabled(isResponding || prompt.isExpired)
         } else {
             Button(role: role) {
                 onChoice(choice)
@@ -147,7 +147,7 @@ struct ApprovalRequestOverlay: View {
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.chatDecision(role == .destructive ? .destructive : .secondary))
-            .disabled(isResponding)
+            .disabled(isResponding || prompt.isExpired)
         }
     }
 

--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -322,6 +322,7 @@ final class ChatPendingActionCoordinator {
               let prompt = approvalPendingBySession[sessionID]
         else {
             if approvalPrompt?.sessionID == sessionID {
+                guard approvalPrompt?.isExpired != true else { return }
                 approvalPrompt = nil
             }
             return
@@ -432,6 +433,7 @@ final class ChatPendingActionCoordinator {
               let prompt = clarificationPendingBySession[sessionID]
         else {
             if clarificationPrompt?.sessionID == sessionID {
+                guard clarificationPrompt?.isExpired != true else { return }
                 clarificationPrompt = nil
             }
             return

--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -105,8 +105,13 @@ final class ChatPendingActionCoordinator {
         } catch {
             if Self.isStalePendingActionError(error) {
                 approvalPendingBySession[prompt.sessionID] = nil
-                approvalPrompt = nil
-                approvalErrorMessage = String(localized: "That approval request expired. The card was cleared; wait for the agent to ask again if needed.")
+                approvalPrompt = ApprovalPromptState(
+                    sessionID: prompt.sessionID,
+                    pending: prompt.pending,
+                    pendingCount: prompt.pendingCount,
+                    isExpired: true
+                )
+                approvalErrorMessage = String(localized: "That approval request expired. Wait for the agent to ask again if needed.")
                 return false
             }
 
@@ -195,8 +200,13 @@ final class ChatPendingActionCoordinator {
         } catch {
             if Self.isStalePendingActionError(error) {
                 clarificationPendingBySession[prompt.sessionID] = nil
-                clarificationPrompt = nil
-                clarificationErrorMessage = String(localized: "That clarification request expired. The card was cleared; wait for the agent to ask again if needed.")
+                clarificationPrompt = ClarificationPromptState(
+                    sessionID: prompt.sessionID,
+                    pending: prompt.pending,
+                    pendingCount: prompt.pendingCount,
+                    isExpired: true
+                )
+                clarificationErrorMessage = String(localized: "That clarification request expired. Wait for the agent to ask again if needed.")
                 return false
             }
 

--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -105,13 +105,16 @@ final class ChatPendingActionCoordinator {
         } catch {
             if Self.isStalePendingActionError(error) {
                 approvalPendingBySession[prompt.sessionID] = nil
-                approvalPrompt = ApprovalPromptState(
-                    sessionID: prompt.sessionID,
-                    pending: prompt.pending,
-                    pendingCount: prompt.pendingCount,
-                    isExpired: true
-                )
-                approvalErrorMessage = String(localized: "That approval request expired. Wait for the agent to ask again if needed.")
+                if approvalPrompt?.sessionID == prompt.sessionID,
+                   approvalPrompt?.pending.approvalId == prompt.pending.approvalId {
+                    approvalPrompt = ApprovalPromptState(
+                        sessionID: prompt.sessionID,
+                        pending: prompt.pending,
+                        pendingCount: prompt.pendingCount,
+                        isExpired: true
+                    )
+                    approvalErrorMessage = String(localized: "That approval request expired. Wait for the agent to ask again if needed.")
+                }
                 return false
             }
 
@@ -206,13 +209,16 @@ final class ChatPendingActionCoordinator {
         } catch {
             if Self.isStalePendingActionError(error) {
                 clarificationPendingBySession[prompt.sessionID] = nil
-                clarificationPrompt = ClarificationPromptState(
-                    sessionID: prompt.sessionID,
-                    pending: prompt.pending,
-                    pendingCount: prompt.pendingCount,
-                    isExpired: true
-                )
-                clarificationErrorMessage = String(localized: "That clarification request expired. Wait for the agent to ask again if needed.")
+                if clarificationPrompt?.sessionID == prompt.sessionID,
+                   clarificationPrompt?.pending.clarifyId == prompt.pending.clarifyId {
+                    clarificationPrompt = ClarificationPromptState(
+                        sessionID: prompt.sessionID,
+                        pending: prompt.pending,
+                        pendingCount: prompt.pendingCount,
+                        isExpired: true
+                    )
+                    clarificationErrorMessage = String(localized: "That clarification request expired. Wait for the agent to ask again if needed.")
+                }
                 return false
             }
 
@@ -330,6 +336,9 @@ final class ChatPendingActionCoordinator {
             if approvalPrompt?.sessionID == sessionID {
                 guard approvalPrompt?.isExpired != true else { return }
                 approvalPrompt = nil
+            } else {
+                approvalPrompt = nil
+                approvalErrorMessage = nil
             }
             return
         }
@@ -441,6 +450,9 @@ final class ChatPendingActionCoordinator {
             if clarificationPrompt?.sessionID == sessionID {
                 guard clarificationPrompt?.isExpired != true else { return }
                 clarificationPrompt = nil
+            } else {
+                clarificationPrompt = nil
+                clarificationErrorMessage = nil
             }
             return
         }

--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -103,6 +103,13 @@ final class ChatPendingActionCoordinator {
             await refreshApprovalPending(sessionID: prompt.sessionID)
             return true
         } catch {
+            if Self.isStalePendingActionError(error) {
+                approvalPendingBySession[prompt.sessionID] = nil
+                approvalPrompt = nil
+                approvalErrorMessage = String(localized: "That approval request expired. The card was cleared; wait for the agent to ask again if needed.")
+                return false
+            }
+
             approvalErrorMessage = error.localizedDescription
             delegate?.pendingActionCoordinatorDidFailAction(error)
             return false
@@ -186,6 +193,13 @@ final class ChatPendingActionCoordinator {
             await refreshClarificationPending(sessionID: prompt.sessionID)
             return true
         } catch {
+            if Self.isStalePendingActionError(error) {
+                clarificationPendingBySession[prompt.sessionID] = nil
+                clarificationPrompt = nil
+                clarificationErrorMessage = String(localized: "That clarification request expired. The card was cleared; wait for the agent to ask again if needed.")
+                return false
+            }
+
             clarificationErrorMessage = error.localizedDescription
             delegate?.pendingActionCoordinatorDidFailAction(error)
             return false
@@ -317,6 +331,11 @@ final class ChatPendingActionCoordinator {
         clarifyStreamClient.start(url: client.clarifyStreamURL(sessionID: sessionID)) { [weak self] event in
             self?.handleClarificationMonitorEvent(event, sessionID: sessionID)
         }
+    }
+
+    private static func isStalePendingActionError(_ error: Error) -> Bool {
+        guard case APIError.http(let statusCode, _) = error else { return false }
+        return statusCode == 409 && (error as? APIError)?.serverStale == true
     }
 
     private func stopClarificationMonitoring(clearPrompt: Bool) {

--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -155,6 +155,12 @@ final class ChatPendingActionCoordinator {
         stopClarificationMonitoring(clearPrompt: clearPrompt)
     }
 
+    func dismissExpiredApprovalPrompt() {
+        guard approvalPrompt?.isExpired == true else { return }
+        approvalPrompt = nil
+        approvalErrorMessage = nil
+    }
+
     func applyApprovalUpdate(_ update: ApprovalPendingResponse, sessionID: String) {
         if let pending = update.pending, !pending.isEmpty {
             let prompt = ApprovalPromptState(

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -306,6 +306,9 @@ struct ChatView: View {
                                 ChatHaptics.approvalBypassEnabled(isEnabled: isHapticsEnabled)
                             }
                         }
+                    },
+                    onDismissExpired: {
+                        viewModel.dismissExpiredApprovalPrompt()
                     }
                 )
                 .zIndex(10)

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -11,6 +11,7 @@ struct ApprovalPromptState: Equatable, Identifiable {
     let sessionID: String
     let pending: PendingApproval
     let pendingCount: Int
+    var isExpired = false
 
     var patternKeys: [String] {
         pending.displayPatternKeys
@@ -25,6 +26,7 @@ struct ClarificationPromptState: Equatable, Identifiable {
     let sessionID: String
     let pending: PendingClarification
     let pendingCount: Int
+    var isExpired = false
 
     var question: String {
         pending.displayQuestion

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -3381,6 +3381,10 @@ final class ChatViewModel {
         await pendingActionCoordinator.skipApprovalsForCurrentSession()
     }
 
+    func dismissExpiredApprovalPrompt() {
+        pendingActionCoordinator.dismissExpiredApprovalPrompt()
+    }
+
     func applyApprovalUpdate(_ update: ApprovalPendingResponse, sessionID: String) {
         pendingActionCoordinator.applyApprovalUpdate(update, sessionID: sessionID)
     }

--- a/HermesMobile/Features/Chat/ClarificationRequestOverlay.swift
+++ b/HermesMobile/Features/Chat/ClarificationRequestOverlay.swift
@@ -127,7 +127,7 @@ struct ClarificationRequestCard: View {
                 .tint(actionButtonBackground)
                 .background(textFieldBackground, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
                 .overlay(textFieldBorder)
-                .disabled(isResponding)
+                .disabled(isResponding || prompt.isExpired)
 
             Button {
                 submitDraft()
@@ -139,7 +139,7 @@ struct ClarificationRequestCard: View {
                     .clipShape(Circle())
             }
             .buttonStyle(.chatTactile(.icon))
-            .disabled(isResponding || trimmedDraft.isEmpty)
+            .disabled(isResponding || prompt.isExpired || trimmedDraft.isEmpty)
             .accessibilityLabel("Submit clarification")
         }
     }
@@ -235,7 +235,7 @@ struct ClarificationRequestCard: View {
                 .choiceButtonSurface(reduceTransparency: reduceTransparency)
         }
         .buttonStyle(.chatTactile(.capsule))
-        .disabled(isResponding)
+        .disabled(isResponding || prompt.isExpired)
     }
 
     private var questionBackground: Color {
@@ -252,7 +252,7 @@ struct ClarificationRequestCard: View {
     }
 
     private var actionButtonBackground: Color {
-        if isResponding || trimmedDraft.isEmpty {
+        if isResponding || prompt.isExpired || trimmedDraft.isEmpty {
             return colorScheme == .dark ? Color.white.opacity(0.18) : Color.black.opacity(0.12)
         }
 
@@ -260,7 +260,7 @@ struct ClarificationRequestCard: View {
     }
 
     private var actionButtonForeground: Color {
-        if isResponding || trimmedDraft.isEmpty {
+        if isResponding || prompt.isExpired || trimmedDraft.isEmpty {
             return Color(.secondaryLabel)
         }
 

--- a/HermesMobile/Features/SessionList/SessionMutator.swift
+++ b/HermesMobile/Features/SessionList/SessionMutator.swift
@@ -5,6 +5,14 @@ struct SessionDuplicateResult {
     let errorMessage: String?
 }
 
+enum SessionMoveError: LocalizedError {
+    case sessionIsStreaming
+
+    var errorDescription: String? {
+        String(localized: "This session is still responding. Wait for it to finish, then move it.")
+    }
+}
+
 struct SessionMutator {
     let client: APIClient
 
@@ -25,7 +33,11 @@ struct SessionMutator {
     }
 
     func move(sessionID: String, to projectID: String?) async throws {
-        _ = try await client.moveSession(id: sessionID, projectID: projectID)
+        do {
+            _ = try await client.moveSession(id: sessionID, projectID: projectID)
+        } catch APIError.http(let statusCode, _) where statusCode == 503 {
+            throw SessionMoveError.sessionIsStreaming
+        }
     }
 
     func duplicate(sessionID: String, title: String) async throws -> SessionDuplicateResult {

--- a/HermesMobile/Models/Approval.swift
+++ b/HermesMobile/Models/Approval.swift
@@ -143,16 +143,27 @@ struct PendingApproval: Decodable, Equatable, Identifiable {
 struct ApprovalRespondResponse: Decodable, Equatable {
     let ok: Bool?
     let choice: ApprovalChoice?
+    let stale: Bool?
+    let staleCleared: Bool?
+    let relayed: Bool?
 
     enum CodingKeys: String, CodingKey {
         case ok
         case choice
+        case stale
+        case staleCleared
+        case staleClearedSnake = "stale_cleared"
+        case relayed
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         ok = container.decodeLossyBoolIfPresent(forKey: .ok)
         choice = try? container.decodeIfPresent(ApprovalChoice.self, forKey: .choice)
+        stale = container.decodeLossyBoolIfPresent(forKey: .stale)
+        staleCleared = container.decodeLossyBoolIfPresent(forKey: .staleCleared)
+            ?? container.decodeLossyBoolIfPresent(forKey: .staleClearedSnake)
+        relayed = container.decodeLossyBoolIfPresent(forKey: .relayed)
     }
 }
 

--- a/HermesMobile/Models/Clarification.swift
+++ b/HermesMobile/Models/Clarification.swift
@@ -168,16 +168,27 @@ struct PendingClarification: Decodable, Equatable, Identifiable {
 struct ClarificationRespondResponse: Decodable, Equatable {
     let ok: Bool?
     let response: String?
+    let stale: Bool?
+    let staleCleared: Bool?
+    let relayed: Bool?
 
     enum CodingKeys: String, CodingKey {
         case ok
         case response
+        case stale
+        case staleCleared
+        case staleClearedSnake = "stale_cleared"
+        case relayed
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         ok = container.decodeLossyBoolIfPresent(forKey: .ok)
         response = container.decodeLossyStringIfPresent(forKey: .response)
+        stale = container.decodeLossyBoolIfPresent(forKey: .stale)
+        staleCleared = container.decodeLossyBoolIfPresent(forKey: .staleCleared)
+            ?? container.decodeLossyBoolIfPresent(forKey: .staleClearedSnake)
+        relayed = container.decodeLossyBoolIfPresent(forKey: .relayed)
     }
 }
 

--- a/HermesMobile/Networking/APIError.swift
+++ b/HermesMobile/Networking/APIError.swift
@@ -79,6 +79,11 @@ enum APIError: LocalizedError {
         return Self.serverErrorMessage(from: body)
     }
 
+    var serverStale: Bool {
+        guard case .http(_, let body) = self else { return false }
+        return Self.serverErrorPayload(from: body)?.stale == true
+    }
+
     static func privacySafeLogCategory(for error: Error) -> String {
         if let apiError = error as? APIError {
             return apiError.privacySafeLogCategory
@@ -102,6 +107,7 @@ private extension APIError {
         let message: String?
         let detail: String?
         let code: String?
+        let stale: Bool?
     }
 
     static func networkMessage(for error: Error) -> String {

--- a/HermesMobile/Networking/SSEClient.swift
+++ b/HermesMobile/Networking/SSEClient.swift
@@ -235,7 +235,7 @@ struct SSEEventDecoder {
             return .streamEnd
         case "cancel":
             return .cancelled
-        case "error":
+        case "error", "apperror":
             guard let payload = decodePayload(ErrorPayload.self, eventType: eventType, from: eventData, decoder: decoder) else {
                 return .error(String(localized: "The stream returned a malformed error event."))
             }

--- a/HermesMobileTests/APIClientAgentControlTests.swift
+++ b/HermesMobileTests/APIClientAgentControlTests.swift
@@ -96,6 +96,19 @@ final class APIClientAgentControlTests: APIClientTestCase {
         XCTAssertNil(observedBodies[3]["approval_id"])
     }
 
+    func testApprovalRespondDecodesStaleAndRelayMetadata() throws {
+        let response = try JSONDecoder().decode(
+            ApprovalRespondResponse.self,
+            from: Data(#"{"ok":true,"choice":"once","stale":false,"stale_cleared":true,"relayed":true}"#.utf8)
+        )
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.choice, .once)
+        XCTAssertEqual(response.stale, false)
+        XCTAssertEqual(response.staleCleared, true)
+        XCTAssertEqual(response.relayed, true)
+    }
+
     func testSessionYoloGetAndPostUseUpstreamShape() async throws {
         var requestCount = 0
         let client = makeClient { request in

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -1010,12 +1010,13 @@ final class ChatViewModelSendTests: XCTestCase {
         let didRespond = await viewModel.respondToApproval(.deny)
 
         XCTAssertFalse(didRespond)
-        XCTAssertNil(viewModel.approvalPrompt)
+        XCTAssertEqual(viewModel.approvalPrompt?.pending.approvalId, "approval-1")
+        XCTAssertEqual(viewModel.approvalPrompt?.isExpired, true)
         XCTAssertNil(viewModel.lastError)
         XCTAssertNil(viewModel.sendErrorMessage)
         XCTAssertEqual(
             viewModel.approvalErrorMessage,
-            "That approval request expired. The card was cleared; wait for the agent to ask again if needed."
+            "That approval request expired. Wait for the agent to ask again if needed."
         )
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
     }

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -1019,6 +1019,11 @@ final class ChatViewModelSendTests: XCTestCase {
             "That approval request expired. Wait for the agent to ask again if needed."
         )
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
+
+        viewModel.dismissExpiredApprovalPrompt()
+
+        XCTAssertNil(viewModel.approvalPrompt)
+        XCTAssertNil(viewModel.approvalErrorMessage)
     }
 
     @MainActor

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -969,6 +969,58 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testStaleApprovalResponseClearsPromptWithoutSendFailure() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let approvalStreamClient = SpySSEStreamingClient()
+        let clarifyStreamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            approvalStreamClient: approvalStreamClient,
+            clarifyStreamClient: clarifyStreamClient
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(#"{"session_id": "session-abc", "stream_id": "stream-123"}"#, for: request)
+            case "/api/approval/respond":
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 409,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+                return (try XCTUnwrap(response), Data(#"{"stale":true,"error":"approval expired"}"#.utf8))
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Run the installer")
+        XCTAssertTrue(didStart)
+        approvalStreamClient.emit(.approvalPending(ApprovalPendingResponse(
+            pending: PendingApproval(
+                approvalId: "approval-1",
+                command: "make install",
+                description: "Install command",
+                patternKey: "install"
+            ),
+            pendingCount: 1
+        )))
+
+        let didRespond = await viewModel.respondToApproval(.deny)
+
+        XCTAssertFalse(didRespond)
+        XCTAssertNil(viewModel.approvalPrompt)
+        XCTAssertNil(viewModel.lastError)
+        XCTAssertNil(viewModel.sendErrorMessage)
+        XCTAssertEqual(
+            viewModel.approvalErrorMessage,
+            "That approval request expired. The card was cleared; wait for the agent to ask again if needed."
+        )
+        XCTAssertEqual(viewModel.activeStreamID, "stream-123")
+    }
+
+    @MainActor
     func testApprovalFallbackPollingFailureStaysDiagnosticOnly() async throws {
         let streamClient = SpySSEStreamingClient()
         let approvalStreamClient = SpySSEStreamingClient()

--- a/HermesMobileTests/ClarificationTests.swift
+++ b/HermesMobileTests/ClarificationTests.swift
@@ -322,12 +322,13 @@ final class ClarificationTests: XCTestCase {
         let didRespond = await viewModel.respondToClarification("Use main")
 
         XCTAssertFalse(didRespond)
-        XCTAssertNil(viewModel.clarificationPrompt)
+        XCTAssertEqual(viewModel.clarificationPrompt?.pending.clarifyId, "clarify-1")
+        XCTAssertEqual(viewModel.clarificationPrompt?.isExpired, true)
         XCTAssertNil(viewModel.lastError)
         XCTAssertNil(viewModel.sendErrorMessage)
         XCTAssertEqual(
             viewModel.clarificationErrorMessage,
-            "That clarification request expired. The card was cleared; wait for the agent to ask again if needed."
+            "That clarification request expired. Wait for the agent to ask again if needed."
         )
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
     }

--- a/HermesMobileTests/ClarificationTests.swift
+++ b/HermesMobileTests/ClarificationTests.swift
@@ -55,6 +55,19 @@ final class ClarificationTests: XCTestCase {
         XCTAssertEqual(minimal.pending?.displayChoices, [])
     }
 
+    func testClarificationRespondDecodesStaleAndRelayMetadata() throws {
+        let response = try JSONDecoder().decode(
+            ClarificationRespondResponse.self,
+            from: Data(#"{"ok":true,"response":"Use main","stale":false,"stale_cleared":true,"relayed":true}"#.utf8)
+        )
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.response, "Use main")
+        XCTAssertEqual(response.stale, false)
+        XCTAssertEqual(response.staleCleared, true)
+        XCTAssertEqual(response.relayed, true)
+    }
+
     func testClarificationAPIUsesVerifiedRoutesAndBodies() async throws {
         var requestCount = 0
         var respondBody: [String: Any]?
@@ -265,6 +278,57 @@ final class ClarificationTests: XCTestCase {
         XCTAssertEqual(viewModel.clarificationPrompt?.pending.clarifyId, "clarify-1")
         XCTAssertNotNil(viewModel.lastError)
         XCTAssertEqual(viewModel.clarificationErrorMessage, viewModel.sendErrorMessage)
+        XCTAssertEqual(viewModel.activeStreamID, "stream-123")
+    }
+
+    @MainActor
+    func testStaleClarificationResponseClearsPromptWithoutSendFailure() async throws {
+        let streamClient = ClarificationSpySSEStreamingClient()
+        let approvalStreamClient = ClarificationSpySSEStreamingClient()
+        let clarifyStreamClient = ClarificationSpySSEStreamingClient()
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            approvalStreamClient: approvalStreamClient,
+            clarifyStreamClient: clarifyStreamClient
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return jsonResponse(#"{"session_id": "session-abc", "stream_id": "stream-123"}"#, for: request)
+            case "/api/clarify/respond":
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 409,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+                return (try XCTUnwrap(response), Data(#"{"stale":true,"error":"clarification expired"}"#.utf8))
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Continue")
+        XCTAssertTrue(didStart)
+        clarifyStreamClient.emit(.clarificationPending(ClarificationPendingResponse(
+            pending: PendingClarification(
+                clarifyId: "clarify-1",
+                question: "Which branch?",
+                sessionId: "session-abc"
+            ),
+            pendingCount: 1
+        )))
+
+        let didRespond = await viewModel.respondToClarification("Use main")
+
+        XCTAssertFalse(didRespond)
+        XCTAssertNil(viewModel.clarificationPrompt)
+        XCTAssertNil(viewModel.lastError)
+        XCTAssertNil(viewModel.sendErrorMessage)
+        XCTAssertEqual(
+            viewModel.clarificationErrorMessage,
+            "That clarification request expired. The card was cleared; wait for the agent to ask again if needed."
+        )
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
     }
 

--- a/HermesMobileTests/SSEClientTests.swift
+++ b/HermesMobileTests/SSEClientTests.swift
@@ -36,37 +36,65 @@ final class SSEClientTests: XCTestCase {
         let client = SSEClient(urlSessionConfiguration: configuration)
         let liveEvent = expectation(description: "received live event before done")
         let doneEvent = expectation(description: "received done event")
+        let receivedLock = NSLock()
         var didFulfillLiveEvent = false
         var receivedEvents: [SSEEvent] = []
+        var capturedHeaders: [String: String] = [:]
 
         client.start(url: URL(string: "https://example.test/api/chat/stream?stream_id=stream-123")!) { event in
+            receivedLock.lock()
             receivedEvents.append(event)
+            if capturedHeaders.isEmpty, let request = DelayedSSEURLProtocol.capturedRequest() {
+                capturedHeaders["Accept"] = request.value(forHTTPHeaderField: "Accept")
+                capturedHeaders["Accept-Encoding"] = request.value(forHTTPHeaderField: "Accept-Encoding")
+                capturedHeaders["Cache-Control"] = request.value(forHTTPHeaderField: "Cache-Control")
+            }
 
+            let shouldFulfillLiveEvent: Bool
             if !didFulfillLiveEvent {
                 switch event {
                 case .reasoning, .toolStarted, .toolCompleted, .token, .interimAssistant:
                     didFulfillLiveEvent = true
-                    liveEvent.fulfill()
+                    shouldFulfillLiveEvent = true
                 default:
-                    break
+                    shouldFulfillLiveEvent = false
                 }
+            } else {
+                shouldFulfillLiveEvent = false
             }
-
+            let shouldFulfillDoneEvent: Bool
             if case .done = event {
+                shouldFulfillDoneEvent = true
+            } else {
+                shouldFulfillDoneEvent = false
+            }
+            receivedLock.unlock()
+
+            if shouldFulfillLiveEvent {
+                liveEvent.fulfill()
+            }
+            if shouldFulfillDoneEvent {
                 doneEvent.fulfill()
             }
         }
 
-        await fulfillment(of: [liveEvent], timeout: 1)
-        XCTAssertFalse(receivedEvents.contains { event in
+        await fulfillment(of: [liveEvent], timeout: 2)
+        receivedLock.lock()
+        let eventsBeforeDone = receivedEvents
+        receivedLock.unlock()
+        XCTAssertFalse(eventsBeforeDone.contains { event in
             if case .done = event { return true }
             return false
         })
 
-        await fulfillment(of: [doneEvent], timeout: 1)
+        await fulfillment(of: [doneEvent], timeout: 2)
         client.stop()
+        receivedLock.lock()
+        let finalEvents = receivedEvents
+        let finalHeaders = capturedHeaders
+        receivedLock.unlock()
 
-        XCTAssertEqual(Array(receivedEvents.prefix(3)), [
+        XCTAssertEqual(Array(finalEvents.prefix(3)), [
             .reasoning("Thinking live."),
             .toolStarted(ToolStreamEvent(
                 eventType: nil,
@@ -79,15 +107,15 @@ final class SSEClientTests: XCTestCase {
             .token("First live token.")
         ])
         XCTAssertEqual(
-            DelayedSSEURLProtocol.capturedRequest()?.value(forHTTPHeaderField: "Accept"),
+            finalHeaders["Accept"],
             "text/event-stream"
         )
         XCTAssertEqual(
-            DelayedSSEURLProtocol.capturedRequest()?.value(forHTTPHeaderField: "Accept-Encoding"),
+            finalHeaders["Accept-Encoding"],
             "identity"
         )
         XCTAssertEqual(
-            DelayedSSEURLProtocol.capturedRequest()?.value(forHTTPHeaderField: "Cache-Control"),
+            finalHeaders["Cache-Control"],
             "no-cache, no-transform"
         )
     }

--- a/HermesMobileTests/SSEClientTests.swift
+++ b/HermesMobileTests/SSEClientTests.swift
@@ -431,6 +431,21 @@ final class SSEClientTests: XCTestCase {
         XCTAssertEqual(event, .transportError("The stream returned a malformed completion event."))
     }
 
+    func testDecodesAppErrorEventAsUserVisibleError() {
+        let event = SSEEventDecoder.decode(
+            eventType: "apperror",
+            data: #"{"message":"Tool approval expired before the agent could continue."}"#
+        )
+
+        XCTAssertEqual(event, .error("Tool approval expired before the agent could continue."))
+    }
+
+    func testMalformedAppErrorPayloadSurfacesErrorEvent() {
+        let event = SSEEventDecoder.decode(eventType: "apperror", data: "{")
+
+        XCTAssertEqual(event, .error("The stream returned a malformed error event."))
+    }
+
     func testMalformedDoneUsagePayloadSurfacesTransportError() {
         let event = SSEEventDecoder.decode(eventType: "done", data: #"{"usage":"bad"}"#)
 

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -1089,6 +1089,45 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertFalse(isMovingSession)
     }
 
+    func testCreateProjectMoveWhileStreamingShowsSpecificMessage() async throws {
+        let viewModel = try await makeViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse(self.sessionListJSON(forLoadCount: 1), for: request)
+            case "/api/projects/create":
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "project": {
+                    "project_id": "project-new",
+                    "name": "Client Work",
+                    "color": "#7cb9ff"
+                  }
+                }
+                """, for: request)
+            case "/api/session/move":
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 503,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+                return (try XCTUnwrap(response), Data(#"{"error":"session is streaming"}"#.utf8))
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        let session = try await MainActor.run { try XCTUnwrap(viewModel.sessions.first) }
+        let didMove = await viewModel.createProject(named: "Client Work", color: "#7cb9ff", moving: session)
+
+        XCTAssertFalse(didMove)
+        let actionErrorMessage = await MainActor.run { viewModel.actionErrorMessage }
+        XCTAssertEqual(actionErrorMessage, "This session is still responding. Wait for it to finish, then move it.")
+    }
+
     func testCreateEmptyProjectCreatesProjectWithoutMovingAnySession() async throws {
         var loadCount = 0
         var requestedPaths: [String] = []


### PR DESCRIPTION
## Summary
- Decode terminal apperror SSE frames as visible stream errors
- Decode approval/clarification stale and relay metadata
- Clear expired approval/clarification cards without turning them into send failures
- Show a specific message when moving a still-streaming session returns 503

## Test Plan
- [x] Added focused decode and UI-state tests for apperror, stale responses, and streaming-session move 503
- [x] git diff --check
- [x] Static delimiter balance check for touched Swift files
- [ ] Full XCTest suite (pending GitHub CI / Mac runner; Linux host has no xcodebuild or swift)

Closes #25