### PR TITLE
iPad: add universal targeting and adaptive session navigation

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		C15210000000000000000006 /* OnboardingConnectPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000006 /* OnboardingConnectPage.swift */; };
 		C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000007 /* OnboardingFlowTests.swift */; };
 		C0391000000000000000000F /* SessionListMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000F /* SessionListMutationTests.swift */; };
+		A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000012 /* SessionNavigationStateTests.swift */; };
 		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
 		C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000010 /* APIEndpointContractTests.swift */; };
 		C03910000000000000000011 /* CronManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000011 /* CronManagementTests.swift */; };
@@ -115,6 +116,7 @@
 		1A2B3C4D5E6F7000000000D0 /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */; };
 		1A2B3C4D5E6F7000000000D1 /* SessionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */; };
 		A04300000000000000000001 /* SessionListComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000011 /* SessionListComponents.swift */; };
+		A10900000000000000000001 /* SessionNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000011 /* SessionNavigationState.swift */; };
 		A04300000000000000000002 /* SessionListActionConfirmations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000012 /* SessionListActionConfirmations.swift */; };
 		A04300000000000000000003 /* SessionMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000013 /* SessionMutator.swift */; };
 		A040C0DE0000000000000001 /* ProjectCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A040C0DE0000000000000002 /* ProjectCreationSheet.swift */; };
@@ -407,6 +409,7 @@
 		C15200000000000000000006 /* OnboardingConnectPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConnectPage.swift; sourceTree = "<group>"; };
 		C15200000000000000000007 /* OnboardingFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowTests.swift; sourceTree = "<group>"; };
 		C0390000000000000000000F /* SessionListMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListMutationTests.swift; sourceTree = "<group>"; };
+		A10900000000000000000012 /* SessionNavigationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationStateTests.swift; sourceTree = "<group>"; };
 		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000010 /* APIEndpointContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointContractTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000011 /* CronManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronManagementTests.swift; sourceTree = "<group>"; };
@@ -437,6 +440,7 @@
 		1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListViewModel.swift; sourceTree = "<group>"; };
 		A04300000000000000000011 /* SessionListComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListComponents.swift; sourceTree = "<group>"; };
+		A10900000000000000000011 /* SessionNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationState.swift; sourceTree = "<group>"; };
 		A04300000000000000000012 /* SessionListActionConfirmations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListActionConfirmations.swift; sourceTree = "<group>"; };
 		A04300000000000000000013 /* SessionMutator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMutator.swift; sourceTree = "<group>"; };
 		A040C0DE0000000000000002 /* ProjectCreationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreationSheet.swift; sourceTree = "<group>"; };
@@ -753,6 +757,7 @@
 					C14600000000000000000001 /* ChatToolbarHeaderTests.swift */,
 					C15200000000000000000007 /* OnboardingFlowTests.swift */,
 				C0390000000000000000000F /* SessionListMutationTests.swift */,
+				A10900000000000000000012 /* SessionNavigationStateTests.swift */,
 				19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */,
 				C03900000000000000000010 /* APIEndpointContractTests.swift */,
 				C03900000000000000000011 /* CronManagementTests.swift */,
@@ -928,6 +933,7 @@
 				1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */,
 				1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */,
 				A04300000000000000000011 /* SessionListComponents.swift */,
+				A10900000000000000000011 /* SessionNavigationState.swift */,
 				A04300000000000000000012 /* SessionListActionConfirmations.swift */,
 				A04300000000000000000013 /* SessionMutator.swift */,
 				C08800000000000000000002 /* SessionHaptics.swift */,
@@ -1508,6 +1514,7 @@
 				1A2B3C4D5E6F7000000000D0 /* SessionRowView.swift in Sources */,
 				1A2B3C4D5E6F7000000000D1 /* SessionListViewModel.swift in Sources */,
 				A04300000000000000000001 /* SessionListComponents.swift in Sources */,
+				A10900000000000000000001 /* SessionNavigationState.swift in Sources */,
 				A04300000000000000000002 /* SessionListActionConfirmations.swift in Sources */,
 				A04300000000000000000003 /* SessionMutator.swift in Sources */,
 				A040C0DE0000000000000001 /* ProjectCreationSheet.swift in Sources */,
@@ -1583,6 +1590,7 @@
 					C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */,
 					C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */,
 				C0391000000000000000000F /* SessionListMutationTests.swift in Sources */,
+				A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */,
 				19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */,
 				C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */,
 				C03910000000000000000011 /* CronManagementTests.swift in Sources */,
@@ -1833,7 +1841,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1862,7 +1870,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -1885,7 +1893,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HermesMobile.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/HermesMobile";
 			};
 			name = Debug;
