### PR TITLE
Give the flaky SSE incremental-events test a CI-safe timeout

### DIFF
--- a/HermesMobileTests/SSEClientTests.swift
+++ b/HermesMobileTests/SSEClientTests.swift
@@ -57,13 +57,15 @@ final class SSEClientTests: XCTestCase {
             }
         }
 
-        await fulfillment(of: [liveEvent], timeout: 1)
+        // Generous deadline: CI runners under parallel-clone load have blown a
+        // 1s budget on wall-clock chunk delays that finish in ~0.3s locally (#76).
+        await fulfillment(of: [liveEvent], timeout: 5)
         XCTAssertFalse(receivedEvents.contains { event in
             if case .done = event { return true }
             return false
         })
 
-        await fulfillment(of: [doneEvent], timeout: 1)
+        await fulfillment(of: [doneEvent], timeout: 5)
         client.stop()
 
         XCTAssertEqual(Array(receivedEvents.prefix(3)), [


### PR DESCRIPTION
## Linked issue

Fixes #76

## What changed

`testSSEClientDeliversIncrementalEventsBeforeDone()` streams fake SSE chunks through `DelayedSSEURLProtocol` with real wall-clock delays (3 × 20ms, then 250ms before `done`) but gave each `fulfillment` wait only a 1-second deadline. On oversubscribed CI runners executing suites on two parallel simulator clones, that budget can be blown by dispatch latency alone — it failed PR #60's CI run (6.45s on this test) despite passing locally at the same commit, and passed on a plain re-run.

Both timeouts are now 5 seconds. The test proves the same thing: chunks are delivered sequentially and `done` still trails the last live event by 250ms, so the no-done-before-live-event assertion is unchanged — only the failure deadline moves. A passing run still completes in ~0.36s.

## How it was tested

- `xcodebuild test -only-testing:HermesMobileTests/SSEClientTests` on the iPhone 17 simulator: all 22 tests passed, the changed test in 0.356s.
- Test-only change; no app code touched.

## Checklist

- [x] The full test suite passes locally (targeted suite run; test-only diff with no production code changes)
- [x] New/changed `Codable` models decode tolerantly — n/a, no model changes
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes — n/a, no API surface touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)