### PR TITLE
Separate cron job sessions from regular sessions

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -319,11 +319,19 @@ struct SessionListRowsSection: View {
     let showsMessageCount: Bool
     let showsWorkspace: Bool
     let actions: SessionListRowActions
+    var title: String? = nil
+    var showsRemoteSearchSpinner = true
+
+    private var headerIsVisible: Bool {
+        (!isSearchActive || title != nil) || (showsRemoteSearchSpinner && viewModel.isSearchingRemoteSessions)
+    }
 
     var body: some View {
-        sessionsHeaderRow
-            .padding(.top, isSearchActive ? 16 : 28)
-            .sessionsScreenListRow()
+        if headerIsVisible {
+            sessionsHeaderRow
+                .padding(.top, isSearchActive ? 16 : 28)
+                .sessionsScreenListRow()
+        }
 
         if viewModel.isLoading && viewModel.sessions.isEmpty {
             sessionLoadingSkeletonRows
@@ -348,15 +356,15 @@ struct SessionListRowsSection: View {
     private var sessionsHeaderRow: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
-                if !isSearchActive {
-                    Text("Sessions")
+                if !isSearchActive || title != nil {
+                    Text(title ?? String(localized: "Sessions"))
                         .font(.title3.bold())
                         .foregroundStyle(.primary)
                 }
 
                 Spacer()
 
-                if viewModel.isSearchingRemoteSessions {
+                if showsRemoteSearchSpinner, viewModel.isSearchingRemoteSessions {
                     ProgressView()
                         .controlSize(.small)
                         .accessibilityLabel("Searching sessions")

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -307,16 +307,41 @@ struct SessionListView: View {
                 )
             }
 
-            SessionListRowsSection(
-                viewModel: viewModel,
-                sessions: visibleSessions,
-                emptyTitle: emptySessionsTitle,
-                emptyDescription: emptySessionsDescription,
-                isSearchActive: isSearchingSessions,
-                showsMessageCount: showsSessionMessageCount,
-                showsWorkspace: showsSessionWorkspace,
-                actions: sessionRowActions
-            )
+            let regularSessions = visibleSessions.filter { !$0.isCronSession }
+            let cronSessions = visibleSessions.filter { $0.isCronSession }
+
+            // Only render the regular-session section when it has content or
+            // when there are no cron sessions either (so the empty-state message
+            // still appears when the list is truly empty). If the regular list
+            // is empty but cron sessions are present, skip it — the Scheduled
+            // jobs section below handles the visible rows.
+            if !regularSessions.isEmpty || cronSessions.isEmpty {
+                SessionListRowsSection(
+                    viewModel: viewModel,
+                    sessions: regularSessions,
+                    emptyTitle: emptySessionsTitle,
+                    emptyDescription: emptySessionsDescription,
+                    isSearchActive: isSearchingSessions,
+                    showsMessageCount: showsSessionMessageCount,
+                    showsWorkspace: showsSessionWorkspace,
+                    actions: sessionRowActions
+                )
+            }
+
+            if !cronSessions.isEmpty {
+                SessionListRowsSection(
+                    viewModel: viewModel,
+                    sessions: cronSessions,
+                    emptyTitle: "",
+                    emptyDescription: nil,
+                    isSearchActive: isSearchingSessions,
+                    showsMessageCount: showsSessionMessageCount,
+                    showsWorkspace: showsSessionWorkspace,
+                    actions: sessionRowActions,
+                    title: String(localized: "Scheduled jobs"),
+                    showsRemoteSearchSpinner: false
+                )
+            }
 
             if showsArchivedEntry {
                 archivedEntryRow


### PR DESCRIPTION
Cron job runs (Daily Standup, Health Check, etc.) currently appear mixed into the main Sessions list alongside regular conversations. This PR separates them into their own "Scheduled jobs" section below regular conversations.

## Changes

- **SessionListComponents.swift**: Added optional `title` parameter to `SessionListRowsSection` (defaults to "Sessions" when nil, preserving existing behavior everywhere else)
- **SessionListView.swift**: Split `visibleSessions` into regular and cron arrays; render a second `SessionListRowsSection` with title "Scheduled jobs" when cron sessions are present

## Behavior

| Before | After |
|--------|-------|
| All sessions in one flat "Sessions" list | Regular conversations under "Sessions", cron runs under "Scheduled jobs" |
| Cron mixed in, pushing regular chats down | Clear separation; each section independently scrollable |

## Compatibility

- `SessionSummary.isCronSession` already existed and correctly detects cron rows
- `showsCronSessions` toggle (Settings) still hides/shows the entire Scheduled jobs section
- No API changes, no new dependencies
- Falls back gracefully: if no cron sessions exist, no second section appears