### PR TITLE
Support audio and video transcript MEDIA previews

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		C0DE34000000000000000006 /* TranscriptMediaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000005 /* TranscriptMediaView.swift */; };
 		C0DE34000000000000000008 /* TranscriptMediaPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */; };
 		C0DE34000000000000000009 /* TranscriptMediaDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */; };
+		C0DE3400000000000000000D /* TranscriptMediaExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */; };
 		C0DE12000000000000000001 /* TranscriptLinkPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000002 /* TranscriptLinkPreview.swift */; };
 		C0DE12000000000000000007 /* TranscriptLinkPreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000008 /* TranscriptLinkPreviewCache.swift */; };
 		C0DE12000000000000000005 /* TranscriptLinkPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000006 /* TranscriptLinkPreviewView.swift */; };
@@ -460,6 +461,7 @@
 		C0DE34000000000000000005 /* TranscriptMediaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaView.swift; sourceTree = "<group>"; };
 		C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaPreviewViewModel.swift; sourceTree = "<group>"; };
 		C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaDataLoader.swift; sourceTree = "<group>"; };
+		C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaExportSupport.swift; sourceTree = "<group>"; };
 		C0DE12000000000000000002 /* TranscriptLinkPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreview.swift; sourceTree = "<group>"; };
 		C0DE12000000000000000008 /* TranscriptLinkPreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewCache.swift; sourceTree = "<group>"; };
 		C0DE12000000000000000006 /* TranscriptLinkPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewView.swift; sourceTree = "<group>"; };
@@ -975,6 +977,7 @@
 				C0DE34000000000000000005 /* TranscriptMediaView.swift */,
 				C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */,
 				C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */,
+				C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */,
 				C0DE12000000000000000002 /* TranscriptLinkPreview.swift */,
 				C0DE12000000000000000008 /* TranscriptLinkPreviewCache.swift */,
 				C0DE12000000000000000006 /* TranscriptLinkPreviewView.swift */,
@@ -1477,6 +1480,7 @@
 				C0DE34000000000000000006 /* TranscriptMediaView.swift in Sources */,
 				C0DE34000000000000000008 /* TranscriptMediaPreviewViewModel.swift in Sources */,
 				C0DE34000000000000000009 /* TranscriptMediaDataLoader.swift in Sources */,
