### PR TITLE
chore: ignore local Codex and Cursor directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ node_modules/
 .agents/
 .sc/
 .claude/
+.codex/
+.cursor/
 
 # App packaging
 *.ipa


### PR DESCRIPTION
Ignores per-machine .codex/ and .cursor/ directories.