@@ -1909,7 +1917,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HermesMobile.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/HermesMobile";
 			};
 			name = Release;
@@ -1938,7 +1946,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1966,7 +1974,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -1993,7 +2001,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -2020,7 +2028,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -569,8 +569,9 @@ struct ChatView: View {
         .overlay(alignment: .top) {
             GitActionToastOverlay(state: gitToastState)
         }
-            .navigationTitle(displayTitle)
-            .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(displayTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("chat-detail:\(viewModel.displayTitle)")
         .task {
             viewModel.setShowsLiveActivityResponseExcerpts(showsLiveActivityResponseExcerpts)
             if loadsInitialMessages {

--- a/HermesMobile/Features/Onboarding/OnboardingWelcomePage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingWelcomePage.swift
@@ -67,7 +67,7 @@ struct OnboardingWelcomePage: View {
                 Spacer(minLength: 32)
 
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("Control your Hermes agent from iPhone.")
+                    Text("Control your Hermes agent from iPhone or iPad.")
                         .font(.system(size: dynamicTypeSize.isAccessibilitySize ? 27 : 31, weight: .bold))
                         .foregroundStyle(.white)
                         .lineLimit(3)

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -318,6 +318,7 @@ struct SessionListRowsSection: View {
     let isSearchActive: Bool
     let showsMessageCount: Bool
     let showsWorkspace: Bool
+    let selectedSessionID: String?
     let actions: SessionListRowActions
 
     var body: some View {
@@ -429,6 +430,12 @@ struct SessionListRowsSection: View {
             )
         }
         .buttonStyle(.plain)
+        .background(
+            session.sessionId == selectedSessionID
+                ? Color.accentColor.opacity(0.12)
+                : Color.clear,
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
         .transition(SessionListMotion.sessionRowTransition(reduceMotion: reduceMotion))
         .swipeActions(edge: .leading, allowsFullSwipe: false) {
             sessionLeadingSwipeActions(for: session)

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -15,12 +15,11 @@ struct SessionListView: View {
 
     @Environment(\.modelContext) private var modelContext
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @State private var viewModel: SessionListViewModel
-    @State private var createdSession: SessionSummary?
-    @State private var pendingNewChat: PendingNewChatRoute?
-    @State private var selectedUtilityDestination: SessionListUtilityDestination?
+    @State private var navigationState: SessionNavigationState
     @State private var sessionPendingRename: SessionSummary?
     @State private var sessionPendingDeletion: SessionSummary?
     @State private var sessionPendingProjectCreation: SessionSummary?
@@ -70,6 +69,11 @@ struct SessionListView: View {
         _pendingDeepLinkedSessionID = pendingDeepLinkedSessionID
         _requestedNewChat = requestedNewChat
         _viewModel = State(initialValue: SessionListViewModel(server: server))
+        _navigationState = State(
+            initialValue: SessionNavigationState(
+                lastSelectedSessionID: SessionNavigationPersistence.load(for: server)
+            )
+        )
         _showsCliSessions = AppStorage(
             wrappedValue: SessionRowDisplaySettings.showsCliSessions(for: server),
             SessionRowDisplaySettings.showCliSessionsKey(for: server)
@@ -81,50 +85,7 @@ struct SessionListView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack(alignment: .bottomTrailing) {
-                Color(.systemBackground)
-                    .ignoresSafeArea()
-
-                content
-
-                if !isSearchingSessions {
-                    newSessionButton
-                        .padding(.trailing, 24)
-                        .padding(.bottom, 22)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                }
-            }
-            .navigationDestination(item: $createdSession) { session in
-                ChatView(session: session, server: server, onAPIError: authManager.handleAPIError)
-            }
-            .navigationDestination(item: $pendingNewChat) { route in
-                PendingNewChatView(
-                    initialDraft: route.initialDraft,
-                    initialAttachments: route.initialAttachments,
-                    autoStartsVoiceInput: route.autoStartsVoiceInput,
-                    profileName: route.profileName,
-                    server: server,
-                    viewModel: viewModel,
-                    onAPIError: authManager.handleAPIError
-                )
-            }
-            .navigationDestination(item: $selectedUtilityDestination) { destination in
-                switch destination {
-                case .settings(let scrollTo):
-                    SettingsView(authManager: authManager, server: server, initialScrollTarget: scrollTo)
-                case .tasks:
-                    TasksView(server: server, onAPIError: authManager.handleAPIError)
-                case .skills:
-                    SkillsView(server: server, onAPIError: authManager.handleAPIError)
-                case .memory:
-                    MemoryView(server: server, onAPIError: authManager.handleAPIError)
-                case .insights:
-                    InsightsView(server: server, onAPIError: authManager.handleAPIError)
-                case .archived:
-                    ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
-                }
-            }
+        navigationContainer
             .sheet(item: $sessionExportShareItem) { item in
                 SessionExportShareSheet(fileURL: item.fileURL)
                     .presentationDetents([.medium, .large])
@@ -228,6 +189,7 @@ struct SessionListView: View {
             .task {
                 await refreshSessionsAndActiveProfile()
                 didCompleteInitialLoad = true
+                restoreLastSelectedSessionIfNeeded()
             }
             .task(id: remoteSearchTaskID) {
                 await viewModel.searchSessions(query: searchText, content: true, depth: 5)
@@ -250,8 +212,13 @@ struct SessionListView: View {
             .onChange(of: requestedNewChat) {
                 openRequestedNewChatIfNeeded()
             }
-            .onChange(of: pendingNewChat) { _, newValue in
-                if newValue == nil {
+            .onChange(of: navigationState.destination) { oldValue, newValue in
+                if case .newChat = oldValue,
+                   case .newChat = newValue {
+                    return
+                }
+
+                if case .newChat = oldValue {
                     viewModel.removeEmptySidebarPlaceholders()
                 }
             }
@@ -271,7 +238,110 @@ struct SessionListView: View {
                     }
                 )
             )
+    }
+
+    @ViewBuilder
+    private var navigationContainer: some View {
+        if horizontalSizeClass == .regular {
+            NavigationSplitView {
+                sessionListSurface
+                    .navigationSplitViewColumnWidth(min: 280, ideal: 340, max: 420)
+            } detail: {
+                NavigationStack {
+                    regularWidthDetail
+                }
+            }
+            .navigationSplitViewStyle(.balanced)
+        } else {
+            NavigationStack {
+                sessionListSurface
+                    .navigationDestination(item: navigationDestinationBinding) { destination in
+                        navigationDestination(destination)
+                    }
+            }
         }
+    }
+
+    private var sessionListSurface: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Color(.systemBackground)
+                .ignoresSafeArea()
+
+            content
+
+            if !isSearchingSessions {
+                newSessionButton
+                    .padding(.trailing, 24)
+                    .padding(.bottom, 22)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var regularWidthDetail: some View {
+        if let destination = navigationState.destination {
+            navigationDestination(destination)
+        } else {
+            ContentUnavailableView {
+                Label("Select a Chat", systemImage: "bubble.left.and.bubble.right")
+            } description: {
+                Text("Choose a session from the sidebar or start a new chat.")
+            } actions: {
+                Button("New Chat", action: openNewChat)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func navigationDestination(_ destination: SessionNavigationDestination) -> some View {
+        switch destination {
+        case .session(let session):
+            ChatView(session: session, server: server, onAPIError: authManager.handleAPIError)
+                .id(session.id)
+        case .newChat(let route):
+            PendingNewChatView(
+                initialDraft: route.initialDraft,
+                initialAttachments: route.initialAttachments,
+                autoStartsVoiceInput: route.autoStartsVoiceInput,
+                profileName: route.profileName,
+                server: server,
+                viewModel: viewModel,
+                onAPIError: authManager.handleAPIError,
+                onSessionCreated: rememberCreatedSession
+            )
+        case .utility(let destination):
+            utilityDestination(destination)
+        }
+    }
+
+    @ViewBuilder
+    private func utilityDestination(_ destination: SessionListUtilityDestination) -> some View {
+        switch destination {
+        case .settings(let scrollTo):
+            SettingsView(authManager: authManager, server: server, initialScrollTarget: scrollTo)
+        case .tasks:
+            TasksView(server: server, onAPIError: authManager.handleAPIError)
+        case .skills:
+            SkillsView(server: server, onAPIError: authManager.handleAPIError)
+        case .memory:
+            MemoryView(server: server, onAPIError: authManager.handleAPIError)
+        case .insights:
+            InsightsView(server: server, onAPIError: authManager.handleAPIError)
+        case .archived:
+            ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
+        }
+    }
+
+    private var navigationDestinationBinding: Binding<SessionNavigationDestination?> {
+        Binding(
+            get: { navigationState.destination },
+            set: { destination in
+                guard destination == nil else { return }
+                navigationState.clearDestination()
+            }
+        )
     }
 
     private var content: some View {
@@ -296,7 +366,7 @@ struct SessionListView: View {
                     projectPendingDeletion: $projectPendingDeletion,
                     projectPendingRename: $projectPendingRename,
                     openDestination: { destination in
-                        selectedUtilityDestination = destination
+                        navigationState.select(destination)
                     },
                     switchActiveProfile: { profile in
                         Task { await switchActiveProfile(profile) }
@@ -315,6 +385,9 @@ struct SessionListView: View {
                 isSearchActive: isSearchingSessions,
                 showsMessageCount: showsSessionMessageCount,
                 showsWorkspace: showsSessionWorkspace,
+                selectedSessionID: horizontalSizeClass == .regular
+                    ? navigationState.selectedSessionID
+                    : nil,
                 actions: sessionRowActions
             )
 
@@ -438,7 +511,7 @@ struct SessionListView: View {
             if searchChromeIsExpanded {
                 closeSearch()
             } else {
-                selectedUtilityDestination = .settings(nil)
+                navigationState.select(.settings(nil))
             }
         } label: {
             ZStack {
@@ -485,7 +558,7 @@ struct SessionListView: View {
                         authManager.switchActiveServer(to: account)
                     },
                     addServer: { isPresentingAddServer = true },
-                    manageServers: { selectedUtilityDestination = .settings(.servers) }
+                    manageServers: { navigationState.select(.settings(.servers)) }
                 )
             }
         }
@@ -493,7 +566,7 @@ struct SessionListView: View {
 
     private var newSessionButton: some View {
         HapticButton(feedbackStyle: .medium) {
-            pendingNewChat = PendingNewChatRoute()
+            openNewChat()
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: "square.and.pencil")
@@ -522,7 +595,7 @@ struct SessionListView: View {
             )
         }
         .buttonStyle(SessionListFloatingChatButtonStyle())
-        .disabled(viewModel.isViewingCachedData || pendingNewChat != nil)
+        .disabled(viewModel.isViewingCachedData || isOpeningNewChat)
         .opacity(viewModel.isViewingCachedData ? 0.45 : 1)
         .accessibilityLabel("New Session")
     }
@@ -555,7 +628,7 @@ struct SessionListView: View {
 
     private var archivedEntryRow: some View {
         HapticButton {
-            selectedUtilityDestination = .archived
+            navigationState.select(.archived)
         } label: {
             HStack(spacing: 12) {
                 Image(systemName: "archivebox")
@@ -715,7 +788,7 @@ struct SessionListView: View {
                 Task { await refreshSessionsAndActiveProfile() }
             },
             open: { session in
-                createdSession = session
+                selectSession(session)
             },
             togglePinned: { session in
                 Task { await togglePinned(session) }
@@ -864,6 +937,7 @@ struct SessionListView: View {
         handleLastError()
 
         if didArchive {
+            removeSessionFromNavigation(session)
             SessionHaptics.archiveStateChanged(isEnabled: isHapticsEnabled)
         }
     }
@@ -877,6 +951,7 @@ struct SessionListView: View {
         handleLastError()
 
         if didDelete {
+            removeSessionFromNavigation(session)
             SessionHaptics.sessionDeleted(isEnabled: isHapticsEnabled)
         }
     }
@@ -898,7 +973,7 @@ struct SessionListView: View {
         handleLastError()
 
         if let duplicatedSession {
-            createdSession = duplicatedSession
+            selectSession(duplicatedSession)
         }
     }
 
@@ -949,9 +1024,11 @@ struct SessionListView: View {
             return
         }
 
-        pendingNewChat = PendingNewChatRoute(
-            initialDraft: draft,
-            initialAttachments: sharedImport.attachments
+        navigationState.select(
+            PendingNewChatRoute(
+                initialDraft: draft,
+                initialAttachments: sharedImport.attachments
+            )
         )
     }
 
@@ -964,13 +1041,13 @@ struct SessionListView: View {
 
         pendingDeepLinkedSessionID = nil
         if let loadedSession = viewModel.sessions.first(where: { $0.sessionId == sessionID }) {
-            createdSession = loadedSession
+            selectSession(loadedSession)
             return
         }
 
         Task {
             if let session = await viewModel.loadSessionForDeepLink(id: sessionID, modelContext: modelContext) {
-                createdSession = session
+                selectSession(session)
             }
             handleLastError()
         }
@@ -983,10 +1060,45 @@ struct SessionListView: View {
     private func openRequestedNewChatIfNeeded() {
         guard let request = requestedNewChat else { return }
         requestedNewChat = nil
-        pendingNewChat = PendingNewChatRoute(
-            autoStartsVoiceInput: request.autoStartsVoiceInput,
-            profileName: request.profileName
+        navigationState.select(
+            PendingNewChatRoute(
+                autoStartsVoiceInput: request.autoStartsVoiceInput,
+                profileName: request.profileName
+            )
         )
+    }
+
+    private var isOpeningNewChat: Bool {
+        guard case .newChat = navigationState.destination else { return false }
+        return true
+    }
+
+    private func openNewChat() {
+        navigationState.select(PendingNewChatRoute())
+    }
+
+    private func selectSession(_ session: SessionSummary) {
+        navigationState.select(session)
+        persistLastSelectedSession()
+    }
+
+    private func rememberCreatedSession(_ session: SessionSummary) {
+        navigationState.remember(session)
+        persistLastSelectedSession()
+    }
+
+    private func removeSessionFromNavigation(_ session: SessionSummary) {
+        navigationState.remove(sessionID: session.sessionId)
+        persistLastSelectedSession()
+    }
+
+    private func restoreLastSelectedSessionIfNeeded() {
+        navigationState.restoreIfNeeded(from: viewModel.sessions)
+        persistLastSelectedSession()
+    }
+
+    private func persistLastSelectedSession() {
+        SessionNavigationPersistence.save(navigationState.lastSelectedSessionID, for: server)
     }
 
 }
@@ -1044,7 +1156,7 @@ struct NewChatRequest: Equatable {
     }
 }
 
-private struct PendingNewChatRoute: Identifiable, Hashable {
+struct PendingNewChatRoute: Identifiable, Hashable {
     let id = UUID()
     let initialDraft: String
     let initialAttachments: [SharedAttachmentImport]
@@ -1106,6 +1218,7 @@ private struct PendingNewChatView: View {
     let server: URL
     let viewModel: SessionListViewModel
     let onAPIError: (Error) -> Void
+    let onSessionCreated: (SessionSummary) -> Void
     let initialAttachments: [SharedAttachmentImport]
     let autoStartsVoiceInput: Bool
     let profileName: String?
@@ -1124,11 +1237,13 @@ private struct PendingNewChatView: View {
         profileName: String? = nil,
         server: URL,
         viewModel: SessionListViewModel,
-        onAPIError: @escaping (Error) -> Void
+        onAPIError: @escaping (Error) -> Void,
+        onSessionCreated: @escaping (SessionSummary) -> Void = { _ in }
     ) {
         self.server = server
         self.viewModel = viewModel
         self.onAPIError = onAPIError
+        self.onSessionCreated = onSessionCreated
         self.initialAttachments = initialAttachments
         self.autoStartsVoiceInput = autoStartsVoiceInput
         self.profileName = profileName
@@ -1254,6 +1369,7 @@ private struct PendingNewChatView: View {
 
         if let session {
             SessionHaptics.sessionCreated(isEnabled: isHapticsEnabled)
+            onSessionCreated(session)
             createdSession = session
         } else {
             creationErrorMessage = viewModel.actionErrorMessage

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -311,6 +311,7 @@ struct SessionListView: View {
                 onAPIError: authManager.handleAPIError,
                 onSessionCreated: rememberCreatedSession
             )
+            .id(route.id)
         case .utility(let destination):
             utilityDestination(destination)
         }
@@ -595,7 +596,7 @@ struct SessionListView: View {
             )
         }
         .buttonStyle(SessionListFloatingChatButtonStyle())
-        .disabled(viewModel.isViewingCachedData || isOpeningNewChat)
+        .disabled(viewModel.isViewingCachedData || navigationState.isCreatingNewChat)
         .opacity(viewModel.isViewingCachedData ? 0.45 : 1)
         .accessibilityLabel("New Session")
     }
@@ -1068,11 +1069,6 @@ struct SessionListView: View {
         )
     }
 
-    private var isOpeningNewChat: Bool {
-        guard case .newChat = navigationState.destination else { return false }
-        return true
-    }
-
     private func openNewChat() {
         navigationState.select(PendingNewChatRoute())
     }
@@ -1093,7 +1089,10 @@ struct SessionListView: View {
     }
 
     private func restoreLastSelectedSessionIfNeeded() {
-        navigationState.restoreIfNeeded(from: viewModel.sessions)
+        navigationState.restoreIfNeeded(
+            from: viewModel.sessions,
+            clearsMissingSelection: viewModel.sessionLoadError == nil
+        )
         persistLastSelectedSession()
     }
 

--- a/HermesMobile/Features/SessionList/SessionNavigationState.swift
+++ b/HermesMobile/Features/SessionList/SessionNavigationState.swift
@@ -26,6 +26,11 @@ struct SessionNavigationState: Equatable {
         destination?.selectedSessionID ?? newChatSessionID
     }
 
+    var isCreatingNewChat: Bool {
+        guard case .newChat = destination else { return false }
+        return newChatSessionID == nil
+    }
+
     mutating func select(_ session: SessionSummary) {
         newChatSessionID = nil
         destination = .session(session)
@@ -57,13 +62,18 @@ struct SessionNavigationState: Equatable {
 
     /// Restores only when no explicit route already won. Deep links, shared drafts,
     /// and App Intent requests therefore take precedence over the stored selection.
-    mutating func restoreIfNeeded(from sessions: [SessionSummary]) {
+    mutating func restoreIfNeeded(
+        from sessions: [SessionSummary],
+        clearsMissingSelection: Bool = true
+    ) {
         guard destination == nil, let lastSelectedSessionID else { return }
 
         guard let session = sessions.first(where: {
             Self.normalized($0.sessionId) == lastSelectedSessionID
         }) else {
-            self.lastSelectedSessionID = nil
+            if clearsMissingSelection {
+                self.lastSelectedSessionID = nil
+            }
             return
         }
 

--- a/HermesMobile/Features/SessionList/SessionNavigationState.swift
+++ b/HermesMobile/Features/SessionList/SessionNavigationState.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+enum SessionNavigationDestination: Hashable, Identifiable {
+    case session(SessionSummary)
+    case newChat(PendingNewChatRoute)
+    case utility(SessionListUtilityDestination)
+
+    var id: Self { self }
+
+    var selectedSessionID: String? {
+        guard case .session(let session) = self else { return nil }
+        return session.sessionId
+    }
+}
+
+struct SessionNavigationState: Equatable {
+    private(set) var destination: SessionNavigationDestination?
+    private(set) var lastSelectedSessionID: String?
+    private var newChatSessionID: String?
+
+    init(lastSelectedSessionID: String? = nil) {
+        self.lastSelectedSessionID = Self.normalized(lastSelectedSessionID)
+    }
+
+    var selectedSessionID: String? {
+        destination?.selectedSessionID ?? newChatSessionID
+    }
+
+    mutating func select(_ session: SessionSummary) {
+        newChatSessionID = nil
+        destination = .session(session)
+        remember(session)
+    }
+
+    mutating func select(_ route: PendingNewChatRoute) {
+        newChatSessionID = nil
+        destination = .newChat(route)
+    }
+
+    mutating func select(_ utility: SessionListUtilityDestination) {
+        newChatSessionID = nil
+        destination = .utility(utility)
+    }
+
+    mutating func remember(_ session: SessionSummary) {
+        guard let sessionID = Self.normalized(session.sessionId) else { return }
+        lastSelectedSessionID = sessionID
+        if case .newChat = destination {
+            newChatSessionID = sessionID
+        }
+    }
+
+    mutating func clearDestination() {
+        destination = nil
+        newChatSessionID = nil
+    }
+
+    /// Restores only when no explicit route already won. Deep links, shared drafts,
+    /// and App Intent requests therefore take precedence over the stored selection.
+    mutating func restoreIfNeeded(from sessions: [SessionSummary]) {
+        guard destination == nil, let lastSelectedSessionID else { return }
+
+        guard let session = sessions.first(where: {
+            Self.normalized($0.sessionId) == lastSelectedSessionID
+        }) else {
+            self.lastSelectedSessionID = nil
+            return
+        }
+
+        destination = .session(session)
+    }
+
+    /// Invalidates both the visible detail and stored restoration target when the
+    /// removed session is the selected or most recently selected session.
+    mutating func remove(sessionID: String?) {
+        guard let sessionID = Self.normalized(sessionID) else { return }
+
+        if selectedSessionID == sessionID {
+            destination = nil
+            newChatSessionID = nil
+        }
+
+        if lastSelectedSessionID == sessionID {
+            lastSelectedSessionID = nil
+        }
+    }
+
+    private static func normalized(_ sessionID: String?) -> String? {
+        guard let sessionID else { return nil }
+        let trimmed = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+enum SessionNavigationPersistence {
+    private static let keyPrefix = "sessionNavigation.lastSelectedSessionID."
+
+    static func key(for server: URL) -> String {
+        keyPrefix + server.absoluteString
+    }
+
+    static func load(for server: URL, defaults: UserDefaults = .standard) -> String? {
+        defaults.string(forKey: key(for: server))
+    }
+
+    static func save(_ sessionID: String?, for server: URL, defaults: UserDefaults = .standard) {
+        let key = key(for: server)
+        if let sessionID {
+            defaults.set(sessionID, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}

--- a/HermesMobile/Resources/Info.plist
+++ b/HermesMobile/Resources/Info.plist
@@ -79,5 +79,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -20298,108 +20298,108 @@
         }
       }
     },
-    "Control your Hermes agent from iPhone." : {
+    "Control your Hermes agent from iPhone or iPad." : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "تحكّم في عميل Hermes من iPhone."
+            "value" : "تحكّم في عميل Hermes من iPhone أو iPad."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Steuere deinen Hermes-Agenten vom iPhone aus."
+            "value" : "Steuere deinen Hermes-Agenten vom iPhone oder iPad aus."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Controla tu agente Hermes desde iPhone."
+            "value" : "Controla tu agente Hermes desde iPhone o iPad."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Contrôlez votre agent Hermes depuis iPhone."
+            "value" : "Contrôlez votre agent Hermes depuis iPhone ou iPad."
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "שלוט בסוכן Hermes שלך מה-iPhone."
+            "value" : "שלוט בסוכן Hermes שלך מה-iPhone או מה-iPad."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Controlla il tuo agente Hermes da iPhone."
+            "value" : "Controlla il tuo agente Hermes da iPhone o iPad."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "iPhoneからHermesエージェントを操作できます。"
+            "value" : "iPhoneまたはiPadからHermesエージェントを操作できます。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "iPhone에서 Hermes 에이전트를 제어하세요."
+            "value" : "iPhone 또는 iPad에서 Hermes 에이전트를 제어하세요."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Bedien uw Hermes-agent vanaf de iPhone."
+            "value" : "Bedien uw Hermes-agent vanaf de iPhone of iPad."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Steruj agentem Hermes z iPhone'a."
+            "value" : "Steruj agentem Hermes z iPhone'a lub iPada."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Controle seu agente Hermes pelo iPhone."
+            "value" : "Controle seu agente Hermes pelo iPhone ou iPad."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Управляйте агентом Hermes с iPhone."
+            "value" : "Управляйте агентом Hermes с iPhone или iPad."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Hermes ajanınızı iPhone'dan kontrol edin."
+            "value" : "Hermes ajanınızı iPhone veya iPad'den kontrol edin."
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "اپنے iPhone سے اپنے Hermes ایجنٹ کو کنٹرول کریں۔"
+            "value" : "اپنے iPhone یا iPad سے اپنے Hermes ایجنٹ کو کنٹرول کریں۔"
           }
         },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "在 iPhone 上控制你的 Hermes 代理。"
+            "value" : "在 iPhone 或 iPad 上控制你的 Hermes 代理。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "在 iPhone 上控制你的 Hermes 智能体。"
+            "value" : "在 iPhone 或 iPad 上控制你的 Hermes 智能体。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "在 iPhone 上控制你的 Hermes 代理人。"
+            "value" : "在 iPhone 或 iPad 上控制你的 Hermes 代理人。"
           }
         }
       }

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -33,6 +33,15 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertNil(state.lastSelectedSessionID)
     }
 
+    func testRestorePreservesStoredSelectionWhenSessionListIsNotAuthoritative() {
+        var state = SessionNavigationState(lastSelectedSessionID: "session-1")
+
+        state.restoreIfNeeded(from: [], clearsMissingSelection: false)
+
+        XCTAssertNil(state.destination)
+        XCTAssertEqual(state.lastSelectedSessionID, "session-1")
+    }
+
     func testExplicitNewChatRouteOverridesStoredSelection() {
         let route = PendingNewChatRoute(initialDraft: "Shared draft")
         var state = SessionNavigationState(lastSelectedSessionID: "session-1")
@@ -61,12 +70,28 @@ final class SessionNavigationStateTests: XCTestCase {
         let created = SessionSummary(sessionId: "created-session")
         var state = SessionNavigationState()
         state.select(route)
+        XCTAssertTrue(state.isCreatingNewChat)
 
         state.remember(created)
 
         XCTAssertEqual(state.destination, .newChat(route))
         XCTAssertEqual(state.selectedSessionID, "created-session")
         XCTAssertEqual(state.lastSelectedSessionID, "created-session")
+        XCTAssertFalse(state.isCreatingNewChat)
+    }
+
+    func testSelectingAnotherNewChatRouteStartsFreshCreationState() {
+        let firstRoute = PendingNewChatRoute()
+        let secondRoute = PendingNewChatRoute()
+        var state = SessionNavigationState()
+        state.select(firstRoute)
+        state.remember(SessionSummary(sessionId: "created-session"))
+
+        state.select(secondRoute)
+
+        XCTAssertEqual(state.destination, .newChat(secondRoute))
+        XCTAssertNil(state.selectedSessionID)
+        XCTAssertTrue(state.isCreatingNewChat)
     }
 
     func testRemovingSelectedSessionClearsDestinationAndRestorationID() {

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import HermesMobile
+
+final class SessionNavigationStateTests: XCTestCase {
+    func testSelectingSessionUpdatesDestinationAndRestorationID() {
+        let session = SessionSummary(sessionId: "session-1", title: "One")
+        var state = SessionNavigationState()
+
+        state.select(session)
+
+        XCTAssertEqual(state.destination, .session(session))
+        XCTAssertEqual(state.selectedSessionID, "session-1")
+        XCTAssertEqual(state.lastSelectedSessionID, "session-1")
+    }
+
+    func testRestoreSelectsStoredSessionWhenItStillExists() {
+        let first = SessionSummary(sessionId: "session-1", title: "One")
+        let second = SessionSummary(sessionId: "session-2", title: "Two")
+        var state = SessionNavigationState(lastSelectedSessionID: "session-2")
+
+        state.restoreIfNeeded(from: [first, second])
+
+        XCTAssertEqual(state.destination, .session(second))
+        XCTAssertEqual(state.lastSelectedSessionID, "session-2")
+    }
+
+    func testRestoreClearsStoredSelectionWhenSessionNoLongerExists() {
+        var state = SessionNavigationState(lastSelectedSessionID: "missing")
+
+        state.restoreIfNeeded(from: [SessionSummary(sessionId: "session-1")])
+
+        XCTAssertNil(state.destination)
+        XCTAssertNil(state.lastSelectedSessionID)
+    }
+
+    func testExplicitNewChatRouteOverridesStoredSelection() {
+        let route = PendingNewChatRoute(initialDraft: "Shared draft")
+        var state = SessionNavigationState(lastSelectedSessionID: "session-1")
+        state.select(route)
+
+        state.restoreIfNeeded(from: [SessionSummary(sessionId: "session-1")])
+
+        XCTAssertEqual(state.destination, .newChat(route))
+        XCTAssertEqual(state.lastSelectedSessionID, "session-1")
+    }
+
+    func testExplicitSessionRouteOverridesStoredSelection() {
+        let stored = SessionSummary(sessionId: "stored")
+        let deepLinked = SessionSummary(sessionId: "deep-linked")
+        var state = SessionNavigationState(lastSelectedSessionID: "stored")
+        state.select(deepLinked)
+
+        state.restoreIfNeeded(from: [stored])
+
+        XCTAssertEqual(state.destination, .session(deepLinked))
+        XCTAssertEqual(state.lastSelectedSessionID, "deep-linked")
+    }
+
+    func testCreatedSessionRemainsSelectedWhileNewChatRouteOwnsItsDraft() {
+        let route = PendingNewChatRoute(initialDraft: "Shared draft")
+        let created = SessionSummary(sessionId: "created-session")
+        var state = SessionNavigationState()
+        state.select(route)
+
+        state.remember(created)
+
+        XCTAssertEqual(state.destination, .newChat(route))
+        XCTAssertEqual(state.selectedSessionID, "created-session")
+        XCTAssertEqual(state.lastSelectedSessionID, "created-session")
+    }
+
+    func testRemovingSelectedSessionClearsDestinationAndRestorationID() {
+        let session = SessionSummary(sessionId: "session-1")
+        var state = SessionNavigationState()
+        state.select(session)
+
+        state.remove(sessionID: "session-1")
+
+        XCTAssertNil(state.destination)
+        XCTAssertNil(state.lastSelectedSessionID)
+    }
+
+    func testRemovingRememberedSessionPreservesDifferentVisibleDestination() {
+        var state = SessionNavigationState(lastSelectedSessionID: "session-1")
+        state.select(SessionListUtilityDestination.tasks)
+
+        state.remove(sessionID: "session-1")
+
+        XCTAssertEqual(state.destination, .utility(.tasks))
+        XCTAssertNil(state.lastSelectedSessionID)
+    }
+
+    func testPersistenceUsesIndependentKeysPerServer() throws {
+        let suiteName = "SessionNavigationStateTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let firstServer = try XCTUnwrap(URL(string: "https://first.example.com"))
+        let secondServer = try XCTUnwrap(URL(string: "https://second.example.com"))
+
+        SessionNavigationPersistence.save("first-session", for: firstServer, defaults: defaults)
+        SessionNavigationPersistence.save("second-session", for: secondServer, defaults: defaults)
+
+        XCTAssertEqual(
+            SessionNavigationPersistence.load(for: firstServer, defaults: defaults),
+            "first-session"
+        )
+        XCTAssertEqual(
+            SessionNavigationPersistence.load(for: secondServer, defaults: defaults),
+            "second-session"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- enable universal iPhone and iPad targeting under the existing Hermex app identity
- add regular-width sidebar/detail navigation while preserving compact stacked navigation
- persist the most recently selected session per server and keep selection valid across creation, deletion, archive, server changes, and explicit routes
- add navigation-state tests and a deterministic UI identity seam for session-switch regression checks
- update onboarding copy and existing translations for iPhone and iPad

Fixes #109

## Validation

- `git diff --check`
- focused `SessionNavigationStateTests`: 9 passed
- full XCTest suite on iPad Pro 13-inch (M5): 1,354 passed, 0 failed, 0 skipped
- signed Debug build/install/launch on iPhone 17 and iPad Pro 13-inch (M5)
- deterministic iPad A-to-B session-switch regression loop: selected detail changed to B and all A detail identifiers disappeared

## Owner manual checks

- validated iPhone session/chat navigation
- validated regular-width iPad sidebar/detail navigation
- validated compact iPad stacked navigation
- validated session creation, selection restoration, deletion, server switching, deep links, shared drafts, and App Intent routing
- validated the follow-up fix for switching directly between sessions in the iPad sidebar
