### PR TITLE
feat: add composer STT provider preference

### DIFF
--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -598,3 +598,87 @@ enum StreamingSendBehavior: String, CaseIterable, Identifiable {
         StreamingSendBehavior(rawValue: rawValue) ?? .steer
     }
 }
+
+enum ComposerSTTProviderPreference: String, CaseIterable, Identifiable {
+    case serverFirst
+    case onDeviceFirst
+    case onDeviceOnly
+
+    static let storageKey = "composerSTTProviderPreference"
+    static let defaultValue: ComposerSTTProviderPreference = .serverFirst
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .serverFirst:
+            String(localized: "Server first")
+        case .onDeviceFirst:
+            String(localized: "On-device first")
+        case .onDeviceOnly:
+            String(localized: "On-device only")
+        }
+    }
+
+    static func storedValue(_ rawValue: String) -> ComposerSTTProviderPreference {
+        ComposerSTTProviderPreference(rawValue: rawValue) ?? defaultValue
+    }
+}
+
+enum ComposerSTTProvider: Equatable {
+    case server
+    case onDevice
+}
+
+enum ComposerSTTProviderPolicy {
+    static func orderedProviders(
+        preference: ComposerSTTProviderPreference,
+        serverConfigured: Bool,
+        onDeviceSupported: Bool
+    ) -> [ComposerSTTProvider] {
+        switch preference {
+        case .serverFirst:
+            return compactProviders(
+                (.server, serverConfigured),
+                (.onDevice, onDeviceSupported)
+            )
+        case .onDeviceFirst:
+            return compactProviders(
+                (.onDevice, onDeviceSupported),
+                (.server, serverConfigured)
+            )
+        case .onDeviceOnly:
+            return compactProviders((.onDevice, onDeviceSupported))
+        }
+    }
+
+    static func fallbackProvider(
+        after failedProvider: ComposerSTTProvider,
+        preference: ComposerSTTProviderPreference,
+        serverConfigured: Bool,
+        onDeviceSupported: Bool
+    ) -> ComposerSTTProvider? {
+        let providers = orderedProviders(
+            preference: preference,
+            serverConfigured: serverConfigured,
+            onDeviceSupported: onDeviceSupported
+        )
+        guard let failedIndex = providers.firstIndex(of: failedProvider) else {
+            return nil
+        }
+
+        let fallbackIndex = providers.index(after: failedIndex)
+        guard fallbackIndex < providers.endIndex else {
+            return nil
+        }
+        return providers[fallbackIndex]
+    }
+
+    private static func compactProviders(
+        _ candidates: (ComposerSTTProvider, Bool)...
+    ) -> [ComposerSTTProvider] {
+        candidates.compactMap { provider, isAvailable in
+            isAvailable ? provider : nil
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -107,6 +107,7 @@ struct MessageComposerView: View {
     /// When true, dictation auto-starts once this composer appears with the app active —
     /// the "New Chat with Voice" App Intent (#338). Defaults to false for normal composers.
     let autoStartsVoiceInput: Bool
+    let apiClient: APIClient?
     let uploadAttachmentErrorMessage: String?
     let onSend: () -> Void
     let onSendVoiceNote: (Data, String) -> Void
@@ -152,6 +153,7 @@ struct MessageComposerView: View {
     @State private var voiceNoteRecorder = ComposerVoiceNoteRecorder()
     @State private var voiceNoteCancelArmed = false
     @State private var didAutoStartVoiceInput = false
+    @AppStorage(ComposerSTTProviderPreference.storageKey) private var sttProviderPreferenceRawValue = ComposerSTTProviderPreference.defaultValue.rawValue
 
     private var showsSlashAutocomplete: Bool {
         let query = draftMessage.drop(while: { $0.isWhitespace })
@@ -816,16 +818,21 @@ struct MessageComposerView: View {
     }
 
     private var voiceStatus: ComposerVoiceStatus? {
-        if voiceInput.isListening {
+        switch voiceInput.state {
+        case .listening:
             return ComposerVoiceStatus(text: String(localized: "Listening..."), systemImage: "waveform", isError: false)
-        }
-
-        if voiceInput.isRequestingPermission {
+        case .serverListening:
+            return ComposerVoiceStatus(text: String(localized: "Recording..."), systemImage: "mic.fill", isError: false)
+        case .transcribing:
+            return ComposerVoiceStatus(text: String(localized: "Transcribing..."), systemImage: "waveform", isError: false)
+        case .requestingPermission:
             return ComposerVoiceStatus(
                 text: String(localized: "Requesting voice permissions..."),
                 systemImage: "mic.badge.plus",
                 isError: false
             )
+        case .idle:
+            break
         }
 
         if let errorMessage = voiceInput.errorMessage {
@@ -1016,6 +1023,9 @@ struct MessageComposerView: View {
 
     @MainActor
     private func toggleVoiceInput() {
+        voiceInput.apiClient = apiClient
+        voiceInput.providerPreference = ComposerSTTProviderPreference.storedValue(sttProviderPreferenceRawValue)
+        voiceInput.locale = .current
         Task {
             await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
                 draftMessage = newDraft

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -388,7 +388,7 @@ struct MessageComposerView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase != .active {
-                voiceInput.stopKeepingTranscript()
+                voiceInput.stopBeforeSubmittingDraft()
                 // Backgrounding stops the recorder's run-loop ticker, so cancel
                 // the in-flight recording rather than leave it silently stalled.
                 cancelVoiceNote()
@@ -528,7 +528,7 @@ struct MessageComposerView: View {
             keyboardIsVisible = false
         }
         .onDisappear {
-            voiceInput.stopKeepingTranscript()
+            voiceInput.stopBeforeSubmittingDraft()
             cancelVoiceNote()
         }
         .padding(.bottom, keyboardIsVisible ? 10 : 0)

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -392,6 +392,7 @@ struct ChatView: View {
             isUploadingAttachment: viewModel.isUploadingAttachment,
             isSendingVoiceNote: viewModel.isSendingVoiceNote,
             autoStartsVoiceInput: autoStartsVoiceInput,
+            apiClient: viewModel.client,
             uploadAttachmentErrorMessage: viewModel.uploadAttachmentErrorMessage,
             onSend: {
                 Task { await sendDraftMessage() }

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -367,7 +367,7 @@ final class ChatViewModel {
     private var currentProfile: String?
     private let isCLISession: Bool
     private let server: URL
-    private let client: APIClient
+    let client: APIClient
     private let streamCoordinator: ChatStreamCoordinator
     private let pendingActionCoordinator: ChatPendingActionCoordinator
     private let attachmentCoordinator: ChatAttachmentCoordinator

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -296,6 +296,7 @@ final class ComposerVoiceInputController {
         let recorder = try AVAudioRecorder(url: recordingURL, settings: Self.serverRecordingSettings)
         recorder.prepareToRecord()
         guard recorder.record() else {
+            try? FileManager.default.removeItem(at: recordingURL)
             throw ComposerVoiceInputError.audioRecorderStartFailed
         }
 

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -12,6 +12,8 @@ final class ComposerVoiceInputController {
         case idle
         case requestingPermission
         case listening
+        case serverListening
+        case transcribing
     }
 
     private(set) var state: State = .idle
@@ -24,12 +26,21 @@ final class ComposerVoiceInputController {
     private var audioEngine: AVAudioEngine?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
+    private var audioRecorder: AVAudioRecorder?
+    private var recordingURL: URL?
     private var draftUpdateSession = ComposerVoiceDraftUpdateSession()
     private var updateDraft: ((String) -> Void)?
     private var suppressNextRecognitionError = false
     private var activatedAudioSessionForRecording = false
     private var audioTapInstalled = false
+    @ObservationIgnored private var transcriptionTask: Task<Void, Never>?
+    @ObservationIgnored private var serverRecordingTimeoutTask: Task<Void, Never>?
+    private var activeTranscriptionID: UUID?
     private let logger = Logger.hermesVoiceInput
+
+    @ObservationIgnored var apiClient: APIClient?
+    @ObservationIgnored var providerPreference = ComposerSTTProviderPreference.defaultValue
+    @ObservationIgnored var locale = Locale.current
 
     init(
         speechRecognizerFactory: @escaping () -> SFSpeechRecognizer? = { SFSpeechRecognizer(locale: Locale.current) },
@@ -40,7 +51,7 @@ final class ComposerVoiceInputController {
     }
 
     var isListening: Bool {
-        state == .listening
+        state == .listening || state == .serverListening || state == .transcribing
     }
 
     var isRequestingPermission: Bool {
@@ -57,14 +68,26 @@ final class ComposerVoiceInputController {
 
     func stopKeepingTranscript() {
         suppressNextRecognitionError = true
-        stopAcceptingDraftUpdates()
-        stopAudio(cancelTask: false)
-        state = .idle
+        switch state {
+        case .serverListening:
+            stopServerRecordingAndTranscribe()
+        case .transcribing:
+            cancelServerTranscription()
+            stopAcceptingDraftUpdates()
+            stopAudio(cancelTask: true)
+            state = .idle
+        case .idle, .requestingPermission, .listening:
+            stopAcceptingDraftUpdates()
+            stopAudio(cancelTask: false)
+            state = .idle
+        }
     }
 
     func stopBeforeSubmittingDraft() {
         suppressNextRecognitionError = true
+        cancelServerTranscription()
         stopAcceptingDraftUpdates()
+        discardServerRecording()
         stopAudio(cancelTask: true)
         state = .idle
     }
@@ -76,13 +99,80 @@ final class ComposerVoiceInputController {
         errorMessage = nil
         liveTranscript = ""
         suppressNextRecognitionError = false
+        cancelServerTranscription()
+        discardServerRecording()
         draftUpdateSession.begin(baseDraft: currentDraft)
         self.updateDraft = updateDraft
         state = .requestingPermission
 
-        guard let speechRecognizer = speechRecognizerForRecording() else {
+        let canUseServer = apiClient != nil
+        let canUseOnDevice = onDeviceSpeechRecognizerForRecording() != nil
+        let providers = ComposerSTTProviderPolicy.orderedProviders(
+            preference: providerPreference,
+            serverConfigured: canUseServer,
+            onDeviceSupported: canUseOnDevice
+        )
+
+        guard let provider = providers.first else {
             fail(
-                String(localized: "Speech recognition is not available for the current locale."),
+                unavailableMessage(
+                    serverConfigured: canUseServer,
+                    onDeviceSupported: canUseOnDevice
+                ),
+                logCategory: .speechUnavailable
+            )
+            return
+        }
+
+        await start(provider: provider)
+    }
+
+    private func start(provider: ComposerSTTProvider) async {
+        switch provider {
+        case .server:
+            await startServerProvider()
+        case .onDevice:
+            await startOnDeviceProvider()
+        }
+    }
+
+    private func startServerProvider() async {
+        let isMicrophonePermissionGranted = await requestMicrophonePermission()
+        logger.info("Server voice input microphone permission completed granted=\(isMicrophonePermissionGranted, privacy: .public)")
+        guard state == .requestingPermission else { return }
+        guard isMicrophonePermissionGranted else {
+            fail(
+                String(localized: "Microphone access is disabled. Enable it in Settings to use voice input."),
+                logCategory: .microphonePermission
+            )
+            return
+        }
+
+        guard ComposerVoiceInputStartPolicy.canStart(appIsActive: UIApplication.shared.applicationState == .active) else {
+            fail(
+                ComposerVoiceInputError.appNotActive.localizedDescription,
+                logCategory: .appNotActive
+            )
+            return
+        }
+
+        do {
+            try startServerRecording()
+            state = .serverListening
+        } catch {
+            await fallbackOrFail(
+                from: .server,
+                message: error.localizedDescription,
+                logCategory: Self.logCategory(for: error)
+            )
+        }
+    }
+
+    private func startOnDeviceProvider() async {
+        guard let speechRecognizer = onDeviceSpeechRecognizerForRecording() else {
+            await fallbackOrFail(
+                from: .onDevice,
+                message: String(localized: "On-device speech recognition is not available for the current locale."),
                 logCategory: .speechUnavailable
             )
             return
@@ -92,8 +182,9 @@ final class ComposerVoiceInputController {
         logger.info("Voice input speech authorization completed status=\(Self.logDescription(for: speechStatus), privacy: .public)")
         guard state == .requestingPermission else { return }
         guard speechStatus == .authorized else {
-            fail(
-                Self.speechAuthorizationMessage(for: speechStatus),
+            await fallbackOrFail(
+                from: .onDevice,
+                message: Self.speechAuthorizationMessage(for: speechStatus),
                 logCategory: .speechAuthorization
             )
             return
@@ -122,7 +213,323 @@ final class ComposerVoiceInputController {
             try startRecognition(speechRecognizer: speechRecognizer)
             state = .listening
         } catch {
-            fail(error.localizedDescription, logCategory: Self.logCategory(for: error))
+            await fallbackOrFail(
+                from: .onDevice,
+                message: error.localizedDescription,
+                logCategory: Self.logCategory(for: error)
+            )
+        }
+    }
+
+    private func fallbackOrFail(
+        from failedProvider: ComposerSTTProvider,
+        message: String,
+        logCategory: VoiceInputFailureLogCategory
+    ) async {
+        let fallback = ComposerSTTProviderPolicy.fallbackProvider(
+            after: failedProvider,
+            preference: providerPreference,
+            serverConfigured: apiClient != nil,
+            onDeviceSupported: onDeviceSpeechRecognizerForRecording() != nil
+        )
+
+        guard let fallback else {
+            fail(message, logCategory: logCategory)
+            return
+        }
+
+        logger.info("Voice input falling back after \(String(describing: failedProvider), privacy: .public)")
+        state = .requestingPermission
+        await start(provider: fallback)
+    }
+
+    private func unavailableMessage(serverConfigured: Bool, onDeviceSupported: Bool) -> String {
+        if providerPreference == .onDeviceOnly {
+            return String(localized: "On-device speech recognition is not available for the current locale.")
+        }
+
+        if !serverConfigured && !onDeviceSupported {
+            return String(localized: "Speech-to-text is not available right now.")
+        }
+
+        if !serverConfigured {
+            return String(localized: "Server speech-to-text is not configured.")
+        }
+
+        return String(localized: "On-device speech recognition is not available for the current locale.")
+    }
+
+    // MARK: - Server STT
+
+    private static let maxServerRecordingDuration: UInt64 = 60
+
+    private static let serverRecordingSettings: [String: Any] = [
+        AVFormatIDKey: Int(kAudioFormatLinearPCM),
+        AVSampleRateKey: 16_000.0,
+        AVNumberOfChannelsKey: 1,
+        AVLinearPCMBitDepthKey: 16,
+        AVLinearPCMIsFloatKey: false
+    ]
+
+    private func startServerRecording() throws {
+        stopAudio(cancelTask: true)
+        logger.info("Server voice input audio startup preparing")
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(
+            ComposerVoiceAudioSessionConfiguration.category,
+            mode: ComposerVoiceAudioSessionConfiguration.mode,
+            options: ComposerVoiceAudioSessionConfiguration.options
+        )
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        activatedAudioSessionForRecording = true
+
+        try ComposerVoiceInputStartPolicy.validateAudioSessionInput(
+            isInputAvailable: audioSession.isInputAvailable,
+            sampleRate: audioSession.sampleRate,
+            inputNumberOfChannels: audioSession.inputNumberOfChannels
+        )
+
+        let recordingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hermex-composer-stt-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+        let recorder = try AVAudioRecorder(url: recordingURL, settings: Self.serverRecordingSettings)
+        recorder.prepareToRecord()
+        guard recorder.record() else {
+            throw ComposerVoiceInputError.audioRecorderStartFailed
+        }
+
+        self.recordingURL = recordingURL
+        audioRecorder = recorder
+        ComposerAudioCaptureState.shared.setCapturing(true)
+        startServerRecordingTimeout()
+        logger.info("Server voice input recording started")
+    }
+
+    private func startServerRecordingTimeout() {
+        serverRecordingTimeoutTask?.cancel()
+        serverRecordingTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.maxServerRecordingDuration * 1_000_000_000)
+            await MainActor.run {
+                guard let self, !Task.isCancelled, self.state == .serverListening else { return }
+                self.stopServerRecordingAndTranscribe()
+            }
+        }
+    }
+
+    private func stopServerRecordingAndTranscribe() {
+        serverRecordingTimeoutTask?.cancel()
+        serverRecordingTimeoutTask = nil
+
+        guard state == .serverListening,
+              let recorder = audioRecorder,
+              let recordingURL
+        else {
+            discardServerRecording()
+            stopAudio(cancelTask: true)
+            state = .idle
+            return
+        }
+
+        if recorder.isRecording {
+            recorder.stop()
+        }
+        audioRecorder = nil
+        ComposerAudioCaptureState.shared.setCapturing(false)
+
+        if activatedAudioSessionForRecording {
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            activatedAudioSessionForRecording = false
+        }
+
+        state = .transcribing
+        liveTranscript = ""
+
+        let transcriptionID = UUID()
+        activeTranscriptionID = transcriptionID
+        transcriptionTask = Task { [weak self] in
+            await self?.finishServerRecording(
+                recordingURL: recordingURL,
+                transcriptionID: transcriptionID
+            )
+        }
+    }
+
+    private func finishServerRecording(recordingURL: URL, transcriptionID: UUID) async {
+        guard isActiveTranscription(transcriptionID), !Task.isCancelled else {
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            return
+        }
+
+        guard let apiClient else {
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            fail(
+                String(localized: "Server speech-to-text is not configured."),
+                logCategory: .speechUnavailable
+            )
+            return
+        }
+
+        do {
+            let audioData = try Data(contentsOf: recordingURL)
+            let response = try await apiClient.transcribeAudio(
+                data: audioData,
+                filename: recordingURL.lastPathComponent
+            )
+
+            guard isActiveTranscription(transcriptionID), !Task.isCancelled else {
+                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+                return
+            }
+
+            if let transcript = response.transcript?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !transcript.isEmpty {
+                liveTranscript = transcript
+                if let composedDraft = draftUpdateSession.composedDraft(for: transcript) {
+                    updateDraft?(composedDraft)
+                }
+                stopAcceptingDraftUpdates()
+                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+                state = .idle
+                suppressNextRecognitionError = false
+                return
+            }
+
+            let serverMessage = response.error ?? String(localized: "Transcription returned no text.")
+            await fallbackFromServerFailure(
+                recordingURL: recordingURL,
+                transcriptionID: transcriptionID,
+                message: serverMessage
+            )
+        } catch {
+            guard isActiveTranscription(transcriptionID), !Task.isCancelled else {
+                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+                return
+            }
+
+            await fallbackFromServerFailure(
+                recordingURL: recordingURL,
+                transcriptionID: transcriptionID,
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    private func fallbackFromServerFailure(
+        recordingURL: URL,
+        transcriptionID: UUID,
+        message: String
+    ) async {
+        guard ComposerSTTProviderPolicy.fallbackProvider(
+            after: .server,
+            preference: providerPreference,
+            serverConfigured: apiClient != nil,
+            onDeviceSupported: onDeviceSpeechRecognizerForRecording() != nil
+        ) == .onDevice,
+              let speechRecognizer = onDeviceSpeechRecognizerForRecording()
+        else {
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            fail(message, logCategory: .speechUnavailable)
+            return
+        }
+
+        let speechStatus = await requestSpeechAuthorization()
+        guard isActiveTranscription(transcriptionID), !Task.isCancelled else {
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            return
+        }
+        guard speechStatus == .authorized else {
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            fail(Self.speechAuthorizationMessage(for: speechStatus), logCategory: .speechAuthorization)
+            return
+        }
+
+        do {
+            let transcript = try await recognizeRecordedFile(
+                recordingURL,
+                speechRecognizer: speechRecognizer
+            )
+            guard isActiveTranscription(transcriptionID), !Task.isCancelled else {
+                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+                return
+            }
+
+            liveTranscript = transcript
+            guard !transcript.isEmpty else {
+                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+                fail(
+                    String(localized: "Transcription returned no text."),
+                    logCategory: .speechUnavailable
+                )
+                return
+            }
+            if let composedDraft = draftUpdateSession.composedDraft(for: transcript) {
+                updateDraft?(composedDraft)
+            }
+            stopAcceptingDraftUpdates()
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            state = .idle
+            suppressNextRecognitionError = false
+        } catch {
+            guard isActiveTranscription(transcriptionID), !Task.isCancelled else {
+                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+                return
+            }
+
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            fail(error.localizedDescription, logCategory: .speechUnavailable)
+        }
+    }
+
+    private func recognizeRecordedFile(
+        _ recordingURL: URL,
+        speechRecognizer: SFSpeechRecognizer
+    ) async throws -> String {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let request = SFSpeechURLRecognitionRequest(url: recordingURL)
+                request.requiresOnDeviceRecognition = true
+                request.shouldReportPartialResults = false
+
+                let resumeBox = SpeechRecognitionContinuationBox()
+                recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
+                    Task { @MainActor in
+                        guard let self, !resumeBox.didResume else { return }
+
+                        if let error {
+                            resumeBox.didResume = true
+                            self.recognitionTask = nil
+                            continuation.resume(throwing: error)
+                            return
+                        }
+
+                        guard let result, result.isFinal else { return }
+                        let transcript = result.bestTranscription.formattedString
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        resumeBox.didResume = true
+                        self.recognitionTask = nil
+                        continuation.resume(returning: transcript)
+                    }
+                }
+            }
+        } onCancel: {
+            Task { @MainActor in
+                self.recognitionTask?.cancel()
+                self.recognitionTask = nil
+            }
+        }
+    }
+
+    private func isActiveTranscription(_ transcriptionID: UUID) -> Bool {
+        activeTranscriptionID == transcriptionID
+    }
+
+    private func cleanupRecordingFile(_ recordingURL: URL, transcriptionID: UUID) {
+        try? FileManager.default.removeItem(at: recordingURL)
+        if isActiveTranscription(transcriptionID) {
+            self.recordingURL = nil
+            activeTranscriptionID = nil
+            transcriptionTask = nil
         }
     }
 
@@ -153,6 +560,7 @@ final class ComposerVoiceInputController {
 
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
+        request.requiresOnDeviceRecognition = true
         recognitionRequest = request
 
         let audioEngine = audioEngineFactory()
@@ -216,6 +624,13 @@ final class ComposerVoiceInputController {
 
     private func stopAudio(cancelTask: Bool) {
         ComposerAudioCaptureState.shared.setCapturing(false)
+        serverRecordingTimeoutTask?.cancel()
+        serverRecordingTimeoutTask = nil
+
+        if let recorder = audioRecorder, recorder.isRecording {
+            recorder.stop()
+        }
+        audioRecorder = nil
 
         if let audioEngine {
             if audioEngine.isRunning {
@@ -249,20 +664,64 @@ final class ComposerVoiceInputController {
         }
     }
 
-    private func speechRecognizerForRecording() -> SFSpeechRecognizer? {
+    private func discardServerRecording() {
+        serverRecordingTimeoutTask?.cancel()
+        serverRecordingTimeoutTask = nil
+
+        if let recorder = audioRecorder, recorder.isRecording {
+            recorder.stop()
+        }
+        audioRecorder = nil
+
+        if let recordingURL {
+            try? FileManager.default.removeItem(at: recordingURL)
+            self.recordingURL = nil
+        }
+    }
+
+    private func cancelServerTranscription() {
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+        activeTranscriptionID = nil
+        if let recordingURL {
+            try? FileManager.default.removeItem(at: recordingURL)
+            self.recordingURL = nil
+        }
+    }
+
+    private func onDeviceSpeechRecognizerForRecording() -> SFSpeechRecognizer? {
         if let speechRecognizer {
-            return speechRecognizer
+            return speechRecognizer.supportsOnDeviceRecognition ? speechRecognizer : nil
         }
 
+        guard Self.isLocaleSupportedBySpeechRecognizer(locale) else {
+            return nil
+        }
         let speechRecognizer = speechRecognizerFactory()
+        guard speechRecognizer?.supportsOnDeviceRecognition == true else {
+            return nil
+        }
         self.speechRecognizer = speechRecognizer
         return speechRecognizer
+    }
+
+    private static func isLocaleSupportedBySpeechRecognizer(_ locale: Locale) -> Bool {
+        let target = normalizedLocaleIdentifier(locale.identifier)
+        return SFSpeechRecognizer.supportedLocales().contains { supportedLocale in
+            normalizedLocaleIdentifier(supportedLocale.identifier) == target
+        }
+    }
+
+    private static func normalizedLocaleIdentifier(_ identifier: String) -> String {
+        identifier.replacingOccurrences(of: "_", with: "-").lowercased()
     }
 
     private func fail(_ message: String, logCategory: VoiceInputFailureLogCategory) {
         logger.error("Voice input failed category=\(logCategory.rawValue, privacy: .public)")
         suppressNextRecognitionError = false
         stopAcceptingDraftUpdates()
+        cancelServerTranscription()
+        discardServerRecording()
         stopAudio(cancelTask: true)
         state = .idle
         errorMessage = message
@@ -322,10 +781,14 @@ final class ComposerVoiceInputController {
             return .invalidInputFormat
         case .appNotActive:
             return .appNotActive
-        case .audioEngineAlreadyRunning:
+        case .audioEngineAlreadyRunning, .audioRecorderStartFailed:
             return .audioEngineAlreadyRunning
         }
     }
+}
+
+private final class SpeechRecognitionContinuationBox {
+    var didResume = false
 }
 
 enum ComposerVoiceMicrophonePermissionRequester {
@@ -349,6 +812,7 @@ enum ComposerVoiceInputError: LocalizedError {
     case invalidInputFormat
     case appNotActive
     case audioEngineAlreadyRunning
+    case audioRecorderStartFailed
 
     var errorDescription: String? {
         switch self {
@@ -360,6 +824,8 @@ enum ComposerVoiceInputError: LocalizedError {
             return String(localized: "Voice input can start only while Hermex is active.")
         case .audioEngineAlreadyRunning:
             return String(localized: "Voice input is already preparing the microphone. Try again in a moment.")
+        case .audioRecorderStartFailed:
+            return String(localized: "Voice input could not start recording. Try again in a moment.")
         }
     }
 }

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -64,6 +64,7 @@ struct SettingsView: View {
     @AppStorage(SessionRowDisplaySettings.showCronSessionsKey) private var showsCronSessions = true
     @State private var cliSessionsSync: CliSessionsSyncModel
     @AppStorage(StreamingSendBehavior.storageKey) private var streamingSendBehaviorRawValue = StreamingSendBehavior.steer.rawValue
+    @AppStorage(ComposerSTTProviderPreference.storageKey) private var sttProviderPreferenceRawValue = ComposerSTTProviderPreference.defaultValue.rawValue
     @AppStorage(ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey) private var showsThinkingAndToolCards = true
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var thinkingCardsStartExpanded = false
     @AppStorage(ChatTranscriptDisplaySettings.toolCardsStartExpandedKey) private var toolCardsStartExpanded = false
@@ -165,6 +166,20 @@ struct SettingsView: View {
                             Text(behavior.settingsDescription).tag(behavior.rawValue)
                         }
                     }
+
+                    SettingsDivider()
+
+                    SettingsPickerRow(
+                        title: String(localized: "Dictation Provider"),
+                        systemImage: "mic",
+                        selection: $sttProviderPreferenceRawValue
+                    ) {
+                        ForEach(ComposerSTTProviderPreference.allCases) { preference in
+                            Text(preference.title).tag(preference.rawValue)
+                        }
+                    }
+
+                    SettingsFootnote(String(localized: "On-device only keeps composer dictation audio off your Hermes server."))
                 }
 
                 SettingsCard(title: String(localized: "Chat")) {

--- a/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
+++ b/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
@@ -184,6 +184,86 @@ final class ComposerVoiceDraftComposerTests: XCTestCase {
         XCTAssertEqual(counter.speechRecognizerCalls, 0)
         XCTAssertEqual(counter.audioEngineCalls, 0)
     }
+
+    func testSTTProviderPreferenceDefaultsToServerFirst() {
+        XCTAssertEqual(ComposerSTTProviderPreference.defaultValue, .serverFirst)
+        XCTAssertEqual(
+            ComposerSTTProviderPreference.storedValue("unknown"),
+            .serverFirst
+        )
+    }
+
+    func testServerFirstPolicyPrefersServerThenOnDevice() {
+        XCTAssertEqual(
+            ComposerSTTProviderPolicy.orderedProviders(
+                preference: .serverFirst,
+                serverConfigured: true,
+                onDeviceSupported: true
+            ),
+            [.server, .onDevice]
+        )
+    }
+
+    func testServerFirstPolicyFallsBackToOnDeviceWhenServerIsNotConfigured() {
+        XCTAssertEqual(
+            ComposerSTTProviderPolicy.orderedProviders(
+                preference: .serverFirst,
+                serverConfigured: false,
+                onDeviceSupported: true
+            ),
+            [.onDevice]
+        )
+    }
+
+    func testOnDeviceFirstPolicyFallsBackToServerWhenOnDeviceIsUnsupported() {
+        XCTAssertEqual(
+            ComposerSTTProviderPolicy.orderedProviders(
+                preference: .onDeviceFirst,
+                serverConfigured: true,
+                onDeviceSupported: false
+            ),
+            [.server]
+        )
+    }
+
+    func testOnDeviceOnlyPolicyNeverRoutesToServer() {
+        XCTAssertEqual(
+            ComposerSTTProviderPolicy.orderedProviders(
+                preference: .onDeviceOnly,
+                serverConfigured: true,
+                onDeviceSupported: true
+            ),
+            [.onDevice]
+        )
+        XCTAssertEqual(
+            ComposerSTTProviderPolicy.orderedProviders(
+                preference: .onDeviceOnly,
+                serverConfigured: true,
+                onDeviceSupported: false
+            ),
+            []
+        )
+    }
+
+    func testProviderPolicyReturnsNextFallbackOnly() {
+        XCTAssertEqual(
+            ComposerSTTProviderPolicy.fallbackProvider(
+                after: .server,
+                preference: .serverFirst,
+                serverConfigured: true,
+                onDeviceSupported: true
+            ),
+            .onDevice
+        )
+        XCTAssertNil(
+            ComposerSTTProviderPolicy.fallbackProvider(
+                after: .server,
+                preference: .onDeviceOnly,
+                serverConfigured: true,
+                onDeviceSupported: true
+            )
+        )
+    }
 }
 
 private final class VoiceInputFactoryCounter {


### PR DESCRIPTION
## Summary
- add Server first, On-device first, and On-device only composer dictation preferences
- record and transcribe through the documented server STT endpoint with policy-controlled fallback
- distinguish recording and transcribing states, with cancellation-safe cleanup

## Validation
- `git diff --check`
- focused simulator XCTest: 26/26 passed
- full simulator XCTest: 1328/1328 passed
- signed Debug build/install/launch on iPhone 17
- physical-device validation through Hermex Branch TestFlight build `1.4 (202607091325)`: passed

Fixes #90