### PR TITLE
chore: track shared agent skills under .agents/skills

### DIFF
--- a/.agents/skills/contributor-pr/SKILL.md
+++ b/.agents/skills/contributor-pr/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: contributor-pr
+description: Triage and review contributor PRs on uzairansaruzi/hermex — private briefing with a verdict, then gated post/fix/merge.
+disable-model-invocation: true
+---
+
+# Contributor PR
+
+Maintainer workflow for pull requests from other contributors on uzairansaruzi/hermex.
+`CONTRIBUTING.md` is the policy source of truth and `AGENTS.md` hard rules apply — cite them, never restate them.
+
+Invoked with no argument → **Triage**. With a PR number or URL → **Review** that one PR.
+
+## Triage
+
+List open contributor PRs. Rank by reviewability: small, focused diffs with a linked issue first. Flag every PR that violates CONTRIBUTING.md's "What PRs we welcome" (large work with no prior issue, multi-change diffs, out-of-scope platforms) and draft a courteous close-with-comment for each flagged one.
+
+Done when every open PR has either a rank or a flag, each with a one-line rationale. Post nothing.
+
+## Review
+
+1. **Pin.** Fetch the PR: diff, commits, checks, reviews, unresolved threads, linked issue, mergeability. Record the head and base SHAs — all evidence below binds to that head. Check the branch out in an isolated worktree; never disturb the main checkout.
+   Done when the exact code under review and every existing piece of feedback are in hand.
+
+2. **Understand.** Trace what the diff does — behavior, not paraphrased hunks: call sites, state, error paths, tests, deletions. Verify API-shape and `Codable` changes per AGENTS.md rules 1 and 3. Give each posted AGY finding an independent verdict: confirmed, or false positive with the reason (the repo is Swift 5 — discount strict-concurrency noise). If AGY hasn't posted yet, record it as a pending gate; don't wait for it.
+   Done when every behavior change maps to the PR's stated intent and every inherited finding has a verdict.
+
+3. **Validate.** A green CI Gate on the pinned head is full-suite test evidence — no local rerun unless CI is stale for that head or suspicious. For behavior or UI changes, build and launch a normally signed simulator build and exercise the changed flow yourself. Anything needing human perception, a physical device, or the live server goes on a short numbered plan for the human.
+   Done when evidence passes for the pinned head, or every remaining check is on the human's numbered list.
+
+4. **Brief.** Deliver in chat, written for a reader new to the codebase but familiar with Hermex's goal:
+   - Verdict: `ready` | `changes needed` | `blocked` | `manual pending`.
+   - Plain-English summary: what the user gets, how the change works, what could break.
+   - Confirmed findings with evidence; pending gates.
+   - Drafts: the public review comment (each actionable item = what happens, why it matters, what resolves it) and, when ready, a squash-commit message.
+   Done when the human can decide the next action without opening GitHub.
+
+5. **Act on explicit command only.** Each action is a separate instruction — a `ready` verdict authorizes nothing:
+   - **post** — submit the approved review text, nothing more.
+   - **fix** — push one small disclosed commit to the contributor branch (requires maintainer-edits allowed; preserve their intent), then redo step 3 on the new head.
+   - **merge** — re-fetch first: if the head SHA moved, restart at step 1. Confirm gates are green, squash-merge with the approved message (toggle `enforce_admins` off, merge, toggle it back on), then report the resulting state of master.
+   Done when the commanded action succeeded and the PR's resulting state is reported accurately.