+				C0DE3400000000000000000D /* TranscriptMediaExportSupport.swift in Sources */,
 				C0DE12000000000000000001 /* TranscriptLinkPreview.swift in Sources */,
 				C0DE12000000000000000007 /* TranscriptLinkPreviewCache.swift in Sources */,
 				C0DE12000000000000000005 /* TranscriptLinkPreviewView.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
@@ -168,6 +168,18 @@ final class ChatAttachmentCoordinator {
         }
     }
 
+    /// Raw transcript media bytes for inline audio/video playback. Local paths
+    /// still require a real session ID so `/api/media` can authorize session media.
+    func transcriptMediaData(for reference: TranscriptMediaReference) async -> Data? {
+        guard let sessionID = delegate?.attachmentSessionID else { return nil }
+
+        do {
+            return try await client.transcriptMediaData(for: reference, sessionID: sessionID)
+        } catch {
+            return nil
+        }
+    }
+
     func prepareForSend(localMessageID: String) -> ChatAttachmentSendPreparation {
         let attachmentsForSend = pendingAttachments
         let messageAttachments = attachmentsForSend.map { pending in

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -47,6 +47,7 @@ struct ChatTranscriptView: View {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let loadTranscriptMediaData: (TranscriptMediaReference) async -> Data?
     let transcriptMediaCacheNamespace: String
     let actionContext: (ChatMessage, Int) -> MessageActionContext?
     let shouldRenderMessageRow: (ChatMessage) -> Bool
@@ -234,6 +235,7 @@ struct ChatTranscriptView: View {
                     loadAttachmentImage: loadAttachmentImage,
                     loadAttachmentData: loadAttachmentData,
                     loadTranscriptMediaImage: loadTranscriptMediaImage,
+                    loadTranscriptMediaData: loadTranscriptMediaData,
                     transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
                     actionContext: actionContext,
                     shouldRenderMessageRow: shouldRenderMessageRow,
@@ -454,6 +456,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let loadTranscriptMediaData: (TranscriptMediaReference) async -> Data?
     let transcriptMediaCacheNamespace: String
     let actionContext: (ChatMessage, Int) -> MessageActionContext?
     let shouldRenderMessageRow: (ChatMessage) -> Bool
@@ -520,6 +523,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                     loadAttachmentImage: loadAttachmentImage,
                     loadAttachmentData: loadAttachmentData,
                     loadTranscriptMediaImage: loadTranscriptMediaImage,
+                    loadTranscriptMediaData: loadTranscriptMediaData,
                     transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
                     onPreviewAttachment: onPreviewAttachment,
                     onPreviewTranscriptMedia: onPreviewTranscriptMedia,
@@ -601,6 +605,7 @@ private struct ChatTranscriptMessageRow: View {
     let loadAttachmentImage: (String) async -> Data?
     let loadAttachmentData: (String) async -> Data?
     let loadTranscriptMediaImage: (TranscriptMediaReference) async -> Data?
+    let loadTranscriptMediaData: (TranscriptMediaReference) async -> Data?
     let transcriptMediaCacheNamespace: String
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
     let onPreviewTranscriptMedia: (TranscriptMediaReference) -> Void
@@ -647,6 +652,7 @@ private struct ChatTranscriptMessageRow: View {
             loadAttachmentImage: loadAttachmentImage,
             loadAttachmentData: loadAttachmentData,
             loadTranscriptMediaImage: loadTranscriptMediaImage,
+            loadTranscriptMediaData: loadTranscriptMediaData,
             transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
             localAttachmentPreviews: localAttachmentPreviews,
             onPreviewAttachment: onPreviewAttachment,

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1135,6 +1135,9 @@ struct ChatView: View {
             loadTranscriptMediaImage: { reference in
                 await viewModel.transcriptMediaThumbnailData(for: reference)
             },
+            loadTranscriptMediaData: { reference in
+                await viewModel.transcriptMediaData(for: reference)
+            },
             transcriptMediaCacheNamespace: transcriptMediaCacheNamespace,
             actionContext: { message, visibleIndex in
                 viewModel.actionContext(for: message, visibleIndex: visibleIndex)

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -1138,6 +1138,10 @@ final class ChatViewModel {
         await attachmentCoordinator.transcriptMediaThumbnailData(for: reference)
     }
 
+    func transcriptMediaData(for reference: TranscriptMediaReference) async -> Data? {
+        await attachmentCoordinator.transcriptMediaData(for: reference)
+    }
+
     func loadMessages(modelContext: ModelContext? = nil) async {
         guard let sessionID else {
             errorMessage = String(localized: "The server did not provide a session ID.")

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -11,6 +11,7 @@ struct MessageBubbleView: View {
     let loadAttachmentImage: ((String) async -> Data?)?
     let loadAttachmentData: ((String) async -> Data?)?
     let loadTranscriptMediaImage: ((TranscriptMediaReference) async -> Data?)?
+    let loadTranscriptMediaData: ((TranscriptMediaReference) async -> Data?)?
     let transcriptMediaCacheNamespace: String
     let localAttachmentPreviews: [String: Data]?
     let onPreviewAttachment: ((MessageAttachment, Data?) -> Void)?
@@ -22,6 +23,7 @@ struct MessageBubbleView: View {
         loadAttachmentImage: ((String) async -> Data?)? = nil,
         loadAttachmentData: ((String) async -> Data?)? = nil,
         loadTranscriptMediaImage: ((TranscriptMediaReference) async -> Data?)? = nil,
+        loadTranscriptMediaData: ((TranscriptMediaReference) async -> Data?)? = nil,
         transcriptMediaCacheNamespace: String = "",
         localAttachmentPreviews: [String: Data]? = nil,
         onPreviewAttachment: ((MessageAttachment, Data?) -> Void)? = nil,
@@ -32,6 +34,7 @@ struct MessageBubbleView: View {
         self.loadAttachmentImage = loadAttachmentImage
         self.loadAttachmentData = loadAttachmentData
         self.loadTranscriptMediaImage = loadTranscriptMediaImage
+        self.loadTranscriptMediaData = loadTranscriptMediaData
         self.transcriptMediaCacheNamespace = transcriptMediaCacheNamespace
         self.localAttachmentPreviews = localAttachmentPreviews
         self.onPreviewAttachment = onPreviewAttachment
@@ -89,6 +92,7 @@ struct MessageBubbleView: View {
                     segments: segments,
                     cacheNamespace: transcriptMediaCacheNamespace,
                     loadMediaImage: loadTranscriptMediaImage,
+                    loadMediaData: loadTranscriptMediaData,
                     onPreviewMedia: onPreviewTranscriptMedia,
                     isStreaming: isStreaming
                 )

--- a/HermesMobile/Features/Chat/TranscriptMedia.swift
+++ b/HermesMobile/Features/Chat/TranscriptMedia.swift
@@ -5,6 +5,13 @@ enum TranscriptMediaSource: Equatable {
     case remoteURL(URL)
 }
 
+enum TranscriptMediaKind: Equatable {
+    case image
+    case audio
+    case video
+    case unsupported
+}
+
 struct TranscriptMediaReference: Equatable, Identifiable {
     let rawReference: String
 
@@ -38,17 +45,37 @@ struct TranscriptMediaReference: Equatable, Identifiable {
         }
     }
 
-    var isRasterImageCandidate: Bool {
+    var mediaKind: TranscriptMediaKind {
         let ext = pathExtension
         if Self.rasterImageExtensions.contains(ext) {
-            return true
+            return .image
+        }
+
+        if Self.audioExtensions.contains(ext) {
+            return .audio
+        }
+
+        if Self.videoExtensions.contains(ext) {
+            return .video
         }
 
         if case .remoteURL = source, ext.isEmpty {
-            return true
+            return .image
         }
 
-        return false
+        return .unsupported
+    }
+
+    var isRasterImageCandidate: Bool {
+        mediaKind == .image
+    }
+
+    var isAudioCandidate: Bool {
+        mediaKind == .audio
+    }
+
+    var isVideoCandidate: Bool {
+        mediaKind == .video
     }
 
     private var pathExtension: String {
@@ -62,6 +89,14 @@ struct TranscriptMediaReference: Equatable, Identifiable {
 
     private static let rasterImageExtensions: Set<String> = [
         "bmp", "gif", "heic", "heif", "ico", "jpg", "jpeg", "png", "tif", "tiff", "webp"
+    ]
+
+    private static let audioExtensions: Set<String> = [
+        "aac", "caf", "m4a", "mp3", "wav"
+    ]
+
+    private static let videoExtensions: Set<String> = [
+        "m4v", "mov", "mp4"
     ]
 }
 

--- a/HermesMobile/Features/Chat/TranscriptMedia.swift
+++ b/HermesMobile/Features/Chat/TranscriptMedia.swift
@@ -78,6 +78,13 @@ struct TranscriptMediaReference: Equatable, Identifiable {
         mediaKind == .video
     }
 
+    var isExtensionlessRemoteMediaCandidate: Bool {
+        if case .remoteURL = source, pathExtension.isEmpty {
+            return true
+        }
+        return false
+    }
+
     private var pathExtension: String {
         switch source {
         case let .remoteURL(url):

--- a/HermesMobile/Features/Chat/TranscriptMediaExportSupport.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaExportSupport.swift
@@ -1,0 +1,136 @@
+import AVFoundation
+import Foundation
+import UIKit
+import UniformTypeIdentifiers
+
+enum TranscriptMediaResolvedExportKind {
+    case image
+    case audio
+    case video
+    case data
+}
+
+enum TranscriptMediaExportSupport {
+    static func payload(
+        for reference: TranscriptMediaReference,
+        data: Data,
+        resolvedKind: TranscriptMediaResolvedExportKind? = nil
+    ) -> FileExportPayload {
+        let descriptor = exportDescriptor(for: reference, data: data, resolvedKind: resolvedKind)
+        return FileExportPayload(
+            data: data,
+            filename: exportFilename(for: reference, fileExtension: descriptor.fileExtension),
+            contentType: descriptor.contentType,
+            isImage: descriptor.kind == .image,
+            isVideo: descriptor.kind == .video
+        )
+    }
+
+    private static func exportDescriptor(
+        for reference: TranscriptMediaReference,
+        data: Data,
+        resolvedKind: TranscriptMediaResolvedExportKind?
+    ) -> TranscriptMediaExportDescriptor {
+        if let fileExtension = reference.exportFileExtension,
+           let contentType = UTType(filenameExtension: fileExtension) {
+            return TranscriptMediaExportDescriptor(
+                kind: exportKind(for: contentType),
+                contentType: contentType,
+                fileExtension: fileExtension
+            )
+        }
+
+        if resolvedKind == .image || UIImage(data: data) != nil {
+            return TranscriptMediaExportDescriptor(kind: .image, contentType: .png, fileExtension: "png")
+        }
+
+        if resolvedKind == .audio || isAudioData(data) {
+            let audioType = audioType(from: data) ?? (UTType(filenameExtension: "m4a") ?? .audio, "m4a")
+            return TranscriptMediaExportDescriptor(
+                kind: .audio,
+                contentType: audioType.contentType,
+                fileExtension: audioType.fileExtension
+            )
+        }
+
+        return TranscriptMediaExportDescriptor(kind: .video, contentType: .mpeg4Movie, fileExtension: "mp4")
+    }
+
+    private static func exportFilename(for reference: TranscriptMediaReference, fileExtension: String) -> String {
+        let baseName = reference.exportBaseName
+        guard URL(fileURLWithPath: baseName).pathExtension.isEmpty else {
+            return baseName
+        }
+
+        return "\(baseName).\(fileExtension)"
+    }
+
+    private static func exportKind(for contentType: UTType) -> TranscriptMediaResolvedExportKind {
+        if contentType.conforms(to: .image) {
+            return .image
+        }
+
+        if contentType.conforms(to: .audio) {
+            return .audio
+        }
+
+        if contentType.conforms(to: .movie) || contentType.conforms(to: .video) {
+            return .video
+        }
+
+        return .data
+    }
+
+    private static func isAudioData(_ data: Data) -> Bool {
+        (try? AVAudioPlayer(data: data)) != nil
+    }
+
+    private static func audioType(from data: Data) -> (contentType: UTType, fileExtension: String)? {
+        if data.starts(with: Array("RIFF".utf8)), data.dropFirst(8).starts(with: Array("WAVE".utf8)) {
+            return (.wav, "wav")
+        }
+
+        if data.starts(with: [0x49, 0x44, 0x33]) {
+            return (.mp3, "mp3")
+        }
+
+        if data.count >= 2 {
+            let bytes = Array(data.prefix(2))
+            if bytes[0] == 0xFF, (bytes[1] & 0xE0) == 0xE0 {
+                return (.mp3, "mp3")
+            }
+        }
+
+        if data.starts(with: Array("caff".utf8)) {
+            return (UTType(filenameExtension: "caf") ?? .audio, "caf")
+        }
+
+        return nil
+    }
+}
+
+private struct TranscriptMediaExportDescriptor {
+    let kind: TranscriptMediaResolvedExportKind
+    let contentType: UTType
+    let fileExtension: String
+}
+
+extension TranscriptMediaReference {
+    var exportBaseName: String {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? String(localized: "Hermes Media") : trimmed
+    }
+
+    var exportFileExtension: String? {
+        let fileExtension: String
+        switch source {
+        case let .remoteURL(url):
+            fileExtension = url.pathExtension
+        case let .localPath(path):
+            fileExtension = URL(fileURLWithPath: path).pathExtension
+        }
+
+        let normalized = fileExtension.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? nil : normalized
+    }
+}

--- a/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
@@ -36,6 +36,18 @@ final class TranscriptMediaPreviewViewModel {
         reference.isRasterImageCandidate && previewData != nil
     }
 
+    var canSaveVideoToPhotos: Bool {
+        videoFileURL != nil && originalData != nil
+    }
+
+    var canSaveMediaToPhotos: Bool {
+        canSaveImageToPhotos || canSaveVideoToPhotos
+    }
+
+    var canExportMedia: Bool {
+        originalData != nil
+    }
+
     func load(force: Bool = false) async {
         guard force || !didLoad else { return }
         loadGeneration += 1
@@ -106,6 +118,10 @@ final class TranscriptMediaPreviewViewModel {
     }
 
     func originalImageData() async throws -> Data {
+        try await originalMediaData()
+    }
+
+    func originalMediaData() async throws -> Data {
         if let originalData {
             return originalData
         }
@@ -115,6 +131,15 @@ final class TranscriptMediaPreviewViewModel {
         originalData = data
         originalByteCount = data.count
         return data
+    }
+
+    func exportPayload() async throws -> FileExportPayload {
+        let data = try await originalMediaData()
+        return TranscriptMediaExportSupport.payload(
+            for: reference,
+            data: data,
+            resolvedKind: resolvedExportKind
+        )
     }
 
     private func transcriptMediaData() async throws -> Data {
@@ -165,6 +190,21 @@ final class TranscriptMediaPreviewViewModel {
         (try? AVAudioPlayer(data: data)) != nil
     }
 
+    private var resolvedExportKind: TranscriptMediaResolvedExportKind? {
+        if previewData != nil {
+            return .image
+        }
+
+        if audioData != nil {
+            return .audio
+        }
+
+        if videoFileURL != nil {
+            return .video
+        }
+
+        return nil
+    }
 }
 
 private enum TranscriptMediaPreviewError: LocalizedError {

--- a/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import SwiftUI
 
@@ -13,6 +14,7 @@ final class TranscriptMediaPreviewViewModel {
     private var temporaryVideoURL: URL?
 
     private(set) var previewData: Data?
+    private(set) var audioData: Data?
     private(set) var videoFileURL: URL?
     private(set) var originalByteCount: Int?
     private(set) var isLoading = false
@@ -40,6 +42,7 @@ final class TranscriptMediaPreviewViewModel {
         let generation = loadGeneration
         didLoad = true
         previewData = nil
+        audioData = nil
         videoFileURL = nil
         originalByteCount = nil
         originalData = nil
@@ -83,9 +86,13 @@ final class TranscriptMediaPreviewViewModel {
                 } else {
                     guard !Task.isCancelled, loadGeneration == generation else { return }
                     if reference.isExtensionlessRemoteMediaCandidate {
-                        let fileURL = try writeTemporaryVideoFile(data)
-                        temporaryVideoURL = fileURL
-                        videoFileURL = fileURL
+                        if Self.isAudioData(data) {
+                            audioData = data
+                        } else {
+                            let fileURL = try writeTemporaryVideoFile(data)
+                            temporaryVideoURL = fileURL
+                            videoFileURL = fileURL
+                        }
                     } else {
                         errorMessage = String(localized: "Could not decode this image.")
                     }
@@ -132,6 +139,9 @@ final class TranscriptMediaPreviewViewModel {
     }
 
     func cleanupTemporaryFiles() {
+        loadGeneration += 1
+        isLoading = false
+        audioData = nil
         removeTemporaryVideoFile()
         videoFileURL = nil
     }
@@ -149,6 +159,10 @@ final class TranscriptMediaPreviewViewModel {
             try? FileManager.default.removeItem(at: temporaryVideoURL)
         }
         temporaryVideoURL = nil
+    }
+
+    private static func isAudioData(_ data: Data) -> Bool {
+        (try? AVAudioPlayer(data: data)) != nil
     }
 
 }

--- a/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
@@ -10,8 +10,10 @@ final class TranscriptMediaPreviewViewModel {
     private var didLoad = false
     private var loadGeneration = 0
     private var originalData: Data?
+    private var temporaryVideoURL: URL?
 
     private(set) var previewData: Data?
+    private(set) var videoFileURL: URL?
     private(set) var originalByteCount: Int?
     private(set) var isLoading = false
     private(set) var errorMessage: String?
@@ -38,10 +40,12 @@ final class TranscriptMediaPreviewViewModel {
         let generation = loadGeneration
         didLoad = true
         previewData = nil
+        videoFileURL = nil
         originalByteCount = nil
         originalData = nil
+        removeTemporaryVideoFile()
 
-        guard reference.isRasterImageCandidate else {
+        guard reference.isRasterImageCandidate || reference.isVideoCandidate else {
             errorMessage = String(localized: "Preview is not available for this media type.")
             return
         }
@@ -60,15 +64,26 @@ final class TranscriptMediaPreviewViewModel {
             guard !Task.isCancelled, loadGeneration == generation else { return }
             originalData = data
             originalByteCount = data.count
-            if let downsampled = await ImagePreviewDownsampler.previewDataAsync(
-                from: data,
-                maxPixelSize: ImagePreviewDownsampler.filePreviewMaxPixelSize
-            ) {
-                guard !Task.isCancelled, loadGeneration == generation else { return }
-                previewData = downsampled
+
+            if reference.isVideoCandidate {
+                let fileURL = try writeTemporaryVideoFile(data)
+                guard !Task.isCancelled, loadGeneration == generation else {
+                    try? FileManager.default.removeItem(at: fileURL)
+                    return
+                }
+                temporaryVideoURL = fileURL
+                videoFileURL = fileURL
             } else {
-                guard !Task.isCancelled, loadGeneration == generation else { return }
-                errorMessage = String(localized: "Could not decode this image.")
+                if let downsampled = await ImagePreviewDownsampler.previewDataAsync(
+                    from: data,
+                    maxPixelSize: ImagePreviewDownsampler.filePreviewMaxPixelSize
+                ) {
+                    guard !Task.isCancelled, loadGeneration == generation else { return }
+                    previewData = downsampled
+                } else {
+                    guard !Task.isCancelled, loadGeneration == generation else { return }
+                    errorMessage = String(localized: "Could not decode this image.")
+                }
             }
         } catch {
             guard !Task.isCancelled, loadGeneration == generation else { return }
@@ -109,6 +124,22 @@ final class TranscriptMediaPreviewViewModel {
         }
         return sessionID
     }
+
+    private func writeTemporaryVideoFile(_ data: Data) throws -> URL {
+        let ext = reference.videoFileExtension
+        let filename = "transcript-media-\(UUID().uuidString).\(ext)"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try data.write(to: url, options: [.atomic])
+        return url
+    }
+
+    private func removeTemporaryVideoFile() {
+        if let temporaryVideoURL {
+            try? FileManager.default.removeItem(at: temporaryVideoURL)
+        }
+        temporaryVideoURL = nil
+    }
+
 }
 
 private enum TranscriptMediaPreviewError: LocalizedError {
@@ -116,5 +147,18 @@ private enum TranscriptMediaPreviewError: LocalizedError {
 
     var errorDescription: String? {
         String(localized: "Preview is not available for this media without a server session.")
+    }
+}
+
+private extension TranscriptMediaReference {
+    var videoFileExtension: String {
+        switch source {
+        case let .remoteURL(url):
+            let ext = url.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+            return ext.isEmpty ? "mp4" : ext
+        case let .localPath(path):
+            let ext = URL(fileURLWithPath: path).pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+            return ext.isEmpty ? "mp4" : ext
+        }
     }
 }

--- a/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaPreviewViewModel.swift
@@ -82,7 +82,13 @@ final class TranscriptMediaPreviewViewModel {
                     previewData = downsampled
                 } else {
                     guard !Task.isCancelled, loadGeneration == generation else { return }
-                    errorMessage = String(localized: "Could not decode this image.")
+                    if reference.isExtensionlessRemoteMediaCandidate {
+                        let fileURL = try writeTemporaryVideoFile(data)
+                        temporaryVideoURL = fileURL
+                        videoFileURL = fileURL
+                    } else {
+                        errorMessage = String(localized: "Could not decode this image.")
+                    }
                 }
             }
         } catch {
@@ -123,6 +129,11 @@ final class TranscriptMediaPreviewViewModel {
             return nil
         }
         return sessionID
+    }
+
+    func cleanupTemporaryFiles() {
+        removeTemporaryVideoFile()
+        videoFileURL = nil
     }
 
     private func writeTemporaryVideoFile(_ data: Data) throws -> URL {

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import AVKit
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 struct TranscriptMediaPreviewItem: Identifiable, Equatable {
     let reference: TranscriptMediaReference
@@ -111,12 +112,16 @@ private struct TranscriptMediaThumbnailView: View {
                 }
             }
         case .audio where loadMediaData != nil:
-            InlineAudioPlayerView(title: reference.displayName) {
-                guard let loadMediaData else { return nil }
-                return await loadMediaData(reference)
+            if let loadMediaData {
+                TranscriptMediaAudioExportView(
+                    reference: reference,
+                    loadMediaData: {
+                        await loadMediaData(reference)
+                    }
+                )
+            } else {
+                TranscriptMediaUnavailableChip(reference: reference)
             }
-            .frame(maxWidth: 280)
-            .accessibilityElement(children: .contain)
 
         case .video:
             Button {
@@ -195,11 +200,11 @@ private struct TranscriptMediaResolvedRemoteView: View {
                 .accessibilityLabel(String(localized: "Open media image \(reference.displayName)"))
 
             case let .audio(data):
-                InlineAudioPlayerView(title: reference.displayName) {
-                    data
-                }
-                .frame(maxWidth: 280)
-                .accessibilityElement(children: .contain)
+                TranscriptMediaAudioExportView(
+                    reference: reference,
+                    initialData: data,
+                    loadMediaData: { data }
+                )
 
             case .video:
                 Button {
@@ -266,6 +271,105 @@ private struct TranscriptMediaResolvedRemoteView: View {
         case audio(Data)
         case video
         case unavailable
+    }
+}
+
+private struct TranscriptMediaAudioExportView: View {
+    let reference: TranscriptMediaReference
+    let loadMediaData: () async -> Data?
+
+    @State private var cachedData: Data?
+    @State private var exportDocument = ExportedFileDocument(data: Data())
+    @State private var exportContentType = UTType.audio
+    @State private var exportFilename = String(localized: "Hermes Media")
+    @State private var isFileExporterPresented = false
+    @State private var isExporting = false
+    @State private var errorMessage: String?
+
+    init(
+        reference: TranscriptMediaReference,
+        initialData: Data? = nil,
+        loadMediaData: @escaping () async -> Data?
+    ) {
+        self.reference = reference
+        self.loadMediaData = loadMediaData
+        _cachedData = State(initialValue: initialData)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            InlineAudioPlayerView(title: reference.displayName) {
+                await audioData()
+            }
+            .frame(maxWidth: 280)
+
+            Button {
+                Task { await exportAudio() }
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .buttonStyle(.chatTactile(.icon))
+            .disabled(isExporting)
+            .accessibilityLabel(String(localized: "Export audio \(reference.displayName)"))
+        }
+        .accessibilityElement(children: .contain)
+        .fileExporter(
+            isPresented: $isFileExporterPresented,
+            document: exportDocument,
+            contentType: exportContentType,
+            defaultFilename: exportFilename
+        ) { result in
+            if case let .failure(error) = result {
+                errorMessage = error.localizedDescription
+            }
+        }
+        .alert(
+            "Media Action Failed",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        errorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK") {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func audioData() async -> Data? {
+        if let cachedData {
+            return cachedData
+        }
+
+        let data = await loadMediaData()
+        guard !Task.isCancelled else { return nil }
+        cachedData = data
+        return data
+    }
+
+    private func exportAudio() async {
+        isExporting = true
+        defer {
+            isExporting = false
+        }
+
+        guard let data = await audioData() else {
+            errorMessage = String(localized: "Could not load media.")
+            return
+        }
+
+        let payload = TranscriptMediaExportSupport.payload(for: reference, data: data, resolvedKind: .audio)
+        exportDocument = ExportedFileDocument(data: payload.data)
+        exportContentType = payload.contentType
+        exportFilename = payload.filename
+        isFileExporterPresented = true
     }
 }
 
@@ -405,6 +509,11 @@ struct TranscriptMediaPreviewView: View {
 
     private let item: TranscriptMediaPreviewItem
     @State private var viewModel: TranscriptMediaPreviewViewModel
+    @State private var exportDocument = ExportedFileDocument(data: Data())
+    @State private var exportContentType = UTType.data
+    @State private var exportFilename = String(localized: "Hermes Media")
+    @State private var isFileExporterPresented = false
+    @State private var isExportingMedia = false
     @State private var isSavingToPhotos = false
     @State private var saveConfirmationMessage: String?
     @State private var errorMessage: String?
@@ -462,15 +571,25 @@ struct TranscriptMediaPreviewView: View {
                     }
                 }
 
-                ToolbarItem(placement: .topBarTrailing) {
-                    if viewModel.canSaveImageToPhotos {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    if viewModel.canSaveMediaToPhotos {
                         Button {
-                            Task { await saveImageToPhotos() }
+                            Task { await saveMediaToPhotos() }
                         } label: {
                             Image(systemName: "photo")
                         }
-                        .disabled(isSavingToPhotos || viewModel.isLoading)
-                        .accessibilityLabel("Save image to Photos")
+                        .disabled(exportActionsAreDisabled)
+                        .accessibilityLabel("Save media to Photos")
+                    }
+
+                    if viewModel.canExportMedia {
+                        Button {
+                            Task { await exportMedia() }
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                        .disabled(exportActionsAreDisabled)
+                        .accessibilityLabel("Export media")
                     }
                 }
             }
@@ -479,6 +598,16 @@ struct TranscriptMediaPreviewView: View {
             }
             .refreshable {
                 await loadMedia(force: true)
+            }
+            .fileExporter(
+                isPresented: $isFileExporterPresented,
+                document: exportDocument,
+                contentType: exportContentType,
+                defaultFilename: exportFilename
+            ) { result in
+                if case let .failure(error) = result {
+                    errorMessage = error.localizedDescription
+                }
             }
             .alert(
                 "Saved",
@@ -619,23 +748,52 @@ struct TranscriptMediaPreviewView: View {
         }
     }
 
-    private func saveImageToPhotos() async {
+    private func exportMedia() async {
+        isExportingMedia = true
+        defer {
+            isExportingMedia = false
+        }
+
+        do {
+            let payload = try await viewModel.exportPayload()
+            exportDocument = ExportedFileDocument(data: payload.data)
+            exportContentType = payload.contentType
+            exportFilename = payload.filename
+            isFileExporterPresented = true
+        } catch {
+            errorMessage = error.localizedDescription
+            onAPIError(error)
+        }
+    }
+
+    private func saveMediaToPhotos() async {
         isSavingToPhotos = true
         defer {
             isSavingToPhotos = false
         }
 
         do {
-            let data = try await viewModel.originalImageData()
-            guard UIImage(data: data) != nil else {
-                throw PhotoLibrarySaveError.notImage
+            let payload = try await viewModel.exportPayload()
+            if payload.isImage {
+                guard UIImage(data: payload.data) != nil else {
+                    throw PhotoLibrarySaveError.notImage
+                }
+                try await PhotoLibrarySaver.saveImageData(payload.data)
+            } else if payload.isVideo {
+                try await PhotoLibrarySaver.saveVideoData(payload.data, contentType: payload.contentType)
+            } else {
+                throw PhotoLibrarySaveError.notPhotosMedia
             }
-            try await PhotoLibrarySaver.saveImageData(data)
-            saveConfirmationMessage = String(localized: "Image saved to Photos.")
+
+            saveConfirmationMessage = String(localized: "Media saved to Photos.")
         } catch {
             errorMessage = error.localizedDescription
             onAPIError(error)
         }
+    }
+
+    private var exportActionsAreDisabled: Bool {
+        viewModel.isLoading || isSavingToPhotos || isExportingMedia
     }
 }
 

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -1,3 +1,4 @@
+import AVKit
 import SwiftUI
 import UIKit
 
@@ -13,6 +14,7 @@ struct TranscriptMediaContentView: View {
     let segments: [TranscriptMediaSegment]
     let cacheNamespace: String
     let loadMediaImage: ((TranscriptMediaReference) async -> Data?)?
+    let loadMediaData: ((TranscriptMediaReference) async -> Data?)?
     let onPreviewMedia: ((TranscriptMediaReference) -> Void)?
     let isStreaming: Bool
 
@@ -20,12 +22,14 @@ struct TranscriptMediaContentView: View {
         segments: [TranscriptMediaSegment],
         cacheNamespace: String,
         loadMediaImage: ((TranscriptMediaReference) async -> Data?)?,
+        loadMediaData: ((TranscriptMediaReference) async -> Data?)?,
         onPreviewMedia: ((TranscriptMediaReference) -> Void)?,
         isStreaming: Bool = false
     ) {
         self.segments = segments
         self.cacheNamespace = cacheNamespace
         self.loadMediaImage = loadMediaImage
+        self.loadMediaData = loadMediaData
         self.onPreviewMedia = onPreviewMedia
         self.isStreaming = isStreaming
     }
@@ -43,6 +47,7 @@ struct TranscriptMediaContentView: View {
                         reference: reference,
                         cacheNamespace: cacheNamespace,
                         loadMediaImage: loadMediaImage,
+                        loadMediaData: loadMediaData,
                         onPreviewMedia: onPreviewMedia
                     )
                     // Pin the image container LTR so media keeps its leading-edge
@@ -59,6 +64,7 @@ private struct TranscriptMediaThumbnailView: View {
     let reference: TranscriptMediaReference
     let cacheNamespace: String
     let loadMediaImage: ((TranscriptMediaReference) async -> Data?)?
+    let loadMediaData: ((TranscriptMediaReference) async -> Data?)?
     let onPreviewMedia: ((TranscriptMediaReference) -> Void)?
 
     @State private var image: UIImage?
@@ -68,7 +74,8 @@ private struct TranscriptMediaThumbnailView: View {
     private let thumbnailHeight: CGFloat = 132
 
     var body: some View {
-        if reference.isRasterImageCandidate, let loadMediaImage {
+        switch reference.mediaKind {
+        case .image where loadMediaImage != nil:
             Button {
                 onPreviewMedia?(reference)
             } label: {
@@ -77,6 +84,7 @@ private struct TranscriptMediaThumbnailView: View {
             .buttonStyle(.chatTactile(.thumbnail))
             .accessibilityLabel(String(localized: "Open media image \(reference.displayName)"))
             .task(id: imageCacheKey) {
+                guard let loadMediaImage else { return }
                 image = nil
                 didAttemptLoad = false
                 let loadedImage = await TranscriptMediaImageCache.shared.image(
@@ -90,7 +98,24 @@ private struct TranscriptMediaThumbnailView: View {
                     didAttemptLoad = true
                 }
             }
-        } else {
+        case .audio where loadMediaData != nil:
+            InlineAudioPlayerView(title: reference.displayName) {
+                guard let loadMediaData else { return nil }
+                return await loadMediaData(reference)
+            }
+            .frame(maxWidth: 280)
+            .accessibilityElement(children: .contain)
+
+        case .video:
+            Button {
+                onPreviewMedia?(reference)
+            } label: {
+                TranscriptMediaVideoTile(reference: reference)
+            }
+            .buttonStyle(.chatTactile(.thumbnail))
+            .accessibilityLabel(String(localized: "Open media video \(reference.displayName)"))
+
+        default:
             TranscriptMediaUnavailableChip(reference: reference)
         }
     }
@@ -122,6 +147,40 @@ private struct TranscriptMediaThumbnailView: View {
                     ProgressView()
                         .tint(Color(.tertiaryLabel))
                 }
+        }
+    }
+}
+
+private struct TranscriptMediaVideoTile: View {
+    let reference: TranscriptMediaReference
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+                .frame(width: 210, height: 132)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(Color(.separator).opacity(0.35), lineWidth: 0.5)
+                )
+
+            VStack(spacing: 8) {
+                Image(systemName: "play.rectangle.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+
+                Text(reference.displayName)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color(.label))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: 172)
+
+                Text("Video")
+                    .font(.caption2)
+                    .foregroundStyle(Color(.secondaryLabel))
+            }
+            .padding(.horizontal, 14)
         }
     }
 }
@@ -162,7 +221,16 @@ private struct TranscriptMediaUnavailableChip: View {
     }
 
     private var iconName: String {
-        reference.isRasterImageCandidate ? "photo" : "doc"
+        switch reference.mediaKind {
+        case .image:
+            "photo"
+        case .audio:
+            "waveform"
+        case .video:
+            "play.rectangle"
+        case .unsupported:
+            "doc"
+        }
     }
 }
 
@@ -259,6 +327,8 @@ struct TranscriptMediaPreviewView: View {
                     }
                 } else if let data = viewModel.previewData, let image = UIImage(data: data) {
                     imageContent(image)
+                } else if let videoURL = viewModel.videoFileURL {
+                    videoContent(videoURL)
                 } else {
                     unavailableContent(String(localized: "Preview is not available for this media."))
                 }
@@ -343,9 +413,27 @@ struct TranscriptMediaPreviewView: View {
         .background(Color(.systemBackground))
     }
 
+    private func videoContent(_ url: URL) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            mediaHeader
+
+            TranscriptVideoPreviewPlayerView(url: url)
+                .frame(maxWidth: .infinity)
+                .aspectRatio(16 / 9, contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(Color(.separator).opacity(0.35), lineWidth: 0.5)
+                )
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(.systemBackground))
+    }
+
     private func unavailableContent(_ message: String) -> some View {
         ContentUnavailableView {
-            Label("No Preview", systemImage: item.reference.isRasterImageCandidate ? "photo" : "doc.questionmark")
+            Label("No Preview", systemImage: unavailableIconName)
         } description: {
             VStack(spacing: 8) {
                 Text(message)
@@ -355,6 +443,19 @@ struct TranscriptMediaPreviewView: View {
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
             }
+        }
+    }
+
+    private var unavailableIconName: String {
+        switch item.reference.mediaKind {
+        case .image:
+            "photo"
+        case .audio:
+            "waveform"
+        case .video:
+            "play.rectangle"
+        case .unsupported:
+            "doc.questionmark"
         }
     }
 
@@ -397,6 +498,30 @@ struct TranscriptMediaPreviewView: View {
         } catch {
             errorMessage = error.localizedDescription
             onAPIError(error)
+        }
+    }
+}
+
+private struct TranscriptVideoPreviewPlayerView: View {
+    let url: URL
+
+    @State private var player: AVPlayer?
+
+    var body: some View {
+        Group {
+            if let player {
+                VideoPlayer(player: player)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .task(id: url) {
+            player?.pause()
+            player = AVPlayer(url: url)
+        }
+        .onDisappear {
+            player?.pause()
         }
     }
 }

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -138,7 +138,11 @@ private struct TranscriptMediaThumbnailView: View {
                         .stroke(Color(.separator).opacity(0.35), lineWidth: 0.5)
                 )
         } else if didAttemptLoad {
-            TranscriptMediaUnavailableChip(reference: reference)
+            if reference.isExtensionlessRemoteMediaCandidate {
+                TranscriptMediaVideoTile(reference: reference)
+            } else {
+                TranscriptMediaUnavailableChip(reference: reference)
+            }
         } else {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(Color(.systemFill))
@@ -393,6 +397,9 @@ struct TranscriptMediaPreviewView: View {
                 }
             } message: {
                 Text(errorMessage ?? "")
+            }
+            .onDisappear {
+                viewModel.cleanupTemporaryFiles()
             }
         }
     }

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -445,6 +445,8 @@ struct TranscriptMediaPreviewView: View {
                     }
                 } else if let data = viewModel.previewData, let image = UIImage(data: data) {
                     imageContent(image)
+                } else if let audioData = viewModel.audioData {
+                    audioContent(audioData)
                 } else if let videoURL = viewModel.videoFileURL {
                     videoContent(videoURL)
                 } else {
@@ -531,6 +533,20 @@ struct TranscriptMediaPreviewView: View {
             }
             .padding()
         }
+        .background(Color(.systemBackground))
+    }
+
+    private func audioContent(_ data: Data) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            mediaHeader
+
+            InlineAudioPlayerView(title: item.reference.displayName) {
+                data
+            }
+            .frame(maxWidth: 360)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(.systemBackground))
     }
 

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import AVKit
 import SwiftUI
 import UIKit
@@ -75,6 +76,17 @@ private struct TranscriptMediaThumbnailView: View {
 
     var body: some View {
         switch reference.mediaKind {
+        case .image where reference.isExtensionlessRemoteMediaCandidate && loadMediaData != nil:
+            if let loadMediaData {
+                TranscriptMediaResolvedRemoteView(
+                    reference: reference,
+                    loadMediaData: loadMediaData,
+                    onPreviewMedia: onPreviewMedia
+                )
+            } else {
+                TranscriptMediaUnavailableChip(reference: reference)
+            }
+
         case .image where loadMediaImage != nil:
             Button {
                 onPreviewMedia?(reference)
@@ -82,7 +94,7 @@ private struct TranscriptMediaThumbnailView: View {
                 thumbnailContent
             }
             .buttonStyle(.chatTactile(.thumbnail))
-            .accessibilityLabel(String(localized: "Open media image \(reference.displayName)"))
+            .accessibilityLabel(imageButtonAccessibilityLabel)
             .task(id: imageCacheKey) {
                 guard let loadMediaImage else { return }
                 image = nil
@@ -124,6 +136,14 @@ private struct TranscriptMediaThumbnailView: View {
         TranscriptMediaImageCacheKey(namespace: cacheNamespace, reference: reference)
     }
 
+    private var imageButtonAccessibilityLabel: String {
+        if image == nil, didAttemptLoad, reference.isExtensionlessRemoteMediaCandidate {
+            return String(localized: "Open media video \(reference.displayName)")
+        }
+
+        return String(localized: "Open media image \(reference.displayName)")
+    }
+
     @ViewBuilder
     private var thumbnailContent: some View {
         if let image {
@@ -152,6 +172,100 @@ private struct TranscriptMediaThumbnailView: View {
                         .tint(Color(.tertiaryLabel))
                 }
         }
+    }
+}
+
+private struct TranscriptMediaResolvedRemoteView: View {
+    let reference: TranscriptMediaReference
+    let loadMediaData: (TranscriptMediaReference) async -> Data?
+    let onPreviewMedia: ((TranscriptMediaReference) -> Void)?
+
+    @State private var resolvedMedia: ResolvedMedia?
+
+    var body: some View {
+        Group {
+            switch resolvedMedia {
+            case let .image(image):
+                Button {
+                    onPreviewMedia?(reference)
+                } label: {
+                    thumbnailContent(image)
+                }
+                .buttonStyle(.chatTactile(.thumbnail))
+                .accessibilityLabel(String(localized: "Open media image \(reference.displayName)"))
+
+            case let .audio(data):
+                InlineAudioPlayerView(title: reference.displayName) {
+                    data
+                }
+                .frame(maxWidth: 280)
+                .accessibilityElement(children: .contain)
+
+            case .video:
+                Button {
+                    onPreviewMedia?(reference)
+                } label: {
+                    TranscriptMediaVideoTile(reference: reference)
+                }
+                .buttonStyle(.chatTactile(.thumbnail))
+                .accessibilityLabel(String(localized: "Open media video \(reference.displayName)"))
+
+            case .unavailable:
+                TranscriptMediaUnavailableChip(reference: reference)
+
+            case nil:
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color(.systemFill))
+                    .frame(width: 210, height: 132)
+                    .overlay {
+                        ProgressView()
+                            .tint(Color(.tertiaryLabel))
+                    }
+            }
+        }
+        .task(id: reference.id) {
+            resolvedMedia = nil
+            guard let data = await loadMediaData(reference) else {
+                guard !Task.isCancelled else { return }
+                resolvedMedia = .unavailable
+                return
+            }
+
+            guard !Task.isCancelled else { return }
+            resolvedMedia = Self.resolve(data)
+        }
+    }
+
+    private func thumbnailContent(_ image: UIImage) -> some View {
+        Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
+            .frame(width: 210, height: 132)
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color(.separator).opacity(0.35), lineWidth: 0.5)
+            )
+    }
+
+    private static func resolve(_ data: Data) -> ResolvedMedia {
+        if let image = UIImage(data: data) {
+            return .image(image)
+        }
+
+        if (try? AVAudioPlayer(data: data)) != nil {
+            return .audio(data)
+        }
+
+        return .video
+    }
+
+    private enum ResolvedMedia {
+        case image(UIImage)
+        case audio(Data)
+        case video
+        case unavailable
     }
 }
 

--- a/HermesMobile/Features/Workspace/FileExportSupport.swift
+++ b/HermesMobile/Features/Workspace/FileExportSupport.swift
@@ -43,21 +43,56 @@ enum PhotoLibrarySaver {
             }
         }
     }
+
+    static func saveVideoData(_ data: Data, contentType: UTType) async throws {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        guard status == .authorized || status == .limited else {
+            throw PhotoLibrarySaveError.notAuthorized
+        }
+
+        guard contentType.conforms(to: .movie) || contentType.conforms(to: .video) else {
+            throw PhotoLibrarySaveError.notVideo
+        }
+
+        let options = PHAssetResourceCreationOptions()
+        options.uniformTypeIdentifier = contentType.identifier
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            PHPhotoLibrary.shared().performChanges {
+                let request = PHAssetCreationRequest.forAsset()
+                request.addResource(with: .video, data: data, options: options)
+            } completionHandler: { didSave, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if didSave {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: PhotoLibrarySaveError.saveFailed)
+                }
+            }
+        }
+    }
 }
 
 enum PhotoLibrarySaveError: LocalizedError {
     case notAuthorized
     case notImage
+    case notVideo
+    case notPhotosMedia
     case saveFailed
 
     var errorDescription: String? {
         switch self {
         case .notAuthorized:
-            String(localized: "Allow Photos access to save images from Hermex.")
+            String(localized: "Allow Photos access to save media from Hermex.")
         case .notImage:
             String(localized: "This file is not an image that can be saved to Photos.")
+        case .notVideo:
+            String(localized: "This file is not a video that can be saved to Photos.")
+        case .notPhotosMedia:
+            String(localized: "Photos can save images and videos. Export audio to Files instead.")
         case .saveFailed:
-            String(localized: "Photos could not save this image.")
+            String(localized: "Photos could not save this media.")
         }
     }
 }

--- a/HermesMobile/Features/Workspace/FilePreviewViewModel.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewViewModel.swift
@@ -127,8 +127,13 @@ final class FilePreviewViewModel {
             data: data,
             filename: exportFilename,
             contentType: UTType(filenameExtension: pathExtension) ?? .data,
-            isImage: isRasterImagePath
+            isImage: isRasterImagePath,
+            isVideo: isVideoPath
         )
+    }
+
+    private var isVideoPath: Bool {
+        ["m4v", "mov", "mp4"].contains(pathExtension)
     }
 
     private var exportFilename: String {
@@ -154,6 +159,7 @@ struct FileExportPayload {
     let filename: String
     let contentType: UTType
     let isImage: Bool
+    let isVideo: Bool
 }
 
 enum FileExportError: LocalizedError {

--- a/HermesMobileTests/ChatAttachmentCoordinatorTests.swift
+++ b/HermesMobileTests/ChatAttachmentCoordinatorTests.swift
@@ -225,6 +225,85 @@ final class ChatAttachmentCoordinatorTests: APIClientTestCase {
         XCTAssertNotNil(thumbnail)
     }
 
+    func testTranscriptLocalAudioMediaIncludesSessionIDOnMediaEndpoint() async throws {
+        let mediaData = Data("audio-bytes".utf8)
+        let mediaPath = "/tmp/generated/clip.mp3"
+        let sessionID = "session-abc"
+        let client = makeAuthenticatedMediaClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/media")
+
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            XCTAssertEqual(query["session_id"], sessionID)
+            XCTAssertEqual(query["path"], mediaPath)
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "audio/mpeg"]
+            )!
+            return (response, mediaData)
+        }
+        let coordinator = makeCoordinator(client: client)
+
+        let data = await coordinator.transcriptMediaData(
+            for: TranscriptMediaReference(rawReference: mediaPath)
+        )
+
+        XCTAssertEqual(data, mediaData)
+    }
+
+    func testTranscriptExternalRemoteVideoUsesPublicMediaSession() async throws {
+        let mediaData = Data("video-bytes".utf8)
+        let remoteURL = try XCTUnwrap(URL(string: "https://cdn.example.test/generated/movie.mp4"))
+        let client = makeAuthenticatedMediaClient { request in
+            XCTAssertEqual(request.url, remoteURL)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Hermes-Test-Session"), "public")
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "video/mp4"]
+            )!
+            return (response, mediaData)
+        }
+        let coordinator = makeCoordinator(client: client)
+
+        let data = await coordinator.transcriptMediaData(
+            for: TranscriptMediaReference(rawReference: remoteURL.absoluteString)
+        )
+
+        XCTAssertEqual(data, mediaData)
+    }
+
+    func testTranscriptLocalAudioWithoutSessionDoesNotRequestMediaEndpoint() async {
+        var requestCount = 0
+        let client = makeAuthenticatedMediaClient { request in
+            requestCount += 1
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("unexpected".utf8))
+        }
+        let coordinator = ChatAttachmentCoordinator(client: client)
+        let delegate = ChatAttachmentCoordinatorDelegateSpy()
+        delegate.attachmentSessionID = nil
+        delegateSpies.append(delegate)
+        coordinator.delegate = delegate
+
+        let data = await coordinator.transcriptMediaData(
+            for: TranscriptMediaReference(rawReference: "/tmp/generated/clip.mp3")
+        )
+
+        XCTAssertNil(data)
+        XCTAssertEqual(requestCount, 0)
+    }
+
     private func makeCoordinator(client: APIClient) -> ChatAttachmentCoordinator {
         let coordinator = ChatAttachmentCoordinator(client: client)
         let delegate = ChatAttachmentCoordinatorDelegateSpy()

--- a/HermesMobileTests/TranscriptMediaParserTests.swift
+++ b/HermesMobileTests/TranscriptMediaParserTests.swift
@@ -117,6 +117,16 @@ final class TranscriptMediaParserTests: XCTestCase {
         XCTAssertEqual(references[7].mediaKind, .video)
     }
 
+    func testExtensionlessRemoteReferenceRemainsImageCandidateButCanFallbackToMedia() throws {
+        let remoteURL = try XCTUnwrap(URL(string: "https://cdn.example.test/media/abc123"))
+        let reference = TranscriptMediaReference(rawReference: remoteURL.absoluteString)
+
+        XCTAssertEqual(reference.source, .remoteURL(remoteURL))
+        XCTAssertEqual(reference.mediaKind, .image)
+        XCTAssertTrue(reference.isRasterImageCandidate)
+        XCTAssertTrue(reference.isExtensionlessRemoteMediaCandidate)
+    }
+
     func testEmptyReferenceDisplayNameFallsBackToMedia() {
         XCTAssertEqual(TranscriptMediaReference(rawReference: "").displayName, "Media")
     }

--- a/HermesMobileTests/TranscriptMediaParserTests.swift
+++ b/HermesMobileTests/TranscriptMediaParserTests.swift
@@ -95,6 +95,28 @@ final class TranscriptMediaParserTests: XCTestCase {
         XCTAssertEqual(media?.isRasterImageCandidate, false)
     }
 
+    func testDetectsAudioAndVideoMediaKinds() {
+        let references = [
+            TranscriptMediaReference(rawReference: "/tmp/output.mp3"),
+            TranscriptMediaReference(rawReference: "/tmp/output.m4a"),
+            TranscriptMediaReference(rawReference: "/tmp/output.wav"),
+            TranscriptMediaReference(rawReference: "/tmp/output.aac"),
+            TranscriptMediaReference(rawReference: "/tmp/output.caf"),
+            TranscriptMediaReference(rawReference: "https://cdn.example.test/output.mp4?download=1"),
+            TranscriptMediaReference(rawReference: "/tmp/output.mov"),
+            TranscriptMediaReference(rawReference: "/tmp/output.m4v")
+        ]
+
+        XCTAssertEqual(references[0].mediaKind, .audio)
+        XCTAssertEqual(references[1].mediaKind, .audio)
+        XCTAssertEqual(references[2].mediaKind, .audio)
+        XCTAssertEqual(references[3].mediaKind, .audio)
+        XCTAssertEqual(references[4].mediaKind, .audio)
+        XCTAssertEqual(references[5].mediaKind, .video)
+        XCTAssertEqual(references[6].mediaKind, .video)
+        XCTAssertEqual(references[7].mediaKind, .video)
+    }
+
     func testEmptyReferenceDisplayNameFallsBackToMedia() {
         XCTAssertEqual(TranscriptMediaReference(rawReference: "").displayName, "Media")
     }

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import UIKit
+import UniformTypeIdentifiers
 @testable import HermesMobile
 
 @MainActor
@@ -35,6 +36,8 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.previewData)
         XCTAssertEqual(viewModel.originalByteCount, imageData.count)
         XCTAssertTrue(viewModel.canSaveImageToPhotos)
+        XCTAssertTrue(viewModel.canSaveMediaToPhotos)
+        XCTAssertTrue(viewModel.canExportMedia)
 
         let queryItems = queryItems(for: try XCTUnwrap(recorder.firstURL))
         XCTAssertEqual(queryItems["session_id"], sessionID)
@@ -42,6 +45,12 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
 
         let originalData = try await viewModel.originalImageData()
         XCTAssertEqual(originalData, imageData)
+        let payload = try await viewModel.exportPayload()
+        XCTAssertEqual(payload.data, imageData)
+        XCTAssertEqual(payload.filename, "example.png")
+        XCTAssertEqual(payload.contentType, .png)
+        XCTAssertTrue(payload.isImage)
+        XCTAssertFalse(payload.isVideo)
         XCTAssertEqual(recorder.requestCount, 1)
     }
 
@@ -70,6 +79,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorMessage)
         XCTAssertNotNil(viewModel.previewData)
         XCTAssertEqual(viewModel.originalByteCount, imageData.count)
+        XCTAssertTrue(viewModel.canExportMedia)
         XCTAssertEqual(recorder.requestCount, 1)
     }
 
@@ -102,6 +112,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorMessage)
         XCTAssertNotNil(viewModel.previewData)
         XCTAssertEqual(viewModel.originalByteCount, imageData.count)
+        XCTAssertTrue(viewModel.canExportMedia)
         XCTAssertEqual(recorder.requestCount, 1)
     }
 
@@ -125,6 +136,8 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.previewData)
         XCTAssertNil(viewModel.lastError)
         XCTAssertFalse(viewModel.canSaveImageToPhotos)
+        XCTAssertFalse(viewModel.canSaveMediaToPhotos)
+        XCTAssertFalse(viewModel.canExportMedia)
         XCTAssertEqual(recorder.requestCount, 0)
     }
 
@@ -180,6 +193,16 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: videoFileURL), videoData)
         XCTAssertEqual(viewModel.originalByteCount, videoData.count)
         XCTAssertFalse(viewModel.canSaveImageToPhotos)
+        XCTAssertTrue(viewModel.canSaveVideoToPhotos)
+        XCTAssertTrue(viewModel.canSaveMediaToPhotos)
+        XCTAssertTrue(viewModel.canExportMedia)
+
+        let payload = try await viewModel.exportPayload()
+        XCTAssertEqual(payload.data, videoData)
+        XCTAssertEqual(payload.filename, "movie.mp4")
+        XCTAssertEqual(payload.contentType, .mpeg4Movie)
+        XCTAssertFalse(payload.isImage)
+        XCTAssertTrue(payload.isVideo)
 
         let queryItems = queryItems(for: try XCTUnwrap(recorder.firstURL))
         XCTAssertEqual(queryItems["session_id"], sessionID)
@@ -189,6 +212,7 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         viewModel.cleanupTemporaryFiles()
         XCTAssertFalse(FileManager.default.fileExists(atPath: videoFileURL.path))
         XCTAssertNil(viewModel.videoFileURL)
+        XCTAssertFalse(viewModel.canSaveMediaToPhotos)
     }
 
     func testLoadLocalVideoWithoutSessionIDDoesNotRequestMediaEndpoint() async {
@@ -243,7 +267,16 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: videoFileURL.path))
         XCTAssertEqual(try Data(contentsOf: videoFileURL), videoData)
         XCTAssertEqual(viewModel.originalByteCount, videoData.count)
+        XCTAssertTrue(viewModel.canSaveVideoToPhotos)
+        XCTAssertTrue(viewModel.canSaveMediaToPhotos)
         XCTAssertEqual(recorder.requestCount, 1)
+
+        let payload = try await viewModel.exportPayload()
+        XCTAssertEqual(payload.data, videoData)
+        XCTAssertEqual(payload.filename, "abc123.mp4")
+        XCTAssertEqual(payload.contentType, .mpeg4Movie)
+        XCTAssertFalse(payload.isImage)
+        XCTAssertTrue(payload.isVideo)
 
         viewModel.cleanupTemporaryFiles()
         XCTAssertFalse(FileManager.default.fileExists(atPath: videoFileURL.path))
@@ -276,7 +309,16 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.videoFileURL)
         XCTAssertEqual(viewModel.audioData, audioData)
         XCTAssertEqual(viewModel.originalByteCount, audioData.count)
+        XCTAssertFalse(viewModel.canSaveMediaToPhotos)
+        XCTAssertTrue(viewModel.canExportMedia)
         XCTAssertEqual(recorder.requestCount, 1)
+
+        let payload = try await viewModel.exportPayload()
+        XCTAssertEqual(payload.data, audioData)
+        XCTAssertEqual(payload.filename, "voice123.wav")
+        XCTAssertEqual(payload.contentType, .wav)
+        XCTAssertFalse(payload.isImage)
+        XCTAssertFalse(payload.isVideo)
     }
 
     func testMediaEndpointErrorIsCaptured() async {
@@ -297,6 +339,8 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.errorMessage)
         XCTAssertNotNil(viewModel.lastError)
         XCTAssertFalse(viewModel.canSaveImageToPhotos)
+        XCTAssertFalse(viewModel.canSaveMediaToPhotos)
+        XCTAssertFalse(viewModel.canExportMedia)
     }
 
     private static let baseURL = URL(string: "https://example.test")!

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -150,6 +150,66 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(recorder.requestCount, 0)
     }
 
+    func testLoadLocalVideoUsesMediaEndpointAndCreatesPlayableFileURL() async throws {
+        let recorder = TranscriptMediaPreviewRequestRecorder()
+        let videoData = Data("video-bytes".utf8)
+        let mediaPath = "/tmp/generated/movie.mp4"
+        let sessionID = "session-123"
+        let client = makeClient { request in
+            recorder.record(request)
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/media")
+            return self.response(statusCode: 200, data: videoData, for: request)
+        }
+        let viewModel = TranscriptMediaPreviewViewModel(
+            server: Self.baseURL,
+            sessionID: sessionID,
+            reference: .init(rawReference: mediaPath),
+            apiClient: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNil(viewModel.lastError)
+        XCTAssertNil(viewModel.previewData)
+        let videoFileURL = try XCTUnwrap(viewModel.videoFileURL)
+        XCTAssertEqual(videoFileURL.pathExtension, "mp4")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: videoFileURL.path))
+        XCTAssertEqual(try Data(contentsOf: videoFileURL), videoData)
+        XCTAssertEqual(viewModel.originalByteCount, videoData.count)
+        XCTAssertFalse(viewModel.canSaveImageToPhotos)
+
+        let queryItems = queryItems(for: try XCTUnwrap(recorder.firstURL))
+        XCTAssertEqual(queryItems["session_id"], sessionID)
+        XCTAssertEqual(queryItems["path"], mediaPath)
+        XCTAssertEqual(recorder.requestCount, 1)
+    }
+
+    func testLoadLocalVideoWithoutSessionIDDoesNotRequestMediaEndpoint() async {
+        let recorder = TranscriptMediaPreviewRequestRecorder()
+        let client = makeClient { request in
+            recorder.record(request)
+            return self.response(statusCode: 200, data: Data(), for: request)
+        }
+        let viewModel = TranscriptMediaPreviewViewModel(
+            server: Self.baseURL,
+            sessionID: "   ",
+            reference: .init(rawReference: "/tmp/generated/movie.mov"),
+            apiClient: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.previewData)
+        XCTAssertNil(viewModel.videoFileURL)
+        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertNotNil(viewModel.lastError)
+        XCTAssertEqual(recorder.requestCount, 0)
+    }
+
     func testMediaEndpointErrorIsCaptured() async {
         let client = makeClient { request in
             self.response(statusCode: 403, data: Data("forbidden".utf8), for: request)

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -249,6 +249,36 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: videoFileURL.path))
     }
 
+    func testExtensionlessRemoteAudioUsesAudioPreviewInsteadOfVideoFallback() async throws {
+        let recorder = TranscriptMediaPreviewRequestRecorder()
+        let audioData = Self.wavData()
+        let remoteURL = try XCTUnwrap(URL(string: "https://cdn.example.test/media/voice123"))
+        let client = makeClient { request in
+            recorder.record(request)
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url, remoteURL)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Hermes-Test-Session"), "public")
+            return self.response(statusCode: 200, data: audioData, for: request)
+        }
+        let viewModel = TranscriptMediaPreviewViewModel(
+            server: Self.baseURL,
+            sessionID: "session-123",
+            reference: .init(rawReference: remoteURL.absoluteString),
+            apiClient: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNil(viewModel.lastError)
+        XCTAssertNil(viewModel.previewData)
+        XCTAssertNil(viewModel.videoFileURL)
+        XCTAssertEqual(viewModel.audioData, audioData)
+        XCTAssertEqual(viewModel.originalByteCount, audioData.count)
+        XCTAssertEqual(recorder.requestCount, 1)
+    }
+
     func testMediaEndpointErrorIsCaptured() async {
         let client = makeClient { request in
             self.response(statusCode: 403, data: Data("forbidden".utf8), for: request)
@@ -325,6 +355,31 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         }
     }
 
+    private static func wavData() -> Data {
+        let sampleRate: UInt32 = 8_000
+        let channelCount: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let sampleCount = 800
+        let dataByteCount = sampleCount * Int(channelCount) * Int(bitsPerSample / 8)
+
+        var data = Data()
+        data.append(contentsOf: "RIFF".utf8)
+        data.appendLittleEndian(UInt32(36 + dataByteCount))
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(channelCount)
+        data.appendLittleEndian(sampleRate)
+        data.appendLittleEndian(sampleRate * UInt32(channelCount) * UInt32(bitsPerSample / 8))
+        data.appendLittleEndian(channelCount * (bitsPerSample / 8))
+        data.appendLittleEndian(bitsPerSample)
+        data.append(contentsOf: "data".utf8)
+        data.appendLittleEndian(UInt32(dataByteCount))
+        data.append(Data(repeating: 0, count: dataByteCount))
+        return data
+    }
+
     private static func hermesCookie(domain: String) -> HTTPCookie? {
         HTTPCookie(properties: [
             .domain: domain,
@@ -387,4 +442,20 @@ private final class TranscriptMediaPreviewMockURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+}
+
+private extension Data {
+    mutating func appendLittleEndian(_ value: UInt16) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { buffer in
+            append(contentsOf: buffer)
+        }
+    }
+
+    mutating func appendLittleEndian(_ value: UInt32) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { buffer in
+            append(contentsOf: buffer)
+        }
+    }
 }

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -185,6 +185,10 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(queryItems["session_id"], sessionID)
         XCTAssertEqual(queryItems["path"], mediaPath)
         XCTAssertEqual(recorder.requestCount, 1)
+
+        viewModel.cleanupTemporaryFiles()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: videoFileURL.path))
+        XCTAssertNil(viewModel.videoFileURL)
     }
 
     func testLoadLocalVideoWithoutSessionIDDoesNotRequestMediaEndpoint() async {
@@ -208,6 +212,41 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.errorMessage)
         XCTAssertNotNil(viewModel.lastError)
         XCTAssertEqual(recorder.requestCount, 0)
+    }
+
+    func testExtensionlessRemoteMediaFallsBackToVideoFileWhenImageDecodeFails() async throws {
+        let recorder = TranscriptMediaPreviewRequestRecorder()
+        let videoData = Data("video-bytes".utf8)
+        let remoteURL = try XCTUnwrap(URL(string: "https://cdn.example.test/media/abc123"))
+        let client = makeClient { request in
+            recorder.record(request)
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url, remoteURL)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Hermes-Test-Session"), "public")
+            return self.response(statusCode: 200, data: videoData, for: request)
+        }
+        let viewModel = TranscriptMediaPreviewViewModel(
+            server: Self.baseURL,
+            sessionID: "session-123",
+            reference: .init(rawReference: remoteURL.absoluteString),
+            apiClient: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNil(viewModel.lastError)
+        XCTAssertNil(viewModel.previewData)
+        let videoFileURL = try XCTUnwrap(viewModel.videoFileURL)
+        XCTAssertEqual(videoFileURL.pathExtension, "mp4")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: videoFileURL.path))
+        XCTAssertEqual(try Data(contentsOf: videoFileURL), videoData)
+        XCTAssertEqual(viewModel.originalByteCount, videoData.count)
+        XCTAssertEqual(recorder.requestCount, 1)
+
+        viewModel.cleanupTemporaryFiles()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: videoFileURL.path))
     }
 
     func testMediaEndpointErrorIsCaptured() async {


### PR DESCRIPTION
Fixes #87

## Summary
- Add transcript MEDIA type detection for raster images, audio, video, and unsupported references.
- Render transcript audio references inline with the existing chat audio player.
- Render transcript video references as media tiles and play them in the transcript preview.
- Preserve session-scoped local `/api/media?path=...&session_id=...` routing and remote media public-session behavior.

## Validation
- Checked upstream `/api/media` route shape in `.codex-tmp/hermes-webui/api/routes.py`.
- `git diff --check`
- XcodeBuildMCP focused simulator tests: `TranscriptMediaParserTests`, `TranscriptMediaPreviewViewModelTests`, `ChatAttachmentCoordinatorTests` (27 passed)
- XcodeBuildMCP full simulator XCTest suite (1317 passed)
- XcodeBuildMCP signed Debug build/install/launch on iPhone 17 simulator

## Owner manual checks
- Confirmed by owner: works on simulator.
- Before merge, spot-check a session containing image, audio, video, and unsupported `MEDIA:` references.
