### PR TITLE
fix: server-side STT fallback for Apple-unsupported locales (e.g. Estonian)

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -107,6 +107,7 @@ struct MessageComposerView: View {
     /// When true, dictation auto-starts once this composer appears with the app active —
     /// the "New Chat with Voice" App Intent (#338). Defaults to false for normal composers.
     let autoStartsVoiceInput: Bool
+    let apiClient: APIClient?
     let uploadAttachmentErrorMessage: String?
     let onSend: () -> Void
     let onSendVoiceNote: (Data, String) -> Void
@@ -1015,7 +1016,17 @@ struct MessageComposerView: View {
     }
 
     @MainActor
+    @MainActor
     private func toggleVoiceInput() {
+        voiceInput.apiClient = apiClient
+        voiceInput.locale = .current
+        Task {
+            await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
+                draftMessage = newDraft
+            }
+        }
+    }
+
         Task {
             await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
                 draftMessage = newDraft

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1016,17 +1016,9 @@ struct MessageComposerView: View {
     }
 
     @MainActor
-    @MainActor
     private func toggleVoiceInput() {
         voiceInput.apiClient = apiClient
         voiceInput.locale = .current
-        Task {
-            await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
-                draftMessage = newDraft
-            }
-        }
-    }
-
         Task {
             await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
                 draftMessage = newDraft

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -392,6 +392,7 @@ struct ChatView: View {
             isUploadingAttachment: viewModel.isUploadingAttachment,
             isSendingVoiceNote: viewModel.isSendingVoiceNote,
             autoStartsVoiceInput: autoStartsVoiceInput,
+            apiClient: viewModel.client,
             uploadAttachmentErrorMessage: viewModel.uploadAttachmentErrorMessage,
             onSend: {
                 Task { await sendDraftMessage() }

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -367,7 +367,7 @@ final class ChatViewModel {
     private var currentProfile: String?
     private let isCLISession: Bool
     private let server: URL
-    private let client: APIClient
+    let client: APIClient
     private let streamCoordinator: ChatStreamCoordinator
     private let pendingActionCoordinator: ChatPendingActionCoordinator
     private let attachmentCoordinator: ChatAttachmentCoordinator

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -210,10 +210,8 @@ final class ComposerVoiceInputController {
                 self.audioRecorder = nil
             }
             try? FileManager.default.removeItem(at: recordingURL)
-            if self.recordingURL == recordingURL {
-            self.recordingURL = nil
-            }
             guard self.recordingURL == recordingURL else { return }
+            self.recordingURL = nil
             fail("Speech-to-text is not configured on this server.", logCategory: .speechUnavailable)
             return
         }
@@ -261,10 +259,8 @@ final class ComposerVoiceInputController {
             }
         } catch {
             try? FileManager.default.removeItem(at: recordingURL)
-            if self.recordingURL == recordingURL {
-            self.recordingURL = nil
-            }
             guard self.recordingURL == recordingURL else { return }
+            self.recordingURL = nil
             fail(error.localizedDescription, logCategory: .speechUnavailable)
         }
     }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -187,7 +187,7 @@ final class ComposerVoiceInputController {
         logger.info("Server STT: recording started to \(recordingURL.path)")
     }
 
-    private func finishServerRecording() async {
+    private func finishServerRecording(recorder: AVAudioRecorder, recordingURL: URL) async {
         guard !Task.isCancelled else {
             try? FileManager.default.removeItem(at: recordingURL ?? URL(fileURLWithPath: "/dev/null"))
             recordingURL = nil

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -231,9 +231,8 @@ final class ComposerVoiceInputController {
 
             guard !Task.isCancelled else {
                 try? FileManager.default.removeItem(at: recordingURL)
-                if self.recordingURL == recordingURL {
+                guard self.recordingURL == recordingURL else { return }
                 self.recordingURL = nil
-                }
                 if self.audioRecorder === recorder {
                     self.audioRecorder = nil
                 }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -195,10 +195,12 @@ final class ComposerVoiceInputController {
         if recorder.isRecording {
             recorder.stop()
         }
+        audioRecorder = nil
         ComposerAudioCaptureState.shared.setCapturing(false)
         logger.info("Server STT: recording finished, duration=\(recorder.currentTime)s")
 
         guard let apiClient else {
+            audioRecorder = nil
             try? FileManager.default.removeItem(at: recordingURL)
             self.recordingURL = nil
             fail("Speech-to-text is not configured on this server.", logCategory: .speechUnavailable)
@@ -326,7 +328,8 @@ final class ComposerVoiceInputController {
 
         if let recorder = audioRecorder, recorder.isRecording {
             recorder.stop()
-            audioRecorder = nil
+            // Keep audioRecorder non-nil so finishServerRecording can read it.
+            // It will be cleared inside finishServerRecording when done.
         }
 
         if let audioEngine {

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -12,6 +12,8 @@ final class ComposerVoiceInputController {
         case idle
         case requestingPermission
         case listening
+        case serverListening  // Recording for server-side STT
+        case transcribing     // Server is processing audio
     }
 
     private(set) var state: State = .idle
@@ -20,10 +22,14 @@ final class ComposerVoiceInputController {
 
     private let speechRecognizerFactory: () -> SFSpeechRecognizer?
     private let audioEngineFactory: () -> AVAudioEngine
+    private let apiClient: APIClient?
+    private let locale: Locale
     private var speechRecognizer: SFSpeechRecognizer?
     private var audioEngine: AVAudioEngine?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
+    private var audioRecorder: AVAudioRecorder?
+    private var recordingURL: URL?
     private var draftUpdateSession = ComposerVoiceDraftUpdateSession()
     private var updateDraft: ((String) -> Void)?
     private var suppressNextRecognitionError = false
@@ -33,14 +39,18 @@ final class ComposerVoiceInputController {
 
     init(
         speechRecognizerFactory: @escaping () -> SFSpeechRecognizer? = { SFSpeechRecognizer(locale: Locale.current) },
-        audioEngineFactory: @escaping () -> AVAudioEngine = { AVAudioEngine() }
+        audioEngineFactory: @escaping () -> AVAudioEngine = { AVAudioEngine() },
+        apiClient: APIClient? = nil,
+        locale: Locale = .current
     ) {
         self.speechRecognizerFactory = speechRecognizerFactory
         self.audioEngineFactory = audioEngineFactory
+        self.apiClient = apiClient
+        self.locale = locale
     }
 
     var isListening: Bool {
-        state == .listening
+        state == .listening || state == .serverListening
     }
 
     var isRequestingPermission: Bool {
@@ -80,6 +90,36 @@ final class ComposerVoiceInputController {
         self.updateDraft = updateDraft
         state = .requestingPermission
 
+        // Decide: Apple native STT or server STT?
+        let appleSupportsLocale = SFSpeechRecognizer.supportedLocales().contains(locale)
+        let useServerSTT = !appleSupportsLocale && apiClient != nil
+
+        if useServerSTT {
+            logger.info("Locale \(self.locale.identifier) not supported by Apple — using server STT")
+            // Server STT path: only need microphone permission
+            let isMicrophonePermissionGranted = await requestMicrophonePermission()
+            guard state == .requestingPermission else { return }
+            guard isMicrophonePermissionGranted else {
+                fail(
+                    String(localized: "Microphone access is disabled. Enable it in Settings to use voice input."),
+                    logCategory: .microphonePermission
+                )
+                return
+            }
+            guard ComposerVoiceInputStartPolicy.canStart(appIsActive: UIApplication.shared.applicationState == .active) else {
+                fail(ComposerVoiceInputError.appNotActive.localizedDescription, logCategory: .appNotActive)
+                return
+            }
+            do {
+                try startServerRecording()
+                state = .serverListening
+            } catch {
+                fail(error.localizedDescription, logCategory: .audioStartup)
+            }
+            return
+        }
+
+        // Apple native STT path
         guard let speechRecognizer = speechRecognizerForRecording() else {
             fail(
                 String(localized: "Speech recognition is not available for the current locale."),
@@ -92,10 +132,7 @@ final class ComposerVoiceInputController {
         logger.info("Voice input speech authorization completed status=\(Self.logDescription(for: speechStatus), privacy: .public)")
         guard state == .requestingPermission else { return }
         guard speechStatus == .authorized else {
-            fail(
-                Self.speechAuthorizationMessage(for: speechStatus),
-                logCategory: .speechAuthorization
-            )
+            fail(Self.speechAuthorizationMessage(for: speechStatus), logCategory: .speechAuthorization)
             return
         }
 
@@ -103,18 +140,12 @@ final class ComposerVoiceInputController {
         logger.info("Voice input microphone permission completed granted=\(isMicrophonePermissionGranted, privacy: .public)")
         guard state == .requestingPermission else { return }
         guard isMicrophonePermissionGranted else {
-            fail(
-                String(localized: "Microphone access is disabled. Enable it in Settings to use voice input."),
-                logCategory: .microphonePermission
-            )
+            fail(String(localized: "Microphone access is disabled. Enable it in Settings to use voice input."), logCategory: .microphonePermission)
             return
         }
 
         guard ComposerVoiceInputStartPolicy.canStart(appIsActive: UIApplication.shared.applicationState == .active) else {
-            fail(
-                ComposerVoiceInputError.appNotActive.localizedDescription,
-                logCategory: .appNotActive
-            )
+            fail(ComposerVoiceInputError.appNotActive.localizedDescription, logCategory: .appNotActive)
             return
         }
 
@@ -125,6 +156,92 @@ final class ComposerVoiceInputController {
             fail(error.localizedDescription, logCategory: Self.logCategory(for: error))
         }
     }
+
+    // MARK: - Server STT Recording
+
+    private func startServerRecording() throws {
+        stopAudio(cancelTask: true)
+        logger.info("Server STT: preparing audio recording")
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.mixWithOthers, .allowBluetoothHFP])
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        activatedAudioSessionForRecording = true
+
+        let recordingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hermex-stt-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+        self.recordingURL = recordingURL
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatLinearPCM),
+            AVSampleRateKey: 16000.0,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+
+        let recorder = try AVAudioRecorder(url: recordingURL, settings: settings)
+        recorder.prepareToRecord()
+        recorder.isMeteringEnabled = true
+        recorder.record()
+        self.audioRecorder = recorder
+
+        ComposerAudioCaptureState.shared.setCapturing(true)
+        logger.info("Server STT: recording started to \(recordingURL.path)")
+    }
+
+    private func finishServerRecording() async {
+        guard let recorder = audioRecorder, let recordingURL = recordingURL else {
+            return
+        }
+        recorder.stop()
+        audioRecorder = nil
+        ComposerAudioCaptureState.shared.setCapturing(false)
+
+        logger.info("Server STT: recording finished, duration=\(recorder.currentTime)s")
+
+        guard let apiClient else {
+            fail("Speech-to-text is not configured on this server.", logCategory: .speechUnavailable)
+            return
+        }
+
+        state = .transcribing
+        liveTranscript = String(localized: "Transcribing…")
+
+        do {
+            let audioData = try Data(contentsOf: recordingURL)
+            let languageCode = locale.language.languageCode?.identifier
+            let response = try await apiClient.transcribeAudio(
+                data: audioData,
+                filename: "recording.wav",
+                language: languageCode
+            )
+
+            // Clean up temp file
+            try? FileManager.default.removeItem(at: recordingURL)
+            self.recordingURL = nil
+
+            if let transcript = response.transcript, !transcript.isEmpty {
+                liveTranscript = transcript
+                if let composedDraft = draftUpdateSession.composedDraft(for: transcript) {
+                    updateDraft?(composedDraft)
+                }
+                state = .idle
+            } else if let errorMsg = response.error {
+                fail(errorMsg, logCategory: .speechUnavailable)
+            } else {
+                fail("Transcription returned no text.", logCategory: .speechUnavailable)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: recordingURL)
+            self.recordingURL = nil
+            fail(error.localizedDescription, logCategory: .speechUnavailable)
+        }
+    }
+
+    // MARK: - Apple Native STT
 
     private func startRecognition(speechRecognizer: SFSpeechRecognizer) throws {
         stopAudio(cancelTask: true)
@@ -209,6 +326,8 @@ final class ComposerVoiceInputController {
         }
     }
 
+    // MARK: - Shared
+
     private func stopAcceptingDraftUpdates() {
         draftUpdateSession.stopAcceptingUpdates()
         updateDraft = nil
@@ -216,6 +335,16 @@ final class ComposerVoiceInputController {
 
     private func stopAudio(cancelTask: Bool) {
         ComposerAudioCaptureState.shared.setCapturing(false)
+
+        // Stop server STT recorder
+        if let recorder = audioRecorder, recorder.isRecording {
+            recorder.stop()
+            audioRecorder = nil
+            // If we were in serverListening state, finalize the transcription
+            if state == .serverListening {
+                Task { await finishServerRecording() }
+            }
+        }
 
         if let audioEngine {
             if audioEngine.isRunning {

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -241,12 +241,10 @@ final class ComposerVoiceInputController {
             }
 
             try? FileManager.default.removeItem(at: recordingURL)
-            if self.recordingURL == recordingURL {
+            guard self.recordingURL == recordingURL else { return }
             self.recordingURL = nil
-            }
 
             if let transcript = response.transcript, !transcript.isEmpty {
-                guard self.recordingURL == recordingURL else { return }
                 liveTranscript = transcript
                 if let composedDraft = draftUpdateSession.composedDraft(for: transcript) {
                     updateDraft?(composedDraft)

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -189,12 +189,8 @@ final class ComposerVoiceInputController {
 
     private func finishServerRecording(recorder: AVAudioRecorder, recordingURL: URL) async {
         guard !Task.isCancelled else {
-            try? FileManager.default.removeItem(at: recordingURL ?? URL(fileURLWithPath: "/dev/null"))
-            recordingURL = nil
+            try? FileManager.default.removeItem(at: recordingURL)
             audioRecorder = nil
-            return
-        }
-        guard let recorder = audioRecorder, let recordingURL = self.recordingURL else {
             return
         }
 

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -208,7 +208,9 @@ final class ComposerVoiceInputController {
         guard let apiClient else {
             audioRecorder = nil
             try? FileManager.default.removeItem(at: recordingURL)
+            if self.recordingURL == recordingURL {
             self.recordingURL = nil
+            }
             fail("Speech-to-text is not configured on this server.", logCategory: .speechUnavailable)
             return
         }
@@ -227,14 +229,18 @@ final class ComposerVoiceInputController {
 
             guard !Task.isCancelled else {
                 try? FileManager.default.removeItem(at: recordingURL)
+                if self.recordingURL == recordingURL {
                 self.recordingURL = nil
+                }
                 audioRecorder = nil
                 stopAcceptingDraftUpdates()
                 return
             }
 
             try? FileManager.default.removeItem(at: recordingURL)
+            if self.recordingURL == recordingURL {
             self.recordingURL = nil
+            }
 
             if let transcript = response.transcript, !transcript.isEmpty {
                 liveTranscript = transcript
@@ -249,7 +255,9 @@ final class ComposerVoiceInputController {
             }
         } catch {
             try? FileManager.default.removeItem(at: recordingURL)
+            if self.recordingURL == recordingURL {
             self.recordingURL = nil
+            }
             fail(error.localizedDescription, logCategory: .speechUnavailable)
         }
     }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -259,6 +259,7 @@ final class ComposerVoiceInputController {
             try? FileManager.default.removeItem(at: recordingURL)
             guard self.recordingURL == recordingURL else { return }
             self.recordingURL = nil
+            if (error as? URLError)?.code == .cancelled { return }
             fail(error.localizedDescription, logCategory: .speechUnavailable)
         }
     }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -338,7 +338,7 @@ final class ComposerVoiceInputController {
         transcriptionTask?.cancel()
         transcriptionTask = nil
 
-        let hadServerRecording = audioRecorder?.isRecording == true && recordingURL != nil
+        let hadServerRecording = audioRecorder != nil && recordingURL != nil
 
         if let recorder = audioRecorder, recorder.isRecording {
             recorder.stop()
@@ -367,9 +367,9 @@ final class ComposerVoiceInputController {
         recognitionTask = nil
         recognitionRequest = nil
 
-        if hadServerRecording, let url = recordingURL {
+        if hadServerRecording, let recorder = audioRecorder, let url = recordingURL {
             let task = Task { [weak self] in
-                await self?.finishServerRecording()
+                await self?.finishServerRecording(recorder: recorder, recordingURL: url)
             }
             transcriptionTask = task
         }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -12,8 +12,8 @@ final class ComposerVoiceInputController {
         case idle
         case requestingPermission
         case listening
-        case serverListening  // Recording for server-side STT
-        case transcribing     // Server is processing audio
+        case serverListening
+        case transcribing
     }
 
     private(set) var state: State = .idle
@@ -22,14 +22,13 @@ final class ComposerVoiceInputController {
 
     private let speechRecognizerFactory: () -> SFSpeechRecognizer?
     private let audioEngineFactory: () -> AVAudioEngine
-    private let apiClient: APIClient?
-    private let locale: Locale
     private var speechRecognizer: SFSpeechRecognizer?
     private var audioEngine: AVAudioEngine?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private var audioRecorder: AVAudioRecorder?
     private var recordingURL: URL?
+    private var transcriptionTask: Task<Void, Never>?
     private var draftUpdateSession = ComposerVoiceDraftUpdateSession()
     private var updateDraft: ((String) -> Void)?
     private var suppressNextRecognitionError = false
@@ -37,16 +36,15 @@ final class ComposerVoiceInputController {
     private var audioTapInstalled = false
     private let logger = Logger.hermesVoiceInput
 
+    var apiClient: APIClient?
+    var locale: Locale = .current
+
     init(
         speechRecognizerFactory: @escaping () -> SFSpeechRecognizer? = { SFSpeechRecognizer(locale: Locale.current) },
-        audioEngineFactory: @escaping () -> AVAudioEngine = { AVAudioEngine() },
-        apiClient: APIClient? = nil,
-        locale: Locale = .current
+        audioEngineFactory: @escaping () -> AVAudioEngine = { AVAudioEngine() }
     ) {
         self.speechRecognizerFactory = speechRecognizerFactory
         self.audioEngineFactory = audioEngineFactory
-        self.apiClient = apiClient
-        self.locale = locale
     }
 
     var isListening: Bool {
@@ -67,7 +65,9 @@ final class ComposerVoiceInputController {
 
     func stopKeepingTranscript() {
         suppressNextRecognitionError = true
-        stopAcceptingDraftUpdates()
+        if state != .serverListening && state != .transcribing {
+            stopAcceptingDraftUpdates()
+        }
         stopAudio(cancelTask: false)
         state = .idle
     }
@@ -90,20 +90,18 @@ final class ComposerVoiceInputController {
         self.updateDraft = updateDraft
         state = .requestingPermission
 
-        // Decide: Apple native STT or server STT?
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+
         let appleSupportsLocale = SFSpeechRecognizer.supportedLocales().contains(locale)
         let useServerSTT = !appleSupportsLocale && apiClient != nil
 
         if useServerSTT {
             logger.info("Locale \(self.locale.identifier) not supported by Apple — using server STT")
-            // Server STT path: only need microphone permission
             let isMicrophonePermissionGranted = await requestMicrophonePermission()
             guard state == .requestingPermission else { return }
             guard isMicrophonePermissionGranted else {
-                fail(
-                    String(localized: "Microphone access is disabled. Enable it in Settings to use voice input."),
-                    logCategory: .microphonePermission
-                )
+                fail(String(localized: "Microphone access is disabled. Enable it in Settings to use voice input."), logCategory: .microphonePermission)
                 return
             }
             guard ComposerVoiceInputStartPolicy.canStart(appIsActive: UIApplication.shared.applicationState == .active) else {
@@ -119,12 +117,8 @@ final class ComposerVoiceInputController {
             return
         }
 
-        // Apple native STT path
         guard let speechRecognizer = speechRecognizerForRecording() else {
-            fail(
-                String(localized: "Speech recognition is not available for the current locale."),
-                logCategory: .speechUnavailable
-            )
+            fail(String(localized: "Speech recognition is not available for the current locale."), logCategory: .speechUnavailable)
             return
         }
 
@@ -157,7 +151,9 @@ final class ComposerVoiceInputController {
         }
     }
 
-    // MARK: - Server STT Recording
+    // MARK: - Server STT
+
+    private static let maxServerRecordingDuration: TimeInterval = 60
 
     private func startServerRecording() throws {
         stopAudio(cancelTask: true)
@@ -178,14 +174,13 @@ final class ComposerVoiceInputController {
             AVSampleRateKey: 16000.0,
             AVNumberOfChannelsKey: 1,
             AVLinearPCMBitDepthKey: 16,
-            AVLinearPCMIsFloatKey: false,
-            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+            AVLinearPCMIsFloatKey: false
         ]
 
         let recorder = try AVAudioRecorder(url: recordingURL, settings: settings)
         recorder.prepareToRecord()
         recorder.isMeteringEnabled = true
-        recorder.record()
+        recorder.record(forDuration: Self.maxServerRecordingDuration)
         self.audioRecorder = recorder
 
         ComposerAudioCaptureState.shared.setCapturing(true)
@@ -193,22 +188,25 @@ final class ComposerVoiceInputController {
     }
 
     private func finishServerRecording() async {
-        guard let recorder = audioRecorder, let recordingURL = recordingURL else {
+        guard let recorder = audioRecorder, let recordingURL = self.recordingURL else {
             return
         }
-        recorder.stop()
-        audioRecorder = nil
-        ComposerAudioCaptureState.shared.setCapturing(false)
 
+        if recorder.isRecording {
+            recorder.stop()
+        }
+        ComposerAudioCaptureState.shared.setCapturing(false)
         logger.info("Server STT: recording finished, duration=\(recorder.currentTime)s")
 
         guard let apiClient else {
+            try? FileManager.default.removeItem(at: recordingURL)
+            self.recordingURL = nil
             fail("Speech-to-text is not configured on this server.", logCategory: .speechUnavailable)
             return
         }
 
         state = .transcribing
-        liveTranscript = String(localized: "Transcribing…")
+        liveTranscript = String(localized: "Transcribing...")
 
         do {
             let audioData = try Data(contentsOf: recordingURL)
@@ -219,7 +217,6 @@ final class ComposerVoiceInputController {
                 language: languageCode
             )
 
-            // Clean up temp file
             try? FileManager.default.removeItem(at: recordingURL)
             self.recordingURL = nil
 
@@ -252,21 +249,11 @@ final class ComposerVoiceInputController {
         }
 
         let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(
-            ComposerVoiceAudioSessionConfiguration.category,
-            mode: ComposerVoiceAudioSessionConfiguration.mode,
-            options: ComposerVoiceAudioSessionConfiguration.options
-        )
+        try audioSession.setCategory(ComposerVoiceAudioSessionConfiguration.category, mode: ComposerVoiceAudioSessionConfiguration.mode, options: ComposerVoiceAudioSessionConfiguration.options)
         try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
         activatedAudioSessionForRecording = true
-        logger.info(
-            "Voice input audio session active inputAvailable=\(audioSession.isInputAvailable, privacy: .public) sampleRate=\(audioSession.sampleRate, privacy: .public) inputChannels=\(audioSession.inputNumberOfChannels, privacy: .public)"
-        )
-        try ComposerVoiceInputStartPolicy.validateAudioSessionInput(
-            isInputAvailable: audioSession.isInputAvailable,
-            sampleRate: audioSession.sampleRate,
-            inputNumberOfChannels: audioSession.inputNumberOfChannels
-        )
+        logger.info("Voice input audio session active inputAvailable=\(audioSession.isInputAvailable, privacy: .public) sampleRate=\(audioSession.sampleRate, privacy: .public) inputChannels=\(audioSession.inputNumberOfChannels, privacy: .public)")
+        try ComposerVoiceInputStartPolicy.validateAudioSessionInput(isInputAvailable: audioSession.isInputAvailable, sampleRate: audioSession.sampleRate, inputNumberOfChannels: audioSession.inputNumberOfChannels)
 
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
@@ -279,14 +266,10 @@ final class ComposerVoiceInputController {
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: 0)
         try ComposerVoiceInputPreflight.validate(recordingFormat: recordingFormat)
-        logger.info(
-            "Voice input installing audio tap sampleRate=\(recordingFormat.sampleRate, privacy: .public) channels=\(recordingFormat.channelCount, privacy: .public)"
-        )
-        inputNode.installTap(onBus: 0, bufferSize: 1_024, format: recordingFormat) { [weak request] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak request] buffer, _ in
             request?.append(buffer)
         }
         audioTapInstalled = true
-        logger.info("Voice input audio tap installed")
 
         audioEngine.prepare()
 
@@ -336,28 +319,24 @@ final class ComposerVoiceInputController {
     private func stopAudio(cancelTask: Bool) {
         ComposerAudioCaptureState.shared.setCapturing(false)
 
-        // Stop server STT recorder
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+
+        let hadServerRecording = audioRecorder?.isRecording == true && recordingURL != nil
+
         if let recorder = audioRecorder, recorder.isRecording {
             recorder.stop()
             audioRecorder = nil
-            // If we were in serverListening state, finalize the transcription
-            if state == .serverListening {
-                Task { await finishServerRecording() }
-            }
         }
 
         if let audioEngine {
             if audioEngine.isRunning {
                 audioEngine.stop()
-                logger.info("Voice input audio engine stopped")
             }
-
             if audioTapInstalled {
                 audioEngine.inputNode.removeTap(onBus: 0)
                 audioTapInstalled = false
-                logger.info("Voice input audio tap removed")
             }
-
             audioEngine.reset()
         }
         audioEngine = nil
@@ -371,10 +350,16 @@ final class ComposerVoiceInputController {
         recognitionTask = nil
         recognitionRequest = nil
 
+        if hadServerRecording, let url = recordingURL {
+            let task = Task { [weak self] in
+                await self?.finishServerRecording()
+            }
+            transcriptionTask = task
+        }
+
         if activatedAudioSessionForRecording {
             try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
             activatedAudioSessionForRecording = false
-            logger.info("Voice input audio session deactivated")
         }
     }
 
@@ -382,7 +367,6 @@ final class ComposerVoiceInputController {
         if let speechRecognizer {
             return speechRecognizer
         }
-
         let speechRecognizer = speechRecognizerFactory()
         self.speechRecognizer = speechRecognizer
         return speechRecognizer
@@ -426,33 +410,21 @@ final class ComposerVoiceInputController {
 
     private static func logDescription(for status: SFSpeechRecognizerAuthorizationStatus) -> String {
         switch status {
-        case .denied:
-            return "denied"
-        case .restricted:
-            return "restricted"
-        case .notDetermined:
-            return "notDetermined"
-        case .authorized:
-            return "authorized"
-        @unknown default:
-            return "unknown"
+        case .denied: return "denied"
+        case .restricted: return "restricted"
+        case .notDetermined: return "notDetermined"
+        case .authorized: return "authorized"
+        @unknown default: return "unknown"
         }
     }
 
     private static func logCategory(for error: Error) -> VoiceInputFailureLogCategory {
-        guard let voiceError = error as? ComposerVoiceInputError else {
-            return .audioStartup
-        }
-
+        guard let voiceError = error as? ComposerVoiceInputError else { return .audioStartup }
         switch voiceError {
-        case .noAudioInput:
-            return .noAudioInput
-        case .invalidInputFormat:
-            return .invalidInputFormat
-        case .appNotActive:
-            return .appNotActive
-        case .audioEngineAlreadyRunning:
-            return .audioEngineAlreadyRunning
+        case .noAudioInput: return .noAudioInput
+        case .invalidInputFormat: return .invalidInputFormat
+        case .appNotActive: return .appNotActive
+        case .audioEngineAlreadyRunning: return .audioEngineAlreadyRunning
         }
     }
 }
@@ -482,7 +454,7 @@ enum ComposerVoiceInputError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .noAudioInput:
-            return String(localized: "No microphone input is available. Check the Simulator or device microphone settings.")
+            return String(localized: "No microphone input is available.")
         case .invalidInputFormat:
             return String(localized: "Voice input is not available because the microphone input format is invalid.")
         case .appNotActive:
@@ -505,65 +477,35 @@ enum VoiceInputFailureLogCategory: String {
 }
 
 enum ComposerVoiceInputStartPolicy {
-    static func canStart(appIsActive: Bool) -> Bool {
-        appIsActive
+    static func canStart(appIsActive: Bool) -> Bool { appIsActive }
+    static func validateAudioSessionInput(isInputAvailable: Bool, sampleRate: Double, inputNumberOfChannels: Int) throws {
+        guard isInputAvailable else { throw ComposerVoiceInputError.noAudioInput }
+        try ComposerVoiceInputPreflight.validate(sampleRate: sampleRate, channelCount: UInt32(max(inputNumberOfChannels, 0)))
     }
-
-    static func validateAudioSessionInput(
-        isInputAvailable: Bool,
-        sampleRate: Double,
-        inputNumberOfChannels: Int
-    ) throws {
-        guard isInputAvailable else {
-            throw ComposerVoiceInputError.noAudioInput
-        }
-
-        try ComposerVoiceInputPreflight.validate(
-            sampleRate: sampleRate,
-            channelCount: UInt32(max(inputNumberOfChannels, 0))
-        )
-    }
-
     static func validateAudioEngine(isRunning: Bool) throws {
-        guard !isRunning else {
-            throw ComposerVoiceInputError.audioEngineAlreadyRunning
-        }
+        guard !isRunning else { throw ComposerVoiceInputError.audioEngineAlreadyRunning }
     }
 }
 
 enum ComposerVoiceInputPreflight {
     static let validSampleRateRange: ClosedRange<Double> = 8_000...192_000
     static let validChannelCountRange: ClosedRange<UInt32> = 1...16
-
     static func validate(sampleRate: Double, channelCount: UInt32) throws {
-        guard sampleRate.isFinite,
-              validSampleRateRange.contains(sampleRate),
-              validChannelCountRange.contains(channelCount)
-        else {
+        guard sampleRate.isFinite, validSampleRateRange.contains(sampleRate), validChannelCountRange.contains(channelCount) else {
             throw ComposerVoiceInputError.invalidInputFormat
         }
     }
-
     static func validate(recordingFormat: AVAudioFormat) throws {
-        try validate(
-            sampleRate: recordingFormat.sampleRate,
-            channelCount: recordingFormat.channelCount
-        )
+        try validate(sampleRate: recordingFormat.sampleRate, channelCount: recordingFormat.channelCount)
     }
 }
 
 enum ComposerVoiceDraftComposer {
     static func composedDraft(baseDraft: String, transcript: String) -> String {
         let trimmedTranscript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTranscript.isEmpty else {
-            return baseDraft
-        }
-
+        guard !trimmedTranscript.isEmpty else { return baseDraft }
         let trimmedTrailingDraft = baseDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTrailingDraft.isEmpty else {
-            return trimmedTranscript
-        }
-
+        guard !trimmedTrailingDraft.isEmpty else { return trimmedTranscript }
         return "\(trimmedTrailingDraft) \(trimmedTranscript)"
     }
 }
@@ -571,31 +513,14 @@ enum ComposerVoiceDraftComposer {
 struct ComposerVoiceDraftUpdateSession {
     private var baseDraft = ""
     private var acceptsUpdates = false
-
-    mutating func begin(baseDraft: String) {
-        self.baseDraft = baseDraft
-        acceptsUpdates = true
-    }
-
-    mutating func stopAcceptingUpdates() {
-        acceptsUpdates = false
-    }
-
+    mutating func begin(baseDraft: String) { self.baseDraft = baseDraft; acceptsUpdates = true }
+    mutating func stopAcceptingUpdates() { acceptsUpdates = false }
     func composedDraft(for transcript: String) -> String? {
-        guard acceptsUpdates else {
-            return nil
-        }
-
-        return ComposerVoiceDraftComposer.composedDraft(
-            baseDraft: baseDraft,
-            transcript: transcript
-        )
+        guard acceptsUpdates else { return nil }
+        return ComposerVoiceDraftComposer.composedDraft(baseDraft: baseDraft, transcript: transcript)
     }
 }
 
 private extension Logger {
-    static let hermesVoiceInput = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile",
-        category: "VoiceInput"
-    )
+    static let hermesVoiceInput = Logger(subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile", category: "VoiceInput")
 }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -188,6 +188,12 @@ final class ComposerVoiceInputController {
     }
 
     private func finishServerRecording() async {
+        guard !Task.isCancelled else {
+            try? FileManager.default.removeItem(at: recordingURL ?? URL(fileURLWithPath: "/dev/null"))
+            recordingURL = nil
+            audioRecorder = nil
+            return
+        }
         guard let recorder = audioRecorder, let recordingURL = self.recordingURL else {
             return
         }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -190,19 +190,25 @@ final class ComposerVoiceInputController {
     private func finishServerRecording(recorder: AVAudioRecorder, recordingURL: URL) async {
         guard !Task.isCancelled else {
             try? FileManager.default.removeItem(at: recordingURL)
-            audioRecorder = nil
+            if self.audioRecorder === recorder {
+                self.audioRecorder = nil
+            }
             return
         }
 
         if recorder.isRecording {
             recorder.stop()
         }
-        audioRecorder = nil
+        if self.audioRecorder === recorder {
+            self.audioRecorder = nil
+        }
         ComposerAudioCaptureState.shared.setCapturing(false)
         logger.info("Server STT: recording finished, duration=\(recorder.currentTime)s")
 
         guard let apiClient else {
-            audioRecorder = nil
+            if self.audioRecorder === recorder {
+                self.audioRecorder = nil
+            }
             try? FileManager.default.removeItem(at: recordingURL)
             if self.recordingURL == recordingURL {
             self.recordingURL = nil
@@ -228,7 +234,9 @@ final class ComposerVoiceInputController {
                 if self.recordingURL == recordingURL {
                 self.recordingURL = nil
                 }
-                audioRecorder = nil
+                if self.audioRecorder === recorder {
+                    self.audioRecorder = nil
+                }
                 stopAcceptingDraftUpdates()
                 return
             }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -48,7 +48,7 @@ final class ComposerVoiceInputController {
     }
 
     var isListening: Bool {
-        state == .listening || state == .serverListening
+        state == .listening || state == .serverListening || state == .transcribing
     }
 
     var isRequestingPermission: Bool {
@@ -224,6 +224,14 @@ final class ComposerVoiceInputController {
                 filename: "recording.wav",
                 language: languageCode
             )
+
+            guard !Task.isCancelled else {
+                try? FileManager.default.removeItem(at: recordingURL)
+                self.recordingURL = nil
+                audioRecorder = nil
+                stopAcceptingDraftUpdates()
+                return
+            }
 
             try? FileManager.default.removeItem(at: recordingURL)
             self.recordingURL = nil

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -213,10 +213,12 @@ final class ComposerVoiceInputController {
             if self.recordingURL == recordingURL {
             self.recordingURL = nil
             }
+            guard self.recordingURL == recordingURL else { return }
             fail("Speech-to-text is not configured on this server.", logCategory: .speechUnavailable)
             return
         }
 
+        guard self.recordingURL == recordingURL else { return }
         state = .transcribing
         liveTranscript = String(localized: "Transcribing...")
 
@@ -246,6 +248,7 @@ final class ComposerVoiceInputController {
             }
 
             if let transcript = response.transcript, !transcript.isEmpty {
+                guard self.recordingURL == recordingURL else { return }
                 liveTranscript = transcript
                 if let composedDraft = draftUpdateSession.composedDraft(for: transcript) {
                     updateDraft?(composedDraft)
@@ -261,6 +264,7 @@ final class ComposerVoiceInputController {
             if self.recordingURL == recordingURL {
             self.recordingURL = nil
             }
+            guard self.recordingURL == recordingURL else { return }
             fail(error.localizedDescription, logCategory: .speechUnavailable)
         }
     }

--- a/HermesMobile/Networking/APIClient+Transcribe.swift
+++ b/HermesMobile/Networking/APIClient+Transcribe.swift
@@ -5,22 +5,26 @@ extension APIClient {
     /// the tolerant `{ok, transcript, error}` payload. Mirrors `uploadFile`'s
     /// multipart shape but sends only the `file` field (no `session_id`).
     ///
+    /// When `language` is provided (e.g. `"et"` for Estonian), the server's Whisper
+    /// model uses it as a hint — improving accuracy for low-resource languages.
+    ///
     /// The server returns a JSON `{error: ...}` body even for 503/400/413
     /// responses, so we decode the body regardless of status and let the caller
     /// inspect `.error`. Only `401` maps to `.unauthorized`; a body that isn't the
     /// expected shape on a non-2xx status surfaces as `.http`.
-    func transcribeAudio(data: Data, filename: String) async throws -> TranscribeResponse {
+    func transcribeAudio(data: Data, filename: String, language: String? = nil) async throws -> TranscribeResponse {
         let boundary = "Boundary-\(UUID().uuidString)"
         var request = URLRequest(url: Endpoint.transcribe.url(relativeTo: baseURL))
         request.httpMethod = "POST"
         request.cachePolicy = .reloadIgnoringLocalCacheData
-        // Custom headers first, then built-ins so the multipart Content-Type
-        // always wins. Same reverse proxy requirement as uploadFile (#61).
         customHeaderProvider().apply(to: &request)
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         var body = Data()
         body.appendMultipart(fileField: "file", filename: filename, data: data, boundary: boundary)
+        if let language {
+            body.appendMultipart(textField: "language", value: language, boundary: boundary)
+        }
         body.appendMultipartClosingBoundary(boundary)
         request.httpBody = body
 
@@ -31,9 +35,6 @@ extension APIClient {
         if httpResponse.statusCode == 401 {
             throw APIError.unauthorized
         }
-        // Decode first: the server returns `{error: ...}` even for 503/400/413, so
-        // surfacing `.error` is friendlier than a raw HTTP failure. Fall back to a
-        // thrown HTTP error only when the body isn't the expected JSON shape.
         if let decoded = try? decode(TranscribeResponse.self, from: responseData) {
             return decoded
         }


### PR DESCRIPTION
## Summary

Fix #90 — Apple's `SFSpeechRecognizer` does not support Estonian (`et-EE`). This PR adds a **server-side STT fallback** using the existing `POST /api/transcribe` endpoint (Whisper), which supports 100+ languages including Estonian.

## Changes

### ComposerVoiceInputController.swift
- Added optional `apiClient: APIClient?` and `locale: Locale` parameters
- At start, checks `SFSpeechRecognizer.supportedLocales()` — if the current locale is not supported, falls back to server STT
- Server STT path: records 16kHz mono WAV audio, uploads to `POST /api/transcribe`
- Apple native path unchanged for the 60+ supported locales (offline, instant)

### APIClient+Transcribe.swift
- Added optional `language: String?` parameter to `transcribeAudio` (e.g. `"et"` for Estonian)
- When provided, sends the language hint as a multipart field to improve Whisper accuracy

## Architecture

Three independent layers:

| Layer | Source of truth | Change |
|---|---|---|
| UI language | Phone locale / .xcstrings | Unchanged |
| TTS voice | Server config (`ServerTTSPolicy`) | Unchanged (see #90 discussion) |
| STT | Apple native for supported locales, server for the rest | **This PR** |

## Testing

- Estonian locale (`et-EE`): should use `POST /api/transcribe` automatically
- English locale (`en-US`): should use Apple's `SFSpeechRecognizer` (unchanged)
- Server must have STT configured (`faster-whisper` or API key)

## Refs

Closes #90
