### PR TITLE
fix: hide delegated subagent sessions by default

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -15,6 +15,16 @@ struct SessionListRowActions {
     let export: (SessionSummary, SessionExportFormat) -> Void
 }
 
+enum SessionRowActionPolicy {
+    static func offersMutationActions(for session: SessionSummary) -> Bool {
+        !session.isSessionReadOnly
+    }
+
+    static func canExport(_ session: SessionSummary, isViewingCachedData: Bool) -> Bool {
+        !isViewingCachedData && hasServerSessionID(session)
+    }
+}
+
 enum SessionListMotion {
     static func disclosureAnimation(reduceMotion: Bool) -> Animation? {
         reduceMotion ? nil : .smooth(duration: 0.28, extraBounce: 0)
@@ -477,7 +487,9 @@ struct SessionListRowsSection: View {
     }
 
     private func canShowSessionMutationActions(for session: SessionSummary) -> Bool {
-        !viewModel.isViewingCachedData && hasServerSessionID(session)
+        SessionRowActionPolicy.offersMutationActions(for: session)
+            && !viewModel.isViewingCachedData
+            && hasServerSessionID(session)
     }
 }
 
@@ -505,44 +517,45 @@ struct SessionRowContextMenu: View {
             }
         }
 
-        Button {
-            actions.togglePinned(session)
-        } label: {
-            Label(session.pinned == true ? "Unpin" : "Pin", systemImage: "pin")
-        }
-        .disabled(!canShowSessionMutationActions || isMutating)
+        if SessionRowActionPolicy.offersMutationActions(for: session) {
+            Button {
+                actions.togglePinned(session)
+            } label: {
+                Label(session.pinned == true ? "Unpin" : "Pin", systemImage: "pin")
+            }
+            .disabled(!canShowSessionMutationActions || isMutating)
 
-        Button {
-            actions.rename(session)
-        } label: {
-            Label("Rename", systemImage: "pencil")
-        }
-        .disabled(isViewingCachedData || isRenamingSession || !hasServerSessionID(session))
+            Button {
+                actions.rename(session)
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            .disabled(isViewingCachedData || isRenamingSession || !hasServerSessionID(session))
 
-        Button {
-            actions.duplicate(session)
-        } label: {
-            Label("Duplicate", systemImage: "doc.on.doc")
-        }
-        .disabled(isViewingCachedData || session.sessionId == nil || isMutating)
+            Button {
+                actions.duplicate(session)
+            } label: {
+                Label("Duplicate", systemImage: "doc.on.doc")
+            }
+            .disabled(isViewingCachedData || session.sessionId == nil || isMutating)
 
-        Menu {
-            SessionProjectMoveMenu(
-                session: session,
-                projects: projects,
-                isCreatingProject: isCreatingProject,
-                isMovingSession: isMovingSession,
-                isLoadingProjects: isLoadingProjects,
-                actions: actions
-            )
-        } label: {
-            Label("Move to Project", systemImage: "folder")
+            Menu {
+                SessionProjectMoveMenu(
+                    session: session,
+                    projects: projects,
+                    isCreatingProject: isCreatingProject,
+                    isMovingSession: isMovingSession,
+                    isLoadingProjects: isLoadingProjects,
+                    actions: actions
+                )
+            } label: {
+                Label("Move to Project", systemImage: "folder")
+            }
+            .disabled(isViewingCachedData || session.sessionId == nil || isMutating)
         }
-        .disabled(isViewingCachedData || session.sessionId == nil || isMutating)
 
-        // Export works for any session the server can see (incl. foreign/CLI
-        // ones — upstream's export handler only gates on the active profile),
-        // so it needs a server session ID and a live connection, like Rename.
+        // Export works for any session the server can see, including read-only
+        // and foreign/CLI rows; it only needs a live server session ID.
         Menu {
             Button {
                 actions.export(session, .html)
@@ -558,25 +571,33 @@ struct SessionRowContextMenu: View {
         } label: {
             Label("Export", systemImage: "square.and.arrow.up")
         }
-        .disabled(!canShowSessionMutationActions || isMutating)
+        .disabled(!canExportSession || isMutating)
 
-        Button {
-            actions.archive(session)
-        } label: {
-            Label("Archive", systemImage: "archivebox")
-        }
-        .disabled(!canShowSessionMutationActions || isMutating)
+        if SessionRowActionPolicy.offersMutationActions(for: session) {
+            Button {
+                actions.archive(session)
+            } label: {
+                Label("Archive", systemImage: "archivebox")
+            }
+            .disabled(!canShowSessionMutationActions || isMutating)
 
-        Button(role: .destructive) {
-            actions.delete(session)
-        } label: {
-            Label("Delete", systemImage: "trash")
+            Button(role: .destructive) {
+                actions.delete(session)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            .disabled(!canShowSessionMutationActions || isMutating)
         }
-        .disabled(!canShowSessionMutationActions || isMutating)
     }
 
     private var canShowSessionMutationActions: Bool {
-        !isViewingCachedData && hasServerSessionID(session)
+        SessionRowActionPolicy.offersMutationActions(for: session)
+            && !isViewingCachedData
+            && hasServerSessionID(session)
+    }
+
+    private var canExportSession: Bool {
+        SessionRowActionPolicy.canExport(session, isViewingCachedData: isViewingCachedData)
     }
 }
 

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -43,6 +43,8 @@ struct SessionListView: View {
     @AppStorage(SessionRowDisplaySettings.showMessageCountKey) private var showsSessionMessageCount = true
     @AppStorage(SessionRowDisplaySettings.showWorkspaceKey) private var showsSessionWorkspace = true
     @AppStorage(SessionRowDisplaySettings.showCronSessionsKey) private var showsCronSessions = true
+    @AppStorage(SessionRowDisplaySettings.showSubagentSessionsKey)
+    private var showsSubagentSessions = SessionRowDisplaySettings.defaultShowsSubagentSessions
     // Per-server key (#19): the CLI toggle mirrors the active server's
     // `show_cli_sessions`, so its cached value must not leak across servers.
     // Configured in `init`, where the server URL is known.
@@ -529,7 +531,11 @@ struct SessionListView: View {
     }
 
     private var automatedSessionVisibility: AutomatedSessionVisibility {
-        AutomatedSessionVisibility(showsCron: showsCronSessions, showsCli: showsCliSessions)
+        AutomatedSessionVisibility(
+            showsCron: showsCronSessions,
+            showsCli: showsCliSessions,
+            showsSubagents: showsSubagentSessions
+        )
     }
 
     /// Bottom-of-list entry to the Archived screen (issue #17). Hidden while

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -362,9 +362,11 @@ private enum SessionRelativeDateFormatter {
 enum SessionRowDisplaySettings {
     static let showMessageCountKey = "sessionRow.showMessageCount"
     static let showWorkspaceKey = "sessionRow.showWorkspace"
-    // Cron and CLI sessions are controlled independently (#256); both default to
-    // shown, and their toggles let users hide each kind separately.
+    // Cron and CLI sessions default to shown; delegated subagents default to
+    // hidden. Each kind has an independent visibility control.
     static let showCronSessionsKey = "sessionRow.showCronSessions"
+    static let showSubagentSessionsKey = "sessionRow.showSubagentSessions"
+    static let defaultShowsSubagentSessions = false
     // Legacy global CLI-sessions key. Since #19 the CLI toggle is stored
     // per-server (it mirrors the server's own `show_cli_sessions` setting, and a
     // value adopted from server A must not leak to server B); this key survives
@@ -390,6 +392,14 @@ enum SessionRowDisplaySettings {
         }
 
         return true
+    }
+
+    static func showsSubagentSessions(in defaults: UserDefaults = .standard) -> Bool {
+        guard let stored = defaults.object(forKey: showSubagentSessionsKey) as? Bool else {
+            return defaultShowsSubagentSessions
+        }
+
+        return stored
     }
 }
 

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -62,6 +62,8 @@ struct SettingsView: View {
     @AppStorage(SessionRowDisplaySettings.showMessageCountKey) private var showsSessionMessageCount = true
     @AppStorage(SessionRowDisplaySettings.showWorkspaceKey) private var showsSessionWorkspace = true
     @AppStorage(SessionRowDisplaySettings.showCronSessionsKey) private var showsCronSessions = true
+    @AppStorage(SessionRowDisplaySettings.showSubagentSessionsKey)
+    private var showsSubagentSessions = SessionRowDisplaySettings.defaultShowsSubagentSessions
     @State private var cliSessionsSync: CliSessionsSyncModel
     @AppStorage(StreamingSendBehavior.storageKey) private var streamingSendBehaviorRawValue = StreamingSendBehavior.steer.rawValue
     @AppStorage(ComposerSTTProviderPreference.storageKey) private var sttProviderPreferenceRawValue = ComposerSTTProviderPreference.defaultValue.rawValue
@@ -300,6 +302,14 @@ struct SettingsView: View {
                             get: { cliSessionsSync.showsCliSessions },
                             set: { cliSessionsSync.setShowsCliSessions($0) }
                         )
+                    )
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        title: String(localized: "Subagent Sessions"),
+                        systemImage: "arrow.triangle.branch",
+                        isOn: $showsSubagentSessions
                     )
 
                     if let syncError = cliSessionsSync.syncErrorMessage {

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -176,8 +176,13 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
     let pendingStartedAt: Double?
     let worktreePath: String?
     let sourceTag: String?
+    let rawSource: String?
     let sessionSource: String?
     let sourceLabel: String?
+    let parentSessionId: String?
+    let relationshipType: String?
+    let readOnly: Bool?
+    let isReadOnly: Bool?
     let matchType: String?
 
     init(
@@ -205,8 +210,13 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         pendingStartedAt: Double? = nil,
         worktreePath: String? = nil,
         sourceTag: String? = nil,
+        rawSource: String? = nil,
         sessionSource: String? = nil,
         sourceLabel: String? = nil,
+        parentSessionId: String? = nil,
+        relationshipType: String? = nil,
+        readOnly: Bool? = nil,
+        isReadOnly: Bool? = nil,
         matchType: String? = nil
     ) {
         self.sessionId = sessionId
@@ -233,8 +243,13 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         self.pendingStartedAt = pendingStartedAt
         self.worktreePath = worktreePath
         self.sourceTag = sourceTag
+        self.rawSource = rawSource
         self.sessionSource = sessionSource
         self.sourceLabel = sourceLabel
+        self.parentSessionId = parentSessionId
+        self.relationshipType = relationshipType
+        self.readOnly = readOnly
+        self.isReadOnly = isReadOnly
         self.matchType = matchType
     }
 
@@ -266,9 +281,14 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         }
         pendingStartedAt = detail.pendingStartedAt
         worktreePath = detail.worktreePath
-        sourceTag = nil
-        sessionSource = nil
-        sourceLabel = nil
+        sourceTag = detail.sourceTag
+        rawSource = detail.rawSource
+        sessionSource = detail.sessionSource
+        sourceLabel = detail.sourceLabel
+        parentSessionId = detail.parentSessionId
+        relationshipType = detail.relationshipType
+        readOnly = detail.readOnly
+        isReadOnly = detail.isReadOnly
         matchType = nil
     }
 
@@ -300,14 +320,35 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
             pendingStartedAt: pendingStartedAt,
             worktreePath: worktreePath,
             sourceTag: sourceTag,
+            rawSource: rawSource,
             sessionSource: sessionSource,
             sourceLabel: sourceLabel,
+            parentSessionId: parentSessionId,
+            relationshipType: relationshipType,
+            readOnly: readOnly,
+            isReadOnly: isReadOnly,
             matchType: matchType
         )
     }
 }
 
 extension SessionSummary {
+    /// Delegated children are identified only by an explicit source marker.
+    /// Parent linkage is shared by ordinary forks and compression continuations,
+    /// so it must never classify a row as a subagent on its own.
+    var isDelegatedSubagentSession: Bool {
+        [sourceTag, rawSource, sessionSource, sourceLabel]
+            .compactMap(Self.normalizedSourceMarker)
+            .contains("subagent")
+    }
+
+    /// Delegated children are runner-owned and view-only. Upstream has also
+    /// emitted both read-only spellings across row sources, so either explicit
+    /// true value preserves that safety for other imported sessions.
+    var isSessionReadOnly: Bool {
+        isDelegatedSubagentSession || readOnly == true || isReadOnly == true
+    }
+
     var shouldAppearInSessionList: Bool {
         !isEmptySidebarPlaceholder
     }
@@ -339,8 +380,8 @@ extension SessionSummary {
             return true
         }
 
-        return [sessionSource, sourceTag, sourceLabel]
-            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        return [sessionSource, sourceTag, rawSource, sourceLabel]
+            .compactMap(Self.normalizedSourceMarker)
             .contains("cron")
     }
 