--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session.

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-with-docs
+description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+Do not enact the plan until I confirm we have reached a shared understanding.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+disable-model-invocation: true
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/.agents/skills/hermes-issue-intake/SKILL.md
+++ b/.agents/skills/hermes-issue-intake/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: hermes-issue-intake
+description: Turns rough Hermes Mobile bugs/features into clear GitHub issues, and unblocks needs-info or ready-for-human issues, by grilling the user one question at a time. Use when the user wants to draft a new hermex issue from a rough item, or unblock an existing needs-info or ready-for-human issue.
+---
+
+# Hermes Issue Intake
+
+Use this in the hermex repo root. Goal: turn a rough item or a blocked issue into a clear GitHub issue — never implement it. **Don't edit code, touch git, or publish/update an issue without user approval.** This guardrail holds for every step below.
+
+## Quick Start
+
+Two branches:
+
+- **Draft** a new issue from a rough bug/feature.
+- **Unblock** an existing `needs-info` or `ready-for-human` issue (e.g. "Resolve needs-info issue #7").
+
+Both run on **grill**: one question at a time, each with a recommended answer, exploring the codebase instead of asking when that answers better (the `grilling` loop).
+
+## Context Rules
+
+1. Read `CURRENT.md`, `docs/agents/issue-tracker.md`, and `docs/agents/triage-labels.md` only as needed. Repo rules are auto-loaded from `CLAUDE.md` — don't re-read them.
+2. Check open GitHub issues only for likely duplicates of this specific item.
+3. Keep context lean: read only the doc sections you need, never the whole `PROJECT_SPEC.md`.
+
+## Intake Flow
+
+1. Restate the rough item in one sentence.
+2. Grill on current behavior, expected behavior, affected surface, repro, examples, and priority — only as needed.
+3. Stop grilling once you can fill every Draft Format field below (mark a field N/A only deliberately).
+4. If the item is too large for one issue, propose smaller vertical slices and ask before handing off to `to-issues`.
+5. Draft the issue, show it, and wait for approval. On approval, publish it and report the URL.
+
+## Draft Format
+
+Show:
+
+- Title
+- Category label: `bug` or `enhancement`
+- State label: `needs-info`, `ready-for-agent`, or `ready-for-human`
+- Optional routing label: `needs-manual-validation` (see below)
+- Body: Context · Current behavior · Expected behavior · Acceptance criteria · Validation plan · Non-goals
+
+For UI issues, include manual simulator validation. For API/server-shaped issues, require route-shape validation from the repo-local upstream copy or the running server before implementation.
+
+## Choosing the state label
+
+Canonical label strings and meanings live in `docs/agents/triage-labels.md`; this is the intake-specific decision logic. Move every item out of `needs-triage` into exactly one state label:
+
+- `ready-for-agent` — narrow, implementable, acceptance criteria clear, no unresolved product/API decision. Defaults to express mode of `hermes-issue-pr-workflow`.
+- `ready-for-human` — valid but needs owner/product/design/API judgment before implementation.
+- `needs-info` — missing repro, affected input, expected behavior, or other blocking detail.
+- `wontfix` — grilling shows the item shouldn't be actioned; recommend closing (owner decides).
+
+Routing flag `needs-manual-validation` combines with `ready-for-agent` to force staged mode; apply it under the rules in `docs/agents/triage-labels.md`.
+
+## Unblocking an issue (`needs-info` / `ready-for-human`)
+
+Use when an existing issue carries one of these labels. Goal: for `needs-info`, collect the missing detail needed to triage/implement; for `ready-for-human`, resolve the product/design/API/owner decision blocking it.
+
+1. Read the issue, comments, and any prior triage notes.
+2. Grill until the blocker is resolved.
+3. Summarize what's new/decided, the remaining unknowns, and the next label: `ready-for-agent`, `ready-for-human`, `needs-info`, or split.
+4. On approval, comment the summary on the issue and update labels. If narrow and clear, relabel `ready-for-agent`; if too large, propose vertical slices and ask before handing off to `to-issues`.
+
+## Publishing
+
+`gh issue create` in the repo, with exactly one category label and one state label (plus `needs-manual-validation` if it applies). After publishing, stop — implementation is `hermes-issue-pr-workflow`'s job, and only when the user asks for it.

