### PR TITLE
Fix transcript MEDIA session-scoped loading

### DIFF
--- a/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
@@ -155,9 +155,10 @@ final class ChatAttachmentCoordinator {
 
     func transcriptMediaThumbnailData(for reference: TranscriptMediaReference) async -> Data? {
         guard reference.isRasterImageCandidate else { return nil }
+        guard let sessionID = delegate?.attachmentSessionID else { return nil }
 
         do {
-            let data = try await client.transcriptMediaData(for: reference)
+            let data = try await client.transcriptMediaData(for: reference, sessionID: sessionID)
             return await ImagePreviewDownsampler.previewDataAsync(
                 from: data,
                 maxPixelSize: ImagePreviewDownsampler.attachmentMaxPixelSize

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -47,6 +47,7 @@ struct ChatTranscriptView: View {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let transcriptMediaCacheNamespace: String
     let actionContext: (ChatMessage, Int) -> MessageActionContext?
     let shouldRenderMessageRow: (ChatMessage) -> Bool
     let onLoadMessages: () async -> Void
@@ -233,6 +234,7 @@ struct ChatTranscriptView: View {
                     loadAttachmentImage: loadAttachmentImage,
                     loadAttachmentData: loadAttachmentData,
                     loadTranscriptMediaImage: loadTranscriptMediaImage,
+                    transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
                     actionContext: actionContext,
                     shouldRenderMessageRow: shouldRenderMessageRow,
                     onPreviewAttachment: onPreviewAttachment,
@@ -452,6 +454,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let transcriptMediaCacheNamespace: String
     let actionContext: (ChatMessage, Int) -> MessageActionContext?
     let shouldRenderMessageRow: (ChatMessage) -> Bool
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
@@ -485,7 +488,8 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
             lhs.hasActiveStream == rhs.hasActiveStream &&
             lhs.isRegeneratingMessage == rhs.isRegeneratingMessage &&
             lhs.isEditingMessage == rhs.isEditingMessage &&
-            lhs.isForkingMessage == rhs.isForkingMessage
+            lhs.isForkingMessage == rhs.isForkingMessage &&
+            lhs.transcriptMediaCacheNamespace == rhs.transcriptMediaCacheNamespace
     }
 
     var body: some View {
@@ -516,6 +520,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                     loadAttachmentImage: loadAttachmentImage,
                     loadAttachmentData: loadAttachmentData,
                     loadTranscriptMediaImage: loadTranscriptMediaImage,
+                    transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
                     onPreviewAttachment: onPreviewAttachment,
                     onPreviewTranscriptMedia: onPreviewTranscriptMedia,
                     onToggleListening: onToggleListening,
@@ -596,6 +601,7 @@ private struct ChatTranscriptMessageRow: View {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let transcriptMediaCacheNamespace: String
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
     let onPreviewTranscriptMedia: (TranscriptMediaReference) -> Void
     let onToggleListening: (MessageActionContext) -> Void
@@ -641,6 +647,7 @@ private struct ChatTranscriptMessageRow: View {
             loadAttachmentImage: loadAttachmentImage,
             loadAttachmentData: loadAttachmentData,
             loadTranscriptMediaImage: loadTranscriptMediaImage,
+            transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
             localAttachmentPreviews: localAttachmentPreviews,
             onPreviewAttachment: onPreviewAttachment,
             onPreviewTranscriptMedia: onPreviewTranscriptMedia,

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -497,14 +497,23 @@ struct ChatView: View {
     private func transcriptMediaPreviewView(for item: TranscriptMediaPreviewItem) -> some View {
         TranscriptMediaPreviewView(
             server: server,
-            sessionID: session.sessionId ?? session.id,
+            sessionID: transcriptMediaSessionID,
             item: item,
             onAPIError: onAPIError
         )
     }
 
+    private var transcriptMediaSessionID: String? {
+        guard let sessionID = session.sessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionID.isEmpty
+        else {
+            return nil
+        }
+        return sessionID
+    }
+
     private var transcriptMediaCacheNamespace: String {
-        "\(server.absoluteString)|\(session.sessionId ?? session.id)"
+        "\(server.absoluteString)|\(transcriptMediaSessionID ?? "local:\(session.id)")"
     }
 
     var body: some View {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -503,6 +503,10 @@ struct ChatView: View {
         )
     }
 
+    private var transcriptMediaCacheNamespace: String {
+        "\(server.absoluteString)|\(session.sessionId ?? session.id)"
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
@@ -1122,6 +1126,7 @@ struct ChatView: View {
             loadTranscriptMediaImage: { reference in
                 await viewModel.transcriptMediaThumbnailData(for: reference)
             },
+            transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
             actionContext: { message, visibleIndex in
                 viewModel.actionContext(for: message, visibleIndex: visibleIndex)
             },

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -494,6 +494,15 @@ struct ChatView: View {
         )
     }
 
+    private func transcriptMediaPreviewView(for item: TranscriptMediaPreviewItem) -> some View {
+        TranscriptMediaPreviewView(
+            server: server,
+            sessionID: session.sessionId ?? session.id,
+            item: item,
+            onAPIError: onAPIError
+        )
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
@@ -672,13 +681,7 @@ struct ChatView: View {
                     restoreComposerFocusAfterPreviewIfNeeded()
                 }
             }
-            .sheet(item: $transcriptMediaPreviewItem) { item in
-                TranscriptMediaPreviewView(
-                    server: server,
-                    item: item,
-                    onAPIError: onAPIError
-                )
-            }
+            .sheet(item: $transcriptMediaPreviewItem, content: transcriptMediaPreviewView)
             .sheet(item: $activeGitSheet, content: gitSheet)
             .sheet(item: $turnDiffPresentation, content: turnDiffSheet)
             .alert(item: $gitAlert, content: gitAlertPresentation)

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -11,6 +11,7 @@ struct MessageBubbleView: View {
     let loadAttachmentImage: ((String) async -> Data?)?
     let loadAttachmentData: ((String) async -> Data?)?
     let loadTranscriptMediaImage: ((TranscriptMediaReference) async -> Data?)?
+    let transcriptMediaCacheNamespace: String
     let localAttachmentPreviews: [String: Data]?
     let onPreviewAttachment: ((MessageAttachment, Data?) -> Void)?
     let onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)?
@@ -21,6 +22,7 @@ struct MessageBubbleView: View {
         loadAttachmentImage: ((String) async -> Data?)? = nil,
         loadAttachmentData: ((String) async -> Data?)? = nil,
         loadTranscriptMediaImage: ((TranscriptMediaReference) async -> Data?)? = nil,
+        transcriptMediaCacheNamespace: String = "",
         localAttachmentPreviews: [String: Data]? = nil,
         onPreviewAttachment: ((MessageAttachment, Data?) -> Void)? = nil,
         onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)? = nil,
@@ -30,6 +32,7 @@ struct MessageBubbleView: View {
         self.loadAttachmentImage = loadAttachmentImage
         self.loadAttachmentData = loadAttachmentData
         self.loadTranscriptMediaImage = loadTranscriptMediaImage
+        self.transcriptMediaCacheNamespace = transcriptMediaCacheNamespace
         self.localAttachmentPreviews = localAttachmentPreviews
         self.onPreviewAttachment = onPreviewAttachment
         self.onPreviewTranscriptMedia = onPreviewTranscriptMedia
@@ -84,6 +87,7 @@ struct MessageBubbleView: View {
             if segments.containsTranscriptMedia {
                 TranscriptMediaContentView(
                     segments: segments,
+                    cacheNamespace: transcriptMediaCacheNamespace,
                     loadMediaImage: loadTranscriptMediaImage,
                     onPreviewMedia: onPreviewTranscriptMedia,
                     isStreaming: isStreaming

--- a/HermesMobile/Features/Chat/TranscriptMediaDataLoader.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaDataLoader.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 extension APIClient {
-    func transcriptMediaData(for reference: TranscriptMediaReference) async throws -> Data {
+    func transcriptMediaData(for reference: TranscriptMediaReference, sessionID: String) async throws -> Data {
         switch reference.source {
         case let .localPath(path):
-            return try await mediaData(path: path)
+            return try await mediaData(sessionID: sessionID, path: path)
         case let .remoteURL(url):
             return try await remoteTranscriptMediaData(from: url)
         }

--- a/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
@@ -4,10 +4,11 @@ import SwiftUI
 @MainActor
 @Observable
 final class TranscriptMediaPreviewViewModel {
-    private let sessionID: String
+    private let sessionID: String?
     private let reference: TranscriptMediaReference
     private let apiClient: APIClient
     private var didLoad = false
+    private var loadGeneration = 0
     private var originalData: Data?
 
     private(set) var previewData: Data?
@@ -18,7 +19,7 @@ final class TranscriptMediaPreviewViewModel {
 
     init(
         server: URL,
-        sessionID: String,
+        sessionID: String?,
         reference: TranscriptMediaReference,
         apiClient: APIClient? = nil
     ) {
@@ -33,9 +34,12 @@ final class TranscriptMediaPreviewViewModel {
 
     func load(force: Bool = false) async {
         guard force || !didLoad else { return }
+        loadGeneration += 1
+        let generation = loadGeneration
         didLoad = true
         previewData = nil
         originalByteCount = nil
+        originalData = nil
 
         guard reference.isRasterImageCandidate else {
             errorMessage = String(localized: "Preview is not available for this media type.")
@@ -46,22 +50,28 @@ final class TranscriptMediaPreviewViewModel {
         errorMessage = nil
         lastError = nil
         defer {
-            isLoading = false
+            if loadGeneration == generation {
+                isLoading = false
+            }
         }
 
         do {
-            let data = try await apiClient.transcriptMediaData(for: reference, sessionID: sessionID)
+            let data = try await transcriptMediaData()
+            guard !Task.isCancelled, loadGeneration == generation else { return }
             originalData = data
             originalByteCount = data.count
             if let downsampled = await ImagePreviewDownsampler.previewDataAsync(
                 from: data,
                 maxPixelSize: ImagePreviewDownsampler.filePreviewMaxPixelSize
             ) {
+                guard !Task.isCancelled, loadGeneration == generation else { return }
                 previewData = downsampled
             } else {
+                guard !Task.isCancelled, loadGeneration == generation else { return }
                 errorMessage = String(localized: "Could not decode this image.")
             }
         } catch {
+            guard !Task.isCancelled, loadGeneration == generation else { return }
             lastError = error
             errorMessage = error.localizedDescription
         }
@@ -72,9 +82,39 @@ final class TranscriptMediaPreviewViewModel {
             return originalData
         }
 
-        let data = try await apiClient.transcriptMediaData(for: reference, sessionID: sessionID)
+        let data = try await transcriptMediaData()
+        try Task.checkCancellation()
         originalData = data
         originalByteCount = data.count
         return data
+    }
+
+    private func transcriptMediaData() async throws -> Data {
+        switch reference.source {
+        case .localPath:
+            guard let sessionID = resolvedSessionID else {
+                throw TranscriptMediaPreviewError.missingSessionID
+            }
+            return try await apiClient.transcriptMediaData(for: reference, sessionID: sessionID)
+        case .remoteURL:
+            return try await apiClient.transcriptMediaData(for: reference, sessionID: resolvedSessionID ?? "")
+        }
+    }
+
+    private var resolvedSessionID: String? {
+        guard let sessionID = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionID.isEmpty
+        else {
+            return nil
+        }
+        return sessionID
+    }
+}
+
+private enum TranscriptMediaPreviewError: LocalizedError {
+    case missingSessionID
+
+    var errorDescription: String? {
+        String(localized: "Preview is not available for this media without a server session.")
     }
 }

--- a/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @MainActor
 @Observable
 final class TranscriptMediaPreviewViewModel {
+    private let sessionID: String
     private let reference: TranscriptMediaReference
     private let apiClient: APIClient
     private var didLoad = false
@@ -15,7 +16,13 @@ final class TranscriptMediaPreviewViewModel {
     private(set) var errorMessage: String?
     private(set) var lastError: Error?
 
-    init(server: URL, reference: TranscriptMediaReference, apiClient: APIClient? = nil) {
+    init(
+        server: URL,
+        sessionID: String,
+        reference: TranscriptMediaReference,
+        apiClient: APIClient? = nil
+    ) {
+        self.sessionID = sessionID
         self.reference = reference
         self.apiClient = apiClient ?? APIClient(baseURL: server)
     }
@@ -43,7 +50,7 @@ final class TranscriptMediaPreviewViewModel {
         }
 
         do {
-            let data = try await apiClient.transcriptMediaData(for: reference)
+            let data = try await apiClient.transcriptMediaData(for: reference, sessionID: sessionID)
             originalData = data
             originalByteCount = data.count
             if let downsampled = await ImagePreviewDownsampler.previewDataAsync(
@@ -65,7 +72,7 @@ final class TranscriptMediaPreviewViewModel {
             return originalData
         }
 
-        let data = try await apiClient.transcriptMediaData(for: reference)
+        let data = try await apiClient.transcriptMediaData(for: reference, sessionID: sessionID)
         originalData = data
         originalByteCount = data.count
         return data

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -11,17 +11,20 @@ struct TranscriptMediaPreviewItem: Identifiable, Equatable {
 
 struct TranscriptMediaContentView: View {
     let segments: [TranscriptMediaSegment]
+    let cacheNamespace: String
     let loadMediaImage: ((TranscriptMediaReference) async -> Data?)?
     let onPreviewMedia: ((TranscriptMediaReference) -> Void)?
     let isStreaming: Bool
 
     init(
         segments: [TranscriptMediaSegment],
+        cacheNamespace: String,
         loadMediaImage: ((TranscriptMediaReference) async -> Data?)?,
         onPreviewMedia: ((TranscriptMediaReference) -> Void)?,
         isStreaming: Bool = false
     ) {
         self.segments = segments
+        self.cacheNamespace = cacheNamespace
         self.loadMediaImage = loadMediaImage
         self.onPreviewMedia = onPreviewMedia
         self.isStreaming = isStreaming
@@ -38,6 +41,7 @@ struct TranscriptMediaContentView: View {
                 case let .media(reference):
                     TranscriptMediaThumbnailView(
                         reference: reference,
+                        cacheNamespace: cacheNamespace,
                         loadMediaImage: loadMediaImage,
                         onPreviewMedia: onPreviewMedia
                     )
@@ -53,6 +57,7 @@ struct TranscriptMediaContentView: View {
 
 private struct TranscriptMediaThumbnailView: View {
     let reference: TranscriptMediaReference
+    let cacheNamespace: String
     let loadMediaImage: ((TranscriptMediaReference) async -> Data?)?
     let onPreviewMedia: ((TranscriptMediaReference) -> Void)?
 
@@ -74,6 +79,7 @@ private struct TranscriptMediaThumbnailView: View {
             .task(id: reference.id) {
                 let loadedImage = await TranscriptMediaImageCache.shared.image(
                     for: reference,
+                    cacheNamespace: cacheNamespace,
                     loadMediaImage: loadMediaImage
                 )
                 guard !Task.isCancelled else { return }
@@ -157,14 +163,15 @@ private struct TranscriptMediaUnavailableChip: View {
 private actor TranscriptMediaImageCache {
     static let shared = TranscriptMediaImageCache()
 
-    private var cache: [String: UIImage] = [:]
-    private var inFlight: [String: Task<UIImage?, Never>] = [:]
+    private var cache: [TranscriptMediaImageCacheKey: UIImage] = [:]
+    private var inFlight: [TranscriptMediaImageCacheKey: Task<UIImage?, Never>] = [:]
 
     func image(
         for reference: TranscriptMediaReference,
+        cacheNamespace: String,
         loadMediaImage: @escaping (TranscriptMediaReference) async -> Data?
     ) async -> UIImage? {
-        let key = reference.id
+        let key = TranscriptMediaImageCacheKey(namespace: cacheNamespace, reference: reference)
         if let cached = cache[key] {
             return cached
         }
@@ -188,6 +195,16 @@ private actor TranscriptMediaImageCache {
             cache[key] = image
         }
         return image
+    }
+}
+
+struct TranscriptMediaImageCacheKey: Hashable {
+    let namespace: String
+    let referenceID: String
+
+    init(namespace: String, reference: TranscriptMediaReference) {
+        self.namespace = namespace
+        referenceID = reference.id
     }
 }
 

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -201,10 +201,21 @@ struct TranscriptMediaPreviewView: View {
     @State private var errorMessage: String?
     @Environment(\.dismiss) private var dismiss
 
-    init(server: URL, item: TranscriptMediaPreviewItem, onAPIError: @escaping (Error) -> Void) {
+    init(
+        server: URL,
+        sessionID: String,
+        item: TranscriptMediaPreviewItem,
+        onAPIError: @escaping (Error) -> Void
+    ) {
         self.item = item
         self.onAPIError = onAPIError
-        _viewModel = State(initialValue: TranscriptMediaPreviewViewModel(server: server, reference: item.reference))
+        _viewModel = State(
+            initialValue: TranscriptMediaPreviewViewModel(
+                server: server,
+                sessionID: sessionID,
+                reference: item.reference
+            )
+        )
     }
 
     var body: some View {

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -76,7 +76,9 @@ private struct TranscriptMediaThumbnailView: View {
             }
             .buttonStyle(.chatTactile(.thumbnail))
             .accessibilityLabel(String(localized: "Open media image \(reference.displayName)"))
-            .task(id: reference.id) {
+            .task(id: imageCacheKey) {
+                image = nil
+                didAttemptLoad = false
                 let loadedImage = await TranscriptMediaImageCache.shared.image(
                     for: reference,
                     cacheNamespace: cacheNamespace,
@@ -91,6 +93,10 @@ private struct TranscriptMediaThumbnailView: View {
         } else {
             TranscriptMediaUnavailableChip(reference: reference)
         }
+    }
+
+    private var imageCacheKey: TranscriptMediaImageCacheKey {
+        TranscriptMediaImageCacheKey(namespace: cacheNamespace, reference: reference)
     }
 
     @ViewBuilder
@@ -220,7 +226,7 @@ struct TranscriptMediaPreviewView: View {
 
     init(
         server: URL,
-        sessionID: String,
+        sessionID: String?,
         item: TranscriptMediaPreviewItem,
         onAPIError: @escaping (Error) -> Void
     ) {

--- a/HermesMobile/Networking/APIClient+Workspace.swift
+++ b/HermesMobile/Networking/APIClient+Workspace.swift
@@ -56,8 +56,8 @@ extension APIClient {
         try await sendData(endpoint: .rawFile(sessionID: sessionID, path: path), method: "GET")
     }
 
-    func mediaData(path: String) async throws -> Data {
-        try await sendData(endpoint: .media(path: path), method: "GET")
+    func mediaData(sessionID: String, path: String) async throws -> Data {
+        try await sendData(endpoint: .media(sessionID: sessionID, path: path), method: "GET")
     }
 
     func remoteTranscriptMediaData(from url: URL) async throws -> Data {

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -51,7 +51,7 @@ enum Endpoint {
     case directoryList(sessionID: String, path: String?)
     case file(sessionID: String, path: String)
     case rawFile(sessionID: String, path: String)
-    case media(path: String)
+    case media(sessionID: String, path: String)
     case gitInfo(sessionID: String)
     case gitStatus(sessionID: String)
     case gitBranches(sessionID: String)
@@ -384,8 +384,11 @@ enum Endpoint {
                 URLQueryItem(name: "session_id", value: sessionID),
                 URLQueryItem(name: "path", value: path)
             ]
-        case let .media(path):
-            return [URLQueryItem(name: "path", value: path)]
+        case let .media(sessionID, path):
+            return [
+                URLQueryItem(name: "session_id", value: sessionID),
+                URLQueryItem(name: "path", value: path)
+            ]
         case let .gitInfo(sessionID),
             let .gitStatus(sessionID),
             let .gitBranches(sessionID):

--- a/HermesMobileTests/APIClientWorkspaceFileTests.swift
+++ b/HermesMobileTests/APIClientWorkspaceFileTests.swift
@@ -517,12 +517,14 @@ final class APIClientWorkspaceFileTests: APIClientTestCase {
     func testMediaDataBuildsExpectedQueryAndReturnsBytes() async throws {
         let expectedData = Data([0x89, 0x50, 0x4E, 0x47])
         let mediaPath = "/Users/hermes/.hermes/browser_screenshots/result image.png"
+        let sessionID = "abc123"
         let client = makeClient { request in
             XCTAssertEqual(request.httpMethod, "GET")
             XCTAssertEqual(request.url?.path, "/api/media")
 
             let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
             let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            XCTAssertEqual(query["session_id"], sessionID)
             XCTAssertEqual(query["path"], mediaPath)
 
             let response = HTTPURLResponse(
@@ -534,7 +536,7 @@ final class APIClientWorkspaceFileTests: APIClientTestCase {
             return (try XCTUnwrap(response), expectedData)
         }
 
-        let response = try await client.mediaData(path: mediaPath)
+        let response = try await client.mediaData(sessionID: sessionID, path: mediaPath)
 
         XCTAssertEqual(response, expectedData)
     }

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -185,9 +185,9 @@ final class ContractReadinessTests: XCTestCase {
             .init(
                 name: "media",
                 method: "GET",
-                endpoint: .media(path: "Assets/icon.png"),
+                endpoint: .media(sessionID: "session-123", path: "Assets/icon.png"),
                 path: "/api/media",
-                query: ["path": "Assets/icon.png"]
+                query: ["session_id": "session-123", "path": "Assets/icon.png"]
             ),
             .init(name: "models", method: "GET", endpoint: .models, path: "/api/models"),
             .init(name: "models live", method: "GET", endpoint: .modelsLive, path: "/api/models/live"),

--- a/HermesMobileTests/ChatAttachmentCoordinatorTests.swift
+++ b/HermesMobileTests/ChatAttachmentCoordinatorTests.swift
@@ -195,6 +195,36 @@ final class ChatAttachmentCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(thumbnail, mediaData)
     }
 
+    func testTranscriptLocalMediaIncludesSessionIDOnMediaEndpoint() async throws {
+        let mediaData = try XCTUnwrap(Self.imageData())
+        let mediaPath = "/Users/hermes/.hermes/browser_screenshots/example.png"
+        let sessionID = "session-abc"
+        let client = makeAuthenticatedMediaClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/media")
+
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            XCTAssertEqual(query["session_id"], sessionID)
+            XCTAssertEqual(query["path"], mediaPath)
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, mediaData)
+        }
+        let coordinator = makeCoordinator(client: client)
+
+        let thumbnail = await coordinator.transcriptMediaThumbnailData(
+            for: TranscriptMediaReference(rawReference: mediaPath)
+        )
+
+        XCTAssertNotNil(thumbnail)
+    }
+
     private func makeCoordinator(client: APIClient) -> ChatAttachmentCoordinator {
         let coordinator = ChatAttachmentCoordinator(client: client)
         let delegate = ChatAttachmentCoordinatorDelegateSpy()

--- a/HermesMobileTests/TranscriptMediaParserTests.swift
+++ b/HermesMobileTests/TranscriptMediaParserTests.swift
@@ -99,6 +99,26 @@ final class TranscriptMediaParserTests: XCTestCase {
         XCTAssertEqual(TranscriptMediaReference(rawReference: "").displayName, "Media")
     }
 
+    func testImageCacheKeySeparatesSameReferenceAcrossSessions() {
+        let reference = TranscriptMediaReference(rawReference: "/tmp/result.png")
+
+        let firstSessionKey = TranscriptMediaImageCacheKey(
+            namespace: "https://one.example.test|session-a",
+            reference: reference
+        )
+        let secondSessionKey = TranscriptMediaImageCacheKey(
+            namespace: "https://one.example.test|session-b",
+            reference: reference
+        )
+        let secondServerKey = TranscriptMediaImageCacheKey(
+            namespace: "https://two.example.test|session-a",
+            reference: reference
+        )
+
+        XCTAssertNotEqual(firstSessionKey, secondSessionKey)
+        XCTAssertNotEqual(firstSessionKey, secondServerKey)
+    }
+
     private func mediaReferences(in segments: [TranscriptMediaSegment]) -> [TranscriptMediaReference] {
         segments.compactMap { segment in
             if case let .media(reference) = segment {

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -13,6 +13,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         let recorder = TranscriptMediaPreviewRequestRecorder()
         let imageData = try XCTUnwrap(Self.imageData())
         let mediaPath = "/Users/hermes/.hermes/browser_screenshots/example.png"
+        let sessionID = "session-123"
         let client = makeClient { request in
             recorder.record(request)
             XCTAssertEqual(request.httpMethod, "GET")
@@ -21,6 +22,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         }
         let viewModel = TranscriptMediaPreviewViewModel(
             server: Self.baseURL,
+            sessionID: sessionID,
             reference: .init(rawReference: mediaPath),
             apiClient: client
         )
@@ -35,6 +37,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.canSaveImageToPhotos)
 
         let queryItems = queryItems(for: try XCTUnwrap(recorder.firstURL))
+        XCTAssertEqual(queryItems["session_id"], sessionID)
         XCTAssertEqual(queryItems["path"], mediaPath)
 
         let originalData = try await viewModel.originalImageData()
@@ -57,6 +60,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         }
         let viewModel = TranscriptMediaPreviewViewModel(
             server: Self.baseURL,
+            sessionID: "session-123",
             reference: .init(rawReference: remoteURL.absoluteString),
             apiClient: client
         )
@@ -88,6 +92,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         }
         let viewModel = TranscriptMediaPreviewViewModel(
             server: Self.baseURL,
+            sessionID: "session-123",
             reference: .init(rawReference: externalURL.absoluteString),
             apiClient: client
         )
@@ -108,6 +113,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         }
         let viewModel = TranscriptMediaPreviewViewModel(
             server: Self.baseURL,
+            sessionID: "session-123",
             reference: .init(rawReference: "/tmp/vector.svg"),
             apiClient: client
         )
@@ -128,6 +134,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         }
         let viewModel = TranscriptMediaPreviewViewModel(
             server: Self.baseURL,
+            sessionID: "session-123",
             reference: .init(rawReference: "/tmp/forbidden.png"),
             apiClient: client
         )

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -128,6 +128,28 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(recorder.requestCount, 0)
     }
 
+    func testLoadLocalImageWithoutSessionIDDoesNotRequestMediaEndpoint() async {
+        let recorder = TranscriptMediaPreviewRequestRecorder()
+        let client = makeClient { request in
+            recorder.record(request)
+            return self.response(statusCode: 200, data: Data(), for: request)
+        }
+        let viewModel = TranscriptMediaPreviewViewModel(
+            server: Self.baseURL,
+            sessionID: nil,
+            reference: .init(rawReference: "/tmp/generated.png"),
+            apiClient: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.previewData)
+        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertNotNil(viewModel.lastError)
+        XCTAssertEqual(recorder.requestCount, 0)
+    }
+
     func testMediaEndpointErrorIsCaptured() async {
         let client = makeClient { request in
             self.response(statusCode: 403, data: Data("forbidden".utf8), for: request)


### PR DESCRIPTION
## Summary

Fixes #70.

This updates transcript `MEDIA:` image loading so Hermex includes the active `session_id` when fetching local-path `/api/media` resources for inline thumbnails and full-screen preview. It matches hermes-webui's session-scoped media authorization for assistant-emitted media paths.

The branch also scopes the transcript media thumbnail cache by server and session, so identical raw `MEDIA:` paths cannot reuse thumbnails across sessions and bypass the new session-aware fetch path.

## Root Cause

Local-path transcript media was fetched as `GET /api/media?path=...` without `session_id`. Upstream `_handle_media` can authorize assistant-emitted `MEDIA:` paths through `_session_media_token_allows_path(...)`, but that path requires the requesting session id.

## Validation

- Owner manual validation passed before publish: agent-sent PNG inline thumbnail and tap-to-preview over Tailscale no longer showed “Media unavailable” or HTTP 403.
- `git diff --check`
- Focused media/parser tests passed, including `TranscriptMediaParserTests.testImageCacheKeySeparatesSameReferenceAcrossSessions`.
- Full XCTest suite passed:
  `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`

## AI Usage

Built with Codex.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes transcript media fetches session-aware. The main changes are:

- Adds `session_id` to local `/api/media` requests.
- Passes session identity into transcript thumbnails and previews.
- Scopes transcript media thumbnail cache keys by server and session.
- Updates focused API, parser, coordinator, and preview tests.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The transcript media path needs fixes around namespace reloads and missing real session ids before merging.

- Endpoint construction now matches the intended session-scoped media request.
- Thumbnail UI state can survive a namespace change and display stale media.
- Preview requests can use a fallback id that the server may not recognize for media authorization.

HermesMobile/Features/Chat/TranscriptMediaView.swift and HermesMobile/Features/Chat/ChatView.swift
</details>

<details open><summary><h3>Security Review</h3></summary>

The PR improves media authorization by adding session-scoped requests and cache keys. The thumbnail view can still retain a previous session's media when the namespace changes but the raw `MEDIA:` path stays the same.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| HermesMobile/Features/Chat/TranscriptMediaView.swift | Adds namespace-aware cache keys and session-aware preview setup, but the thumbnail task lifecycle still only tracks the raw media reference. |
| HermesMobile/Features/Chat/ChatView.swift | Passes session identity into transcript media preview and cache namespace construction, with a fallback that can be unsuitable for media authorization. |
| HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift | Requires a delegate session id before loading transcript media thumbnails and forwards it to the media data loader. |
| HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift | Stores the session id and uses it for both preview loading and original image loading. |
| HermesMobile/Networking/Endpoints.swift | Adds `session_id` to the media endpoint query alongside the requested path. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Transcript as Transcript MEDIA item
    participant Thumb as Thumbnail view
    participant Cache as Namespace cache
    participant API as /api/media
    Transcript->>Thumb: reference + cacheNamespace
    Thumb->>Cache: lookup(namespace, reference)
    Cache->>API: GET path + session_id
    API-->>Cache: image bytes
    Cache-->>Thumb: UIImage
    Thumb-->>Transcript: render thumbnail
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Transcript as Transcript MEDIA item
    participant Thumb as Thumbnail view
    participant Cache as Namespace cache
    participant API as /api/media
    Transcript->>Thumb: reference + cacheNamespace
    Thumb->>Cache: lookup(namespace, reference)
    Cache->>API: GET path + session_id
    API-->>Cache: image bytes
    Cache-->>Thumb: UIImage
    Thumb-->>Transcript: render thumbnail
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AHermesMobile%2FFeatures%2FChat%2FTranscriptMediaView.swift%3A79%0A**Namespace%20Changes%20Skip%20Reload**%0A%0AWhen%20the%20same%20raw%20%60MEDIA%3A%60%20path%20appears%20after%20switching%20server%20or%20session%2C%20the%20cache%20key%20changes%20but%20this%20task%20id%20does%20not.%20SwiftUI%20can%20keep%20the%20thumbnail's%20%60image%60%20or%20%60didAttemptLoad%60%20state%20for%20the%20reused%20segment%2C%20so%20the%20row%20can%20keep%20showing%20the%20previous%20session's%20image%20or%20a%20stale%20unavailable%20chip%20without%20reading%20the%20new%20namespace-scoped%20cache.%0A%0A%23%23%23%20Issue%202%20of%202%0AHermesMobile%2FFeatures%2FChat%2FChatView.swift%3A500%0A**Synthetic%20Session%20Sent%20To%20Media**%0A%0AWhen%20%60session.sessionId%60%20is%20absent%2C%20this%20sends%20%60session.id%60%20as%20the%20%60%2Fapi%2Fmedia%60%20%60session_id%60.%20That%20fallback%20can%20be%20a%20local%20or%20synthetic%20identifier%20instead%20of%20the%20server%20session%20id%20required%20by%20media%20authorization%2C%20so%20tapping%20a%20local%20transcript%20%60MEDIA%3A%60%20item%20can%20open%20the%20preview%20sheet%20and%20then%20fail%20with%20a%20rejected%20media%20request.%0A%0A&repo=uzairansaruzi%2Fhermex&pr=86&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22uzairansaruzi%2Fhermex%22%20on%20the%20existing%20branch%20%22issue%2F70-media-session-id%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22issue%2F70-media-session-id%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AHermesMobile%2FFeatures%2FChat%2FTranscriptMediaView.swift%3A79%0A**Namespace%20Changes%20Skip%20Reload**%0A%0AWhen%20the%20same%20raw%20%60MEDIA%3A%60%20path%20appears%20after%20switching%20server%20or%20session%2C%20the%20cache%20key%20changes%20but%20this%20task%20id%20does%20not.%20SwiftUI%20can%20keep%20the%20thumbnail's%20%60image%60%20or%20%60didAttemptLoad%60%20state%20for%20the%20reused%20segment%2C%20so%20the%20row%20can%20keep%20showing%20the%20previous%20session's%20image%20or%20a%20stale%20unavailable%20chip%20without%20reading%20the%20new%20namespace-scoped%20cache.%0A%0A%23%23%23%20Issue%202%20of%202%0AHermesMobile%2FFeatures%2FChat%2FChatView.swift%3A500%0A**Synthetic%20Session%20Sent%20To%20Media**%0A%0AWhen%20%60session.sessionId%60%20is%20absent%2C%20this%20sends%20%60session.id%60%20as%20the%20%60%2Fapi%2Fmedia%60%20%60session_id%60.%20That%20fallback%20can%20be%20a%20local%20or%20synthetic%20identifier%20instead%20of%20the%20server%20session%20id%20required%20by%20media%20authorization%2C%20so%20tapping%20a%20local%20transcript%20%60MEDIA%3A%60%20item%20can%20open%20the%20preview%20sheet%20and%20then%20fail%20with%20a%20rejected%20media%20request.%0A%0A&repo=uzairansaruzi%2Fhermex&pr=86&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AHermesMobile%2FFeatures%2FChat%2FTranscriptMediaView.swift%3A79%0A**Namespace%20Changes%20Skip%20Reload**%0A%0AWhen%20the%20same%20raw%20%60MEDIA%3A%60%20path%20appears%20after%20switching%20server%20or%20session%2C%20the%20cache%20key%20changes%20but%20this%20task%20id%20does%20not.%20SwiftUI%20can%20keep%20the%20thumbnail's%20%60image%60%20or%20%60didAttemptLoad%60%20state%20for%20the%20reused%20segment%2C%20so%20the%20row%20can%20keep%20showing%20the%20previous%20session's%20image%20or%20a%20stale%20unavailable%20chip%20without%20reading%20the%20new%20namespace-scoped%20cache.%0A%0A%23%23%23%20Issue%202%20of%202%0AHermesMobile%2FFeatures%2FChat%2FChatView.swift%3A500%0A**Synthetic%20Session%20Sent%20To%20Media**%0A%0AWhen%20%60session.sessionId%60%20is%20absent%2C%20this%20sends%20%60session.id%60%20as%20the%20%60%2Fapi%2Fmedia%60%20%60session_id%60.%20That%20fallback%20can%20be%20a%20local%20or%20synthetic%20identifier%20instead%20of%20the%20server%20session%20id%20required%20by%20media%20authorization%2C%20so%20tapping%20a%20local%20transcript%20%60MEDIA%3A%60%20item%20can%20open%20the%20preview%20sheet%20and%20then%20fail%20with%20a%20rejected%20media%20request.%0A%0A&pr=86&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(chat): scope transcript media thumbn..."](https://github.com/uzairansaruzi/hermex/commit/d71817271f28a65e9fa9caf26c18482cf7908d34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42573939)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->