### PR TITLE
[codex] Remove implemented TTS gap

### DIFF
--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -110,7 +110,6 @@ sub-paths of a group. Do not reorder casually.
 | `/api/mcp/` | roadmap | P5 | admin | MCP Servers & Tools |
 | `/api/wiki/` | roadmap | P5 | read | Wiki / Knowledge System |
 | `/api/notes/` | roadmap | P5 | read | Notes / Knowledge — search/sources/item |
-| `/api/tts` | roadmap | P5 | privacy | Text-to-Speech — server-side; mobile can use native TTS |
 | `/api/project-os/` | roadmap | P5 | read | Project-OS dashboard |
 
 ### Implemented (for reference, derived — not parsed)


### PR DESCRIPTION
## What changed

- Removed the stale `/api/tts` roadmap row from the feature-gap index.

## Why

`/api/tts` shipped in #35 and is now derived as implemented from `Endpoints.swift`; retaining a manual roadmap row incorrectly classified it as an outstanding gap.

## Validation

- `git diff --cached --check` (before commit)
- Documentation-only change; XCTest not run.
