### PR TITLE
Stop lossy int decoding from trapping on out of range values

### DIFF
--- a/HermesMobile/Features/Chat/ToolCallDisplayFormatter.swift
+++ b/HermesMobile/Features/Chat/ToolCallDisplayFormatter.swift
@@ -218,7 +218,9 @@ enum ToolCallDisplayFormatter {
         switch value {
         case .number(let value):
             guard value.isFinite else { return nil }
-            return Int(value)
+            // Int(exactly:) so an out-of-range exit code from tool output
+            // becomes nil instead of trapping (#62).
+            return Int(exactly: value.rounded(.towardZero))
         case .string(let value):
             return Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
         case .bool, .object, .array, .null:

--- a/HermesMobile/Models/ChatMessage.swift
+++ b/HermesMobile/Models/ChatMessage.swift
@@ -350,7 +350,11 @@ extension KeyedDecodingContainer {
 
         if let value = try? decodeIfPresent(Double.self, forKey: key),
            value.isFinite {
-            return Int(value)
+            // Int(exactly:) instead of Int(_:), which traps on doubles outside
+            // Int range, so a huge server value decodes to nil instead of
+            // crashing (#62). Truncation toward zero matches Int(_:) for
+            // values that fit.
+            return Int(exactly: value.rounded(.towardZero))
         }
 
         guard let stringValue = try? decodeIfPresent(String.self, forKey: key) else {
@@ -368,7 +372,8 @@ extension KeyedDecodingContainer {
             return nil
         }
 
-        return Int(value)
+        // Same out-of-range guard as the numeric branch above (#62).
+        return Int(exactly: value.rounded(.towardZero))
     }
 
     func decodeLossyBoolIfPresent(forKey key: Key) -> Bool? {

--- a/HermesMobileTests/APIClientSessionDetailTests.swift
+++ b/HermesMobileTests/APIClientSessionDetailTests.swift
@@ -436,6 +436,36 @@ final class APIClientSessionDetailTests: APIClientTestCase {
         XCTAssertNil(toolCall.args)
     }
 
+    func testSessionToleratesNumericFieldsOutsideIntRange() async throws {
+        // Values beyond Int range reach the lossy int decoder's Double branch,
+        // which used to trap instead of decoding to nil (#62).
+        let client = makeClient { request in
+            apiTestJSONResponse("""
+            {
+              "session": {
+                "session_id": "huge-numbers",
+                "message_count": 1e300,
+                "input_tokens": -1e300,
+                "output_tokens": "1e300",
+                "context_length": 9223372036854775808,
+                "messages": [
+                  {"role": "assistant", "content": "Still standing"}
+                ]
+              }
+            }
+            """, for: request)
+        }
+
+        let response = try await client.session(id: "huge-numbers")
+        let session = try XCTUnwrap(response.session)
+
+        XCTAssertNil(session.messageCount)
+        XCTAssertNil(session.inputTokens)
+        XCTAssertNil(session.outputTokens)
+        XCTAssertNil(session.contextLength)
+        XCTAssertEqual(session.messages?.first?.content, "Still standing")
+    }
+
     func testSessionDecodesCompressionAnchorMetadata() async throws {
         let client = makeClient { request in
             apiTestJSONResponse("""
@@ -1256,6 +1286,17 @@ final class APIClientSessionDetailTests: APIClientTestCase {
         )
 
         XCTAssertEqual(display?.text, "pwd")
+    }
+
+    func testToolCallDisplayFormatterToleratesOutOfRangeExitCode() {
+        // An exit code beyond Int range comes straight from tool output and
+        // used to trap while rendering the card (#62).
+        let display = ToolCallDisplayFormatter.resultDisplay(
+            preview: #"{"output":"done\n","exit_code":1e300,"error":null}"#,
+            toolName: "terminal"
+        )
+
+        XCTAssertEqual(display?.text, "done")
     }
 
     func testToolCallDisplayFormatterFallsBackToOriginalPreviewWhenParsingFails() {


### PR DESCRIPTION
Fixes #62

## What

`decodeLossyIntIfPresent` only checked `isFinite` before converting the decoded Double with `Int(_:)`, which traps at runtime for values outside Int range. The Double branch is reached exactly when the direct Int decode fails, so a server field like `"message_count": 1e300` crashed the app instead of decoding to nil. The helper backs many server supplied fields (message counts, token counts, sizes, offsets), and the same trap sat in the terminal exit code parser in `ToolCallDisplayFormatter`, where the value comes from tool output.

## How

All three sites (the numeric and string branches of the helper, plus the exit code parser) now convert through `Int(exactly:)` on the value truncated toward zero. Anything that fits in Int keeps the exact previous behavior, anything that does not yields nil, in line with the tolerant decoding rule.

## Tests

A session decode test covering out of range values through all three lossy paths (raw number, negative, numeric string, and Int.max plus one) and a formatter test with a huge exit code. Both trap without the fix.

Full suite: 1191 passed, 0 failed.