### PR TITLE
Feat: add camera capture to composer attachment menu (#78)

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		A710739233F64F4FA4C2B700 /* ComposerVoiceInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A710739233F64F4FA4C2B710 /* ComposerVoiceInputController.swift */; };
 		A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */; };
 		B53F3F24A5C24D9E8E54A810 /* SlashCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1CE5F12B9E4D4D9E5A01C1 /* SlashCommandExecutor.swift */; };
+		C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CAM000000000000000B002 /* CameraPickerView.swift */; };
 		C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000002 /* ChatComposerView.swift */; };
 		C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */; };
 		105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */; };
@@ -612,6 +613,7 @@
 		A04500000000000000000014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A04500000000000000000017 /* HermesLiveActivityWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HermesLiveActivityWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A04500000000000000000018 /* LiveActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityTests.swift; sourceTree = "<group>"; };
+		C0CAM000000000000000B002 /* CameraPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPickerView.swift; sourceTree = "<group>"; };
 		C0DEC0DE0000000000000002 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
 		C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelTests.swift; sourceTree = "<group>"; };
 		FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandAutocompleteView.swift; sourceTree = "<group>"; };
@@ -938,6 +940,7 @@
 				C05100000000000000000012 /* ChatMessageActions.swift */,
 				C05100000000000000000013 /* ChatGoalControls.swift */,
 				C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */,
+				C0CAM000000000000000B002 /* CameraPickerView.swift */,
 				C0DEC0DE0000000000000002 /* ChatComposerView.swift */,
 				C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */,
 				C04900000000000000000002 /* ChatComposerTextInputView.swift */,
@@ -1439,7 +1442,8 @@
 					C05100000000000000000002 /* ChatMessageActions.swift in Sources */,
 					C05100000000000000000003 /* ChatGoalControls.swift in Sources */,
 					C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */,
-					C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */,
+					C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */,
+				C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */,
 					C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */,
 					C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */,
 					C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */,

--- a/HermesMobile/Features/Chat/CameraPickerView.swift
+++ b/HermesMobile/Features/Chat/CameraPickerView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import UIKit
+
+struct CameraPickerView: UIViewControllerRepresentable {
+    let onCapture: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCapture: onCapture, dismiss: dismiss)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onCapture: (UIImage) -> Void
+        let dismiss: DismissAction
+
+        init(onCapture: @escaping (UIImage) -> Void, dismiss: DismissAction) {
+            self.onCapture = onCapture
+            self.dismiss = dismiss
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            let image = info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage
+            if let image {
+                onCapture(image)
+            }
+            dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            dismiss()
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/CameraPickerView.swift
+++ b/HermesMobile/Features/Chat/CameraPickerView.swift
@@ -11,12 +11,19 @@ struct CameraPickerView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
-        picker.sourceType = .camera
+        picker.sourceType = Self.preferredSourceType
         picker.delegate = context.coordinator
         return picker
     }
 
     func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    private static var preferredSourceType: UIImagePickerController.SourceType {
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            return .camera
+        }
+        return .photoLibrary
+    }
 
     final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
         let onCapture: (UIImage) -> Void

--- a/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
@@ -35,6 +35,10 @@ final class ChatAttachmentCoordinator {
         activeUploadCount > 0
     }
 
+    var uploadInFlightCount: Int {
+        activeUploadCount
+    }
+
     weak var delegate: ChatAttachmentCoordinatorDelegate?
 
     private let client: APIClient

