### PR TITLE
feat(chat): gate reasoning efforts by model

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerConfigLoader.swift
+++ b/HermesMobile/Features/Chat/ChatComposerConfigLoader.swift
@@ -7,6 +7,8 @@ struct ChatComposerConfigState: Equatable, Sendable {
     var currentProfile: String?
     var selectedProfileName: String?
     var selectedReasoningEffort: String?
+    var supportedReasoningEfforts: [String]?
+    var supportsReasoningEffort: Bool?
     var modelCatalogGroups: [ModelCatalogGroup]
     var agentCommands: [AgentCommand]
     var workspaceRoots: [WorkspaceRoot]
@@ -21,6 +23,8 @@ struct ChatComposerConfigState: Equatable, Sendable {
         currentProfile: String? = nil,
         selectedProfileName: String? = nil,
         selectedReasoningEffort: String? = nil,
+        supportedReasoningEfforts: [String]? = nil,
+        supportsReasoningEffort: Bool? = nil,
         modelCatalogGroups: [ModelCatalogGroup] = [],
         agentCommands: [AgentCommand] = [],
         workspaceRoots: [WorkspaceRoot] = [],
@@ -34,6 +38,8 @@ struct ChatComposerConfigState: Equatable, Sendable {
         self.currentProfile = currentProfile
         self.selectedProfileName = selectedProfileName
         self.selectedReasoningEffort = selectedReasoningEffort
+        self.supportedReasoningEfforts = supportedReasoningEfforts
+        self.supportsReasoningEffort = supportsReasoningEffort
         self.modelCatalogGroups = modelCatalogGroups
         self.agentCommands = agentCommands
         self.workspaceRoots = workspaceRoots
@@ -101,8 +107,13 @@ struct ChatComposerConfigLoader {
                     ?? Self.uniqueProvider(for: state.currentModel, in: state.modelCatalogGroups)
             }
 
-            let reasoningResponse = try await client.reasoning()
-            state.selectedReasoningEffort = reasoningResponse.effectiveEffort
+            let reasoningResponse = try await client.reasoning(
+                model: state.currentModel,
+                provider: state.currentModelProvider
+            )
+            state.supportedReasoningEfforts = reasoningResponse.normalizedSupportedEfforts
+            state.supportsReasoningEffort = reasoningResponse.supportsReasoningEffort
+            state.selectedReasoningEffort = Self.effectiveReasoningEffort(from: reasoningResponse)
 
             let workspaceResponse = try await client.workspaces()
             state.workspaceRoots = workspaceResponse.workspaces ?? []
@@ -124,6 +135,20 @@ struct ChatComposerConfigLoader {
             state: state,
             configurationError: configurationError
         )
+    }
+
+    private static func effectiveReasoningEffort(from response: ReasoningStatusResponse) -> String? {
+        let effort = nonEmpty(response.effectiveEffort)
+        guard response.supportsReasoningEffort != false,
+              let supported = response.normalizedSupportedEfforts,
+              !supported.isEmpty,
+              let effort,
+              !supported.contains(effort)
+        else {
+            return effort
+        }
+
+        return supported.first
     }
 
     private static func profileSummary(

--- a/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
@@ -241,6 +241,7 @@ struct ComposerModelMenu: View {
 
 struct ComposerReasoningMenu: View {
     let selectedReasoningEffort: String?
+    let supportedReasoningEfforts: [String]?
     let reasoningTitle: String
     let isDisabled: Bool
     let width: CGFloat
@@ -272,7 +273,7 @@ struct ComposerReasoningMenu: View {
         UIMenu(
             title: String(localized: "Reasoning"),
             options: [.displayInline],
-            children: ReasoningEffortOption.allCases.map { option in
+            children: reasoningOptions.map { option in
                 UIAction(
                     title: option.title,
                     state: selectedReasoningEffort == option.id ? .on : .off
@@ -283,6 +284,15 @@ struct ComposerReasoningMenu: View {
                 }
             }
         )
+    }
+
+    private var reasoningOptions: [ReasoningEffortOption] {
+        guard let supportedReasoningEfforts else {
+            return ReasoningEffortOption.allCases
+        }
+
+        let options = supportedReasoningEfforts.map { ReasoningEffortOption(id: $0, title: ReasoningEffortOption.title(for: $0)) }
+        return options.isEmpty ? [] : options
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -93,6 +93,8 @@ struct MessageComposerView: View {
     let selectedProfileTitle: String
     let isLoadingModels: Bool
     let selectedReasoningEffort: String?
+    let supportedReasoningEfforts: [String]?
+    let supportsReasoningEffort: Bool?
     let isUpdatingConfiguration: Bool
     let pendingAttachments: [PendingAttachment]
     let isUploadingAttachment: Bool
@@ -760,17 +762,21 @@ struct MessageComposerView: View {
         }
     }
 
+    @ViewBuilder
     private var reasoningMenu: some View {
-        ComposerReasoningMenu(
-            selectedReasoningEffort: selectedReasoningEffort,
-            reasoningTitle: reasoningTitle,
-            isDisabled: isConfigurationControlDisabled,
-            width: reasoningControlWidth,
-            color: metaControlColor,
-            controlFont: metaControlFont,
-            chevronFont: metaChevronFont,
-            onSelectReasoningEffort: onSelectReasoningEffort
-        )
+        if supportsReasoningEffort != false {
+            ComposerReasoningMenu(
+                selectedReasoningEffort: selectedReasoningEffort,
+                supportedReasoningEfforts: supportedReasoningEfforts,
+                reasoningTitle: reasoningTitle,
+                isDisabled: isConfigurationControlDisabled,
+                width: reasoningControlWidth,
+                color: metaControlColor,
+                controlFont: metaControlFont,
+                chevronFont: metaChevronFont,
+                onSelectReasoningEffort: onSelectReasoningEffort
+            )
+        }
     }
 
     private func selectModel(_ option: ModelCatalogOption) {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -168,6 +168,8 @@ struct ChatView: View {
             selectedProfileTitle: viewModel.selectedProfileTitle,
             isLoadingModels: viewModel.isLoadingComposerConfiguration,
             selectedReasoningEffort: viewModel.selectedReasoningEffort,
+            supportedReasoningEfforts: viewModel.supportedReasoningEfforts,
+            supportsReasoningEffort: viewModel.supportsReasoningEffort,
             isUpdatingConfiguration: viewModel.isUpdatingComposerConfiguration,
             pendingAttachments: viewModel.pendingAttachments,
             isUploadingAttachment: viewModel.isUploadingAttachment,

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -188,6 +188,8 @@ final class ChatViewModel {
     private(set) var isSingleProfileMode = false
     private(set) var selectedProfileName: String?
     private(set) var selectedReasoningEffort: String?
+    private(set) var supportedReasoningEfforts: [String]?
+    private(set) var supportsReasoningEffort: Bool?
     private(set) var isLoadingComposerConfiguration = false
     private(set) var isUpdatingComposerConfiguration = false
     private(set) var composerConfigurationErrorMessage: String?
@@ -578,6 +580,8 @@ final class ChatViewModel {
             currentProfile: currentProfile,
             selectedProfileName: selectedProfileName,
             selectedReasoningEffort: selectedReasoningEffort,
+            supportedReasoningEfforts: supportedReasoningEfforts,
+            supportsReasoningEffort: supportsReasoningEffort,
             modelCatalogGroups: modelCatalogGroups,
             agentCommands: agentCommands,
             workspaceRoots: workspaceRoots,
@@ -594,6 +598,8 @@ final class ChatViewModel {
         currentProfile = state.currentProfile
         selectedProfileName = state.selectedProfileName
         selectedReasoningEffort = state.selectedReasoningEffort
+        supportedReasoningEfforts = state.supportedReasoningEfforts
+        supportsReasoningEffort = state.supportsReasoningEffort
         modelCatalogGroups = state.modelCatalogGroups
         agentCommands = state.agentCommands
         workspaceRoots = state.workspaceRoots
@@ -644,6 +650,7 @@ final class ChatViewModel {
             currentModelProvider = response.session?.modelProvider ?? option.providerID
             currentWorkspace = response.session?.workspace ?? currentWorkspace
             pendingExplicitModelPick = true
+            await refreshReasoningCapabilitiesForCurrentModel()
             return true
         } catch {
             lastError = error
@@ -853,6 +860,31 @@ final class ChatViewModel {
             composerConfigurationErrorMessage = error.localizedDescription
             return false
         }
+    }
+
+    private func refreshReasoningCapabilitiesForCurrentModel() async {
+        do {
+            let response = try await client.reasoning(model: currentModel, provider: currentModelProvider)
+            supportedReasoningEfforts = response.normalizedSupportedEfforts
+            supportsReasoningEffort = response.supportsReasoningEffort
+            selectedReasoningEffort = Self.effectiveReasoningEffort(from: response)
+        } catch {
+            // Non-fatal: keep the last-known/fallback menu if capability refresh fails.
+        }
+    }
+
+    private static func effectiveReasoningEffort(from response: ReasoningStatusResponse) -> String? {
+        let effort = nonEmpty(response.effectiveEffort)
+        guard response.supportsReasoningEffort != false,
+              let supported = response.normalizedSupportedEfforts,
+              !supported.isEmpty,
+              let effort,
+              !supported.contains(effort)
+        else {
+            return effort
+        }
+
+        return supported.first
     }
 
     func uploadAttachment(data: Data, filename: String, previewData: Data? = nil) async {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -863,8 +863,15 @@ final class ChatViewModel {
     }
 
     private func refreshReasoningCapabilitiesForCurrentModel() async {
+        let expectedModel = currentModel
+        let expectedProvider = currentModelProvider
+
         do {
-            let response = try await client.reasoning(model: currentModel, provider: currentModelProvider)
+            let response = try await client.reasoning(model: expectedModel, provider: expectedProvider)
+            guard !Task.isCancelled,
+                  currentModel == expectedModel,
+                  currentModelProvider == expectedProvider
+            else { return }
             supportedReasoningEfforts = response.normalizedSupportedEfforts
             supportsReasoningEffort = response.supportsReasoningEffort
             selectedReasoningEffort = Self.effectiveReasoningEffort(from: response)

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -295,10 +295,24 @@ struct ReasoningStatusResponse: Decodable, Equatable {
     let showReasoning: Bool?
     let reasoningEffort: String?
     let effort: String?
+    let supportedEfforts: [String]?
+    let supportsReasoningEffort: Bool?
     let error: String?
 
     var effectiveEffort: String? {
         reasoningEffort ?? effort
+    }
+
+    var normalizedSupportedEfforts: [String]? {
+        guard let supportedEfforts else { return nil }
+        var seen = Set<String>()
+        var normalized: [String] = []
+        for effort in supportedEfforts {
+            let trimmed = effort.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { continue }
+            normalized.append(trimmed)
+        }
+        return normalized
     }
 }
 

--- a/HermesMobile/Networking/APIClient+ServerPanels.swift
+++ b/HermesMobile/Networking/APIClient+ServerPanels.swift
@@ -24,13 +24,13 @@ extension APIClient {
         )
     }
 
-    func reasoning() async throws -> ReasoningStatusResponse {
-        try await send(endpoint: .reasoning, method: "GET")
+    func reasoning(model: String? = nil, provider: String? = nil) async throws -> ReasoningStatusResponse {
+        try await send(endpoint: .reasoning(model: model, provider: provider), method: "GET")
     }
 
     func saveReasoningEffort(_ effort: String) async throws -> ReasoningStatusResponse {
         try await send(
-            endpoint: .reasoning,
+            endpoint: .reasoning(model: nil, provider: nil),
             method: "POST",
             body: ReasoningEffortRequest(effort: effort)
         )
@@ -38,7 +38,7 @@ extension APIClient {
 
     func saveReasoningDisplay(_ display: String) async throws -> ReasoningStatusResponse {
         try await send(
-            endpoint: .reasoning,
+            endpoint: .reasoning(model: nil, provider: nil),
             method: "POST",
             body: ReasoningDisplayRequest(display: display)
         )

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -67,7 +67,7 @@ enum Endpoint {
     case modelsLive
     case commands
     case defaultModel
-    case reasoning
+    case reasoning(model: String?, provider: String?)
     case personalities
     case setPersonality
     case profiles
@@ -367,6 +367,11 @@ enum Endpoint {
                 items.append(URLQueryItem(name: "limit", value: "\(limit)"))
             }
             return items
+        case let .reasoning(model, provider):
+            return [
+                URLQueryItem(name: "model", value: model),
+                URLQueryItem(name: "provider", value: provider)
+            ].filter { $0.value?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
         case let .insights(days):
             return [URLQueryItem(name: "days", value: "\(days)")]
         case let .skillContent(name, file):

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -224,21 +224,29 @@ final class APIClientConfigurationTests: APIClientTestCase {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/reasoning")
             XCTAssertEqual(request.httpMethod, "GET")
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            XCTAssertEqual(query["model"], "gpt-5")
+            XCTAssertEqual(query["provider"], "openai")
             XCTAssertNil(request.httpBody)
 
             return apiTestJSONResponse("""
             {
               "show_reasoning": true,
-              "reasoning_effort": "high"
+              "reasoning_effort": "high",
+              "supported_efforts": ["low", "medium", "high"],
+              "supports_reasoning_effort": true
             }
             """, for: request)
         }
 
-        let response = try await client.reasoning()
+        let response = try await client.reasoning(model: "gpt-5", provider: "openai")
 
         XCTAssertEqual(response.showReasoning, true)
         XCTAssertEqual(response.reasoningEffort, "high")
         XCTAssertEqual(response.effectiveEffort, "high")
+        XCTAssertEqual(response.normalizedSupportedEfforts, ["low", "medium", "high"])
+        XCTAssertEqual(response.supportsReasoningEffort, true)
     }
 
     func testSaveReasoningEffortBuildsExpectedBodyAndDecodesResponse() async throws {

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -175,8 +175,14 @@ final class ContractReadinessTests: XCTestCase {
             .init(name: "models live", method: "GET", endpoint: .modelsLive, path: "/api/models/live"),
             .init(name: "commands", method: "GET", endpoint: .commands, path: "/api/commands"),
             .init(name: "default model", method: "POST", endpoint: .defaultModel, path: "/api/default-model"),
-            .init(name: "reasoning read", method: "GET", endpoint: .reasoning, path: "/api/reasoning"),
-            .init(name: "reasoning save", method: "POST", endpoint: .reasoning, path: "/api/reasoning"),
+            .init(
+                name: "reasoning read",
+                method: "GET",
+                endpoint: .reasoning(model: "gpt-5", provider: "openai"),
+                path: "/api/reasoning",
+                query: ["model": "gpt-5", "provider": "openai"]
+            ),
+            .init(name: "reasoning save", method: "POST", endpoint: .reasoning(model: nil, provider: nil), path: "/api/reasoning"),
             .init(name: "personalities", method: "GET", endpoint: .personalities, path: "/api/personalities"),
             .init(name: "set personality", method: "POST", endpoint: .setPersonality, path: "/api/personality/set"),
             .init(name: "profiles", method: "GET", endpoint: .profiles, path: "/api/profiles"),

--- a/HermesMobileTests/ChatComposerConfigLoaderTests.swift
+++ b/HermesMobileTests/ChatComposerConfigLoaderTests.swift
@@ -49,7 +49,11 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
                 }
                 """, for: request)
             case "/api/reasoning":
-                return apiTestJSONResponse(#"{"reasoning_effort": "medium"}"#, for: request)
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                XCTAssertEqual(query["model"], openRouterModel)
+                XCTAssertEqual(query["provider"], "openrouter")
+                return apiTestJSONResponse(#"{"reasoning_effort": "medium", "supported_efforts": ["low", "medium"], "supports_reasoning_effort": true}"#, for: request)
             case "/api/workspaces":
                 return apiTestJSONResponse(#"{"workspaces": [{"path": "/tmp/workspace"}], "last": "/tmp/workspace"}"#, for: request)
             case "/api/commands":
@@ -71,6 +75,8 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
         XCTAssertEqual(result.state.currentModelProvider, "openrouter")
         XCTAssertEqual(result.state.currentWorkspace, "/tmp/workspace")
         XCTAssertEqual(result.state.selectedReasoningEffort, "medium")
+        XCTAssertEqual(result.state.supportedReasoningEfforts, ["low", "medium"])
+        XCTAssertEqual(result.state.supportsReasoningEffort, true)
         XCTAssertEqual(result.state.workspaceSuggestions, ["/tmp/workspace"])
         XCTAssertEqual(result.state.agentCommands.map(\.name), ["status"])
         XCTAssertEqual(requestPaths, [
@@ -116,7 +122,11 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
                 }
                 """, for: request)
             case "/api/reasoning":
-                return apiTestJSONResponse(#"{"reasoning_effort": "high"}"#, for: request)
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                XCTAssertEqual(query["model"], sessionModel)
+                XCTAssertEqual(query["provider"], "openai")
+                return apiTestJSONResponse(#"{"reasoning_effort": "high", "supported_efforts": ["low", "medium"], "supports_reasoning_effort": true}"#, for: request)
             case "/api/workspaces":
                 return apiTestJSONResponse(#"{"workspaces": [{"path": "/tmp/workspace"}]}"#, for: request)
             case "/api/commands":
@@ -143,7 +153,8 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
         XCTAssertEqual(result.state.currentModel, sessionModel)
         XCTAssertEqual(result.state.currentModelProvider, "openai")
         XCTAssertEqual(result.state.selectedProfileName, "work")
-        XCTAssertEqual(result.state.selectedReasoningEffort, "high")
+        XCTAssertEqual(result.state.selectedReasoningEffort, "low")
+        XCTAssertEqual(result.state.supportedReasoningEfforts, ["low", "medium"])
     }
 
     func testLoadReturnsPartialStateAndStillRefreshesCommandsWhenConfigurationFails() async throws {
@@ -188,6 +199,33 @@ final class ChatComposerConfigLoaderTests: APIClientTestCase {
         XCTAssertNil(result.state.currentModelProvider)
         XCTAssertEqual(result.state.agentCommands.map(\.name), ["status"])
         XCTAssertEqual(requestPaths, ["/api/profiles", "/api/models", "/api/commands"])
+    }
+
+    func testLoadKeepsLegacyReasoningMenuWhenCapabilityFieldsAreMissing() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/profiles":
+                return apiTestJSONResponse(#"{"active":"default","profiles":[{"name":"default","model":"gpt-5.4","provider":"openai","is_default":true}]}"#, for: request)
+            case "/api/models":
+                return apiTestJSONResponse(#"{"default_model":"gpt-5.4","groups":[]}"#, for: request)
+            case "/api/reasoning":
+                return apiTestJSONResponse(#"{"reasoning_effort":"medium"}"#, for: request)
+            case "/api/workspaces":
+                return apiTestJSONResponse(#"{"workspaces":[]}"#, for: request)
+            case "/api/commands":
+                return apiTestJSONResponse(#"{"commands":[]}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let result = await ChatComposerConfigLoader(client: client).loadConfiguration(from: ChatComposerConfigState())
+
+        XCTAssertNil(result.configurationError)
+        XCTAssertEqual(result.state.selectedReasoningEffort, "medium")
+        XCTAssertNil(result.state.supportedReasoningEfforts)
+        XCTAssertNil(result.state.supportsReasoningEffort)
     }
 
     func testLoadStoresSingleProfileModeFromProfilesResponse() async throws {

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -4583,6 +4583,12 @@ final class ChatViewModelSendTests: XCTestCase {
                   }
                 }
                 """, for: request)
+            case "/api/reasoning":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                XCTAssertEqual(query["model"], openRouterModel)
+                XCTAssertEqual(query["provider"], "openrouter")
+                return apiTestJSONResponse(#"{"reasoning_effort":"medium","supported_efforts":["low","medium"],"supports_reasoning_effort":true}"#, for: request)
             case "/api/chat/start":
                 let body = try XCTUnwrap(apiTestJSONBody(from: request))
                 XCTAssertEqual(body["model"] as? String, openRouterModel)
@@ -4609,7 +4615,7 @@ final class ChatViewModelSendTests: XCTestCase {
         let didStart = await viewModel.sendMessage("Use the selected OpenRouter model")
 
         XCTAssertTrue(didStart)
-        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/chat/start"])
+        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/reasoning", "/api/chat/start"])
         XCTAssertEqual(streamClient.startedURLs.count, 1)
     }
 
@@ -4633,6 +4639,12 @@ final class ChatViewModelSendTests: XCTestCase {
                   }
                 }
                 """, for: request)
+            case "/api/reasoning":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                XCTAssertEqual(query["model"], openRouterModel)
+                XCTAssertEqual(query["provider"], "openrouter")
+                return apiTestJSONResponse(#"{"reasoning_effort":"medium","supported_efforts":["low","medium"],"supports_reasoning_effort":true}"#, for: request)
             case "/api/chat/start":
                 chatStartBodies.append(try XCTUnwrap(apiTestJSONBody(from: request)))
                 if chatStartBodies.count == 1 {
@@ -4696,6 +4708,12 @@ final class ChatViewModelSendTests: XCTestCase {
                   }
                 }
                 """, for: request)
+            case "/api/reasoning":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                XCTAssertEqual(query["model"], customModel)
+                XCTAssertEqual(query["provider"], "openrouter")
+                return apiTestJSONResponse(#"{"reasoning_effort":"low","supported_efforts":["low","medium"],"supports_reasoning_effort":true}"#, for: request)
             case "/api/chat/start":
                 let body = try XCTUnwrap(apiTestJSONBody(from: request))
                 XCTAssertEqual(body["model"] as? String, customModel)
@@ -4724,7 +4742,7 @@ final class ChatViewModelSendTests: XCTestCase {
         let didStart = await viewModel.sendMessage("Use the custom OpenRouter model")
 
         XCTAssertTrue(didStart)
-        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/chat/start"])
+        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/reasoning", "/api/chat/start"])
         XCTAssertEqual(streamClient.startedURLs.count, 1)
     }
 
@@ -4911,6 +4929,12 @@ final class ChatViewModelSendTests: XCTestCase {
                   }
                 }
                 """, for: request)
+            case "/api/reasoning":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                XCTAssertEqual(query["model"], customModel)
+                XCTAssertEqual(query["provider"], "openrouter")
+                return apiTestJSONResponse(#"{"reasoning_effort":"low","supported_efforts":["low","medium"],"supports_reasoning_effort":true}"#, for: request)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)
@@ -4926,7 +4950,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedModelID, customModel)
         XCTAssertEqual(viewModel.selectedModelProviderID, "openrouter")
         XCTAssertNil(viewModel.composerConfigurationErrorMessage)
-        XCTAssertEqual(requestPaths, ["/api/session/update"])
+        XCTAssertEqual(requestPaths, ["/api/session/update", "/api/reasoning"])
     }
 
     @MainActor

--- a/HermesMobileTests/CustomHeaderInjectionTests.swift
+++ b/HermesMobileTests/CustomHeaderInjectionTests.swift
@@ -234,13 +234,13 @@ final class CustomHeaderAPIClientInjectionTests: APIClientTestCase {
 @MainActor
 final class CustomHeaderSSEInjectionTests: XCTestCase {
     override func tearDown() {
-        MockURLProtocol.requestHandler = nil
+        SSEHeaderCaptureURLProtocol.requestHandler = nil
         super.tearDown()
     }
 
     func testSSEStreamCarriesCustomHeadersUnderBuiltIns() async throws {
         let captured = expectation(description: "sse request captured")
-        MockURLProtocol.requestHandler = { request in
+        SSEHeaderCaptureURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sse")
             // Built-in Accept must win over a user-supplied Accept.
             XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/event-stream")
@@ -256,7 +256,7 @@ final class CustomHeaderSSEInjectionTests: XCTestCase {
         }
 
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
+        configuration.protocolClasses = [SSEHeaderCaptureURLProtocol.self]
         let client = SSEClient(
             urlSessionConfiguration: configuration,
             customHeaderProvider: {
@@ -281,7 +281,7 @@ final class CustomHeaderSSEInjectionTests: XCTestCase {
         CustomHeaderStore.shared.replace(with: [CustomHeader(name: "Authorization", value: "Bearer active-a")])
 
         let captured = expectation(description: "sse request captured")
-        MockURLProtocol.requestHandler = { request in
+        SSEHeaderCaptureURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer active-a")
             captured.fulfill()
             let response = HTTPURLResponse(
@@ -294,7 +294,7 @@ final class CustomHeaderSSEInjectionTests: XCTestCase {
         }
 
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
+        configuration.protocolClasses = [SSEHeaderCaptureURLProtocol.self]
         // No explicit provider → uses the default active-server store.
         let client = SSEClient(urlSessionConfiguration: configuration)
 
@@ -322,6 +322,36 @@ final class CustomHeaderSSEInjectionTests: XCTestCase {
         let streamA = try XCTUnwrap(URL(string: "https://a.test/api/chat/stream?stream_id=s1"))
         XCTAssertEqual(storage.cookies(for: streamA)?.map(\.value), ["a-cookie"])
     }
+}
+
+private final class SSEHeaderCaptureURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }
 
 // MARK: - AuthManager configure / lifecycle


### PR DESCRIPTION
## Summary
- Decode supported_efforts and supports_reasoning_effort from /api/reasoning
- Query reasoning capability with the active model/provider
- Build the composer reasoning menu from server-supported efforts and hide it when unsupported
- Refresh reasoning capability after model changes and snap unsupported selections to server-supported effort

## Test Plan
- [x] Added query/decode coverage for model-aware reasoning capability metadata
- [x] Added composer config tests for supported effort filtering and legacy fallback
- [x] git diff --check
- [x] Static delimiter balance check for touched Swift files
- [ ] Full XCTest suite (pending GitHub CI / Mac runner; Linux host has no xcodebuild or swift)

Closes #18