### PR TITLE
Chat: Add TTS playback bar controls

### DIFF
--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -209,6 +209,7 @@ private struct ListenPlaybackBar: View {
         }
         .font(AppFont.caption2().monospacedDigit())
         .foregroundStyle(.secondary)
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel(String(localized: "\(AudioDurationFormatter.string(from: boundedDisplayTime)) of \(AudioDurationFormatter.string(from: duration))"))
     }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -107,6 +107,151 @@ final class NavigationAppearanceObserverViewController: UIViewController {
     }
 }
 
+private struct ListenPlaybackBar: View {
+    let phase: ListenPlaybackPhase
+    let displayTime: TimeInterval
+    let duration: TimeInterval
+    let speed: ListenPlaybackSpeed
+    let onTogglePlayPause: () -> Void
+    let onStop: () -> Void
+    let onScrub: (TimeInterval) -> Void
+    let onScrubbingChanged: (Bool) -> Void
+    let onSpeedChange: (ListenPlaybackSpeed) -> Void
+
+    private var isReady: Bool {
+        phase == .playing || phase == .paused
+    }
+
+    private var isPlaying: Bool {
+        phase == .playing
+    }
+
+    private var boundedDisplayTime: TimeInterval {
+        min(max(0, displayTime), max(duration, 0))
+    }
+
+    private var sliderUpperBound: TimeInterval {
+        max(duration, 0.01)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                playPauseButton
+
+                VStack(alignment: .leading, spacing: 4) {
+                    scrubber
+                    timeRow
+                }
+                .frame(maxWidth: .infinity)
+
+                speedMenu
+                stopButton
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+
+            Divider()
+        }
+        .background(.regularMaterial)
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var playPauseButton: some View {
+        if phase == .loading {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.14))
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(Color.accentColor)
+            }
+            .frame(width: 34, height: 34)
+            .accessibilityLabel(String(localized: "Preparing audio"))
+        } else {
+            Button(action: onTogglePlayPause) {
+                ZStack {
+                    Circle()
+                        .fill(Color.accentColor)
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(.white)
+                }
+                .frame(width: 34, height: 34)
+            }
+            .buttonStyle(.chatTactile(.icon))
+            .disabled(!isReady)
+            .accessibilityLabel(isPlaying ? String(localized: "Pause audio") : String(localized: "Play audio"))
+        }
+    }
+
+    private var scrubber: some View {
+        Slider(
+            value: Binding(
+                get: { boundedDisplayTime },
+                set: { onScrub($0) }
+            ),
+            in: 0...sliderUpperBound,
+            onEditingChanged: onScrubbingChanged
+        )
+        .tint(Color.accentColor)
+        .disabled(!isReady || duration <= 0)
+        .accessibilityLabel(String(localized: "Playback position"))
+    }
+
+    private var timeRow: some View {
+        HStack(spacing: 8) {
+            Text(AudioDurationFormatter.string(from: boundedDisplayTime))
+            Text("/")
+            Text(AudioDurationFormatter.string(from: duration))
+            Spacer(minLength: 0)
+        }
+        .font(AppFont.caption2().monospacedDigit())
+        .foregroundStyle(.secondary)
+        .accessibilityLabel(String(localized: "\(AudioDurationFormatter.string(from: boundedDisplayTime)) of \(AudioDurationFormatter.string(from: duration))"))
+    }
+
+    private var speedMenu: some View {
+        Menu {
+            ForEach(ListenPlaybackSpeed.allCases) { option in
+                Button {
+                    onSpeedChange(option)
+                } label: {
+                    HStack {
+                        Text(option.title)
+                        if option == speed {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            Text(speed.title)
+                .font(AppFont.caption().weight(.semibold))
+                .monospacedDigit()
+                .frame(minWidth: 36, minHeight: 30)
+                .padding(.horizontal, 6)
+                .background(Color(.secondarySystemBackground), in: Capsule())
+        }
+        .disabled(!isReady)
+        .accessibilityLabel(String(localized: "Playback speed"))
+        .accessibilityValue(speed.title)
+    }
+
+    private var stopButton: some View {
+        Button(action: onStop) {
+            Image(systemName: "xmark")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 30, height: 30)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.chatTactile(.icon))
+        .accessibilityLabel(String(localized: "Stop audio"))
+    }
+}
+
 struct ChatView: View {
     private let bottomAnchorID = "chat-bottom-anchor"
     private let transcriptMessageSpacing: CGFloat = 10
@@ -355,11 +500,14 @@ struct ChatView: View {
                     ChatOfflineCacheBanner()
                 }
 
+                listenPlaybackBar
+
                 messageContent
                     // Scope RTL to the chat transcript only (#259): the offline
                     // banner above stays in the app's default direction.
                     .environment(\.layoutDirection, chatLayoutDirection)
             }
+            .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: viewModel.showsListenPlaybackBar)
 
             BottomComposerMaterialFade(composerHeight: composerHeight)
 
@@ -616,6 +764,34 @@ struct ChatView: View {
             } message: {
                 Text(viewModel.messageActionErrorMessage ?? "")
             }
+    }
+
+    @ViewBuilder
+    private var listenPlaybackBar: some View {
+        if viewModel.showsListenPlaybackBar {
+            ListenPlaybackBar(
+                phase: viewModel.listenPlaybackPhase,
+                displayTime: viewModel.listenPlaybackDisplayTime,
+                duration: viewModel.listenPlaybackDuration,
+                speed: viewModel.listenPlaybackSpeed,
+                onTogglePlayPause: {
+                    viewModel.toggleListenPlaybackPlayPause()
+                },
+                onStop: {
+                    viewModel.stopListening()
+                },
+                onScrub: { time in
+                    viewModel.scrubListenPlayback(to: time)
+                },
+                onScrubbingChanged: { isScrubbing in
+                    viewModel.setListenPlaybackScrubbing(isScrubbing)
+                },
+                onSpeedChange: { speed in
+                    viewModel.setListenPlaybackSpeed(speed)
+                }
+            )
+            .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
+        }
     }
 
     private var gitAvailabilityTaskID: String {
@@ -1618,6 +1794,7 @@ struct ChatView: View {
                 beginResponseCompletionBackgroundTask()
             }
         case .active:
+            viewModel.refreshListenPlaybackProgressAfterSceneActivation()
             endResponseCompletionBackgroundTask()
             Task {
                 await viewModel.reconnectStreamIfNeeded(modelContext: modelContext)

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -1,7 +1,136 @@
 import Foundation
 import AVFoundation
+import MediaPlayer
 import Observation
 import SwiftData
+
+enum ListenPlaybackPhase: Equatable {
+    case idle
+    case loading
+    case playing
+    case paused
+}
+
+enum ListenPlaybackSpeed: Double, CaseIterable, Identifiable {
+    case half = 0.5
+    case normal = 1
+    case oneAndHalf = 1.5
+    case double = 2
+
+    static let storageKey = "Chat.listenPlaybackSpeed"
+    static let defaultValue: ListenPlaybackSpeed = .normal
+
+    var id: Double { rawValue }
+
+    var title: String {
+        switch self {
+        case .half:
+            return "0.5x"
+        case .normal:
+            return "1x"
+        case .oneAndHalf:
+            return "1.5x"
+        case .double:
+            return "2x"
+        }
+    }
+
+    static func stored(in userDefaults: UserDefaults) -> ListenPlaybackSpeed {
+        let storedValue = userDefaults.double(forKey: storageKey)
+        return allCases.first { abs($0.rawValue - storedValue) < 0.001 } ?? defaultValue
+    }
+}
+
+struct ListenNowPlayingSnapshot: Equatable {
+    let title: String
+    let duration: TimeInterval
+    let elapsedTime: TimeInterval
+    let speed: ListenPlaybackSpeed
+    let isPlaying: Bool
+}
+
+@MainActor
+protocol ListenRemoteControlControlling {
+    func configure(
+        play: @escaping @MainActor () -> Void,
+        pause: @escaping @MainActor () -> Void,
+        togglePlayPause: @escaping @MainActor () -> Void,
+        changePlaybackPosition: @escaping @MainActor (TimeInterval) -> Void
+    )
+    func update(_ snapshot: ListenNowPlayingSnapshot)
+    func clear()
+}
+
+@MainActor
+final class ListenRemoteControlController: ListenRemoteControlControlling {
+    private var commandTargets: [(MPRemoteCommand, Any)] = []
+
+    func configure(
+        play: @escaping @MainActor () -> Void,
+        pause: @escaping @MainActor () -> Void,
+        togglePlayPause: @escaping @MainActor () -> Void,
+        changePlaybackPosition: @escaping @MainActor (TimeInterval) -> Void
+    ) {
+        clearCommandTargets()
+
+        let commandCenter = MPRemoteCommandCenter.shared()
+        commandCenter.playCommand.isEnabled = true
+        commandTargets.append((commandCenter.playCommand, commandCenter.playCommand.addTarget { _ in
+            Task { @MainActor in play() }
+            return .success
+        }))
+
+        commandCenter.pauseCommand.isEnabled = true
+        commandTargets.append((commandCenter.pauseCommand, commandCenter.pauseCommand.addTarget { _ in
+            Task { @MainActor in pause() }
+            return .success
+        }))
+
+        commandCenter.togglePlayPauseCommand.isEnabled = true
+        commandTargets.append((commandCenter.togglePlayPauseCommand, commandCenter.togglePlayPauseCommand.addTarget { _ in
+            Task { @MainActor in togglePlayPause() }
+            return .success
+        }))
+
+        commandCenter.changePlaybackPositionCommand.isEnabled = true
+        commandTargets.append((
+            commandCenter.changePlaybackPositionCommand,
+            commandCenter.changePlaybackPositionCommand.addTarget { event in
+                guard let event = event as? MPChangePlaybackPositionCommandEvent else {
+                    return .commandFailed
+                }
+                Task { @MainActor in changePlaybackPosition(event.positionTime) }
+                return .success
+            }
+        ))
+    }
+
+    func update(_ snapshot: ListenNowPlayingSnapshot) {
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+            MPMediaItemPropertyTitle: snapshot.title,
+            MPMediaItemPropertyArtist: "Hermex",
+            MPMediaItemPropertyPlaybackDuration: max(0, snapshot.duration),
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: max(0, snapshot.elapsedTime),
+            MPNowPlayingInfoPropertyPlaybackRate: snapshot.isPlaying ? snapshot.speed.rawValue : 0,
+            MPNowPlayingInfoPropertyDefaultPlaybackRate: snapshot.speed.rawValue
+        ]
+        MPNowPlayingInfoCenter.default().playbackState = snapshot.isPlaying ? .playing : .paused
+    }
+
+    func clear() {
+        clearCommandTargets()
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        MPNowPlayingInfoCenter.default().playbackState = .stopped
+    }
+
+    private func clearCommandTargets() {
+        commandTargets.forEach { command, target in
+            command.removeTarget(target)
+            command.isEnabled = false
+        }
+        commandTargets.removeAll()
+    }
+}
 
 struct ApprovalPromptState: Equatable, Identifiable {
     var id: String {
@@ -237,6 +366,8 @@ final class ChatViewModel {
     private let liveActivityManager: any AgentLiveActivityManaging
     private let speechSynthesizerFactory: () -> any ChatSpeechSynthesizing
     private let listenAudioSession: any ListenAudioSessionControlling
+    private let listenRemoteControlCenter: any ListenRemoteControlControlling
+    private let userDefaults: UserDefaults
     private let pollingIntervals: ChatPollingIntervals
     // Real-time window over which rapid streaming updates coalesce into a single
     // scroll trigger / first content flush. Injectable so tests can drive
@@ -272,6 +403,13 @@ final class ChatViewModel {
     // arriving after stop/switch carries a stale ID and is dropped instead of
     // starting audio the user no longer wants.
     private var activeListenRequestID: UUID?
+    private var listenPlaybackTitle = String(localized: "Hermex response")
+    private(set) var listenPlaybackPhase: ListenPlaybackPhase = .idle
+    private(set) var listenPlaybackElapsedTime: TimeInterval = 0
+    private(set) var listenPlaybackDuration: TimeInterval = 0
+    private(set) var listenPlaybackScrubTime: TimeInterval?
+    private(set) var listenPlaybackSpeed: ListenPlaybackSpeed
+    @ObservationIgnored private var listenPlaybackTicker: Timer?
     private var showsLiveActivityResponseExcerpts: Bool
     private var hasCompletedCurrentResponse: Bool { streamCoordinator.hasCompletedCurrentResponse }
     private var isStreamConnectionSuspended: Bool { streamCoordinator.isConnectionSuspended }
@@ -315,7 +453,9 @@ final class ChatViewModel {
         streamingMaxRevealLagNanoseconds: UInt64 = 1_000_000_000,
         speechSynthesizerFactory: @escaping () -> any ChatSpeechSynthesizing = { AVSpeechSynthesizer() },
         listenAudioSession: (any ListenAudioSessionControlling)? = nil,
-        serverTTSAudioPlayerFactory: (@MainActor (Data) throws -> any ListenAudioPlaying)? = nil
+        listenRemoteControlCenter: (any ListenRemoteControlControlling)? = nil,
+        serverTTSAudioPlayerFactory: (@MainActor (Data) throws -> any ListenAudioPlaying)? = nil,
+        userDefaults: UserDefaults = .standard
     ) {
         sessionID = session.sessionId
         currentWorkspace = session.workspace
@@ -350,6 +490,9 @@ final class ChatViewModel {
         self.streamingMaxRevealLagNanoseconds = streamingMaxRevealLagNanoseconds
         self.speechSynthesizerFactory = speechSynthesizerFactory
         self.listenAudioSession = listenAudioSession ?? ListenAudioSessionController()
+        self.listenRemoteControlCenter = listenRemoteControlCenter ?? ListenRemoteControlController()
+        self.userDefaults = userDefaults
+        self.listenPlaybackSpeed = ListenPlaybackSpeed.stored(in: userDefaults)
         self.serverTTSAudioPlayerFactory = serverTTSAudioPlayerFactory
             ?? { try ServerTTSAudioPlayer(data: $0) }
         displayTitle = Self.displayTitle(from: session.title)
@@ -363,6 +506,7 @@ final class ChatViewModel {
         pendingStreamingScrollTriggerTask?.cancel()
         pendingStreamingContentFlushTask?.cancel()
         listenPreparationTask?.cancel()
+        listenPlaybackTicker?.invalidate()
     }
 
     func setShowsLiveActivityResponseExcerpts(_ shows: Bool) {
@@ -370,6 +514,14 @@ final class ChatViewModel {
 
         showsLiveActivityResponseExcerpts = shows
         streamCoordinator.setShowsLiveActivityResponseExcerpts(shows)
+    }
+
+    var showsListenPlaybackBar: Bool {
+        listenPlaybackPhase != .idle
+    }
+
+    var listenPlaybackDisplayTime: TimeInterval {
+        listenPlaybackScrubTime ?? listenPlaybackElapsedTime
     }
 
     nonisolated static func resetActiveStreamSnapshotsForTesting() {
@@ -3330,10 +3482,12 @@ final class ChatViewModel {
         // on #35). Activation happens at the two playback-start points instead —
         // `startServerAudioPlayback` and `speakWithOnDeviceSynthesizer`.
         listeningMessageID = context.messageID
+        beginListenPlaybackPreparation(for: context)
 
         guard ServerTTSPolicy.shouldUseServerTTS(for: listenText) else {
             // Over the server's 5000-char request cap: go straight to the on-device
             // path (chunking is a non-goal of #15).
+            clearListenPlaybackState()
             speakWithOnDeviceSynthesizer(listenText)
             return
         }
@@ -3366,9 +3520,10 @@ final class ChatViewModel {
                 return
             }
 
-            if let audioData, self.startServerAudioPlayback(audioData) {
+            if let audioData, self.startServerAudioPlayback(audioData, title: self.listenPlaybackTitle) {
                 return
             }
+            self.clearListenPlaybackState()
             self.speakWithOnDeviceSynthesizer(listenText)
         }
     }
@@ -3388,6 +3543,47 @@ final class ChatViewModel {
             speechSynthesizer.stopSpeaking(at: .immediate)
         }
         finishListening()
+    }
+
+    func toggleListenPlaybackPlayPause() {
+        switch listenPlaybackPhase {
+        case .playing:
+            pauseListenPlayback()
+        case .paused:
+            resumeListenPlayback()
+        case .idle, .loading:
+            break
+        }
+    }
+
+    func setListenPlaybackSpeed(_ speed: ListenPlaybackSpeed) {
+        guard listenPlaybackSpeed != speed else { return }
+        listenPlaybackSpeed = speed
+        userDefaults.set(speed.rawValue, forKey: ListenPlaybackSpeed.storageKey)
+        listenAudioPlayer?.rate = Float(speed.rawValue)
+        updateListenNowPlaying()
+    }
+
+    func scrubListenPlayback(to time: TimeInterval) {
+        listenPlaybackScrubTime = boundedListenPlaybackTime(time)
+    }
+
+    func setListenPlaybackScrubbing(_ scrubbing: Bool) {
+        if scrubbing {
+            listenPlaybackScrubTime = listenPlaybackElapsedTime
+        } else if let target = listenPlaybackScrubTime {
+            seekListenPlayback(to: target)
+            listenPlaybackScrubTime = nil
+        }
+    }
+
+    func refreshListenPlaybackProgressAfterSceneActivation() {
+        guard listenPlaybackPhase == .playing || listenPlaybackPhase == .paused else { return }
+
+        updateListenPlaybackProgressFromPlayer()
+        if listenPlaybackPhase == .playing {
+            startListenPlaybackTicker()
+        }
     }
 
     func suspendStreamForBackground() {
@@ -4292,9 +4488,29 @@ final class ChatViewModel {
         activeListenRequestID = nil
         listenAudioPlayer = nil
         listeningMessageID = nil
+        clearListenPlaybackState()
         // Release the shared session so any audio we interrupted can resume. Safe to
         // call when nothing was speaking: `setActive(false)` no-ops via `try?`.
         listenAudioSession.deactivate()
+    }
+
+    private func beginListenPlaybackPreparation(for context: MessageActionContext) {
+        listenPlaybackTitle = String(localized: "Hermex response \(context.visibleIndex + 1)")
+        listenPlaybackPhase = .loading
+        listenPlaybackElapsedTime = 0
+        listenPlaybackDuration = 0
+        listenPlaybackScrubTime = nil
+        stopListenPlaybackTicker()
+        listenRemoteControlCenter.clear()
+    }
+
+    private func clearListenPlaybackState() {
+        listenPlaybackPhase = .idle
+        listenPlaybackElapsedTime = 0
+        listenPlaybackDuration = 0
+        listenPlaybackScrubTime = nil
+        stopListenPlaybackTicker()
+        listenRemoteControlCenter.clear()
     }
 
     /// Speaks `text` with the on-device `AVSpeechSynthesizer` — the pre-#15 Listen
@@ -4315,7 +4531,7 @@ final class ChatViewModel {
     /// Attempts to start playback of server-synthesized audio bytes. Returns
     /// `false` when the bytes can't be decoded into a player or playback fails to
     /// start, so the caller can fall back to the on-device synthesizer.
-    private func startServerAudioPlayback(_ audioData: Data) -> Bool {
+    private func startServerAudioPlayback(_ audioData: Data, title: String) -> Bool {
         guard let player = try? serverTTSAudioPlayerFactory(audioData) else {
             return false
         }
@@ -4324,6 +4540,13 @@ final class ChatViewModel {
         player.onFinish = { [weak self] in
             self?.handleListenPlayerCompletion(for: playerID)
         }
+        player.prepareToPlay()
+        player.rate = Float(listenPlaybackSpeed.rawValue)
+        listenPlaybackTitle = title
+        listenPlaybackElapsedTime = player.currentTime
+        listenPlaybackDuration = player.duration
+        listenPlaybackScrubTime = nil
+        configureListenRemoteControls()
 
         // Activate the session only once decodable audio is in hand, immediately
         // before playback, so the network wait never held it (review on #35). If
@@ -4336,7 +4559,88 @@ final class ChatViewModel {
 
         listenAudioPlayer = player
         activeListenPlayerID = playerID
+        listenPlaybackPhase = .playing
+        startListenPlaybackTicker()
+        updateListenPlaybackProgressFromPlayer()
+        updateListenNowPlaying()
         return true
+    }
+
+    private func pauseListenPlayback() {
+        guard listenPlaybackPhase == .playing, let player = listenAudioPlayer else { return }
+        player.pause()
+        updateListenPlaybackProgressFromPlayer()
+        listenPlaybackPhase = .paused
+        stopListenPlaybackTicker()
+        updateListenNowPlaying()
+    }
+
+    private func resumeListenPlayback() {
+        guard listenPlaybackPhase == .paused, let player = listenAudioPlayer else { return }
+        player.rate = Float(listenPlaybackSpeed.rawValue)
+        listenAudioSession.activate()
+        guard player.play() else { return }
+        listenPlaybackPhase = .playing
+        startListenPlaybackTicker()
+        updateListenPlaybackProgressFromPlayer()
+        updateListenNowPlaying()
+    }
+
+    private func seekListenPlayback(to time: TimeInterval) {
+        guard let player = listenAudioPlayer else { return }
+        let boundedTime = boundedListenPlaybackTime(time)
+        player.currentTime = boundedTime
+        listenPlaybackElapsedTime = boundedTime
+        updateListenNowPlaying()
+    }
+
+    private func boundedListenPlaybackTime(_ time: TimeInterval) -> TimeInterval {
+        guard time.isFinite else { return 0 }
+        let upperBound = listenPlaybackDuration > 0 ? listenPlaybackDuration : max(time, 0)
+        return min(max(0, time), upperBound)
+    }
+
+    private func startListenPlaybackTicker() {
+        stopListenPlaybackTicker()
+        let timer = Timer(timeInterval: 0.2, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateListenPlaybackProgressFromPlayer()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        listenPlaybackTicker = timer
+    }
+
+    private func stopListenPlaybackTicker() {
+        listenPlaybackTicker?.invalidate()
+        listenPlaybackTicker = nil
+    }
+
+    private func updateListenPlaybackProgressFromPlayer() {
+        guard listenPlaybackScrubTime == nil, let player = listenAudioPlayer else { return }
+        listenPlaybackElapsedTime = boundedListenPlaybackTime(player.currentTime)
+        listenPlaybackDuration = max(0, player.duration)
+        updateListenNowPlaying()
+    }
+
+    private func configureListenRemoteControls() {
+        listenRemoteControlCenter.configure(
+            play: { [weak self] in self?.resumeListenPlayback() },
+            pause: { [weak self] in self?.pauseListenPlayback() },
+            togglePlayPause: { [weak self] in self?.toggleListenPlaybackPlayPause() },
+            changePlaybackPosition: { [weak self] position in self?.seekListenPlayback(to: position) }
+        )
+    }
+
+    private func updateListenNowPlaying() {
+        guard listenPlaybackPhase == .playing || listenPlaybackPhase == .paused else { return }
+        listenRemoteControlCenter.update(ListenNowPlayingSnapshot(
+            title: listenPlaybackTitle,
+            duration: listenPlaybackDuration,
+            elapsedTime: listenPlaybackElapsedTime,
+            speed: listenPlaybackSpeed,
+            isPlaying: listenPlaybackPhase == .playing
+        ))
     }
 
     /// Completion routed from the server-TTS audio player. Mirrors
@@ -5207,9 +5511,14 @@ protocol ListenAudioPlaying: AnyObject {
     /// Fired on the main actor when playback finishes naturally.
     /// `stop()` must not fire it.
     var onFinish: (@MainActor () -> Void)? { get set }
+    var currentTime: TimeInterval { get set }
+    var duration: TimeInterval { get }
+    var rate: Float { get set }
 
+    func prepareToPlay()
     @discardableResult
     func play() -> Bool
+    func pause()
     func stop()
 }
 
@@ -5220,16 +5529,34 @@ protocol ListenAudioPlaying: AnyObject {
 final class ServerTTSAudioPlayer: NSObject, ListenAudioPlaying {
     private let player: AVAudioPlayer
     var onFinish: (@MainActor () -> Void)?
+    var currentTime: TimeInterval {
+        get { player.currentTime }
+        set { player.currentTime = newValue }
+    }
+    var duration: TimeInterval { player.duration }
+    var rate: Float {
+        get { player.rate }
+        set { player.rate = newValue }
+    }
 
     init(data: Data) throws {
         player = try AVAudioPlayer(data: data)
         super.init()
         player.delegate = self
+        player.enableRate = true
+    }
+
+    func prepareToPlay() {
+        player.prepareToPlay()
     }
 
     @discardableResult
     func play() -> Bool {
         player.play()
+    }
+
+    func pause() {
+        player.pause()
     }
 
     func stop() {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -65,6 +65,15 @@ protocol ListenRemoteControlControlling {
 final class ListenRemoteControlController: ListenRemoteControlControlling {
     private var commandTargets: [(MPRemoteCommand, Any)] = []
 
+    deinit {
+        commandTargets.forEach { command, target in
+            command.removeTarget(target)
+            command.isEnabled = false
+        }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        MPNowPlayingInfoCenter.default().playbackState = .stopped
+    }
+
     func configure(
         play: @escaping @MainActor () -> Void,
         pause: @escaping @MainActor () -> Void,
@@ -4620,7 +4629,6 @@ final class ChatViewModel {
         guard listenPlaybackScrubTime == nil, let player = listenAudioPlayer else { return }
         listenPlaybackElapsedTime = boundedListenPlaybackTime(player.currentTime)
         listenPlaybackDuration = max(0, player.duration)
-        updateListenNowPlaying()
     }
 
     private func configureListenRemoteControls() {

--- a/HermesMobile/Resources/Info.plist
+++ b/HermesMobile/Resources/Info.plist
@@ -65,6 +65,10 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -193,7 +193,9 @@ final class ChatViewModelSendTests: XCTestCase {
     @MainActor
     func testListenPrefersServerTTSAndPlaysReturnedAudio() async throws {
         let audioSession = SpyListenAudioSession()
+        let remoteControlCenter = SpyListenRemoteControlCenter()
         let player = SpyListenAudioPlayer()
+        player.duration = 83
         var receivedAudioData: [Data] = []
         var createdSynthesizers = 0
         let serverAudio = Data([0xFF, 0xF3, 0x18, 0xC4])
@@ -203,6 +205,7 @@ final class ChatViewModelSendTests: XCTestCase {
                 return SpySpeechSynthesizer()
             },
             listenAudioSession: audioSession,
+            listenRemoteControlCenter: remoteControlCenter,
             serverTTSAudioPlayerFactory: { data in
                 receivedAudioData.append(data)
                 return player
@@ -236,6 +239,8 @@ final class ChatViewModelSendTests: XCTestCase {
         ))
 
         viewModel.toggleListening(to: context)
+        XCTAssertTrue(viewModel.showsListenPlaybackBar)
+        XCTAssertEqual(viewModel.listenPlaybackPhase, .loading)
         // Regression (review on #35): no session activation while the fetch is in
         // flight — only once decoded server audio is about to play.
         XCTAssertEqual(audioSession.activateCount, 0)
@@ -243,10 +248,23 @@ final class ChatViewModelSendTests: XCTestCase {
 
         // Server audio plays; the on-device synthesizer is never touched.
         XCTAssertEqual(receivedAudioData, [serverAudio])
+        XCTAssertEqual(player.prepareToPlayCount, 1)
         XCTAssertEqual(player.playCount, 1)
+        XCTAssertEqual(player.rate, Float(1))
         XCTAssertEqual(createdSynthesizers, 0)
         XCTAssertEqual(viewModel.listeningMessageID, "assistant-20")
+        XCTAssertTrue(viewModel.showsListenPlaybackBar)
+        XCTAssertEqual(viewModel.listenPlaybackPhase, .playing)
+        XCTAssertEqual(viewModel.listenPlaybackDuration, 83)
         XCTAssertEqual(audioSession.activateCount, 1)
+        XCTAssertEqual(remoteControlCenter.configureCount, 1)
+        XCTAssertEqual(remoteControlCenter.snapshots.last, ListenNowPlayingSnapshot(
+            title: "Hermex response 1",
+            duration: 83,
+            elapsedTime: 0,
+            speed: .normal,
+            isPlaying: true
+        ))
 
         // Natural finish tears listen state down and releases the session. The
         // defensive stopListening() at the start of toggleListening also
@@ -254,7 +272,189 @@ final class ChatViewModelSendTests: XCTestCase {
         let deactivationsBeforeFinish = audioSession.deactivateCount
         player.finishPlayback()
         XCTAssertNil(viewModel.listeningMessageID)
+        XCTAssertFalse(viewModel.showsListenPlaybackBar)
         XCTAssertGreaterThan(audioSession.deactivateCount, deactivationsBeforeFinish)
+    }
+
+    @MainActor
+    func testListenPlaybackCanPauseResumeSeekAndUseRemoteCommands() async throws {
+        let player = SpyListenAudioPlayer()
+        player.duration = 120
+        let remoteControlCenter = SpyListenRemoteControlCenter()
+        let viewModel = try makeViewModel(
+            listenRemoteControlCenter: remoteControlCenter,
+            serverTTSAudioPlayerFactory: { _ in player }
+        ) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, Data([0xFF, 0xF3]))
+        }
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: "Give me controls.",
+                timestamp: 1_770_000_025,
+                messageId: "assistant-25"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
+
+        remoteControlCenter.firePause()
+        XCTAssertEqual(player.pauseCount, 1)
+        XCTAssertEqual(viewModel.listenPlaybackPhase, .paused)
+        XCTAssertFalse(try XCTUnwrap(remoteControlCenter.snapshots.last).isPlaying)
+
+        remoteControlCenter.firePlay()
+        XCTAssertEqual(player.playCount, 2)
+        XCTAssertEqual(viewModel.listenPlaybackPhase, .playing)
+        XCTAssertTrue(try XCTUnwrap(remoteControlCenter.snapshots.last).isPlaying)
+
+        remoteControlCenter.fireChangePlaybackPosition(37)
+        XCTAssertEqual(player.currentTime, 37)
+        XCTAssertEqual(viewModel.listenPlaybackElapsedTime, 37)
+
+        viewModel.toggleListenPlaybackPlayPause()
+        XCTAssertEqual(player.pauseCount, 2)
+        XCTAssertEqual(viewModel.listenPlaybackPhase, .paused)
+
+        remoteControlCenter.fireTogglePlayPause()
+        XCTAssertEqual(player.playCount, 3)
+        XCTAssertEqual(viewModel.listenPlaybackPhase, .playing)
+    }
+
+    @MainActor
+    func testListenPlaybackResyncsProgressWhenSceneBecomesActive() async throws {
+        let player = SpyListenAudioPlayer()
+        player.duration = 90
+        let viewModel = try makeViewModel(
+            serverTTSAudioPlayerFactory: { _ in player }
+        ) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, Data([0xFF, 0xF3]))
+        }
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: "Keep progress honest.",
+                timestamp: 1_770_000_026,
+                messageId: "assistant-26"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
+        XCTAssertEqual(viewModel.listenPlaybackElapsedTime, 0)
+
+        // Simulates background audio advancing while the foreground UI timer is not
+        // firing. Returning to the scene must pull the latest player time into the bar.
+        player.currentTime = 42
+        viewModel.refreshListenPlaybackProgressAfterSceneActivation()
+
+        XCTAssertEqual(viewModel.listenPlaybackElapsedTime, 42)
+        XCTAssertEqual(viewModel.listenPlaybackDisplayTime, 42)
+    }
+
+    @MainActor
+    func testListenPlaybackSeekAndSpeedPersist() async throws {
+        let userDefaults = try makeEphemeralUserDefaults()
+        let player = SpyListenAudioPlayer()
+        player.duration = 120
+        let viewModel = try makeViewModel(
+            serverTTSAudioPlayerFactory: { _ in player },
+            userDefaults: userDefaults
+        ) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, Data([0xFF, 0xF3]))
+        }
+        let context = try XCTUnwrap(MessageActionContext(
+            message: ChatMessage(
+                role: "assistant",
+                content: "Remember my speed.",
+                timestamp: 1_770_000_026,
+                messageId: "assistant-26"
+            ),
+            visibleIndex: 0,
+            messagesOffset: 0
+        ))
+
+        viewModel.toggleListening(to: context)
+        await viewModel.listenPreparationTask?.value
+
+        viewModel.scrubListenPlayback(to: 64)
+        XCTAssertEqual(viewModel.listenPlaybackDisplayTime, 64)
+        XCTAssertEqual(player.currentTime, 0)
+
+        viewModel.setListenPlaybackScrubbing(false)
+        XCTAssertEqual(player.currentTime, 64)
+        XCTAssertEqual(viewModel.listenPlaybackElapsedTime, 64)
+        XCTAssertNil(viewModel.listenPlaybackScrubTime)
+
+        viewModel.setListenPlaybackSpeed(.oneAndHalf)
+        XCTAssertEqual(player.rate, Float(1.5))
+        XCTAssertEqual(userDefaults.double(forKey: ListenPlaybackSpeed.storageKey), 1.5)
+
+        let reloadedViewModel = try makeViewModel(userDefaults: userDefaults) { request in
+            XCTFail("Reading stored playback speed should not hit \(request.url?.path ?? "unknown path")")
+            throw URLError(.badServerResponse)
+        }
+        XCTAssertEqual(reloadedViewModel.listenPlaybackSpeed, .oneAndHalf)
+    }
+
+    @MainActor
+    func testStartingListenOnDifferentMessageStopsCurrentServerAudio() async throws {
+        let firstPlayer = SpyListenAudioPlayer()
+        let secondPlayer = SpyListenAudioPlayer()
+        var players = [firstPlayer, secondPlayer]
+        let viewModel = try makeViewModel(
+            serverTTSAudioPlayerFactory: { _ in
+                players.removeFirst()
+            }
+        ) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, Data([0xFF, 0xF3]))
+        }
+        func makeContext(_ id: String, text: String, visibleIndex: Int) throws -> MessageActionContext {
+            try XCTUnwrap(MessageActionContext(
+                message: ChatMessage(role: "assistant", content: text, timestamp: 1_770_000_030, messageId: id),
+                visibleIndex: visibleIndex,
+                messagesOffset: 0
+            ))
+        }
+
+        viewModel.toggleListening(to: try makeContext("assistant-30", text: "First audio.", visibleIndex: 0))
+        await viewModel.listenPreparationTask?.value
+        viewModel.toggleListening(to: try makeContext("assistant-31", text: "Second audio.", visibleIndex: 1))
+        await viewModel.listenPreparationTask?.value
+
+        XCTAssertEqual(firstPlayer.stopCount, 1)
+        XCTAssertEqual(secondPlayer.playCount, 1)
+        XCTAssertEqual(viewModel.listeningMessageID, "assistant-31")
+        XCTAssertEqual(viewModel.listenPlaybackPhase, .playing)
     }
 
     @MainActor
@@ -6652,6 +6852,13 @@ final class ChatViewModelSendTests: XCTestCase {
         return (response, Data(#"{"error": "TTS engine unavailable"}"#.utf8))
     }
 
+    private func makeEphemeralUserDefaults() throws -> UserDefaults {
+        let suiteName = "HermesMobileTests.\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+
     @MainActor
     private func makeViewModel(
         streamClient: SSEStreamingClient? = nil,
@@ -6663,7 +6870,9 @@ final class ChatViewModelSendTests: XCTestCase {
         streamingScrollCoalescingDelayNanoseconds: UInt64 = 16_000_000,
         speechSynthesizerFactory: @escaping () -> any ChatSpeechSynthesizing = { AVSpeechSynthesizer() },
         listenAudioSession: (any ListenAudioSessionControlling)? = nil,
+        listenRemoteControlCenter: (any ListenRemoteControlControlling)? = nil,
         serverTTSAudioPlayerFactory: (@MainActor (Data) throws -> any ListenAudioPlaying)? = nil,
+        userDefaults: UserDefaults = .standard,
         handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
     ) throws -> ChatViewModel {
         MockURLProtocol.requestHandler = handler
@@ -6694,7 +6903,9 @@ final class ChatViewModelSendTests: XCTestCase {
             speechSynthesizerFactory: speechSynthesizerFactory,
             // Default to a spy so unit tests never drive the live shared AVAudioSession.
             listenAudioSession: listenAudioSession ?? SpyListenAudioSession(),
-            serverTTSAudioPlayerFactory: serverTTSAudioPlayerFactory
+            listenRemoteControlCenter: listenRemoteControlCenter ?? SpyListenRemoteControlCenter(),
+            serverTTSAudioPlayerFactory: serverTTSAudioPlayerFactory,
+            userDefaults: userDefaults
         )
 
         if let spyStreamClient = resolvedStreamClient as? SpySSEStreamingClient {
@@ -6932,12 +7143,25 @@ private final class SpySpeechSynthesizer: ChatSpeechSynthesizing {
 private final class SpyListenAudioPlayer: ListenAudioPlaying {
     var onFinish: (@MainActor () -> Void)?
     var playResult = true
+    var currentTime: TimeInterval = 0
+    var duration: TimeInterval = 75
+    var rate: Float = 1
     private(set) var playCount = 0
+    private(set) var pauseCount = 0
     private(set) var stopCount = 0
+    private(set) var prepareToPlayCount = 0
+
+    func prepareToPlay() {
+        prepareToPlayCount += 1
+    }
 
     func play() -> Bool {
         playCount += 1
         return playResult
+    }
+
+    func pause() {
+        pauseCount += 1
     }
 
     func stop() {
@@ -6968,6 +7192,55 @@ private final class SpyListenAudioSession: ListenAudioSessionControlling {
     func deactivate() {
         deactivateCount += 1
         recorder?.record("deactivate")
+    }
+}
+
+@MainActor
+private final class SpyListenRemoteControlCenter: ListenRemoteControlControlling {
+    private(set) var configureCount = 0
+    private(set) var clearCount = 0
+    private(set) var snapshots: [ListenNowPlayingSnapshot] = []
+    private var playHandler: (@MainActor () -> Void)?
+    private var pauseHandler: (@MainActor () -> Void)?
+    private var togglePlayPauseHandler: (@MainActor () -> Void)?
+    private var changePlaybackPositionHandler: (@MainActor (TimeInterval) -> Void)?
+
+    func configure(
+        play: @escaping @MainActor () -> Void,
+        pause: @escaping @MainActor () -> Void,
+        togglePlayPause: @escaping @MainActor () -> Void,
+        changePlaybackPosition: @escaping @MainActor (TimeInterval) -> Void
+    ) {
+        configureCount += 1
+        playHandler = play
+        pauseHandler = pause
+        togglePlayPauseHandler = togglePlayPause
+        changePlaybackPositionHandler = changePlaybackPosition
+    }
+
+    func update(_ snapshot: ListenNowPlayingSnapshot) {
+        snapshots.append(snapshot)
+    }
+
+    func clear() {
+        clearCount += 1
+        snapshots.removeAll()
+    }
+
+    func firePlay() {
+        playHandler?()
+    }
+
+    func firePause() {
+        pauseHandler?()
+    }
+
+    func fireTogglePlayPause() {
+        togglePlayPauseHandler?()
+    }
+
+    func fireChangePlaybackPosition(_ position: TimeInterval) {
+        changePlaybackPositionHandler?(position)
     }
 }
 

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -194,6 +194,7 @@ final class ChatViewModelSendTests: XCTestCase {
     func testListenPrefersServerTTSAndPlaysReturnedAudio() async throws {
         let audioSession = SpyListenAudioSession()
         let remoteControlCenter = SpyListenRemoteControlCenter()
+        let userDefaults = try makeEphemeralUserDefaults()
         let player = SpyListenAudioPlayer()
         player.duration = 83
         var receivedAudioData: [Data] = []
@@ -209,7 +210,8 @@ final class ChatViewModelSendTests: XCTestCase {
             serverTTSAudioPlayerFactory: { data in
                 receivedAudioData.append(data)
                 return player
-            }
+            },
+            userDefaults: userDefaults
         ) { request in
             XCTAssertEqual(request.url?.path, "/api/tts")
             guard let body = apiTestBodyData(from: request),
@@ -334,7 +336,9 @@ final class ChatViewModelSendTests: XCTestCase {
     func testListenPlaybackResyncsProgressWhenSceneBecomesActive() async throws {
         let player = SpyListenAudioPlayer()
         player.duration = 90
+        let remoteControlCenter = SpyListenRemoteControlCenter()
         let viewModel = try makeViewModel(
+            listenRemoteControlCenter: remoteControlCenter,
             serverTTSAudioPlayerFactory: { _ in player }
         ) { request in
             let response = HTTPURLResponse(
@@ -359,6 +363,7 @@ final class ChatViewModelSendTests: XCTestCase {
         viewModel.toggleListening(to: context)
         await viewModel.listenPreparationTask?.value
         XCTAssertEqual(viewModel.listenPlaybackElapsedTime, 0)
+        let nowPlayingUpdatesAfterStart = remoteControlCenter.snapshots.count
 
         // Simulates background audio advancing while the foreground UI timer is not
         // firing. Returning to the scene must pull the latest player time into the bar.
@@ -367,6 +372,7 @@ final class ChatViewModelSendTests: XCTestCase {
 
         XCTAssertEqual(viewModel.listenPlaybackElapsedTime, 42)
         XCTAssertEqual(viewModel.listenPlaybackDisplayTime, 42)
+        XCTAssertEqual(remoteControlCenter.snapshots.count, nowPlayingUpdatesAfterStart)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Adds a server-side TTS playback bar for assistant messages in Chat, with visible loading, play/pause, seeking, elapsed/duration display, playback speed selection, and stop controls.

Also wires TTS playback into iOS background audio behavior and Now Playing remote commands so playback can continue and be controlled outside the foreground app. Foreground activation now resyncs playback progress from the audio player to avoid stale elapsed time after returning from background.

Closes #75.

## Validation

- `git diff --check`
- Focused `ChatViewModelSendTests`: 135 passed
- Full XCTest suite via XcodeBuildMCP: 1306 passed
- Signed Debug build/install/launch via XcodeBuildMCP succeeded on iPhone 17 simulator
- Owner manual validation: playback bar, seeking, speed controls, background playback, and foreground progress resync

## Notes

Draft PR for staged review.