### PR TITLE
CI: reduce PR Build and Test feedback time

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -65,6 +65,9 @@ jobs:
     env:
       PROJECT_PATH: HermesMobile.xcodeproj
       SCHEME: HermesMobile
+      DERIVED_DATA_PATH: DerivedData
+      RESULT_BUNDLE_PATH: TestResults.xcresult
+      TEST_WORKER_COUNT: 1
 
     steps:
       - name: Check out
@@ -98,24 +101,96 @@ jobs:
           echo "Using simulator: ${name}"
           echo "name=${name}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and test
+      - name: Build for testing
         env:
           SIMULATOR_NAME: ${{ steps.sim.outputs.name }}
         run: |
           set -euo pipefail
-          xcodebuild test \
+          start_seconds=${SECONDS}
+          xcodebuild build-for-testing \
             -project "${PROJECT_PATH}" \
             -scheme "${SCHEME}" \
             -destination "platform=iOS Simulator,name=${SIMULATOR_NAME}" \
-            -resultBundlePath TestResults.xcresult \
+            -derivedDataPath "${DERIVED_DATA_PATH}" \
+            -showBuildTimingSummary \
             CODE_SIGNING_ALLOWED=NO
+          duration_seconds=$((SECONDS - start_seconds))
+          echo "Build-for-testing duration: ${duration_seconds}s"
+          echo "### PR CI timing" >> "${GITHUB_STEP_SUMMARY}"
+          echo "- Build for testing: ${duration_seconds}s" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Test without building
+        env:
+          SIMULATOR_NAME: ${{ steps.sim.outputs.name }}
+        run: |
+          set -euo pipefail
+          start_seconds=${SECONDS}
+          xcodebuild test-without-building \
+            -project "${PROJECT_PATH}" \
+            -scheme "${SCHEME}" \
+            -destination "platform=iOS Simulator,name=${SIMULATOR_NAME}" \
+            -derivedDataPath "${DERIVED_DATA_PATH}" \
+            -resultBundlePath "${RESULT_BUNDLE_PATH}" \
+            -parallel-testing-enabled YES \
+            -parallel-testing-worker-count "${TEST_WORKER_COUNT}" \
+            CODE_SIGNING_ALLOWED=NO
+          duration_seconds=$((SECONDS - start_seconds))
+          echo "Test-without-building duration: ${duration_seconds}s"
+          echo "- Test without building (${TEST_WORKER_COUNT} workers): ${duration_seconds}s" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Report slowest tests
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ ! -d "${RESULT_BUNDLE_PATH}" ]]; then
+            echo "No result bundle is available; skipping slow-test reporting."
+            exit 0
+          fi
+
+          xcrun xcresulttool get test-results tests \
+            --path "${RESULT_BUNDLE_PATH}" \
+            --compact > test-results.json
+
+          python3 - <<'PY' | tee slowest-tests.txt
+          import json
+
+          with open("test-results.json", encoding="utf-8") as results_file:
+              results = json.load(results_file)
+
+          tests = []
+
+          def visit(node, parents):
+              name = node.get("name", "<unnamed>")
+              node_type = node.get("nodeType")
+              path = [*parents, name]
+              duration = node.get("durationInSeconds")
+              if node_type == "Test Case" and isinstance(duration, (int, float)):
+                  tests.append((duration, " / ".join(path)))
+              for child in node.get("children", []):
+                  visit(child, path)
+
+          for root in results.get("testNodes", []):
+              visit(root, [])
+
+          print("Slowest test cases:")
+          for duration, name in sorted(tests, reverse=True)[:20]:
+              print(f"{duration:8.3f}s  {name}")
+          PY
+
+          {
+            echo ""
+            echo "#### Slowest test cases"
+            echo '```text'
+            cat slowest-tests.txt
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload test results on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: test-results
-          path: TestResults.xcresult
+          path: ${{ env.RESULT_BUNDLE_PATH }}
           if-no-files-found: ignore
 
   gate:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -73,18 +73,6 @@ jobs:
       - name: Check out
         uses: actions/checkout@v7
 
-      - name: Restore SwiftPM cache
-        id: swiftpm-cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/Library/Caches/org.swift.swiftpm
-            ${{ env.DERIVED_DATA_PATH }}/SourcePackages
-          key: ${{ runner.os }}-${{ runner.arch }}-swiftpm-${{ hashFiles('HermesMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-
-      - name: Report SwiftPM cache result
-        run: 'echo "SwiftPM cache hit: ${{ steps.swiftpm-cache.outputs.cache-hit }}"'
-
       - name: Show Xcode version
         run: xcodebuild -version
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -67,7 +67,7 @@ jobs:
       SCHEME: HermesMobile
       DERIVED_DATA_PATH: DerivedData
       RESULT_BUNDLE_PATH: TestResults.xcresult
-      TEST_WORKER_COUNT: 1
+      TEST_WORKER_COUNT: 2
 
     steps:
       - name: Check out
@@ -140,6 +140,7 @@ jobs:
 
       - name: Report slowest tests
         if: always()
+        continue-on-error: true
         run: |
           set -euo pipefail
           if [[ ! -d "${RESULT_BUNDLE_PATH}" ]]; then

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -67,7 +67,7 @@ jobs:
       SCHEME: HermesMobile
       DERIVED_DATA_PATH: DerivedData
       RESULT_BUNDLE_PATH: TestResults.xcresult
-      TEST_WORKER_COUNT: 2
+      TEST_WORKER_COUNT: 3
 
     steps:
       - name: Check out

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -67,11 +67,23 @@ jobs:
       SCHEME: HermesMobile
       DERIVED_DATA_PATH: DerivedData
       RESULT_BUNDLE_PATH: TestResults.xcresult
-      TEST_WORKER_COUNT: 3
+      TEST_WORKER_COUNT: 1
 
     steps:
       - name: Check out
         uses: actions/checkout@v7
+
+      - name: Restore SwiftPM cache
+        id: swiftpm-cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ${{ env.DERIVED_DATA_PATH }}/SourcePackages
+          key: ${{ runner.os }}-${{ runner.arch }}-swiftpm-${{ hashFiles('HermesMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+
+      - name: Report SwiftPM cache result
+        run: 'echo "SwiftPM cache hit: ${{ steps.swiftpm-cache.outputs.cache-hit }}"'
 
       - name: Show Xcode version
         run: xcodebuild -version


### PR DESCRIPTION
Fixes #106

## Summary

- split the monolithic XCTest invocation into build-for-testing and test-without-building
- report phase durations and Xcode build timing details
- extract the 20 slowest test cases from the xcresult bundle without allowing diagnostic failures to fail otherwise successful CI
- run the complete suite with one explicit simulator test worker
- preserve fork safety, superseded-run cancellation, documentation-only skipping, failure artifacts, and the required CI Gate contract

## Baseline

Six representative successful Build and Test jobs before optimization:

| Run | Duration |
|---|---:|
| 29118286107 | 21m14s |
| 29116223535 | 22m28s |
| 29069603779 | 10m45s |
| 29051071825 | 22m20s |
| 29049798915 | 20m55s |
| 28988927892 | 15m25s |

Historical median: 21m05s.

## Final optimized runs

All three runs used identical commit 95695e8, one explicit worker, the full 1,345-test suite, and no SwiftPM cache.

| Attempt | Build | Tests | Build and Test job | Result |
|---|---:|---:|---:|---|
| 1 | 2m15s | 4m43s | 7m24s | Passed |
| 2 | 2m12s | 4m10s | 7m12s | Passed |
| 3 | 2m22s | 6m41s | 9m35s | Passed |

Final median: 7m24s, approximately 65% faster than the historical median.

## Rejected approaches

### Two workers

Passed all 1,345 tests, but test execution regressed to 16m29s and the job took 19m00s. Simulator contention made timing-sensitive tests dramatically slower.

### Three workers

Failed after 38m05s of test execution when a simulator test runner timed out while preparing. The required CI Gate correctly failed and the 243 MB xcresult failure artifact uploaded successfully.

### SwiftPM caching

A cache miss took 10m38s and saved approximately 188 MB with about 6s save overhead. A cache hit restored approximately 179 MB in about 4s and took 7m32s total. Most apparent improvement came from unrelated test-runtime variance; the plausible build benefit was roughly 31–35 seconds. This did not justify cache-key maintenance and large cache transfers under the lowest-complexity criterion.

## Acceptance validation

- full 1,345-test suite passed locally through split build/test commands
- full suite passed in all three final hosted runs
- Xcode build timing summary appears in CI output
- slowest tests are extracted from the result bundle
- documentation-only run 29162593471 skipped Build and Test and passed CI Gate
- non-documentation changes run the complete suite
- historical superseded PR runs confirm per-PR cancellation remains operational
- three-worker failure confirmed failure artifact availability and CI Gate propagation
- workflow uses no repository secrets and retains read-only fork-safe permissions

## Owner checks

No app UI or runtime behavior changed. In the Actions UI, confirm the PR CI summary shows separate build and test durations plus the slowest-test table.