### PR TITLE
Fix gateway approval id fallback

### DIFF
--- a/HermesMobile/Models/Approval.swift
+++ b/HermesMobile/Models/Approval.swift
@@ -89,7 +89,7 @@ struct PendingApproval: Decodable, Equatable, Identifiable {
         patternKey: String? = nil,
         patternKeys: [String]? = nil
     ) {
-        self.approvalId = approvalId
+        self.approvalId = Self.normalizedApprovalId(approvalId)
         self.command = command
         self.description = description
         self.patternKey = patternKey
@@ -97,6 +97,7 @@ struct PendingApproval: Decodable, Equatable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
+        case id
         case approvalId
         case approvalIdSnake = "approval_id"
         case command
@@ -109,8 +110,7 @@ struct PendingApproval: Decodable, Equatable, Identifiable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        approvalId = container.decodeLossyStringIfPresent(forKey: .approvalId)
-            ?? container.decodeLossyStringIfPresent(forKey: .approvalIdSnake)
+        approvalId = Self.decodeApprovalId(from: container)
         command = container.decodeLossyStringIfPresent(forKey: .command)
         description = container.decodeLossyStringIfPresent(forKey: .description)
         patternKey = container.decodeLossyStringIfPresent(forKey: .patternKey)
@@ -137,6 +137,21 @@ struct PendingApproval: Decodable, Equatable, Identifiable {
         }
 
         return nil
+    }
+
+    private static func decodeApprovalId(from container: KeyedDecodingContainer<CodingKeys>) -> String? {
+        for key in [CodingKeys.approvalId, .approvalIdSnake, .id] {
+            if let value = normalizedApprovalId(container.decodeLossyStringIfPresent(forKey: key)) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
+    private static func normalizedApprovalId(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 }
 

--- a/HermesMobileTests/APIClientAgentControlTests.swift
+++ b/HermesMobileTests/APIClientAgentControlTests.swift
@@ -62,6 +62,28 @@ final class APIClientAgentControlTests: APIClientTestCase {
         XCTAssertEqual(response.pendingCount, 1)
     }
 
+    func testPendingApprovalDecodesServerIdentifierAliases() throws {
+        let decoder = JSONDecoder()
+
+        let snake = try decoder.decode(
+            PendingApproval.self,
+            from: Data(#"{"approval_id":"approval-snake","command":"make install"}"#.utf8)
+        )
+        let camel = try decoder.decode(
+            PendingApproval.self,
+            from: Data(#"{"approvalId":"approval-camel","command":"make install"}"#.utf8)
+        )
+        let gatewayID = try decoder.decode(
+            PendingApproval.self,
+            from: Data(#"{"approval_id":"   ","id":"approval-gateway","command":"make install"}"#.utf8)
+        )
+
+        XCTAssertEqual(snake.approvalId, "approval-snake")
+        XCTAssertEqual(camel.approvalId, "approval-camel")
+        XCTAssertEqual(gatewayID.approvalId, "approval-gateway")
+        XCTAssertEqual(gatewayID.id, "approval-gateway")
+    }
+
     func testRespondApprovalBuildsExpectedBodyForAllChoices() async throws {
         var observedBodies: [[String: Any]] = []
         let client = makeClient { request in

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -1343,15 +1343,18 @@ final class ChatViewModelSendTests: XCTestCase {
             "session-abc"
         )
 
-        approvalStreamClient.emit(.approvalPending(ApprovalPendingResponse(
-            pending: PendingApproval(
-                approvalId: "approval-1",
-                command: "curl https://example.test/install.sh | bash",
-                description: "High risk command",
-                patternKeys: ["network_download", "pipe_to_shell"]
-            ),
-            pendingCount: 2
-        )))
+        let gatewayApproval = ApprovalPendingResponse.streamPayload(from: Data("""
+        {
+          "pending": {
+            "id": "approval-1",
+            "command": "curl https://example.test/install.sh | bash",
+            "description": "High risk command",
+            "pattern_keys": ["network_download", "pipe_to_shell"]
+          },
+          "pending_count": 2
+        }
+        """.utf8))
+        approvalStreamClient.emit(.approvalPending(gatewayApproval))
 
         XCTAssertEqual(viewModel.approvalPrompt?.sessionID, "session-abc")
         XCTAssertEqual(viewModel.approvalPrompt?.pending.approvalId, "approval-1")
@@ -1367,6 +1370,49 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertNil(viewModel.approvalPrompt)
         XCTAssertEqual(streamClient.stopCount, 0)
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
+    }
+
+    @MainActor
+    func testApprovalResponseDoesNotUseSyntheticDisplayIDWhenServerIdentifierMissing() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let approvalStreamClient = SpySSEStreamingClient()
+        var respondBody: [String: Any]?
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            approvalStreamClient: approvalStreamClient
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(#"{"session_id": "session-abc", "stream_id": "stream-123"}"#, for: request)
+            case "/api/approval/respond":
+                respondBody = try XCTUnwrap(apiTestJSONBody(from: request))
+                return apiTestJSONResponse(#"{"ok": true, "choice": "once"}"#, for: request)
+            case "/api/approval/pending":
+                return apiTestJSONResponse(#"{"pending": null, "pending_count": 0}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Run the installer")
+        XCTAssertTrue(didStart)
+        approvalStreamClient.emit(.approvalPending(ApprovalPendingResponse(
+            pending: PendingApproval(
+                command: "make install",
+                description: "Install command",
+                patternKey: "install"
+            ),
+            pendingCount: 1
+        )))
+
+        XCTAssertEqual(viewModel.approvalPrompt?.pending.id, "make install-Install command-install")
+
+        await viewModel.respondToApproval(.once)
+
+        XCTAssertEqual(respondBody?["session_id"] as? String, "session-abc")
+        XCTAssertEqual(respondBody?["choice"] as? String, "once")
+        XCTAssertNil(respondBody?["approval_id"])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Decode gateway Runs API approval identifiers from `id` as well as `approval_id` / `approvalId`.
- Normalize `PendingApproval.approvalId` so blank identifiers remain nil.
- Keep approval responses using only the real server approval id, not the synthetic display fallback.

Fixes #69

## Validation
- `git diff --check`
- Focused simulator tests on iPhone 17: `xcodebuild test -quiet -project HermesMobile.xcodeproj -scheme HermesMobile -configuration Debug -destination 'platform=iOS Simulator,id=2F5FED41-E76A-4ED8-8F4A-8151FEB7F8FC' -parallel-testing-enabled NO -skipMacroValidation -collect-test-diagnostics never COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES -only-testing:HermesMobileTests/APIClientAgentControlTests/testPendingApprovalDecodesServerIdentifierAliases -only-testing:HermesMobileTests/ChatViewModelSendTests/testApprovalStreamPublishesPromptAndRespondsWithoutStoppingChatStream -only-testing:HermesMobileTests/ChatViewModelSendTests/testApprovalResponseDoesNotUseSyntheticDisplayIDWhenServerIdentifierMissing`
- Signed Debug build/install/launch via XcodeBuildMCP `build_run_sim` on iPhone 17

## Manual validation
- Owner tested against gateway + Runs API approval flow and reported: works.
