### PR TITLE
iPad: adapt secondary destinations and workspace flows

### DIFF
--- a/HermesMobile/Features/Insights/InsightsView.swift
+++ b/HermesMobile/Features/Insights/InsightsView.swift
@@ -14,6 +14,7 @@ struct InsightsView: View {
 
     var body: some View {
         content
+            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Usage Analytics")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Insights/InsightsView.swift
+++ b/HermesMobile/Features/Insights/InsightsView.swift
@@ -14,7 +14,7 @@ struct InsightsView: View {
 
     var body: some View {
         content
-            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
+            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Usage Analytics")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Memory/MemoryView.swift
+++ b/HermesMobile/Features/Memory/MemoryView.swift
@@ -15,6 +15,7 @@ struct MemoryView: View {
 
     var body: some View {
         content
+            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Memory")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Memory/MemoryView.swift
+++ b/HermesMobile/Features/Memory/MemoryView.swift
@@ -15,7 +15,7 @@ struct MemoryView: View {
 
     var body: some View {
         content
-            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
+            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Memory")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -430,6 +430,7 @@ struct SessionListRowsSection: View {
             )
         }
         .buttonStyle(.plain)
+        .id(session.id)
         .background(
             session.sessionId == selectedSessionID
                 ? Color.accentColor.opacity(0.12)

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -252,6 +252,7 @@ struct SessionListView: View {
                 }
             }
             .navigationSplitViewStyle(.balanced)
+            .id(navigationState.rootRevision)
         } else {
             NavigationStack {
                 sessionListSurface
@@ -319,20 +320,23 @@ struct SessionListView: View {
 
     @ViewBuilder
     private func utilityDestination(_ destination: SessionListUtilityDestination) -> some View {
-        switch destination {
-        case .settings(let scrollTo):
-            SettingsView(authManager: authManager, server: server, initialScrollTarget: scrollTo)
-        case .tasks:
-            TasksView(server: server, onAPIError: authManager.handleAPIError)
-        case .skills:
-            SkillsView(server: server, onAPIError: authManager.handleAPIError)
-        case .memory:
-            MemoryView(server: server, onAPIError: authManager.handleAPIError)
-        case .insights:
-            InsightsView(server: server, onAPIError: authManager.handleAPIError)
-        case .archived:
-            ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
+        Group {
+            switch destination {
+            case .settings(let scrollTo):
+                SettingsView(authManager: authManager, server: server, initialScrollTarget: scrollTo)
+            case .tasks:
+                TasksView(server: server, onAPIError: authManager.handleAPIError)
+            case .skills:
+                SkillsView(server: server, onAPIError: authManager.handleAPIError)
+            case .memory:
+                MemoryView(server: server, onAPIError: authManager.handleAPIError)
+            case .insights:
+                InsightsView(server: server, onAPIError: authManager.handleAPIError)
+            case .archived:
+                ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
+            }
         }
+        .adaptiveSecondaryNavigationTitle()
     }
 
     private var navigationDestinationBinding: Binding<SessionNavigationDestination?> {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -33,6 +33,7 @@ struct SessionListView: View {
     @State private var isSearchFocused = false
     @State private var searchChromeIsExpanded = false
     @State private var selectedProjectID: String?
+    @State private var sidebarScrollPosition: String?
     @State private var didCompleteInitialLoad = false
     @FocusState private var searchFieldIsFocused: Bool
     @AppStorage(SessionSidebarDisclosureSettings.profilesAreExpandedKey)
@@ -412,6 +413,7 @@ struct SessionListView: View {
         // with the tightly-packed navigation rows.
         .environment(\.defaultMinListRowHeight, 0)
         .scrollContentBackground(.hidden)
+        .scrollPosition(id: $sidebarScrollPosition)
         .background(Color(.systemBackground))
         .scrollDismissesKeyboard(.interactively)
         // Disclosure subrows are real List rows; drive their fold from the List

--- a/HermesMobile/Features/SessionList/SessionNavigationState.swift
+++ b/HermesMobile/Features/SessionList/SessionNavigationState.swift
@@ -16,6 +16,7 @@ enum SessionNavigationDestination: Hashable, Identifiable {
 struct SessionNavigationState: Equatable {
     private(set) var destination: SessionNavigationDestination?
     private(set) var lastSelectedSessionID: String?
+    private(set) var rootRevision = 0
     private var newChatSessionID: String?
 
     init(lastSelectedSessionID: String? = nil) {
@@ -32,17 +33,20 @@ struct SessionNavigationState: Equatable {
     }
 
     mutating func select(_ session: SessionSummary) {
+        rootRevision += 1
         newChatSessionID = nil
         destination = .session(session)
         remember(session)
     }
 
     mutating func select(_ route: PendingNewChatRoute) {
+        rootRevision += 1
         newChatSessionID = nil
         destination = .newChat(route)
     }
 
     mutating func select(_ utility: SessionListUtilityDestination) {
+        rootRevision += 1
         newChatSessionID = nil
         destination = .utility(utility)
     }

--- a/HermesMobile/Features/Settings/ArchivedSessionsView.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsView.swift
@@ -20,7 +20,7 @@ struct ArchivedSessionsView: View {
 
     var body: some View {
         content
-            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
+            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Archived Sessions")
             .navigationDestination(item: $openedSession) { session in
                 // Opening an archived session reuses the normal read path —

--- a/HermesMobile/Features/Settings/ArchivedSessionsView.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsView.swift
@@ -20,6 +20,7 @@ struct ArchivedSessionsView: View {
 
     var body: some View {
         content
+            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Archived Sessions")
             .navigationDestination(item: $openedSession) { session in
                 // Opening an archived session reuses the normal read path —

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -485,6 +485,7 @@ struct SettingsView: View {
             .padding(.horizontal, 16)
             .padding(.top, 18)
             .padding(.bottom, 36)
+            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
         }
         .background(Color(.systemBackground))
         .navigationTitle("Settings")

--- a/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
+++ b/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
@@ -1,5 +1,38 @@
 import SwiftUI
 
+enum AdaptiveReadableContentWidth {
+    static let secondaryDestination: CGFloat = 800
+    static let workspace: CGFloat = 1_000
+}
+
+private struct AdaptiveReadableContentModifier: ViewModifier {
+    let maxWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: maxWidth)
+            .frame(maxWidth: .infinity)
+    }
+}
+
+extension View {
+    func adaptiveReadableContent(maxWidth: CGFloat) -> some View {
+        modifier(AdaptiveReadableContentModifier(maxWidth: maxWidth))
+    }
+
+    func adaptiveSecondaryNavigationTitle() -> some View {
+        modifier(AdaptiveSecondaryNavigationTitleModifier())
+    }
+}
+
+private struct AdaptiveSecondaryNavigationTitleModifier: ViewModifier {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    func body(content: Content) -> some View {
+        content.navigationBarTitleDisplayMode(horizontalSizeClass == .regular ? .inline : .automatic)
+    }
+}
+
 enum GlassPreference {
     static let isEnabledKey = "adaptiveGlass.isEnabled"
     static let defaultIsEnabled = true

--- a/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
+++ b/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
@@ -17,15 +17,24 @@ private struct AdaptiveReadableContentModifier: ViewModifier {
 
 private struct AdaptiveReadableScrollContentModifier: ViewModifier {
     let maxWidth: CGFloat
+    @State private var width: CGFloat = 0
 
     func body(content: Content) -> some View {
-        GeometryReader { proxy in
-            content.contentMargins(
+        content
+            .background {
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear { width = proxy.size.width }
+                        .onChange(of: proxy.size.width) { _, newWidth in
+                            width = newWidth
+                        }
+                }
+            }
+            .contentMargins(
                 .horizontal,
-                max((proxy.size.width - maxWidth) / 2, 0),
+                max((width - maxWidth) / 2, 0),
                 for: .scrollContent
             )
-        }
     }
 }
 
@@ -33,7 +42,6 @@ extension View {
     func adaptiveReadableContent(maxWidth: CGFloat) -> some View {
         modifier(AdaptiveReadableContentModifier(maxWidth: maxWidth))
     }
-
 
     func adaptiveReadableScrollContent(maxWidth: CGFloat) -> some View {
         modifier(AdaptiveReadableScrollContentModifier(maxWidth: maxWidth))

--- a/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
+++ b/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
@@ -15,9 +15,28 @@ private struct AdaptiveReadableContentModifier: ViewModifier {
     }
 }
 
+private struct AdaptiveReadableScrollContentModifier: ViewModifier {
+    let maxWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        GeometryReader { proxy in
+            content.contentMargins(
+                .horizontal,
+                max((proxy.size.width - maxWidth) / 2, 0),
+                for: .scrollContent
+            )
+        }
+    }
+}
+
 extension View {
     func adaptiveReadableContent(maxWidth: CGFloat) -> some View {
         modifier(AdaptiveReadableContentModifier(maxWidth: maxWidth))
+    }
+
+
+    func adaptiveReadableScrollContent(maxWidth: CGFloat) -> some View {
+        modifier(AdaptiveReadableScrollContentModifier(maxWidth: maxWidth))
     }
 
     func adaptiveSecondaryNavigationTitle() -> some View {

--- a/HermesMobile/Features/Skills/SkillsView.swift
+++ b/HermesMobile/Features/Skills/SkillsView.swift
@@ -16,6 +16,7 @@ struct SkillsView: View {
 
     var body: some View {
         content
+            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Skills")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Skills/SkillsView.swift
+++ b/HermesMobile/Features/Skills/SkillsView.swift
@@ -16,7 +16,7 @@ struct SkillsView: View {
 
     var body: some View {
         content
-            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
+            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Skills")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -15,6 +15,7 @@ struct TasksView: View {
 
     var body: some View {
         content
+            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Tasks")
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -15,7 +15,7 @@ struct TasksView: View {
 
     var body: some View {
         content
-            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
+            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Tasks")
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -22,6 +22,7 @@ struct FileBrowserView: View {
 
             content
         }
+            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
             .navigationTitle("Files")
             .navigationBarTitleDisplayMode(.inline)
             .task {

--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -21,8 +21,8 @@ struct FileBrowserView: View {
             searchBar
 
             content
+                .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
         }
-            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
             .navigationTitle("Files")
             .navigationBarTitleDisplayMode(.inline)
             .task {

--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -22,7 +22,7 @@ struct FileBrowserView: View {
 
             content
         }
-            .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
+            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
             .navigationTitle("Files")
             .navigationBarTitleDisplayMode(.inline)
             .task {

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -46,6 +46,7 @@ struct FilePreviewView: View {
                 }
             }
         }
+        .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
         .navigationTitle(displayName)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -46,7 +46,7 @@ struct FilePreviewView: View {
                 }
             }
         }
-        .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
+        .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
         .navigationTitle(displayName)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/HermesMobile/Features/Workspace/GitDiffView.swift
+++ b/HermesMobile/Features/Workspace/GitDiffView.swift
@@ -23,6 +23,7 @@ struct GitDiffView: View {
     var body: some View {
         NavigationStack {
             content
+                .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
                 .navigationTitle(file.displayPath)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/HermesMobile/Features/Workspace/GitDiffView.swift
+++ b/HermesMobile/Features/Workspace/GitDiffView.swift
@@ -23,7 +23,7 @@ struct GitDiffView: View {
     var body: some View {
         NavigationStack {
             content
-                .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
+                .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
                 .navigationTitle(file.displayPath)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/HermesMobile/Features/Workspace/GitWorkspaceView.swift
+++ b/HermesMobile/Features/Workspace/GitWorkspaceView.swift
@@ -19,6 +19,7 @@ struct GitWorkspaceView: View {
     var body: some View {
         NavigationStack {
             content
+                .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
                 .navigationTitle("Git")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/HermesMobile/Features/Workspace/GitWorkspaceView.swift
+++ b/HermesMobile/Features/Workspace/GitWorkspaceView.swift
@@ -19,7 +19,7 @@ struct GitWorkspaceView: View {
     var body: some View {
         NavigationStack {
             content
-                .adaptiveReadableContent(maxWidth: AdaptiveReadableContentWidth.workspace)
+                .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
                 .navigationTitle("Git")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -115,6 +115,36 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertNil(state.lastSelectedSessionID)
     }
 
+    func testUtilityDestinationRemainsSelectedAcrossLayoutReevaluation() {
+        var state = SessionNavigationState()
+        state.select(SessionListUtilityDestination.settings(nil))
+
+        let reevaluatedState = state
+
+        XCTAssertEqual(reevaluatedState.destination, .utility(.settings(nil)))
+        XCTAssertNil(reevaluatedState.selectedSessionID)
+    }
+
+    func testReselectingRootDestinationAdvancesNavigationRevision() {
+        var state = SessionNavigationState()
+        state.select(SessionListUtilityDestination.skills)
+        let firstRevision = state.rootRevision
+
+        state.select(SessionListUtilityDestination.skills)
+
+        XCTAssertEqual(state.destination, .utility(.skills))
+        XCTAssertGreaterThan(state.rootRevision, firstRevision)
+    }
+
+    func testReadableContentWidthsKeepSecondaryAndWorkspaceSurfacesDistinct() {
+        XCTAssertEqual(AdaptiveReadableContentWidth.secondaryDestination, 800)
+        XCTAssertEqual(AdaptiveReadableContentWidth.workspace, 1_000)
+        XCTAssertLessThan(
+            AdaptiveReadableContentWidth.secondaryDestination,
+            AdaptiveReadableContentWidth.workspace
+        )
+    }
+
     func testPersistenceUsesIndependentKeysPerServer() throws {
         let suiteName = "SessionNavigationStateTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))


### PR DESCRIPTION
## Summary

- give secondary iPad destinations intentional readable widths without constraining chats
- keep workspace, file preview, and Git surfaces readable on larger canvases
- use stable inline iPad titles when the sidebar collapses
- reset nested detail navigation when a sidebar root is selected
- preserve existing compact iPhone navigation and native button semantics

## Validation

- `git diff --check`
- full XCTest suite: 1,359 passed, 0 failed, 0 skipped
- signed Debug build installed and launched on iPad Pro 13-inch (M5)
- manually validated Settings, Tasks, Skills, Memory, Insights, nested navigation, sidebar collapse, and representative workspace flows

## Owner manual checks

- open every secondary destination in portrait and landscape
- collapse and restore the sidebar and confirm titles remain visible
- open a nested destination, then select another sidebar root and confirm it replaces the nested screen
- exercise Files, preview, Git, and diff from a chat
- confirm representative compact iPhone navigation remains stacked

Fixes #110