--- a/.agents/skills/hermes-issue-pr-workflow/SKILL.md
+++ b/.agents/skills/hermes-issue-pr-workflow/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: hermes-issue-pr-workflow
+description: Runs the Hermes Mobile issue-to-PR development workflow in staged mode (human gate per stage) or express mode (autonomous from approved plan to review-addressed PR). Use when working in the hermex repo from a GitHub issue — starting an issue, addressing bot reviews on its PR, or post-merge cleanup.
+---
+
+# Hermes Issue PR Workflow
+
+Use this in the hermex repo root. Source of truth: `CURRENT.md`, `docs/agents/issue-tracker.md`, and the GitHub issue/PR — plus the repo rules already auto-loaded from `CLAUDE.md` (don't re-read `CLAUDE.md`/`AGENTS.md`; it's already in context). If repo state is not ready, stop and report the blocker.
+
+## Modes
+
+- **Express (default for `ready-for-agent`):** one human gate after the plan, then autonomous through implement → PR → bot reviews → review fixes → final handoff. Use unless the issue is large/risky or labeled `needs-manual-validation`.
+- **Staged:** every stage is human-gated. Use for `needs-manual-validation` issues, large/risky changes, human-scoped work, or when the user asks.
+
+```text
+Use hermes-issue-pr-workflow. Express issue #13.
+Use hermes-issue-pr-workflow. Start issue #13.   (staged)
+```
+
+Both modes begin with Stage 1 and do not edit code until the user approves the plan.
+
+## Shared procedures
+
+**Green bar.** Validate with `git diff --check` + build/tests via XcodeBuildMCP (raw `xcodebuild`/`xcrun simctl` fallback). Never proceed on red; never hide failed validation. The full unit suite must pass on the final head commit before any PR is reported merge-ready (both modes).
+
+**In scope.** Implement only the approved scope — no unrelated redesigns. (`CLAUDE.md`'s hard rules — no new dependencies, no invented API, tolerant decoding, no broken builds — already apply; don't restate them.)
+
+**Open the PR.** Push the feature branch, then open a PR into `master` with `Fixes #<issue>`, summary, validation, and owner manual checks. (Mode decides draft vs. ready for review.)
+
+**Wait for reviews.** Marking a PR ready for review — and any later push to it — auto-triggers the bot review(s). To force one by hand, post `/hermes review` as its own standalone comment.
+
+```bash
+.agents/skills/hermes-issue-pr-workflow/scripts/wait-for-reviews.sh <pr-number>
+```
+
+The script blocks only on the *required* review (Antigravity) and prints which landed. Exit 0: proceed. Exit 2: timeout — report which review is missing and continue with whatever landed, noting the gap. Other active reviewers (current roster in memory) also post on ready/push and must be triaged too — let them land before running **Review triage**.
+
+**Review triage.** Fetch every review body, inline review thread, and PR comment from each reviewer (more than one bot may review). Triage adversarially — you are not defending this code: for each finding, first try to prove it correct against repo/spec/code and state that evidence before classifying it. Classify each as **Valid**, **Probably valid**, **Needs human decision**, or **False positive**. Resolution: implement Valid + Probably-valid, defer Needs-human-decision to the final report, skip False positives with stated evidence.
+
+**Triage coverage.** Advisory pre-merge check that the *final* review round was actually triaged (review rounds landing right before merge historically went undispositioned):
+
+```bash
+.agents/skills/hermes-issue-pr-workflow/scripts/check-triage-coverage.sh <pr-number>
+```
+
+Exit 0: covered (triage newer than the last round, or the last round had no findings). Exit 3: warning — the last round has undispositioned findings (triage it) or failed outright (re-trigger `/hermes review full`). Never report a PR merge-ready while this warns.
+
+**Refresh follow-ups.** Re-derive the Manual/Owner Follow-Up list from `gh pr list --state open` / `gh issue list` — keep only verifiably open items; never copy `CURRENT.md`'s previous list forward (it goes stale).
+
+## Express Mode
+
+After the user approves the Stage 1 plan, run E2–E5 without further gates. Pushing the feature branch, opening the PR, marking it ready for review, and pushing review-fix commits are pre-authorized. Merging and pushing `master` are never authorized.
+
+### E1 - Plan Gate
+
+Run Stage 1, then state: "Express mode: after approval I will implement, publish the PR, address bot reviews, and report back for your manual test + merge." Stop and wait for approval.
+
+### E2 - Implement and Publish
+
+1. Follow **In scope**.
+2. Reach the **green bar**; iterate until green.
+3. Update `CURRENT.md` (**Refresh follow-ups**), commit code + handoff together.
+4. **Open the PR** and mark it ready for review.
+
+### E3 - Wait for Bot Reviews
+
+Run **Wait for reviews** for the PR.
+
+### E4 - Triage and Address Reviews
+
+1. Run **Review triage**.
+2. Implement the fixes, then reach the **green bar**.
+3. Commit, push, and post a triage summary comment (classification table + what was fixed/skipped/deferred).
+4. If the fixes were substantial (new logic, not just test/doc tweaks), run **Wait for reviews** again — the push in step 3 already re-triggered the follow-up review — and repeat E4 once. At most two fix rounds; if findings persist, stop and escalate to the user.
+
+### E5 - Handoff
+
+Abort conditions (any time in E2–E4): tests can't go green within scope, a finding needs a product/API decision, or the change grows beyond the Stage 1 file list. On abort: stop, leave the branch + PR as-is, report state + blocker.
+
+Final report:
+
+1. Diff summary and behavior changed, in simple terms.
+2. Confirm the **green bar** held on the final head commit.
+3. Review triage table, including deferred Needs-human-decision items and any missing/silent bot review.
+4. The issue's manual validation checklist for the owner.
+5. Boot the simulator with the final branch build and leave it running for the owner's manual test.
+6. Run **Triage coverage**; on a warning, triage the final round first (one extra E4 pass) — never hand off merge instructions while it warns.
+7. Exact GitHub UI actions to merge. Do not merge.
+
+After the user merges, run Stage 8.
+
+## Staged Mode
+
+### Stage 1 - Start Issue
+
+1. Read `CURRENT.md`.
+2. Fetch the issue; confirm it is open and `ready-for-agent`, unless the user wants human-scoped work.
+3. Check `git status` and current branch.
+4. Switch to `master`, pull `--ff-only`, create `issue/<issue-number>-<short-slug>`.
+5. Do not edit code.
+6. Report branch, cleanliness, one-sentence issue summary, what we'll address and why in simple terms, and the smallest implementation plan. Stop.
+
+### Stage 2 - Implement
+
+1. Restate the files expected to be touched before editing.
+2. Follow **In scope**.
+3. Reach the **green bar** (focused build/test is fine mid-flow).
+4. Report files changed, behavior changed (in simple terms), validation, and owner manual checks. Leave the simulator open for manual tests. Do not commit unless approved.
+
+### Stage 3 - Checkpoint Commit
+
+1. Record owner manual validation notes if provided.
+2. Re-run `git diff --check`, summarize the diff, and update `CURRENT.md` (**Refresh follow-ups**).
+3. Commit code + handoff together. Do not push.
+4. Report commit hash and clean status.
+
+### Stage 4 - Publish Draft PR
+
+1. Confirm clean status and correct branch.
+2. **Open the PR** as a draft.
+3. Do not merge or push `master`. Report the PR URL.
+
+### Stage 5 - Review PR
+
+Mark the PR ready for review, run **Wait for reviews**, then run **Review triage**, give a minimal fix plan, and do not edit until approved.
+
+### Stage 6 - Address Review
+
+1. Implement approved fixes only; explicitly skip false positives and deferred human decisions.
+2. Reach the **green bar** (focused).
+3. Report changed files and validation.
+4. Commit review fixes, push, comment on the PR, and confirm the PR updated when the user approves.
+
+### Stage 7 - Final PR Check
+
+1. Confirm clean local status.
+2. **Precondition: the green bar held on the final head commit.** If the full suite hasn't been run on that commit, run it now; never report ready on red or stale results.
+3. Check PR state, head commit, unresolved review threads, comments, and checks; confirm the body links the issue with `Fixes #<issue>`.
+4. Run **Triage coverage** (below). On a warning, run **Review triage** for the final round (and post the triage comment) before reporting ready.
+5. If ready, tell the user the exact GitHub UI actions to mark ready/merge. Do not merge unless explicitly asked.
+
+### Stage 8 - Post-Merge Cleanup
+
+1. Fetch/prune origin; switch to `master`; pull `--ff-only`.
+2. Confirm the linked issue is closed; delete the local feature branch if safe.
+3. Report clean status and latest `master` commit. For other pending work, follow **Refresh follow-ups** rather than echoing `CURRENT.md`.
+
+## Guardrails
+
+- Express pre-authorizes feature-branch pushes and PR publishing only; staged keeps every push behind user approval. Merging and pushing `master` are never auto-authorized in either mode.
+- `needs-manual-validation` issues must use staged mode so the owner tests before the PR publishes.

