### PR TITLE
Hide empty new chat sessions from the session list

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -243,6 +243,11 @@ struct SessionListView: View {
             .onChange(of: requestedNewChat) {
                 openRequestedNewChatIfNeeded()
             }
+            .onChange(of: pendingNewChat) { _, newValue in
+                if newValue == nil {
+                    viewModel.removeEmptySidebarPlaceholders()
+                }
+            }
             .refreshable {
                 await refreshSessionsAndActiveProfile()
             }

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -887,6 +887,15 @@ final class SessionListViewModel {
         actionErrorMessage = nil
     }
 
+    /// Drops any empty Untitled placeholders still held in memory. Used when
+    /// returning from the pending new-chat flow so stale rows cannot flash during
+    /// the navigation pop animation.
+    func removeEmptySidebarPlaceholders() {
+        let filtered = sessions.filter(\.shouldAppearInSessionList)
+        guard filtered.count != sessions.count else { return }
+        sessions = filtered
+    }
+
     private static func normalizedSearchQuery(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -174,7 +174,8 @@ final class SessionListViewModel {
 
         do {
             let response = try await client.sessions()
-            let visibleSessions = (response.sessions ?? []).filter { $0.archived != true }
+            let visibleSessions = (response.sessions ?? [])
+                .filter { $0.archived != true && $0.shouldAppearInSessionList }
             applySessions(visibleSessions, archivedCount: response.archivedCount, animation: animation)
             isViewingCachedData = false
 
@@ -195,6 +196,7 @@ final class SessionListViewModel {
             if CacheFallbackPolicy.shouldUseCache(for: error), let modelContext {
                 do {
                     let cachedSessions = try CacheStore.cachedSessions(serverURL: server, in: modelContext)
+                        .filter(\.shouldAppearInSessionList)
                     if !cachedSessions.isEmpty {
                         sessions = cachedSessions
                         isViewingCachedData = true
@@ -401,11 +403,13 @@ final class SessionListViewModel {
             }
 
             let session = SessionSummary(from: sessionDetail)
-            if session.archived != true, !sessions.contains(where: { $0.sessionId == session.sessionId }) {
+            if session.archived != true,
+               session.shouldAppearInSessionList,
+               !sessions.contains(where: { $0.sessionId == session.sessionId }) {
                 sessions.insert(session, at: 0)
             }
 
-            if let modelContext {
+            if let modelContext, session.shouldAppearInSessionList {
                 do {
                     try CacheStore.cacheSession(session, serverURL: server, in: modelContext)
                 } catch {
@@ -853,17 +857,19 @@ final class SessionListViewModel {
                 return nil
             }
 
-            if let existingIndex = sessions.firstIndex(where: { $0.sessionId == newSession.sessionId }) {
-                sessions[existingIndex] = newSession
-            } else {
-                sessions.insert(newSession, at: 0)
-            }
+            if newSession.shouldAppearInSessionList {
+                if let existingIndex = sessions.firstIndex(where: { $0.sessionId == newSession.sessionId }) {
+                    sessions[existingIndex] = newSession
+                } else {
+                    sessions.insert(newSession, at: 0)
+                }
 
-            if let modelContext {
-                do {
-                    try CacheStore.cacheSession(newSession, serverURL: server, in: modelContext)
-                } catch {
-                    cacheErrorMessage = error.localizedDescription
+                if let modelContext {
+                    do {
+                        try CacheStore.cacheSession(newSession, serverURL: server, in: modelContext)
+                    } catch {
+                        cacheErrorMessage = error.localizedDescription
+                    }
                 }
             }
 

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -315,6 +315,8 @@ extension SessionSummary {
     /// Mirrors hermes-webui's visible-sidebar safety net for just-created
     /// placeholders: hide only the known empty Untitled shape, while keeping rows
     /// with content, pending work, streaming state, or explicit user/server state.
+    /// Sort timestamps such as ``lastMessageAt`` are intentionally ignored here —
+    /// ``compact()`` sets them from ``updated_at`` even for zero-message sessions.
     var isEmptySidebarPlaceholder: Bool {
         guard hasPlaceholderTitle else { return false }
         guard !hasSidebarState else { return false }
@@ -359,7 +361,6 @@ extension SessionSummary {
     private var hasMessageActivity: Bool {
         if let messageCount, messageCount > 0 { return true }
         if let userMessageCount, userMessageCount > 0 { return true }
-        if let lastMessageAt, lastMessageAt > 0 { return true }
         return false
     }
 

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -171,6 +171,10 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
     let activeStreamId: String?
     let isStreaming: Bool?
     let isCliSession: Bool?
+    let userMessageCount: Int?
+    let hasPendingUserMessage: Bool?
+    let pendingStartedAt: Double?
+    let worktreePath: String?
     let sourceTag: String?
     let sessionSource: String?
     let sourceLabel: String?
@@ -196,6 +200,10 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         activeStreamId: String? = nil,
         isStreaming: Bool? = nil,
         isCliSession: Bool? = nil,
+        userMessageCount: Int? = nil,
+        hasPendingUserMessage: Bool? = nil,
+        pendingStartedAt: Double? = nil,
+        worktreePath: String? = nil,
         sourceTag: String? = nil,
         sessionSource: String? = nil,
         sourceLabel: String? = nil,
@@ -220,6 +228,10 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         self.activeStreamId = activeStreamId
         self.isStreaming = isStreaming
         self.isCliSession = isCliSession
+        self.userMessageCount = userMessageCount
+        self.hasPendingUserMessage = hasPendingUserMessage
+        self.pendingStartedAt = pendingStartedAt
+        self.worktreePath = worktreePath
         self.sourceTag = sourceTag
         self.sessionSource = sessionSource
         self.sourceLabel = sourceLabel
@@ -232,7 +244,7 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         workspace = detail.workspace
         model = detail.model
         modelProvider = detail.modelProvider
-        messageCount = detail.messageCount
+        messageCount = detail.messageCount ?? detail.messages?.count
         createdAt = detail.createdAt
         updatedAt = detail.updatedAt
         lastMessageAt = detail.lastMessageAt
@@ -246,6 +258,14 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         activeStreamId = detail.activeStreamId
         isStreaming = nil
         isCliSession = detail.isCliSession
+        userMessageCount = nil
+        if Self.nonEmpty(detail.pendingUserMessage) != nil || detail.pendingAttachments?.isEmpty == false {
+            hasPendingUserMessage = true
+        } else {
+            hasPendingUserMessage = nil
+        }
+        pendingStartedAt = detail.pendingStartedAt
+        worktreePath = nil
         sourceTag = nil
         sessionSource = nil
         sourceLabel = nil
@@ -275,6 +295,10 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
             activeStreamId: activeStreamId,
             isStreaming: isStreaming,
             isCliSession: isCliSession,
+            userMessageCount: userMessageCount,
+            hasPendingUserMessage: hasPendingUserMessage,
+            pendingStartedAt: pendingStartedAt,
+            worktreePath: worktreePath,
             sourceTag: sourceTag,
             sessionSource: sessionSource,
             sourceLabel: sourceLabel,
@@ -284,6 +308,21 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
 }
 
 extension SessionSummary {
+    var shouldAppearInSessionList: Bool {
+        !isEmptySidebarPlaceholder
+    }
+
+    /// Mirrors hermes-webui's visible-sidebar safety net for just-created
+    /// placeholders: hide only the known empty Untitled shape, while keeping rows
+    /// with content, pending work, streaming state, or explicit user/server state.
+    var isEmptySidebarPlaceholder: Bool {
+        guard hasPlaceholderTitle else { return false }
+        guard !hasSidebarState else { return false }
+        guard !hasMessageActivity else { return false }
+
+        return messageCount == 0 || userMessageCount == 0
+    }
+
     /// True when this row originates from a scheduled cron job.
     ///
     /// Mirrors hermes-webui's `is_cron_session` (`api/models.py`): a `cron`
@@ -303,6 +342,32 @@ extension SessionSummary {
             .contains("cron")
     }
 
+    private var hasPlaceholderTitle: Bool {
+        guard let normalizedTitle = Self.nonEmpty(title)?.lowercased() else { return true }
+        return normalizedTitle == "untitled" || normalizedTitle == "untitled session"
+    }
+
+    private var hasSidebarState: Bool {
+        pinned == true
+            || isStreaming == true
+            || Self.nonEmpty(activeStreamId) != nil
+            || hasPendingUserMessage == true
+            || pendingStartedAt != nil
+            || Self.nonEmpty(worktreePath) != nil
+    }
+
+    private var hasMessageActivity: Bool {
+        if let messageCount, messageCount > 0 { return true }
+        if let userMessageCount, userMessageCount > 0 { return true }
+        if let lastMessageAt, lastMessageAt > 0 { return true }
+        return false
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 }
 
 /// Which automated session kinds the session list should show. Cron jobs and

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -265,7 +265,7 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
             hasPendingUserMessage = nil
         }
         pendingStartedAt = detail.pendingStartedAt
-        worktreePath = nil
+        worktreePath = detail.worktreePath
         sourceTag = nil
         sessionSource = nil
         sourceLabel = nil
@@ -424,6 +424,7 @@ struct SessionDetail: Decodable, Equatable, Identifiable {
     let pendingUserMessage: String?
     let pendingAttachments: [JSONValue]?
     let pendingStartedAt: Double?
+    let worktreePath: String?
     let contextLength: Int?
     let thresholdTokens: Int?
     let lastPromptTokens: Int?
@@ -457,6 +458,7 @@ struct SessionDetail: Decodable, Equatable, Identifiable {
         case pendingUserMessage
         case pendingAttachments
         case pendingStartedAt
+        case worktreePath
         case contextLength
         case thresholdTokens
         case lastPromptTokens
@@ -499,6 +501,7 @@ struct SessionDetail: Decodable, Equatable, Identifiable {
         pendingUserMessage = container.decodeLossyStringIfPresent(forKey: .pendingUserMessage)
         pendingAttachments = try? container.decodeIfPresent([JSONValue].self, forKey: .pendingAttachments)
         pendingStartedAt = container.decodeLossyDoubleIfPresent(forKey: .pendingStartedAt)
+        worktreePath = container.decodeLossyStringIfPresent(forKey: .worktreePath)
         contextLength = container.decodeLossyIntIfPresent(forKey: .contextLength)
         thresholdTokens = container.decodeLossyIntIfPresent(forKey: .thresholdTokens)
         lastPromptTokens = container.decodeLossyIntIfPresent(forKey: .lastPromptTokens)

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -320,7 +320,7 @@ extension SessionSummary {
         guard !hasSidebarState else { return false }
         guard !hasMessageActivity else { return false }
 
-        return messageCount == 0 || userMessageCount == 0
+        return (messageCount ?? 0) == 0 && (userMessageCount ?? 0) == 0
     }
 
     /// True when this row originates from a scheduled cron job.

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -296,6 +296,10 @@ private extension SessionSummary {
         activeStreamId = cachedSession.activeStreamId
         isStreaming = cachedSession.isStreaming
         isCliSession = cachedSession.isCliSession
+        userMessageCount = cachedSession.userMessageCount
+        hasPendingUserMessage = cachedSession.hasPendingUserMessage
+        pendingStartedAt = cachedSession.pendingStartedAt
+        worktreePath = cachedSession.worktreePath
         sourceTag = cachedSession.sourceTag
         sessionSource = cachedSession.sessionSource
         sourceLabel = cachedSession.sourceLabel

--- a/HermesMobile/Persistence/CachedSession.swift
+++ b/HermesMobile/Persistence/CachedSession.swift
@@ -29,6 +29,10 @@ final class CachedSession {
     var activeStreamId: String?
     var isStreaming: Bool?
     var isCliSession: Bool?
+    var userMessageCount: Int?
+    var hasPendingUserMessage: Bool?
+    var pendingStartedAt: Double?
+    var worktreePath: String?
     var sourceTag: String?
     var sessionSource: String?
     var sourceLabel: String?
@@ -68,6 +72,10 @@ final class CachedSession {
         activeStreamId = session.activeStreamId
         isStreaming = session.isStreaming
         isCliSession = session.isCliSession
+        userMessageCount = session.userMessageCount
+        hasPendingUserMessage = session.hasPendingUserMessage
+        pendingStartedAt = session.pendingStartedAt
+        worktreePath = session.worktreePath
         sourceTag = session.sourceTag
         sessionSource = session.sessionSource
         sourceLabel = session.sourceLabel

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -334,6 +334,49 @@ final class SessionListMutationTests: XCTestCase {
     }
 
     @MainActor
+    func testCreateSessionKeepsWorktreeBackedUntitledSessionWithoutCounts() async throws {
+        let context = try makeContext()
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/workspaces":
+                return apiTestJSONResponse("""
+                {
+                  "workspaces": [
+                    {"path": "/tmp/workspace", "name": "Workspace"}
+                  ],
+                  "last": "/tmp/workspace"
+                }
+                """, for: request)
+            case "/api/session/new":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "worktree-new",
+                    "title": "Untitled Session",
+                    "workspace": "/tmp/workspace",
+                    "worktree_path": "/tmp/hermes-worktree",
+                    "archived": false
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let created = await viewModel.createSession(modelContext: context)
+
+        XCTAssertEqual(created?.sessionId, "worktree-new")
+        XCTAssertEqual(viewModel.sessions.compactMap(\.sessionId), ["worktree-new"])
+        XCTAssertEqual(
+            try CacheStore.cachedSessions(serverURL: serverURL, in: context).compactMap(\.sessionId),
+            ["worktree-new"]
+        )
+    }
+
+    @MainActor
     func testLoadActiveProfileUsesProfilesEndpointAndStoresCurrentProfile() async throws {
         var requestedPaths: [String] = []
         let viewModel = try makeViewModel { request in

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -179,6 +179,11 @@ final class SessionListMutationTests: XCTestCase {
                   "archived": false
                 },
                 {
+                  "session_id": "empty-placeholder-missing-count",
+                  "title": "Untitled Session",
+                  "archived": false
+                },
+                {
                   "session_id": "contentful-untitled",
                   "title": "Untitled Session",
                   "message_count": 2,
@@ -304,8 +309,7 @@ final class SessionListMutationTests: XCTestCase {
                     "session_id": "new-123",
                     "title": "Untitled Session",
                     "workspace": "/tmp/workspace",
-                    "archived": false,
-                    "messages": []
+                    "archived": false
                   }
                 }
                 """, for: request)

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -232,7 +232,6 @@ final class SessionListMutationTests: XCTestCase {
 
         let expectedIDs = [
             "contentful-untitled",
-            "recent-untitled",
             "streaming-untitled",
             "pending-untitled",
             "worktree-untitled",
@@ -309,6 +308,8 @@ final class SessionListMutationTests: XCTestCase {
                     "session_id": "new-123",
                     "title": "Untitled Session",
                     "workspace": "/tmp/workspace",
+                    "updated_at": 1770000000,
+                    "last_message_at": 1770000000,
                     "archived": false
                   }
                 }

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -164,6 +164,85 @@ final class SessionListMutationTests: XCTestCase {
     }
 
     @MainActor
+    func testLoadFiltersEmptyUntitledPlaceholdersButKeepsRealUntitledRows() async throws {
+        let context = try makeContext()
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/sessions")
+            return apiTestJSONResponse("""
+            {
+              "sessions": [
+                {
+                  "session_id": "empty-placeholder",
+                  "title": "Untitled Session",
+                  "message_count": 0,
+                  "archived": false
+                },
+                {
+                  "session_id": "contentful-untitled",
+                  "title": "Untitled Session",
+                  "message_count": 2,
+                  "archived": false
+                },
+                {
+                  "session_id": "recent-untitled",
+                  "title": "Untitled",
+                  "message_count": 0,
+                  "last_message_at": 1770000000,
+                  "archived": false
+                },
+                {
+                  "session_id": "streaming-untitled",
+                  "title": "Untitled",
+                  "message_count": 0,
+                  "active_stream_id": "stream-123",
+                  "archived": false
+                },
+                {
+                  "session_id": "pending-untitled",
+                  "title": "Untitled",
+                  "message_count": 0,
+                  "has_pending_user_message": true,
+                  "archived": false
+                },
+                {
+                  "session_id": "worktree-untitled",
+                  "title": "Untitled",
+                  "message_count": 0,
+                  "worktree_path": "/tmp/hermes-worktree",
+                  "archived": false
+                },
+                {
+                  "session_id": "named-empty",
+                  "title": "Planning",
+                  "message_count": 0,
+                  "archived": false
+                }
+              ]
+            }
+            """, for: request)
+        }
+
+        await viewModel.load(modelContext: context)
+
+        let expectedIDs = [
+            "contentful-untitled",
+            "recent-untitled",
+            "streaming-untitled",
+            "pending-untitled",
+            "worktree-untitled",
+            "named-empty"
+        ]
+        let loadedIDs = viewModel.sessions.compactMap(\.sessionId)
+        XCTAssertEqual(Set(loadedIDs), Set(expectedIDs))
+        XCTAssertEqual(loadedIDs.count, expectedIDs.count)
+
+        let cachedIDs = try CacheStore.cachedSessions(serverURL: serverURL, in: context).compactMap(\.sessionId)
+        XCTAssertEqual(Set(cachedIDs), Set(expectedIDs))
+        XCTAssertEqual(cachedIDs.count, expectedIDs.count)
+    }
+
+    @MainActor
     func testLoadDoesNotUseCachedSessionsForRealServerError() async throws {
         let context = try makeContext()
         let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
@@ -194,7 +273,9 @@ final class SessionListMutationTests: XCTestCase {
     }
 
     @MainActor
-    func testCreateSessionInsertsReturnedSessionWithoutReloadingSessionList() async throws {
+    func testCreateSessionReturnsEmptyPlaceholderWithoutInsertingIntoSessionList() async throws {
+        let context = try makeContext()
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
         var requestedPaths: [String] = []
         let viewModel = try makeViewModel { request in
             let path = request.url?.path
@@ -223,7 +304,8 @@ final class SessionListMutationTests: XCTestCase {
                     "session_id": "new-123",
                     "title": "Untitled Session",
                     "workspace": "/tmp/workspace",
-                    "archived": false
+                    "archived": false,
+                    "messages": []
                   }
                 }
                 """, for: request)
@@ -236,10 +318,11 @@ final class SessionListMutationTests: XCTestCase {
             }
         }
 
-        let created = await viewModel.createSession()
+        let created = await viewModel.createSession(modelContext: context)
 
         XCTAssertEqual(created?.sessionId, "new-123")
-        XCTAssertEqual(viewModel.sessions.compactMap(\.sessionId), ["new-123"])
+        XCTAssertTrue(viewModel.sessions.isEmpty)
+        XCTAssertTrue(try CacheStore.cachedSessions(serverURL: serverURL, in: context).isEmpty)
         XCTAssertEqual(requestedPaths, ["/api/workspaces", "/api/session/new"])
         XCTAssertFalse(viewModel.isCreatingSession)
         XCTAssertNil(viewModel.actionErrorMessage)


### PR DESCRIPTION
Fixes #83

## Summary
- Hide only empty Untitled/Untitled Session placeholder rows from the session list.
- Preserve real untitled sessions when they have messages, last message activity, pending work, streaming state, worktree state, or a non-placeholder title.
- Persist the extra sidebar metadata through the cache and cover load/create filtering with tests.

## Validation
- `git diff --check`
- Focused `SessionListMutationTests`: 54 tests passed
- Full XCTest suite: 1307 tests, 0 failures

## Owner manual checks
1. Launch the app.
2. Create a new chat.
3. Do not send a message.
4. Navigate back to the sessions list.
5. Confirm no empty `Untitled` session appears, including transiently.
6. Confirm real existing untitled/contentful sessions still appear.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hides empty new-chat placeholders while keeping real sessions visible. The main changes are:

- Filters empty `Untitled` and `Untitled Session` rows from live and cached session lists.
- Preserves pending, streaming, worktree, and message-count metadata in session summaries.
- Stores the extra sidebar metadata in the session cache.
- Adds tests for loading and creating placeholder and worktree-backed sessions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| HermesMobile/Models/Session.swift | Adds the placeholder visibility check and carries sidebar metadata from detail responses into summaries. |
| HermesMobile/Features/SessionList/SessionListViewModel.swift | Applies the visibility check to session loading, cache fallback, deep-link handling, new-session creation, and placeholder cleanup. |
| HermesMobile/Persistence/CachedSession.swift | Adds cached fields for message, pending, and worktree metadata. |
| HermesMobile/Persistence/CacheStore.swift | Restores the new cached sidebar metadata into session summaries. |
| HermesMobileTests/SessionListMutationTests.swift | Adds coverage for filtering empty placeholders and keeping real untitled sessions. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Stop treating session timestamps as side..."](https://github.com/uzairansaruzi/hermex/commit/379d8fb0fc7b7094ebe1769ee401a9ef458eecad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42479738)</sub>

<!-- /greptile_comment -->