### PR TITLE
Apply custom headers to upload and transcribe requests

### DIFF
--- a/HermesMobile/Networking/APIClient+Transcribe.swift
+++ b/HermesMobile/Networking/APIClient+Transcribe.swift
@@ -14,6 +14,9 @@ extension APIClient {
         var request = URLRequest(url: Endpoint.transcribe.url(relativeTo: baseURL))
         request.httpMethod = "POST"
         request.cachePolicy = .reloadIgnoringLocalCacheData
+        // Custom headers first, then built-ins so the multipart Content-Type
+        // always wins. Same reverse proxy requirement as uploadFile (#61).
+        customHeaderProvider().apply(to: &request)
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         var body = Data()

--- a/HermesMobile/Networking/APIClient+Upload.swift
+++ b/HermesMobile/Networking/APIClient+Upload.swift
@@ -6,6 +6,10 @@ extension APIClient {
         var request = URLRequest(url: Endpoint.upload.url(relativeTo: baseURL))
         request.httpMethod = "POST"
         request.cachePolicy = .reloadIgnoringLocalCacheData
+        // Custom headers first, then built-ins so the multipart Content-Type
+        // always wins. Without them the upload is rejected by auth reverse
+        // proxies that every other request path already passes (#61).
+        customHeaderProvider().apply(to: &request)
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         var body = Data()

--- a/HermesMobile/Networking/APIClient.swift
+++ b/HermesMobile/Networking/APIClient.swift
@@ -18,7 +18,9 @@ actor APIClient {
     private let encoder: JSONEncoder
     /// Read when building each request so live edits apply without rebuilding the
     /// client. Defaults to the process-wide store; tests inject a fixed list (#255).
-    private let customHeaderProvider: @Sendable () -> [CustomHeader]
+    /// Internal, not private, because the upload and transcribe extensions build
+    /// their multipart requests by hand and need the same header injection (#61).
+    let customHeaderProvider: @Sendable () -> [CustomHeader]
 
     init(
         baseURL: URL,

--- a/HermesMobileTests/CustomHeaderInjectionTests.swift
+++ b/HermesMobileTests/CustomHeaderInjectionTests.swift
@@ -195,6 +195,35 @@ final class CustomHeaderAPIClientInjectionTests: APIClientTestCase {
         _ = try? await client.sessions()
     }
 
+    func testUploadRequestCarriesCustomHeadersAndMultipartContentTypeWins() async throws {
+        let (client, _) = makeHeaderClient([
+            CustomHeader(name: "Authorization", value: "Bearer upload"),
+            CustomHeader(name: "Content-Type", value: "application/evil")
+        ]) { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer upload")
+            // The built-in multipart Content-Type is set after the custom
+            // headers, so it wins its key.
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary="),
+                true
+            )
+            return try self.ok(request)
+        }
+
+        _ = try? await client.uploadFile(sessionID: "s1", data: Data("bytes".utf8), filename: "a.png")
+    }
+
+    func testTranscribeRequestCarriesCustomHeaders() async throws {
+        let (client, _) = makeHeaderClient([
+            CustomHeader(name: "Authorization", value: "Bearer stt")
+        ]) { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer stt")
+            return try self.ok(request)
+        }
+
+        _ = try? await client.transcribeAudio(data: Data("clip".utf8), filename: "v.m4a")
+    }
+
     func testDownloadRequestCarriesCustomHeaders() async throws {
         let (client, session) = makeHeaderClient([
             CustomHeader(name: "Authorization", value: "Bearer media")


### PR DESCRIPTION
Fixes #61

## What

`uploadFile` and `transcribeAudio` build their multipart requests by hand and never applied the configured custom headers, so servers behind an auth reverse proxy rejected attachment uploads and voice transcription with 401 or 403 while every other request worked.

## How

Both methods now call `customHeaderProvider().apply(to:)` before setting the multipart Content-Type, following the custom headers first, built ins win convention from `sendData`. The provider moves from private to internal so the two extension files can reach it, the same access level as the `session` property they already use. Both endpoints only ever target the user's own server, so the off origin leak guard from #277 is not a concern here.

## Tests

Two new tests in `CustomHeaderInjectionTests` following the existing injection pattern. One asserts the upload request carries the headers and that the built in multipart Content-Type wins over a user supplied one, the other asserts the transcribe request carries the headers.

Full suite: 1191 passed, 0 failed.