--- a/.agents/skills/hermes-issue-pr-workflow/scripts/check-triage-coverage.sh
+++ b/.agents/skills/hermes-issue-pr-workflow/scripts/check-triage-coverage.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Advisory pre-merge triage-coverage check (AGY gap analysis, Phase 6 item 9).
+#
+# Warns when the LAST AGY review round on a PR reported findings but no human
+# triage comment is newer than that round. Untriaged findings historically
+# leaked exactly this way — review rounds landing in the same session the PR
+# merged (#332 r3, #345 r3-r4, #353) were never dispositioned by anyone.
+#
+# Usage: check-triage-coverage.sh <pr-number>
+# Exit 0: covered — triage is newer than the last review round, or that round
+#         reported no actionable findings (nothing to disposition).
+# Exit 3: ADVISORY WARNING — last round has undispositioned findings, or the
+#         last round failed outright (head effectively unreviewed).
+# Exit 1: usage/API error.
+set -euo pipefail
+
+REPO="uzairansaruzi/hermex"
+PR="${1:?usage: check-triage-coverage.sh <pr-number>}"
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+  --jq '[.[] | {created_at, updated_at, body}]' > "$TMP"
+
+python3 - "$TMP" <<'PY'
+import json, re, sys
+
+raw = open(sys.argv[1]).read()
+# --paginate emits one JSON array per page, concatenated; merge them.
+dec, idx, comments = json.JSONDecoder(), 0, []
+while idx < len(raw):
+    try:
+        obj, idx = dec.raw_decode(raw, idx)
+    except json.JSONDecodeError:
+        break
+    comments.extend(obj)
+    while idx < len(raw) and raw[idx] in " \n\r\t":
+        idx += 1
+
+MARK = re.compile(r"hermes-agy-(followup-)?review:")
+FIND = re.compile(r"<!--\s*agy-findings-v1\s*-->\s*```json\s*(.*?)\s*```", re.S)
+
+def stamp(c):
+    return max(c.get("created_at") or "", c.get("updated_at") or "")
+
+review_time, findings, failed = None, None, False
+for c in comments:
+    body = c.get("body") or ""
+    if not MARK.search(body):
+        continue
+    t = stamp(c)
+    if review_time is None or t > review_time:
+        review_time = t
+        failed = "## Hermes review failed" in body
+        m = FIND.search(body)
+        findings = None
+        if m:
+            try:
+                findings = len(json.loads(m.group(1)))
+            except Exception:
+                findings = None
+
+triage_time = max(
+    (stamp(c) for c in comments
+     if (c.get("body") or "").lstrip().startswith("## Review triage")),
+    default="")
+
+if review_time is None:
+    print("no AGY review found on this PR — nothing to check")
+    sys.exit(0)
+if failed:
+    print(f"WARNING: the last AGY review round FAILED (comment updated {review_time}) — "
+          "the head is effectively unreviewed. Re-trigger with `/hermes review full` before merging.")
+    sys.exit(3)
+if findings == 0:
+    print(f"last review round ({review_time}) reported no actionable findings — triage not required")
+    sys.exit(0)
+
+n = "unknown" if findings is None else findings
+if triage_time > review_time:
+    print(f"triage coverage OK: newest triage ({triage_time}) is newer than the "
+          f"last review round ({review_time}, findings: {n})")
+    sys.exit(0)
+
+latest = triage_time or "never"
+print(f"WARNING: last review round ({review_time}) reports {n} finding(s) but the "
+      f"newest human triage comment is older ({latest}). Triage the final round before merging.")
+sys.exit(3)
+PY