@@ -369,18 +410,32 @@ extension SessionSummary {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
+
+    private static func normalizedSourceMarker(_ value: String?) -> String? {
+        nonEmpty(value)?.lowercased()
+    }
 }
 
-/// Which automated session kinds the session list should show. Cron jobs and
-/// CLI-imported sessions are controlled independently (#256) so a user can hide
-/// one without the other. A row that is neither cron nor CLI is always shown, so
-/// unknown/missing source data never hides a normal session.
+/// Which non-standard session kinds the session list should show. Cron jobs,
+/// CLI imports, and delegated subagents are controlled independently. A row
+/// with unknown/missing source data remains visible as a normal session.
 struct AutomatedSessionVisibility: Equatable {
     var showsCron: Bool
     var showsCli: Bool
+    var showsSubagents: Bool
 
-    /// Show every kind — the app's default state.
-    static let showAll = AutomatedSessionVisibility(showsCron: true, showsCli: true)
+    /// Show every kind, primarily for explicit opt-in and tests.
+    static let showAll = AutomatedSessionVisibility(
+        showsCron: true,
+        showsCli: true,
+        showsSubagents: true
+    )
+
+    init(showsCron: Bool, showsCli: Bool, showsSubagents: Bool = false) {
+        self.showsCron = showsCron
+        self.showsCli = showsCli
+        self.showsSubagents = showsSubagents
+    }
 
     /// Whether `session` should remain visible under these toggles.
     ///
@@ -388,6 +443,7 @@ struct AutomatedSessionVisibility: Equatable {
     /// every row by `_normalize_sidebar_source_flags` in `api/routes.py`); cron
     /// detection is client-side (`SessionSummary.isCronSession`).
     func shows(_ session: SessionSummary) -> Bool {
+        if session.isDelegatedSubagentSession, !showsSubagents { return false }
         if session.isCronSession, !showsCron { return false }
         if session.isCliSession == true, !showsCli { return false }
         return true
@@ -430,6 +486,14 @@ struct SessionDetail: Decodable, Equatable, Identifiable {
     let thresholdTokens: Int?
     let lastPromptTokens: Int?
     let isCliSession: Bool?
+    let sourceTag: String?
+    let rawSource: String?
+    let sessionSource: String?
+    let sourceLabel: String?
+    let parentSessionId: String?
+    let relationshipType: String?
+    let readOnly: Bool?
+    let isReadOnly: Bool?
     let messages: [ChatMessage]?
     let toolCalls: [PersistedToolCall]?
     let messagesTruncated: Bool?
@@ -464,6 +528,14 @@ struct SessionDetail: Decodable, Equatable, Identifiable {
         case thresholdTokens
         case lastPromptTokens
         case isCliSession
+        case sourceTag
+        case rawSource
+        case sessionSource
+        case sourceLabel
+        case parentSessionId
+        case relationshipType
+        case readOnly
+        case isReadOnly
         case messages
         case toolCalls
         case messagesTruncated
@@ -507,6 +579,14 @@ struct SessionDetail: Decodable, Equatable, Identifiable {
         thresholdTokens = container.decodeLossyIntIfPresent(forKey: .thresholdTokens)
         lastPromptTokens = container.decodeLossyIntIfPresent(forKey: .lastPromptTokens)
         isCliSession = container.decodeLossyBoolIfPresent(forKey: .isCliSession)
+        sourceTag = container.decodeLossyStringIfPresent(forKey: .sourceTag)
+        rawSource = container.decodeLossyStringIfPresent(forKey: .rawSource)
+        sessionSource = container.decodeLossyStringIfPresent(forKey: .sessionSource)
+        sourceLabel = container.decodeLossyStringIfPresent(forKey: .sourceLabel)
+        parentSessionId = container.decodeLossyStringIfPresent(forKey: .parentSessionId)
+        relationshipType = container.decodeLossyStringIfPresent(forKey: .relationshipType)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+        isReadOnly = container.decodeLossyBoolIfPresent(forKey: .isReadOnly)
         messages = Self.decodeMessagesTolerantly(from: container)
         toolCalls = Self.decodeToolCallsTolerantly(from: container)
         messagesTruncated = container.decodeLossyBoolIfPresent(forKey: .underscoredMessagesTruncated)

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -301,8 +301,13 @@ private extension SessionSummary {
         pendingStartedAt = cachedSession.pendingStartedAt
         worktreePath = cachedSession.worktreePath
         sourceTag = cachedSession.sourceTag
+        rawSource = cachedSession.rawSource
         sessionSource = cachedSession.sessionSource
         sourceLabel = cachedSession.sourceLabel
+        parentSessionId = cachedSession.parentSessionId
+        relationshipType = cachedSession.relationshipType
+        readOnly = cachedSession.readOnly
+        isReadOnly = cachedSession.isReadOnly
         matchType = nil
     }
 }

--- a/HermesMobile/Persistence/CachedSession.swift
+++ b/HermesMobile/Persistence/CachedSession.swift
@@ -34,8 +34,13 @@ final class CachedSession {
     var pendingStartedAt: Double?
     var worktreePath: String?
     var sourceTag: String?
+    var rawSource: String?
     var sessionSource: String?
     var sourceLabel: String?
+    var parentSessionId: String?
+    var relationshipType: String?
+    var readOnly: Bool?
+    var isReadOnly: Bool?
     var cachedAt: Date
     var expiresAt: Date
 
@@ -77,8 +82,13 @@ final class CachedSession {
         pendingStartedAt = session.pendingStartedAt
         worktreePath = session.worktreePath
         sourceTag = session.sourceTag
+        rawSource = session.rawSource
         sessionSource = session.sessionSource
         sourceLabel = session.sourceLabel
+        parentSessionId = session.parentSessionId
+        relationshipType = session.relationshipType
+        readOnly = session.readOnly
+        isReadOnly = session.isReadOnly
         self.cachedAt = cachedAt
         expiresAt = cachedAt.addingTimeInterval(CachePolicy.ttl)
     }

--- a/HermesMobileTests/APIClientSessionListTests.swift
+++ b/HermesMobileTests/APIClientSessionListTests.swift
@@ -45,6 +45,57 @@ final class APIClientSessionListTests: APIClientTestCase {
         XCTAssertEqual(response.archivedCount, 8)
     }
 
+    func testSessionsDecodesDelegationAndReadOnlyMetadataTolerantly() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/sessions")
+            return apiTestJSONResponse("""
+            {
+              "sessions": [
+                {
+                  "session_id": "subagent-child",
+                  "source_tag": "subagent",
+                  "raw_source": "subagent",
+                  "session_source": "other",
+                  "source_label": "Subagent",
+                  "parent_session_id": "parent-1",
+                  "relationship_type": "child_session",
+                  "read_only": true
+                },
+                {
+                  "session_id": "legacy-read-only",
+                  "is_read_only": true
+                },
+                {
+                  "session_id": "older-server-row"
+                }
+              ]
+            }
+            """, for: request)
+        }
+
+        let response = try await client.sessions()
+        let sessions = try XCTUnwrap(response.sessions)
+        let child = try XCTUnwrap(sessions.first)
+
+        XCTAssertEqual(child.sourceTag, "subagent")
+        XCTAssertEqual(child.rawSource, "subagent")
+        XCTAssertEqual(child.sessionSource, "other")
+        XCTAssertEqual(child.sourceLabel, "Subagent")
+        XCTAssertEqual(child.parentSessionId, "parent-1")
+        XCTAssertEqual(child.relationshipType, "child_session")
+        XCTAssertEqual(child.readOnly, true)
+        XCTAssertNil(child.isReadOnly)
+        XCTAssertTrue(child.isDelegatedSubagentSession)
+        XCTAssertTrue(child.isSessionReadOnly)
+
+        XCTAssertTrue(sessions[1].isSessionReadOnly)
+        XCTAssertNil(sessions[2].sourceTag)
+        XCTAssertNil(sessions[2].parentSessionId)
+        XCTAssertNil(sessions[2].readOnly)
+        XCTAssertFalse(sessions[2].isDelegatedSubagentSession)
+        XCTAssertFalse(sessions[2].isSessionReadOnly)
+    }
+
     func testSessionsIncludeArchivedBuildsQueryAndDecodesMergedRows() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.httpMethod, "GET")

--- a/HermesMobileTests/CacheStoreTests.swift
+++ b/HermesMobileTests/CacheStoreTests.swift
@@ -58,6 +58,49 @@ final class CacheStoreTests: XCTestCase {
         XCTAssertEqual(updatedSession.expiresAt, secondCachedAt.addingTimeInterval(CachePolicy.ttl))
     }
 
+    func testCachedSessionsPreserveSubagentClassificationAndReadOnlySafety() throws {
+        let context = try makeContext()
+        let serverURL = URL(string: "https://example.test")!
+        let cachedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let now = cachedAt.addingTimeInterval(60)
+        let response = try decodeSessions("""
+        {
+          "sessions": [
+            {
+              "session_id": "subagent-child",
+              "title": "Delegated research",
+              "source_tag": "subagent",
+              "raw_source": "subagent",
+              "session_source": "other",
+              "source_label": "Subagent",
+              "parent_session_id": "parent-1",
+              "relationship_type": "child_session",
+              "read_only": true,
+              "archived": false
+            }
+          ]
+        }
+        """)
+
+        try CacheStore.cacheSessions(
+            try XCTUnwrap(response.sessions),
+            serverURL: serverURL,
+            in: context,
+            cachedAt: cachedAt
+        )
+
+        let cached = try XCTUnwrap(
+            CacheStore.cachedSessions(serverURL: serverURL, in: context, now: now).first
+        )
+        XCTAssertEqual(cached.rawSource, "subagent")
+        XCTAssertEqual(cached.parentSessionId, "parent-1")
+        XCTAssertEqual(cached.relationshipType, "child_session")
+        XCTAssertTrue(cached.isDelegatedSubagentSession)
+        XCTAssertTrue(cached.isSessionReadOnly)
+        XCTAssertFalse(AutomatedSessionVisibility(showsCron: true, showsCli: true).shows(cached))
+        XCTAssertTrue(AutomatedSessionVisibility.showAll.shows(cached))
+    }
+
     func testCacheMessagesWritesLoadedWindowAndRemovesStaleMessages() throws {
         let context = try makeContext()
         let serverURL = URL(string: "https://example.test")!

--- a/HermesMobileTests/SessionIdentityTests.swift
+++ b/HermesMobileTests/SessionIdentityTests.swift
@@ -178,6 +178,35 @@ final class SessionSidebarDisclosureSettingsTests: XCTestCase {
     }
 }
 
+final class SessionRowDisplaySettingsTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "SessionRowDisplaySettingsTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testSubagentSessionsDefaultHiddenAndPersistStoredChoice() {
+        XCTAssertFalse(SessionRowDisplaySettings.showsSubagentSessions(in: defaults))
+
+        defaults.set(true, forKey: SessionRowDisplaySettings.showSubagentSessionsKey)
+        XCTAssertTrue(SessionRowDisplaySettings.showsSubagentSessions(in: defaults))
+
+        defaults.set(false, forKey: SessionRowDisplaySettings.showSubagentSessionsKey)
+        XCTAssertFalse(SessionRowDisplaySettings.showsSubagentSessions(in: defaults))
+    }
+}
+
 /// The avatar long-press server switcher's menu contents (#283). The switch
 /// action itself is #17's `AuthManager.switchActiveServer`, covered by
 /// `AuthManagerStateTests`; these cover the pure model that decides what the

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -32,6 +32,15 @@ final class SessionListMutationTests: XCTestCase {
                     archived: false,
                     projectId: "project-2",
                     profile: "work"
+                ),
+                SessionSummary(
+                    sessionId: "cached-subagent",
+                    title: "Cached delegated work",
+                    archived: false,
+                    projectId: "project-1",
+                    profile: "work",
+                    sourceTag: "subagent",
+                    readOnly: true
                 )
             ],
             serverURL: serverURL,
