### PR TITLE
CI: switch TestFlight workflows to manual signing (#4)

### DIFF
--- a/.github/workflows/external-testflight.yml
+++ b/.github/workflows/external-testflight.yml
@@ -64,7 +64,10 @@ jobs:
           set -euo pipefail
 
           missing=0
-          for name in APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_PRIVATE_KEY; do
+          for name in \
+            APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_PRIVATE_KEY \
+            DIST_CERT_P12_BASE64 DIST_CERT_P12_PASSWORD \
+            PROVISION_PROFILE_APP_BASE64 PROVISION_PROFILE_SHAREEXT_BASE64 PROVISION_PROFILE_WIDGET_BASE64; do
             if [[ -z "${!name}" ]]; then
               echo "Missing required secret: ${name}" >&2
               missing=1
@@ -142,6 +145,41 @@ jobs:
           echo "Export options: ${EXPORT_OPTIONS_PLIST}"
           echo "This workflow uploads only; App Store Connect external group assignment and Beta App Review submission remain manual."
 
+      - name: Import signing assets
+        env:
+          DIST_CERT_P12_BASE64: ${{ secrets.DIST_CERT_P12_BASE64 }}
+          DIST_CERT_P12_PASSWORD: ${{ secrets.DIST_CERT_P12_PASSWORD }}
+          PROVISION_PROFILE_APP_BASE64: ${{ secrets.PROVISION_PROFILE_APP_BASE64 }}
+          PROVISION_PROFILE_SHAREEXT_BASE64: ${{ secrets.PROVISION_PROFILE_SHAREEXT_BASE64 }}
+          PROVISION_PROFILE_WIDGET_BASE64: ${{ secrets.PROVISION_PROFILE_WIDGET_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          KEYCHAIN_PATH="${RUNNER_TEMP}/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          echo "SIGNING_KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "${GITHUB_ENV}"
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security set-keychain-settings -lut 3600 "${KEYCHAIN_PATH}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security list-keychains -d user -s "${KEYCHAIN_PATH}" $(security list-keychains -d user | tr -d '"')
+
+          echo "${DIST_CERT_P12_BASE64}" | base64 --decode > "${RUNNER_TEMP}/dist_cert.p12"
+          security import "${RUNNER_TEMP}/dist_cert.p12" \
+            -k "${KEYCHAIN_PATH}" \
+            -P "${DIST_CERT_P12_PASSWORD}" \
+            -A -t cert -f pkcs12
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          rm -f "${RUNNER_TEMP}/dist_cert.p12"
+
+          PP_DIR="${HOME}/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "${PP_DIR}"
+          echo "${PROVISION_PROFILE_APP_BASE64}"      | base64 --decode > "${PP_DIR}/hermex_app.mobileprovision"
+          echo "${PROVISION_PROFILE_SHAREEXT_BASE64}" | base64 --decode > "${PP_DIR}/hermex_shareext.mobileprovision"
+          echo "${PROVISION_PROFILE_WIDGET_BASE64}"   | base64 --decode > "${PP_DIR}/hermex_widget.mobileprovision"
+
       - name: Show Xcode version
         run: xcodebuild -version
 
@@ -165,7 +203,6 @@ jobs:
             -destination "generic/platform=iOS" \
             -archivePath "${ARCHIVE_PATH}" \
             -derivedDataPath "${DERIVED_DATA_PATH}" \
-            -allowProvisioningUpdates \
             -authenticationKeyPath "${APP_STORE_CONNECT_KEY_PATH}" \
             -authenticationKeyID "${APP_STORE_CONNECT_KEY_ID}" \
             -authenticationKeyIssuerID "${APP_STORE_CONNECT_ISSUER_ID}" \
@@ -182,7 +219,15 @@ jobs:
             -archivePath "${ARCHIVE_PATH}" \
             -exportPath "${EXPORT_PATH}" \
             -exportOptionsPlist "${EXPORT_OPTIONS_PLIST}" \
-            -allowProvisioningUpdates \
             -authenticationKeyPath "${APP_STORE_CONNECT_KEY_PATH}" \
             -authenticationKeyID "${APP_STORE_CONNECT_KEY_ID}" \
             -authenticationKeyIssuerID "${APP_STORE_CONNECT_ISSUER_ID}"
+
+      - name: Clean up signing assets
+        if: always()
+        run: |
+          security delete-keychain "${SIGNING_KEYCHAIN_PATH}" 2>/dev/null || true
+          rm -f \
+            "${HOME}/Library/MobileDevice/Provisioning Profiles/hermex_app.mobileprovision" \
+            "${HOME}/Library/MobileDevice/Provisioning Profiles/hermex_shareext.mobileprovision" \
+            "${HOME}/Library/MobileDevice/Provisioning Profiles/hermex_widget.mobileprovision"

--- a/.github/workflows/external-testflight.yml
+++ b/.github/workflows/external-testflight.yml
@@ -60,6 +60,12 @@ jobs:
           fi
 
       - name: Check required secrets
+        env:
+          DIST_CERT_P12_BASE64: ${{ secrets.DIST_CERT_P12_BASE64 }}
+          DIST_CERT_P12_PASSWORD: ${{ secrets.DIST_CERT_P12_PASSWORD }}
+          PROVISION_PROFILE_APP_BASE64: ${{ secrets.PROVISION_PROFILE_APP_BASE64 }}
+          PROVISION_PROFILE_SHAREEXT_BASE64: ${{ secrets.PROVISION_PROFILE_SHAREEXT_BASE64 }}
+          PROVISION_PROFILE_WIDGET_BASE64: ${{ secrets.PROVISION_PROFILE_WIDGET_BASE64 }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/internal-testflight.yml
+++ b/.github/workflows/internal-testflight.yml
@@ -64,7 +64,10 @@ jobs:
           set -euo pipefail
 
           missing=0
-          for name in APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_PRIVATE_KEY; do
+          for name in \
+            APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_PRIVATE_KEY \
+            DIST_CERT_P12_BASE64 DIST_CERT_P12_PASSWORD \
+            PROVISION_PROFILE_APP_BASE64 PROVISION_PROFILE_SHAREEXT_BASE64 PROVISION_PROFILE_WIDGET_BASE64; do
             if [[ -z "${!name}" ]]; then
               echo "Missing required secret: ${name}" >&2
               missing=1
@@ -141,6 +144,41 @@ jobs:
           echo "Build number: ${BUILD_NUMBER}"
           echo "Export options: ${EXPORT_OPTIONS_PLIST}"
 
+      - name: Import signing assets
+        env:
+          DIST_CERT_P12_BASE64: ${{ secrets.DIST_CERT_P12_BASE64 }}
+          DIST_CERT_P12_PASSWORD: ${{ secrets.DIST_CERT_P12_PASSWORD }}
+          PROVISION_PROFILE_APP_BASE64: ${{ secrets.PROVISION_PROFILE_APP_BASE64 }}
+          PROVISION_PROFILE_SHAREEXT_BASE64: ${{ secrets.PROVISION_PROFILE_SHAREEXT_BASE64 }}
+          PROVISION_PROFILE_WIDGET_BASE64: ${{ secrets.PROVISION_PROFILE_WIDGET_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          KEYCHAIN_PATH="${RUNNER_TEMP}/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          echo "SIGNING_KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "${GITHUB_ENV}"
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security set-keychain-settings -lut 3600 "${KEYCHAIN_PATH}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security list-keychains -d user -s "${KEYCHAIN_PATH}" $(security list-keychains -d user | tr -d '"')
+
+          echo "${DIST_CERT_P12_BASE64}" | base64 --decode > "${RUNNER_TEMP}/dist_cert.p12"
+          security import "${RUNNER_TEMP}/dist_cert.p12" \
+            -k "${KEYCHAIN_PATH}" \
+            -P "${DIST_CERT_P12_PASSWORD}" \
+            -A -t cert -f pkcs12
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          rm -f "${RUNNER_TEMP}/dist_cert.p12"
+
+          PP_DIR="${HOME}/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "${PP_DIR}"
+          echo "${PROVISION_PROFILE_APP_BASE64}"      | base64 --decode > "${PP_DIR}/hermex_app.mobileprovision"
+          echo "${PROVISION_PROFILE_SHAREEXT_BASE64}" | base64 --decode > "${PP_DIR}/hermex_shareext.mobileprovision"
+          echo "${PROVISION_PROFILE_WIDGET_BASE64}"   | base64 --decode > "${PP_DIR}/hermex_widget.mobileprovision"
+
       - name: Show Xcode version
         run: xcodebuild -version
 
@@ -164,7 +202,6 @@ jobs:
             -destination "generic/platform=iOS" \
             -archivePath "${ARCHIVE_PATH}" \
             -derivedDataPath "${DERIVED_DATA_PATH}" \
-            -allowProvisioningUpdates \
             -authenticationKeyPath "${APP_STORE_CONNECT_KEY_PATH}" \
             -authenticationKeyID "${APP_STORE_CONNECT_KEY_ID}" \
             -authenticationKeyIssuerID "${APP_STORE_CONNECT_ISSUER_ID}" \
@@ -181,7 +218,15 @@ jobs:
             -archivePath "${ARCHIVE_PATH}" \
             -exportPath "${EXPORT_PATH}" \
             -exportOptionsPlist "${EXPORT_OPTIONS_PLIST}" \
-            -allowProvisioningUpdates \
             -authenticationKeyPath "${APP_STORE_CONNECT_KEY_PATH}" \
             -authenticationKeyID "${APP_STORE_CONNECT_KEY_ID}" \
             -authenticationKeyIssuerID "${APP_STORE_CONNECT_ISSUER_ID}"
+
+      - name: Clean up signing assets
+        if: always()
+        run: |
+          security delete-keychain "${SIGNING_KEYCHAIN_PATH}" 2>/dev/null || true
+          rm -f \
+            "${HOME}/Library/MobileDevice/Provisioning Profiles/hermex_app.mobileprovision" \
+            "${HOME}/Library/MobileDevice/Provisioning Profiles/hermex_shareext.mobileprovision" \
+            "${HOME}/Library/MobileDevice/Provisioning Profiles/hermex_widget.mobileprovision"

--- a/.github/workflows/internal-testflight.yml
+++ b/.github/workflows/internal-testflight.yml
@@ -60,6 +60,12 @@ jobs:
           fi
 
       - name: Check required secrets
+        env:
+          DIST_CERT_P12_BASE64: ${{ secrets.DIST_CERT_P12_BASE64 }}
+          DIST_CERT_P12_PASSWORD: ${{ secrets.DIST_CERT_P12_PASSWORD }}
+          PROVISION_PROFILE_APP_BASE64: ${{ secrets.PROVISION_PROFILE_APP_BASE64 }}
+          PROVISION_PROFILE_SHAREEXT_BASE64: ${{ secrets.PROVISION_PROFILE_SHAREEXT_BASE64 }}
+          PROVISION_PROFILE_WIDGET_BASE64: ${{ secrets.PROVISION_PROFILE_WIDGET_BASE64 }}
         run: |
           set -euo pipefail
 

--- a/TESTFLIGHT.md
+++ b/TESTFLIGHT.md
@@ -739,3 +739,50 @@ External TestFlight is ready when all are true:
 - Share extension auto-launch risk is consciously accepted or removed.
 - No open P0/P1 issue blocks normal use.
 - Beta App Review approves the build.
+
+## CI Signing Credentials
+
+Both TestFlight workflows (`internal-testflight.yml`, `external-testflight.yml`) use **manual signing** — a stored Apple Distribution certificate and three provisioning profiles — rather than automatic signing. This prevents the workflows from minting new distribution certificates on every run and exhausting the Apple Developer cert cap.
+
+### Required GitHub secrets
+
+Add these secrets to **both** the `internal-testflight` and `external-testflight` GitHub environments (Settings → Environments):
+
+| Secret | Contents |
+|---|---|
+| `DIST_CERT_P12_BASE64` | base64-encoded Apple Distribution `.p12` |
+| `DIST_CERT_P12_PASSWORD` | password used when exporting the `.p12` |
+| `PROVISION_PROFILE_APP_BASE64` | base64-encoded App Store profile for `com.uzairansar.hermesmobile` |
+| `PROVISION_PROFILE_SHAREEXT_BASE64` | base64-encoded App Store profile for `com.uzairansar.hermesmobile.shareextension` |
+| `PROVISION_PROFILE_WIDGET_BASE64` | base64-encoded App Store profile for `com.uzairansar.hermesmobile.liveactivitywidget` |
+
+### Exporting the certificate
+
+1. Open **Keychain Access** → My Certificates → find "Apple Distribution: …".
+2. Right-click → Export → choose `.p12` format, set a strong password.
+3. Base64-encode it: `base64 -i cert.p12 | pbcopy` — paste as `DIST_CERT_P12_BASE64`.
+4. Store the password as `DIST_CERT_P12_PASSWORD`.
+
+### Downloading provisioning profiles
+
+Each profile must be the **App Store** variant (not Development or Ad Hoc):
+
+| Bundle ID | Profile name |
+|---|---|
+| `com.uzairansar.hermesmobile` | `Hermes Mobile App Store` |
+| `com.uzairansar.hermesmobile.shareextension` | `Hermes Mobile Share Extension App Store` |
+| `com.uzairansar.hermesmobile.liveactivitywidget` | `Hermes Mobile Live Activity App Store` |
+
+Download from [developer.apple.com](https://developer.apple.com) → Certificates, IDs & Profiles → Profiles, then:
+
+```
+base64 -i HermesMobileAppStore.mobileprovision | pbcopy   # → PROVISION_PROFILE_APP_BASE64
+base64 -i HermesShareExtensionAppStore.mobileprovision | pbcopy   # → PROVISION_PROFILE_SHAREEXT_BASE64
+base64 -i HermesLiveActivityAppStore.mobileprovision | pbcopy   # → PROVISION_PROFILE_WIDGET_BASE64
+```
+
+### Rotation and expiry
+
+- **Distribution certificates** expire after ~1 year. Apple also caps accounts at 3 active distribution certs. Renew in Xcode (Preferences → Accounts → Manage Certificates) or the Developer Portal, re-export the `.p12`, and update the two secrets.
+- **Provisioning profiles** expire after ~1 year (or sooner if the certificate they reference is revoked). Download the renewed profile and update the corresponding secret. Profile names are stable across renewals so the export options plists need no changes.
+- After rotating any secret, trigger one workflow run manually to confirm it resolves before the next scheduled release.

--- a/ci/ExternalTestFlightExportOptions.plist
+++ b/ci/ExternalTestFlightExportOptions.plist
@@ -8,8 +8,17 @@
 	<false/>
 	<key>method</key>
 	<string>app-store-connect</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.uzairansar.hermesmobile</key>
+		<string>Hermes Mobile App Store</string>
+		<key>com.uzairansar.hermesmobile.shareextension</key>
+		<string>Hermes Mobile Share Extension App Store</string>
+		<key>com.uzairansar.hermesmobile.liveactivitywidget</key>
+		<string>Hermes Mobile Live Activity App Store</string>
+	</dict>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
 	<key>teamID</key>
 	<string>6GYD9C9N6R</string>
 	<key>uploadSymbols</key>

--- a/ci/TestFlightExportOptions.plist
+++ b/ci/TestFlightExportOptions.plist
@@ -8,8 +8,17 @@
 	<false/>
 	<key>method</key>
 	<string>app-store-connect</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.uzairansar.hermesmobile</key>
+		<string>Hermes Mobile App Store</string>
+		<key>com.uzairansar.hermesmobile.shareextension</key>
+		<string>Hermes Mobile Share Extension App Store</string>
+		<key>com.uzairansar.hermesmobile.liveactivitywidget</key>
+		<string>Hermes Mobile Live Activity App Store</string>
+	</dict>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
 	<key>teamID</key>
 	<string>6GYD9C9N6R</string>
 	<key>testFlightInternalTestingOnly</key>


### PR DESCRIPTION
Closes #4

## Summary

- Switches both TestFlight workflows from automatic signing (`-allowProvisioningUpdates`) to manual signing with a stored distribution identity, preventing Apple's distribution certificate cap from being exhausted on consecutive CI runs
- Adds an "Import signing assets" step that creates a per-run temp keychain (random password, 1-hour lock timeout), imports the `.p12`, and installs the three provisioning profiles from base64 secrets
- Adds a matching "Clean up signing assets" step (`if: always()`) that deletes the keychain and profile files regardless of build outcome
- Extends "Check required secrets" in both workflows to gate on the five new signing secrets before any work begins
- Updates both `ExportOptions` plists: `signingStyle: manual` + `provisioningProfiles` dict mapping all three bundle IDs to their App Store profile names
- Documents the five secrets, cert/profile export commands, and a rotation/expiry note in `TESTFLIGHT.md`

## Secrets required (maintainer)

Add to both the `internal-testflight` and `external-testflight` GitHub environments before triggering a run:

| Secret | Contents |
|---|---|
| `DIST_CERT_P12_BASE64` | `base64 -i cert.p12` |
| `DIST_CERT_P12_PASSWORD` | `.p12` export password |
| `PROVISION_PROFILE_APP_BASE64` | App Store profile for `com.uzairansar.hermesmobile` |
| `PROVISION_PROFILE_SHAREEXT_BASE64` | App Store profile for `com.uzairansar.hermesmobile.shareextension` |
| `PROVISION_PROFILE_WIDGET_BASE64` | App Store profile for `com.uzairansar.hermesmobile.liveactivitywidget` |

The PR is safe to merge before secrets exist; workflows will fail fast at "Check required secrets" with a clear message until they're in place.

Built with Claude Code (claude-sonnet-4-6).