### PR TITLE
Fix sideways keyboard slide when starting a new chat

### DIFF
--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1759,7 +1759,7 @@ struct ChatView: View {
 
         guard viewModel.errorMessage == nil, canFocusComposer else { return }
         didApplyInitialComposerFocusPolicy = true
-        requestComposerFocusIfPossible()
+        requestComposerFocusIfPossible(waitingForPushToSettle: true)
     }
 
     private func presentPreviewRestoringComposerFocusIfNeeded(_ present: () -> Void) {
@@ -1776,11 +1776,18 @@ struct ChatView: View {
         requestComposerFocusIfPossible()
     }
 
-    private func requestComposerFocusIfPossible() {
+    private func requestComposerFocusIfPossible(waitingForPushToSettle: Bool = false) {
         guard canFocusComposer else { return }
 
         Task { @MainActor in
-            await Task.yield()
+            if waitingForPushToSettle {
+                // The initial focus can land while the navigation push is
+                // still animating, which makes the keyboard slide in sideways
+                // with the view. Wait for the transition to settle (#53).
+                try? await Task.sleep(for: .milliseconds(450))
+            } else {
+                await Task.yield()
+            }
             guard canFocusComposer else { return }
             composerIsFocused = true
         }

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -65,6 +65,10 @@ struct ChatView: View {
     /// When true, the composer auto-starts voice dictation on appear — set by the
     /// "New Chat with Voice" App Intent (#338). Defaults to false for normal opens.
     let autoStartsVoiceInput: Bool
+    /// Whether the initial composer focus should wait for the navigation push to
+    /// settle (#53). PendingNewChatView passes false when its keyboard is already
+    /// up at swap time, so the handoff refocuses immediately instead of bouncing.
+    let delaysInitialComposerFocus: Bool
 
     @State private var draftMessage = ""
     @State private var isScrolledNearBottom = true
@@ -113,13 +117,15 @@ struct ChatView: View {
         initialDraft: String = "",
         initialAttachments: [SharedAttachmentImport] = [],
         loadsInitialMessages: Bool = true,
-        autoStartsVoiceInput: Bool = false
+        autoStartsVoiceInput: Bool = false,
+        delaysInitialComposerFocus: Bool = true
     ) {
         self.session = session
         self.server = server
         self.onAPIError = onAPIError
         self.loadsInitialMessages = loadsInitialMessages
         self.autoStartsVoiceInput = autoStartsVoiceInput
+        self.delaysInitialComposerFocus = delaysInitialComposerFocus
         _draftMessage = State(initialValue: initialDraft)
         _initialAttachments = State(initialValue: initialAttachments)
         _viewModel = State(initialValue: ChatViewModel(
@@ -1759,7 +1765,7 @@ struct ChatView: View {
 
         guard viewModel.errorMessage == nil, canFocusComposer else { return }
         didApplyInitialComposerFocusPolicy = true
-        requestComposerFocusIfPossible(waitingForPushToSettle: true)
+        requestComposerFocusIfPossible(waitingForPushToSettle: delaysInitialComposerFocus)
     }
 
     private func presentPreviewRestoringComposerFocusIfNeeded(_ present: () -> Void) {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -39,6 +39,74 @@ private enum TurnDiffPresentation: Identifiable {
     }
 }
 
+/// Reports the first completed UIKit appearance transition for a SwiftUI destination.
+/// `NavigationStack` does not expose push completion directly, while `viewDidAppear`
+/// and the transition coordinator remain synchronized with system animation speed.
+struct NavigationAppearanceCompletionObserver: UIViewControllerRepresentable {
+    let action: @MainActor () -> Void
+
+    func makeUIViewController(context: Context) -> NavigationAppearanceObserverViewController {
+        NavigationAppearanceObserverViewController(action: action)
+    }
+
+    func updateUIViewController(
+        _ uiViewController: NavigationAppearanceObserverViewController,
+        context: Context
+    ) {
+        uiViewController.action = action
+    }
+}
+
+@MainActor
+final class NavigationAppearanceObserverViewController: UIViewController {
+    var action: @MainActor () -> Void
+
+    private var isAwaitingTransitionCompletion = false
+    private var didReportAppearance = false
+
+    init(action: @escaping @MainActor () -> Void) {
+        self.action = action
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = false
+        view.accessibilityElementsHidden = true
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        guard !didReportAppearance, let coordinator = transitionCoordinator else { return }
+        isAwaitingTransitionCompletion = true
+        coordinator.animate(alongsideTransition: nil) { [weak self] context in
+            guard let self else { return }
+            isAwaitingTransitionCompletion = false
+            guard !context.isCancelled else { return }
+            reportAppearanceIfNeeded()
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !isAwaitingTransitionCompletion else { return }
+        reportAppearanceIfNeeded()
+    }
+
+    private func reportAppearanceIfNeeded() {
+        guard !didReportAppearance else { return }
+        didReportAppearance = true
+        action()
+    }
+}
+
 struct ChatView: View {
     private let bottomAnchorID = "chat-bottom-anchor"
     private let transcriptMessageSpacing: CGFloat = 10
@@ -65,10 +133,6 @@ struct ChatView: View {
     /// When true, the composer auto-starts voice dictation on appear — set by the
     /// "New Chat with Voice" App Intent (#338). Defaults to false for normal opens.
     let autoStartsVoiceInput: Bool
-    /// Whether the initial composer focus should wait for the navigation push to
-    /// settle (#53). PendingNewChatView passes false when its keyboard is already
-    /// up at swap time, so the handoff refocuses immediately instead of bouncing.
-    let delaysInitialComposerFocus: Bool
 
     @State private var draftMessage = ""
     @State private var isScrolledNearBottom = true
@@ -102,6 +166,8 @@ struct ChatView: View {
     @State private var gitAlert: GitChatAlert?
     @State private var composerHeight: CGFloat = 52
     @State private var composerIsFocused = false
+    @State private var didCompleteInitialAppearance = false
+    @State private var isInitialComposerFocusContentReady = false
     @State private var didApplyInitialComposerFocusPolicy = false
     @State private var shouldRestoreComposerFocusAfterPreview = false
     @State private var responseCompletionNotificationTracker = ResponseCompletionNotificationTracker()
@@ -117,15 +183,13 @@ struct ChatView: View {
         initialDraft: String = "",
         initialAttachments: [SharedAttachmentImport] = [],
         loadsInitialMessages: Bool = true,
-        autoStartsVoiceInput: Bool = false,
-        delaysInitialComposerFocus: Bool = true
+        autoStartsVoiceInput: Bool = false
     ) {
         self.session = session
         self.server = server
         self.onAPIError = onAPIError
         self.loadsInitialMessages = loadsInitialMessages
         self.autoStartsVoiceInput = autoStartsVoiceInput
-        self.delaysInitialComposerFocus = delaysInitialComposerFocus
         _draftMessage = State(initialValue: initialDraft)
         _initialAttachments = State(initialValue: initialAttachments)
         _viewModel = State(initialValue: ChatViewModel(
@@ -271,6 +335,11 @@ struct ChatView: View {
         // The composer flips wholesale with the transcript under the RTL
         // toggle (#259): input, placeholder, and chrome mirror together.
         .environment(\.layoutDirection, chatLayoutDirection)
+        .background(
+            NavigationAppearanceCompletionObserver(action: handleInitialAppearanceCompletion)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        )
     }
 
     var body: some View {
@@ -328,11 +397,13 @@ struct ChatView: View {
                 await loadMessages(appliesInitialFocus: false)
             }
             if initialAttachments.isEmpty {
+                isInitialComposerFocusContentReady = true
                 applyInitialComposerFocusPolicyIfNeeded()
             }
             await viewModel.loadComposerConfiguration()
             await viewModel.refreshApprovalBypassState()
             await uploadInitialAttachmentsIfNeeded()
+            isInitialComposerFocusContentReady = true
             applyInitialComposerFocusPolicyIfNeeded()
             if let lastError = viewModel.lastError {
                 onAPIError(lastError)
@@ -1755,8 +1826,14 @@ struct ChatView: View {
             && viewModel.uploadAttachmentErrorMessage == nil
     }
 
+    private func handleInitialAppearanceCompletion() {
+        didCompleteInitialAppearance = true
+        applyInitialComposerFocusPolicyIfNeeded()
+    }
+
     private func applyInitialComposerFocusPolicyIfNeeded() {
         guard !didApplyInitialComposerFocusPolicy else { return }
+        guard didCompleteInitialAppearance, isInitialComposerFocusContentReady else { return }
 
         if !viewModel.messages.isEmpty {
             didApplyInitialComposerFocusPolicy = true
@@ -1765,7 +1842,7 @@ struct ChatView: View {
 
         guard viewModel.errorMessage == nil, canFocusComposer else { return }
         didApplyInitialComposerFocusPolicy = true
-        requestComposerFocusIfPossible(waitingForPushToSettle: delaysInitialComposerFocus)
+        requestComposerFocusIfPossible()
     }
 
     private func presentPreviewRestoringComposerFocusIfNeeded(_ present: () -> Void) {
@@ -1782,18 +1859,11 @@ struct ChatView: View {
         requestComposerFocusIfPossible()
     }
 
-    private func requestComposerFocusIfPossible(waitingForPushToSettle: Bool = false) {
+    private func requestComposerFocusIfPossible() {
         guard canFocusComposer else { return }
 
         Task { @MainActor in
-            if waitingForPushToSettle {
-                // The initial focus can land while the navigation push is
-                // still animating, which makes the keyboard slide in sideways
-                // with the view. Wait for the transition to settle (#53).
-                try? await Task.sleep(for: .milliseconds(450))
-            } else {
-                await Task.yield()
-            }
+            await Task.yield()
             guard canFocusComposer else { return }
             composerIsFocused = true
         }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -1004,6 +1004,7 @@ private struct PendingNewChatView: View {
     @State private var createdSession: SessionSummary?
     @State private var draftMessage = ""
     @State private var didStartCreation = false
+    @State private var didRequestComposerFocus = false
     @State private var creationErrorMessage: String?
     @FocusState private var composerIsFocused: Bool
 
@@ -1161,8 +1162,14 @@ private struct PendingNewChatView: View {
     }
 
     private func requestPendingComposerFocus() {
+        guard !didRequestComposerFocus else { return }
+        didRequestComposerFocus = true
+
         Task { @MainActor in
-            await Task.yield()
+            // Focusing while the navigation push is still animating makes the
+            // keyboard slide in horizontally along with the view. Wait for the
+            // push transition to settle before raising the keyboard (#53).
+            try? await Task.sleep(for: .milliseconds(450))
             guard createdSession == nil else { return }
             composerIsFocused = true
         }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -1036,7 +1036,8 @@ private struct PendingNewChatView: View {
                     initialDraft: draftMessage,
                     initialAttachments: initialAttachments,
                     loadsInitialMessages: false,
-                    autoStartsVoiceInput: autoStartsVoiceInput
+                    autoStartsVoiceInput: autoStartsVoiceInput,
+                    delaysInitialComposerFocus: !composerIsFocused
                 )
             } else {
                 pendingContent

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -1036,15 +1036,18 @@ private struct PendingNewChatView: View {
                     initialDraft: draftMessage,
                     initialAttachments: initialAttachments,
                     loadsInitialMessages: false,
-                    autoStartsVoiceInput: autoStartsVoiceInput,
-                    delaysInitialComposerFocus: !composerIsFocused
+                    autoStartsVoiceInput: autoStartsVoiceInput
                 )
             } else {
                 pendingContent
             }
         }
+        .background(
+            NavigationAppearanceCompletionObserver(action: requestPendingComposerFocus)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        )
         .task {
-            requestPendingComposerFocus()
             await createSessionIfNeeded()
         }
     }
@@ -1076,9 +1079,6 @@ private struct PendingNewChatView: View {
         }
         .navigationTitle("New Chat")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            requestPendingComposerFocus()
-        }
     }
 
     private var pendingComposer: some View {
@@ -1167,10 +1167,7 @@ private struct PendingNewChatView: View {
         didRequestComposerFocus = true
 
         Task { @MainActor in
-            // Focusing while the navigation push is still animating makes the
-            // keyboard slide in horizontally along with the view. Wait for the
-            // push transition to settle before raising the keyboard (#53).
-            try? await Task.sleep(for: .milliseconds(450))
+            await Task.yield()
             guard createdSession == nil else { return }
             composerIsFocused = true
         }


### PR DESCRIPTION
## Linked issue

Fixes #53

## What changed

The composer was auto focused while the NavigationStack push animation was still in flight, so iOS composited the keyboard rise with the horizontal slide of the incoming view. That is why the keyboard appeared to drift in from the side on a new chat but rose normally in existing sessions, where nothing auto focuses.

Two changes:

- `PendingNewChatView.requestPendingComposerFocus()` now waits out the push transition (450 ms) before setting focus, instead of a single `Task.yield()`. A `didRequestComposerFocus` flag also makes the two call sites (`.task` and `onAppear`) request focus only once.
- `ChatView`'s initial composer focus policy gets the same settle wait. This covers fast session creation, where the created session swaps `ChatView` in while the push is still animating and its own focus request reintroduced the drift. Refocus after send and after closing a preview keep the old immediate behavior since they never run during a push.

## How it was tested

- Full XCTest suite on the iPhone 17 simulator: 1189 passed, 0 failed.
- Manual simulator pass (iPhone 17, iOS 26.5, portrait, software keyboard): home page, tap the chat FAB, keyboard now rises vertically with no horizontal shift across repeated focus/dismiss cycles. Opening an existing session with messages is unchanged. Refocus after sending a message is still immediate.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)
