### PR TITLE
Persist tool call and structured content fields in the offline cache

### DIFF
--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -311,6 +311,18 @@ private extension ChatMessage {
         } else {
             attachments = nil
         }
+        let toolCalls: [JSONValue]?
+        if let data = cachedMessage.toolCallsData {
+            toolCalls = try? JSONDecoder().decode([JSONValue].self, from: data)
+        } else {
+            toolCalls = nil
+        }
+        let contentParts: [JSONValue]?
+        if let data = cachedMessage.contentPartsData {
+            contentParts = try? JSONDecoder().decode([JSONValue].self, from: data)
+        } else {
+            contentParts = nil
+        }
         self.init(
             role: cachedMessage.role,
             content: cachedMessage.content,
@@ -318,6 +330,9 @@ private extension ChatMessage {
             messageId: cachedMessage.messageId,
             name: cachedMessage.name,
             toolCallId: cachedMessage.toolCallId,
+            toolUseId: cachedMessage.toolUseId,
+            toolCalls: toolCalls,
+            contentParts: contentParts,
             reasoning: cachedMessage.reasoning,
             attachments: attachments
         )

--- a/HermesMobile/Persistence/CachedMessage.swift
+++ b/HermesMobile/Persistence/CachedMessage.swift
@@ -13,6 +13,9 @@ final class CachedMessage {
     var messageId: String?
     var name: String?
     var toolCallId: String?
+    var toolUseId: String?
+    var toolCallsData: Data?
+    var contentPartsData: Data?
     var reasoning: String?
     var attachmentsData: Data?
     var cachedAt: Date
@@ -57,6 +60,17 @@ final class CachedMessage {
         messageId = message.messageId
         name = message.name
         toolCallId = message.toolCallId
+        toolUseId = message.toolUseId
+        if let toolCalls = message.toolCalls, !toolCalls.isEmpty {
+            toolCallsData = try? JSONEncoder().encode(toolCalls)
+        } else {
+            toolCallsData = nil
+        }
+        if let contentParts = message.contentParts, !contentParts.isEmpty {
+            contentPartsData = try? JSONEncoder().encode(contentParts)
+        } else {
+            contentPartsData = nil
+        }
         reasoning = message.reasoning
         if let attachments = message.attachments, !attachments.isEmpty {
             attachmentsData = try? JSONEncoder().encode(attachments)

--- a/HermesMobileTests/CacheStoreTests.swift
+++ b/HermesMobileTests/CacheStoreTests.swift
@@ -514,6 +514,60 @@ final class CacheStoreTests: XCTestCase {
         XCTAssertEqual(attachment.isImage, true)
     }
 
+    func testCacheMessagesRoundTripsToolCallAndStructuredContentFields() throws {
+        let context = try makeContext()
+        let serverURL = URL(string: "https://example.test")!
+        let cachedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let now = cachedAt.addingTimeInterval(60)
+
+        let toolCalls: [JSONValue] = [
+            .object([
+                "id": .string("call-1"),
+                "function": .object([
+                    "name": .string("read_file"),
+                    "arguments": .string("{\"path\": \"notes.txt\"}")
+                ])
+            ])
+        ]
+        let contentParts: [JSONValue] = [
+            .object(["type": .string("text"), "text": .string("Reading the file")]),
+            .object(["type": .string("tool_use"), "id": .string("call-1")])
+        ]
+
+        let messages = [
+            ChatMessage(
+                role: "assistant",
+                content: "Reading the file",
+                timestamp: 1_770_000_000,
+                messageId: "m1",
+                toolUseId: "call-1",
+                toolCalls: toolCalls,
+                contentParts: contentParts
+            )
+        ]
+
+        try CacheStore.cacheMessages(
+            messages,
+            serverURL: serverURL,
+            sessionID: "abc123",
+            in: context,
+            cachedAt: cachedAt
+        )
+
+        let cachedMessages = try CacheStore.cachedMessages(
+            serverURL: serverURL,
+            sessionID: "abc123",
+            in: context,
+            now: now
+        )
+
+        XCTAssertEqual(cachedMessages.count, 1)
+        let restored = try XCTUnwrap(cachedMessages.first)
+        XCTAssertEqual(restored.toolUseId, "call-1")
+        XCTAssertEqual(restored.toolCalls, toolCalls)
+        XCTAssertEqual(restored.contentParts, contentParts)
+    }
+
     // MARK: - Per-server isolation (#18)
 
     func testCachedMessagesAreScopedToTheirServerForTheSameSessionID() throws {


### PR DESCRIPTION
## Linked issue

Fixes #57

## What changed

`ChatMessage` carries `toolUseId`, `toolCalls` and `contentParts`, but the offline cache dropped all three on every round trip. `CachedMessage.apply()` never persisted them and the restore path `ChatMessage(cachedMessage:)` never passed them back, so transcripts loaded from the cache silently lost tool call rows and structured content.

- `CachedMessage` gains `toolUseId`, `toolCallsData` and `contentPartsData`. The two arrays are stored as JSON encoded `Data`, the same pattern already used for `attachmentsData`, and `apply()` populates them.
- `ChatMessage(cachedMessage:)` in `CacheStore.swift` decodes them back.
- The new attributes are all optional, so SwiftData lightweight migration handles existing stores in place.

## How it was tested

- New unit test `testCacheMessagesRoundTripsToolCallAndStructuredContentFields` caches an assistant message carrying a tool call and structured content parts, restores it through `CacheStore.cachedMessages`, and asserts all three fields survive.
- Full XCTest suite on the iPhone 17 simulator: 1190 passed, 0 failed.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)