--- a/.agents/skills/hermes-issue-pr-workflow/scripts/wait-for-reviews.sh
+++ b/.agents/skills/hermes-issue-pr-workflow/scripts/wait-for-reviews.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Wait for the PR review bot(s) on a hermex PR.
+#   - Hermes Antigravity review: issue comment containing "hermes-agy-review:" or
+#     "hermes-agy-followup-review:" (posted by webhook from the owner account)
+#   - Cursor Bugbot: a completed "Cursor Bugbot" check run on the head SHA
+#     (fires even when Bugbot finds nothing; findings, if any, arrive as a
+#     review authored by "cursor[bot]")
+#
+# Cursor Bugbot is TEMPORARILY DISABLED (owner out of usage, 2026-06-14), so by
+# default this script only waits for the Antigravity review and never blocks on
+# the Bugbot check run (which would otherwise burn the full timeout). Re-enable
+# the Bugbot wait when usage is back:  WAIT_FOR_BUGBOT=1 wait-for-reviews.sh ...
+#
+# Usage: wait-for-reviews.sh <pr-number> [timeout-seconds] [poll-seconds]
+#   Env: WAIT_FOR_BUGBOT=1  also require the Cursor Bugbot check (default 0 = skip).
+# Exit 0: required review(s) detected. Exit 2: timeout (prints which landed). Exit 1: usage/repo error.
+
+set -euo pipefail
+
+REPO="uzairansaruzi/hermex"
+PR="${1:?usage: wait-for-reviews.sh <pr-number> [timeout-seconds] [poll-seconds]}"
+TIMEOUT="${2:-1800}"
+POLL="${3:-90}"
+WAIT_FOR_BUGBOT="${WAIT_FOR_BUGBOT:-0}"
+
+# Only count activity after the PR's current head commit was pushed, so a
+# follow-up wait after new commits doesn't match stale reviews of older code.
+SINCE="$(gh pr view "$PR" --repo "$REPO" --json commits \
+  --jq '.commits[-1].committedDate')"
+echo "PR #${PR}: waiting for reviews newer than head commit (${SINCE})," \
+     "timeout ${TIMEOUT}s, polling every ${POLL}s"
+
+elapsed=0
+agy=""
+# Cursor Bugbot temporarily disabled: pre-mark it satisfied so the loop never
+# blocks on a check run that won't appear. Set WAIT_FOR_BUGBOT=1 to wait for it.
+if [[ "$WAIT_FOR_BUGBOT" == "1" ]]; then
+  bugbot=""
+else
+  bugbot="skip"
+  echo "Cursor Bugbot wait DISABLED (WAIT_FOR_BUGBOT=0) — only requiring the Antigravity review."
+fi
+
+while true; do
+  if [[ -z "$agy" ]]; then
+    agy="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+      --jq "[.[] | select(.created_at > \"${SINCE}\")
+                 | select(.body | test(\"hermes-agy-(followup-)?review:\"))] | length")"
+    [[ "$agy" != "0" ]] || agy=""
+    [[ -z "$agy" ]] || echo "✓ Antigravity review landed (${elapsed}s)"
+  fi
+
+  if [[ -z "$bugbot" ]]; then
+    head_sha="$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
+    bugbot_run="$(gh api "repos/${REPO}/commits/${head_sha}/check-runs" \
+      --jq "[.check_runs[] | select(.name == \"Cursor Bugbot\")
+                           | select(.status == \"completed\")] | first | .conclusion // empty")"
+    if [[ -n "$bugbot_run" ]]; then
+      bugbot="yes"
+      echo "✓ Cursor Bugbot check run completed: ${bugbot_run} (${elapsed}s)"
+    fi
+  fi
+
+  if [[ -n "$agy" && -n "$bugbot" ]]; then
+    if [[ "$bugbot" == "skip" ]]; then
+      echo "Antigravity review landed after ${elapsed}s (Bugbot wait disabled)."
+    else
+      echo "Both reviews landed after ${elapsed}s."
+    fi
+    exit 0
+  fi
+
+  if (( elapsed >= TIMEOUT )); then
+    echo "TIMEOUT after ${elapsed}s."
+    [[ -n "$agy" ]] && echo "  Antigravity: landed" || echo "  Antigravity: MISSING"
+    if [[ "$bugbot" == "skip" ]]; then
+      echo "  Cursor Bugbot: skipped (WAIT_FOR_BUGBOT=0)"
+    else
+      [[ -n "$bugbot" ]] && echo "  Cursor Bugbot: landed" || echo "  Cursor Bugbot: missing (likely no findings)"
+    fi
+    exit 2
+  fi
+
+  sleep "$POLL"
+  elapsed=$(( elapsed + POLL ))
+done

--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,13 @@ Config/Local.xcconfig
 UPDATES.md
 .obsidian/
 
-# Local agent tooling (per-machine caches, skills, session state)
+# Local agent tooling (per-machine caches, session state)
 node_modules/
 .codex-tmp/
-.agents/
+.agents/*
+!.agents/skills/
+!.agents/skills/**
+.agents/**/.DS_Store
 .sc/
 .claude/
 .codex/


### PR DESCRIPTION
## Summary
- Track repo-local Hermes agent skills under `.agents/skills` so contributors share the same workflow helpers.
- Update `.gitignore` to allow those skills while still ignoring other `.agents` caches and `.DS_Store`.
- Scrub absolute local paths and point review scripts at the repo-relative skill paths.

## Test plan
- [x] Confirm no secrets/PII in skill files before push
- [x] Confirm `.DS_Store` stays ignored under `.agents/skills`
- [ ] Spot-check that skills render correctly after merge on a fresh clone

Made with [Cursor](https://cursor.com)