--- a/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatAttachmentCoordinator.swift
@@ -30,6 +30,7 @@ final class ChatAttachmentCoordinator {
     private(set) var uploadAttachmentErrorMessage: String?
     private(set) var localAttachmentPreviews: [String: [String: Data]] = [:]
     private var activeUploadCount = 0
+    private(set) var uploadStartGeneration = 0
 
     var isUploadingAttachment: Bool {
         activeUploadCount > 0
@@ -84,6 +85,7 @@ final class ChatAttachmentCoordinator {
         let uploadFilename = reserveUploadFilename(preferredFilename: displayFilename)
 
         activeUploadCount += 1
+        uploadStartGeneration += 1
         uploadAttachmentErrorMessage = nil
         delegate?.attachmentCoordinatorWillUpload()
         defer {

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -147,6 +147,7 @@ struct MessageComposerView: View {
     @State private var shouldRestoreFocusAfterUpload = false
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
     @State private var showPhotoPicker = false
+    @State private var showCameraPicker = false
     @State private var showFileImporter = false
     @State private var voiceInput = ComposerVoiceInputController()
     @State private var voiceNoteRecorder = ComposerVoiceNoteRecorder()
@@ -594,6 +595,18 @@ struct MessageComposerView: View {
                 onPhotoItemSelected(item)
             }
         }
+        .sheet(isPresented: $showCameraPicker) {
+            CameraPickerView { image in
+                deferFocusRestoreUntilUploadCompletes()
+                onPasteImages([image])
+            }
+            .ignoresSafeArea()
+        }
+        .onChange(of: showCameraPicker) { _, isPresented in
+            if !isPresented {
+                restoreFocusAfterPresentationDismissalSettles()
+            }
+        }
     }
 
     private func composerOptionsMenu() -> UIMenu {
@@ -618,6 +631,16 @@ struct MessageComposerView: View {
                         Task { @MainActor in
                             prepareForComposerPresentation()
                             showPhotoPicker = true
+                        }
+                    },
+                    UIAction(
+                        title: String(localized: "Camera"),
+                        image: UIImage(systemName: "camera"),
+                        attributes: UIImagePickerController.isSourceTypeAvailable(.camera) ? [] : .disabled
+                    ) { _ in
+                        Task { @MainActor in
+                            prepareForComposerPresentation()
+                            showCameraPicker = true
                         }
                     }
                 ]

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -104,6 +104,7 @@ struct MessageComposerView: View {
     let pendingAttachments: [PendingAttachment]
     let isUploadingAttachment: Bool
     let attachmentUploadCount: Int
+    let attachmentUploadGeneration: Int
     let isSendingVoiceNote: Bool
     /// When true, dictation auto-starts once this composer appears with the app active —
     /// the "New Chat with Voice" App Intent (#338). Defaults to false for normal composers.
@@ -157,9 +158,8 @@ struct MessageComposerView: View {
 
     private enum DeferredUploadFocusPhase: Equatable {
         case none
-        case waitingForNextUploadToComplete
-        case waitingForExistingUploadsToDrain(existingCount: Int)
-        case waitingForAllUploadsToFinish
+        case waitingForUploadStart(afterGeneration: Int)
+        case waitingForUploadsToFinish
     }
 
     private var showsSlashAutocomplete: Bool {
@@ -518,8 +518,11 @@ struct MessageComposerView: View {
                 restoreFocusAfterPresentationDismissalSettles()
             }
         }
-        .onChange(of: attachmentUploadCount) { oldCount, newCount in
-            handleDeferredUploadFocusTransition(from: oldCount, to: newCount)
+        .onChange(of: attachmentUploadGeneration) { _, newGeneration in
+            handleDeferredUploadStart(newGeneration)
+        }
+        .onChange(of: attachmentUploadCount) { _, newCount in
+            handleDeferredUploadCountChange(newCount)
         }
         .onChange(of: uploadAttachmentErrorMessage) { _, newValue in
             if newValue != nil {
@@ -1117,32 +1120,25 @@ struct MessageComposerView: View {
     private func deferFocusRestoreUntilUploadCompletes() {
         guard shouldRestoreFocusAfterPresentation else { return }
         shouldRestoreFocusAfterPresentation = false
+        deferredUploadFocusPhase = .waitingForUploadStart(afterGeneration: attachmentUploadGeneration)
+    }
 
-        if attachmentUploadCount > 0 {
-            deferredUploadFocusPhase = .waitingForExistingUploadsToDrain(existingCount: attachmentUploadCount)
+    private func handleDeferredUploadStart(_ newGeneration: Int) {
+        guard case let .waitingForUploadStart(afterGeneration) = deferredUploadFocusPhase,
+              newGeneration > afterGeneration
+        else { return }
+
+        if attachmentUploadCount == 0 {
+            restoreFocusAfterDeferredUploadIfNeeded()
         } else {
-            deferredUploadFocusPhase = .waitingForNextUploadToComplete
+            deferredUploadFocusPhase = .waitingForUploadsToFinish
         }
     }
 
-    private func handleDeferredUploadFocusTransition(from oldCount: Int, to newCount: Int) {
-        switch deferredUploadFocusPhase {
-        case .none:
-            return
-        case .waitingForNextUploadToComplete:
-            if oldCount > 0, newCount == 0 {
-                restoreFocusAfterDeferredUploadIfNeeded()
-            }
-        case let .waitingForExistingUploadsToDrain(existingCount):
-            if newCount > existingCount {
-                deferredUploadFocusPhase = .waitingForAllUploadsToFinish
-            } else if newCount == 0 {
-                deferredUploadFocusPhase = .waitingForNextUploadToComplete
-            }
-        case .waitingForAllUploadsToFinish:
-            if newCount == 0 {
-                restoreFocusAfterDeferredUploadIfNeeded()
-            }
+    private func handleDeferredUploadCountChange(_ newCount: Int) {
+        guard case .waitingForUploadsToFinish = deferredUploadFocusPhase else { return }
+        if newCount == 0 {
+            restoreFocusAfterDeferredUploadIfNeeded()
         }
     }
 

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -103,6 +103,7 @@ struct MessageComposerView: View {
     let isUpdatingConfiguration: Bool
     let pendingAttachments: [PendingAttachment]
     let isUploadingAttachment: Bool
+    let attachmentUploadCount: Int
     let isSendingVoiceNote: Bool
     /// When true, dictation auto-starts once this composer appears with the app active —
     /// the "New Chat with Voice" App Intent (#338). Defaults to false for normal composers.
@@ -144,7 +145,7 @@ struct MessageComposerView: View {
     @State private var recentModelKeys = ModelRecentsStore.shared.recentKeys
     @State private var keyboardIsVisible = false
     @State private var shouldRestoreFocusAfterPresentation = false
-    @State private var shouldRestoreFocusAfterUpload = false
+    @State private var deferredUploadFocusPhase: DeferredUploadFocusPhase = .none
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
     @State private var showPhotoPicker = false
     @State private var showCameraPicker = false
@@ -153,6 +154,13 @@ struct MessageComposerView: View {
     @State private var voiceNoteRecorder = ComposerVoiceNoteRecorder()
     @State private var voiceNoteCancelArmed = false
     @State private var didAutoStartVoiceInput = false
+
+    private enum DeferredUploadFocusPhase: Equatable {
+        case none
+        case waitingForNextUploadToComplete
+        case waitingForExistingUploadsToDrain(existingCount: Int)
+        case waitingForAllUploadsToFinish
+    }
 
     private var showsSlashAutocomplete: Bool {
         let query = draftMessage.drop(while: { $0.isWhitespace })
@@ -464,7 +472,7 @@ struct MessageComposerView: View {
                 }
 
                 shouldRestoreFocusAfterPresentation = false
-                shouldRestoreFocusAfterUpload = false
+                deferredUploadFocusPhase = .none
                 noticeMessage = error.localizedDescription
             }
         }
@@ -510,14 +518,12 @@ struct MessageComposerView: View {
                 restoreFocusAfterPresentationDismissalSettles()
             }
         }
-        .onChange(of: isUploadingAttachment) { _, isUploading in
-            if !isUploading {
-                restoreFocusAfterUploadIfNeeded()
-            }
+        .onChange(of: attachmentUploadCount) { oldCount, newCount in
+            handleDeferredUploadFocusTransition(from: oldCount, to: newCount)
         }
         .onChange(of: uploadAttachmentErrorMessage) { _, newValue in
             if newValue != nil {
-                shouldRestoreFocusAfterUpload = false
+                deferredUploadFocusPhase = .none
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
@@ -1111,12 +1117,38 @@ struct MessageComposerView: View {
     private func deferFocusRestoreUntilUploadCompletes() {
         guard shouldRestoreFocusAfterPresentation else { return }
         shouldRestoreFocusAfterPresentation = false
-        shouldRestoreFocusAfterUpload = true
+
+        if attachmentUploadCount > 0 {
+            deferredUploadFocusPhase = .waitingForExistingUploadsToDrain(existingCount: attachmentUploadCount)
+        } else {
+            deferredUploadFocusPhase = .waitingForNextUploadToComplete
+        }
     }
 
-    private func restoreFocusAfterUploadIfNeeded() {
-        guard shouldRestoreFocusAfterUpload else { return }
-        shouldRestoreFocusAfterUpload = false
+    private func handleDeferredUploadFocusTransition(from oldCount: Int, to newCount: Int) {
+        switch deferredUploadFocusPhase {
+        case .none:
+            return
+        case .waitingForNextUploadToComplete:
+            if oldCount > 0, newCount == 0 {
+                restoreFocusAfterDeferredUploadIfNeeded()
+            }
+        case let .waitingForExistingUploadsToDrain(existingCount):
+            if newCount > existingCount {
+                deferredUploadFocusPhase = .waitingForAllUploadsToFinish
+            } else if newCount == 0 {
+                deferredUploadFocusPhase = .waitingForNextUploadToComplete
+            }
+        case .waitingForAllUploadsToFinish:
+            if newCount == 0 {
+                restoreFocusAfterDeferredUploadIfNeeded()
+            }
+        }
+    }
+
+    private func restoreFocusAfterDeferredUploadIfNeeded() {
+        guard deferredUploadFocusPhase != .none else { return }
+        deferredUploadFocusPhase = .none
         requestTextViewFocusIfPossible()
     }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -175,6 +175,7 @@ struct ChatView: View {
             pendingAttachments: viewModel.pendingAttachments,
             isUploadingAttachment: viewModel.isUploadingAttachment,
             attachmentUploadCount: viewModel.attachmentUploadCount,
+            attachmentUploadGeneration: viewModel.attachmentUploadGeneration,
             isSendingVoiceNote: viewModel.isSendingVoiceNote,
             autoStartsVoiceInput: autoStartsVoiceInput,
             uploadAttachmentErrorMessage: viewModel.uploadAttachmentErrorMessage,

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -174,6 +174,7 @@ struct ChatView: View {
             isUpdatingConfiguration: viewModel.isUpdatingComposerConfiguration,
             pendingAttachments: viewModel.pendingAttachments,
             isUploadingAttachment: viewModel.isUploadingAttachment,
+            attachmentUploadCount: viewModel.attachmentUploadCount,
             isSendingVoiceNote: viewModel.isSendingVoiceNote,
             autoStartsVoiceInput: autoStartsVoiceInput,
             uploadAttachmentErrorMessage: viewModel.uploadAttachmentErrorMessage,

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -208,6 +208,7 @@ final class ChatViewModel {
     var pendingAttachments: [PendingAttachment] { attachmentCoordinator.pendingAttachments }
     var isUploadingAttachment: Bool { attachmentCoordinator.isUploadingAttachment }
     var attachmentUploadCount: Int { attachmentCoordinator.uploadInFlightCount }
+    var attachmentUploadGeneration: Int { attachmentCoordinator.uploadStartGeneration }
     var uploadAttachmentErrorMessage: String? { attachmentCoordinator.uploadAttachmentErrorMessage }
     var localAttachmentPreviews: [String: [String: Data]] { attachmentCoordinator.localAttachmentPreviews }
     private(set) var pinnedLocalNotices: [String] = []

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -207,6 +207,7 @@ final class ChatViewModel {
     private(set) var composerConfigurationErrorMessage: String?
     var pendingAttachments: [PendingAttachment] { attachmentCoordinator.pendingAttachments }
     var isUploadingAttachment: Bool { attachmentCoordinator.isUploadingAttachment }
+    var attachmentUploadCount: Int { attachmentCoordinator.uploadInFlightCount }
     var uploadAttachmentErrorMessage: String? { attachmentCoordinator.uploadAttachmentErrorMessage }
     var localAttachmentPreviews: [String: [String: Data]] { attachmentCoordinator.localAttachmentPreviews }
     private(set) var pinnedLocalNotices: [String] = []

--- a/HermesMobile/Resources/Info.plist
+++ b/HermesMobile/Resources/Info.plist
@@ -52,6 +52,8 @@
 	</dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Hermex needs microphone access to dictate text into the message composer.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Hermex needs camera access to capture and attach photos directly in chat.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Hermex needs photo library access to attach images to chat messages.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -54700,6 +54700,112 @@
         }
       }
     },
+    "Camera" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "كاميرا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kamera"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cámara"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Caméra"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מצלמה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fotocamera"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "カメラ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "카메라"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Camera"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aparat"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Câmera"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Камера"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kamera"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کیمرہ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "相機"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "相机"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "相機"
+          }
+        }
+      }
+    },
     "Photos" : {
       "localizations" : {
         "ar" : {


### PR DESCRIPTION
## Linked issue

Fixes #78

## What changed

- adds a Camera option to the existing Attach menu alongside Photos and Attach File
- presents `UIImagePickerController` with the `.camera` source when camera hardware is available
- sends captured photos through the existing image upload path so they appear in the composer attachment tray like library and pasted images
- keeps the Camera option disabled on simulator / devices without camera hardware instead of crashing
- adds `NSCameraUsageDescription` and localized `Camera` strings

## How it was tested

- `git diff --check`
- `xcodebuild build -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'`
- `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'`

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

AI source: built with OpenAI Codex in pi.
