### PR TITLE
Clear the optimistic checkmark when a profile switch fails

### DIFF
--- a/HermesMobile/Features/Settings/DefaultProfilePickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultProfilePickerView.swift
@@ -295,6 +295,7 @@ struct DefaultProfilePickerView: View {
             let response = try await APIClient(baseURL: server).switchProfile(name: name)
             if let error = response.error?.trimmingCharacters(in: .whitespacesAndNewlines), !error.isEmpty {
                 saveError = error
+                selectedProfileName = nil
                 return
             }
 
@@ -314,6 +315,7 @@ struct DefaultProfilePickerView: View {
             dismiss()
         } catch {
             saveError = error.localizedDescription
+            selectedProfileName = nil
         }
     }
 }


### PR DESCRIPTION
## Linked issue

Fixes #59

## What changed

`save()` in `DefaultProfilePickerView` sets `selectedProfileName` optimistically before the switch request, but neither failure path cleared it. Since `isSelected()` treats `selectedProfileName` as selected, the profile that failed to switch kept a checkmark alongside the actually active profile until the picker was closed and reopened.

The fix resets `selectedProfileName` to nil on both failure paths, the server reported error return and the catch for thrown errors. On success the flow is unchanged.

## How it was tested

- Full XCTest suite on the iPhone 17 simulator: 1189 passed, 0 failed. The save logic lives in view local state with no view model, so there is no unit seam for a targeted test.
- Manual check recipe (pending a pass on a device or simulator with the server stopped): tap another profile in the picker, the error should appear and the failed row should not keep a second checkmark. With the server up, switching should work and dismiss the picker as before.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)