@@ -53,11 +62,23 @@ final class SessionListMutationTests: XCTestCase {
 
         XCTAssertEqual(
             Set(viewModel.sessions.compactMap(\.sessionId)),
-            Set(["cached-project-one", "cached-project-two"])
+            Set(["cached-project-one", "cached-project-two", "cached-subagent"])
         )
         XCTAssertEqual(
-            viewModel.visibleSessions(searchText: "", selectedProjectID: "project-1").compactMap(\.sessionId),
+            viewModel.visibleSessions(
+                searchText: "",
+                selectedProjectID: "project-1",
+                automatedVisibility: AutomatedSessionVisibility(showsCron: true, showsCli: true)
+            ).compactMap(\.sessionId),
             ["cached-project-one"]
+        )
+        XCTAssertEqual(
+            Set(viewModel.visibleSessions(
+                searchText: "",
+                selectedProjectID: "project-1",
+                automatedVisibility: .showAll
+            ).compactMap(\.sessionId)),
+            Set(["cached-project-one", "cached-subagent"])
         )
         XCTAssertTrue(viewModel.isViewingCachedData)
         XCTAssertNil(viewModel.errorMessage)
@@ -2194,11 +2215,76 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertFalse(SessionSummary(sessionId: "s6").isCronSession)
     }
 
+    func testDelegatedSubagentRequiresExplicitSourceMarker() {
+        XCTAssertTrue(SessionSummary(sessionId: "s1", sourceTag: "subagent").isDelegatedSubagentSession)
+        XCTAssertTrue(SessionSummary(sessionId: "s2", rawSource: " SubAgent ").isDelegatedSubagentSession)
+        XCTAssertTrue(SessionSummary(sessionId: "s3", sessionSource: "subagent").isDelegatedSubagentSession)
+        XCTAssertTrue(SessionSummary(sessionId: "s4", sourceLabel: "Subagent").isDelegatedSubagentSession)
+
+        XCTAssertFalse(
+            SessionSummary(
+                sessionId: "fork",
+                sourceTag: "fork",
+                parentSessionId: "parent",
+                relationshipType: "fork"
+            ).isDelegatedSubagentSession
+        )
+        XCTAssertFalse(
+            SessionSummary(
+                sessionId: "continuation",
+                sessionSource: "webui",
+                parentSessionId: "parent",
+                relationshipType: "compression_continuation"
+            ).isDelegatedSubagentSession
+        )
+        XCTAssertFalse(SessionSummary(sessionId: "parent-only", parentSessionId: "parent").isDelegatedSubagentSession)
+        XCTAssertFalse(SessionSummary(sessionId: "cron_1", sourceTag: "cron").isDelegatedSubagentSession)
+        XCTAssertFalse(SessionSummary(sessionId: "cli", isCliSession: true).isDelegatedSubagentSession)
+        XCTAssertFalse(SessionSummary(sessionId: "normal").isDelegatedSubagentSession)
+    }
+
+    func testReadOnlyRowsOfferExportButNoMutationActions() {
+        let currentShape = SessionSummary(sessionId: "current", readOnly: true)
+        let legacyShape = SessionSummary(sessionId: "legacy", isReadOnly: true)
+        let normal = SessionSummary(sessionId: "normal")
+
+        XCTAssertFalse(SessionRowActionPolicy.offersMutationActions(for: currentShape))
+        XCTAssertFalse(SessionRowActionPolicy.offersMutationActions(for: legacyShape))
+        XCTAssertFalse(
+            SessionRowActionPolicy.offersMutationActions(
+                for: SessionSummary(sessionId: "subagent", sourceTag: "subagent")
+            )
+        )
+        XCTAssertTrue(SessionRowActionPolicy.offersMutationActions(for: normal))
+
+        XCTAssertTrue(SessionRowActionPolicy.canExport(currentShape, isViewingCachedData: false))
+        XCTAssertFalse(SessionRowActionPolicy.canExport(currentShape, isViewingCachedData: true))
+        XCTAssertFalse(
+            SessionRowActionPolicy.canExport(
+                SessionSummary(sessionId: nil, readOnly: true),
+                isViewingCachedData: false
+            )
+        )
+    }
+
     func testAutomatedVisibilityShowAllKeepsEveryKind() {
         let visibility = AutomatedSessionVisibility.showAll
         XCTAssertTrue(visibility.shows(SessionSummary(sessionId: "cron_1")))
         XCTAssertTrue(visibility.shows(SessionSummary(sessionId: "cli-1", isCliSession: true)))
+        XCTAssertTrue(visibility.shows(SessionSummary(sessionId: "subagent", sourceTag: "subagent")))
         XCTAssertTrue(visibility.shows(SessionSummary(sessionId: "normal")))
+    }
+
+    func testAutomatedVisibilityHidesSubagentsByDefaultAndShowsThemWhenEnabled() {
+        let child = SessionSummary(sessionId: "subagent", sourceTag: "subagent")
+        XCTAssertFalse(AutomatedSessionVisibility(showsCron: true, showsCli: true).shows(child))
+        XCTAssertTrue(
+            AutomatedSessionVisibility(
+                showsCron: true,
+                showsCli: true,
+                showsSubagents: true
+            ).shows(child)
+        )
     }
 
     func testAutomatedVisibilityHidesCronIndependently() {
@@ -2278,6 +2364,97 @@ final class SessionListMutationTests: XCTestCase {
                 automatedVisibility: AutomatedSessionVisibility(showsCron: false, showsCli: false)
             ).compactMap(\.sessionId),
             ["normal-1", "normal-2"]
+        )
+    }
+
+    @MainActor
+    func testVisibleSessionsFiltersSubagentsAcrossSearchAndProjects() async throws {
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [
+                    {"session_id": "normal-p1", "title": "Planning", "project_id": "p1", "last_message_at": 40},
+                    {"session_id": "subagent-p1", "title": "Delegated research", "project_id": "p1", "source_tag": "subagent", "read_only": true, "last_message_at": 30},
+                    {"session_id": "fork-p1", "title": "Ordinary fork", "project_id": "p1", "parent_session_id": "normal-p1", "relationship_type": "fork", "last_message_at": 20},
+                    {"session_id": "normal-p2", "title": "Other project", "project_id": "p2", "last_message_at": 10}
+                  ]
+                }
+                """, for: request)
+            case "/api/sessions/search":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [
+                    {"session_id": "subagent-p1", "title": "Delegated research", "match_type": "content"},
+                    {"session_id": "normal-p2", "title": "Other project", "match_type": "content"}
+                  ],
+                  "query": "needle",
+                  "count": 2
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        let hidden = AutomatedSessionVisibility(showsCron: true, showsCli: true)
+        let shown = AutomatedSessionVisibility(
+            showsCron: true,
+            showsCli: true,
+            showsSubagents: true
+        )
+
+        XCTAssertEqual(
+            viewModel.visibleSessions(
+                searchText: "",
+                selectedProjectID: "p1",
+                automatedVisibility: hidden
+            ).compactMap(\.sessionId),
+            ["normal-p1", "fork-p1"]
+        )
+        XCTAssertEqual(
+            viewModel.visibleSessions(
+                searchText: "",
+                selectedProjectID: "p1",
+                automatedVisibility: shown
+            ).compactMap(\.sessionId),
+            ["normal-p1", "subagent-p1", "fork-p1"]
+        )
+        XCTAssertTrue(
+            viewModel.visibleSessions(
+                searchText: "delegated",
+                selectedProjectID: nil,
+                automatedVisibility: hidden
+            ).isEmpty
+        )
+        XCTAssertEqual(
+            viewModel.visibleSessions(
+                searchText: "delegated",
+                selectedProjectID: nil,
+                automatedVisibility: shown
+            ).compactMap(\.sessionId),
+            ["subagent-p1"]
+        )
+
+        await viewModel.searchSessions(query: "needle", debounceNanoseconds: 0)
+
+        XCTAssertTrue(
+            viewModel.visibleSessions(
+                searchText: "needle",
+                selectedProjectID: "p1",
+                automatedVisibility: hidden
+            ).isEmpty
+        )
+        XCTAssertEqual(
+            viewModel.visibleSessions(
+                searchText: "needle",
+                selectedProjectID: "p1",
+                automatedVisibility: shown
+            ).compactMap(\.sessionId),
+            ["subagent-p1"]
         )
     }
 


### PR DESCRIPTION
## Summary

- decode delegated-session source, lineage, and read-only row metadata tolerantly
- add a persisted Subagent Sessions visibility toggle that defaults off across normal, searched, project-filtered, and cached lists
- keep read-only rows openable/exportable while removing mutation menus and swipe actions

## Validation

- API contract checked against pinned hermes-webui commit 2f3e42dc649e6d2bae572a0655681d9bb212c78d
- git diff --check
- focused iPhone 17 simulator tests: 92 passed
- full iPhone 17 simulator XCTest suite: 1335 passed, 0 failed
- signed Debug simulator compile passed

## Owner manual checks

- confirm delegated subagent sessions are absent with the default setting
- enable Settings > Sessions > Subagent Sessions and confirm delegated rows appear
- open a delegated row and confirm its transcript remains viewable
- long-press and swipe the row: export remains available, while pin, rename, duplicate, project move, archive, and delete are absent
- disable the setting and confirm the rows disappear again without changing Cron Sessions or CLI Sessions visibility

Fixes #97