### PR TITLE
iPad: harden presentations and keyboard interactions

### DIFF
--- a/HermesMobile/Features/Chat/ChatAttachmentPreviewView.swift
+++ b/HermesMobile/Features/Chat/ChatAttachmentPreviewView.swift
@@ -137,6 +137,7 @@ struct ChatAttachmentPreviewView: View {
                 await loadAttachment(force: true)
             }
         }
+        .adaptivePagePresentation()
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Chat/ChatComposerSelectorSheets.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSelectorSheets.swift
@@ -61,6 +61,7 @@ struct ComposerModelPickerSheet: View {
                 }
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private var customModelEntry: some View {
@@ -496,9 +497,11 @@ struct ComposerWorkspacePickerSheet: View {
                     WorkspaceManagerView(server: managementServer) {
                         await onRegistryChanged()
                     }
+                    .adaptiveFormPresentation()
                 }
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private func workspaceButton(path: String, name: String?) -> some View {

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -9,7 +9,9 @@ struct ComposerTextInputView: View {
     @Binding var measuredHeight: CGFloat
 
     let isDisabled: Bool
+    let isKeyboardSendEnabled: Bool
     let verticalPadding: CGFloat
+    let onKeyboardSend: () -> Void
     let onPasteFileProviders: ([NSItemProvider]) -> Void
     let onPasteFileURLs: ([URL]) -> Void
     let onPasteImageProviders: ([NSItemProvider]) -> Void
@@ -21,6 +23,8 @@ struct ComposerTextInputView: View {
                 text: $text,
                 isFocused: $isFocused,
                 isDisabled: isDisabled,
+                isKeyboardSendEnabled: isKeyboardSendEnabled,
+                onKeyboardSend: onKeyboardSend,
                 onHeightChange: updateMeasuredHeight,
                 onPasteFileProviders: onPasteFileProviders,
                 onPasteFileURLs: onPasteFileURLs,
@@ -57,6 +61,8 @@ private struct ComposerTextView: UIViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
     let isDisabled: Bool
+    let isKeyboardSendEnabled: Bool
+    let onKeyboardSend: () -> Void
     let onHeightChange: (CGFloat) -> Void
     let onPasteFileProviders: ([NSItemProvider]) -> Void
     let onPasteFileURLs: ([URL]) -> Void
@@ -77,6 +83,8 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         textView.textContentType = .none
+        textView.isKeyboardSendEnabled = isKeyboardSendEnabled
+        textView.onKeyboardSend = onKeyboardSend
         textView.pasteConfiguration = UIPasteConfiguration(
             acceptableTypeIdentifiers: [
                 UTType.fileURL.identifier,
@@ -108,6 +116,8 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.isEditable = !isDisabled
         textView.isSelectable = !isDisabled
         textView.textColor = isDisabled ? .secondaryLabel : .label
+        textView.isKeyboardSendEnabled = isKeyboardSendEnabled
+        textView.onKeyboardSend = onKeyboardSend
         textView.onPasteFileProviders = onPasteFileProviders
         textView.onPasteFileURLs = onPasteFileURLs
         textView.onPasteImageProviders = onPasteImageProviders
@@ -194,6 +204,8 @@ private struct ComposerTextView: UIViewRepresentable {
     }
 
     final class PastingTextView: UITextView {
+        var isKeyboardSendEnabled = false
+        var onKeyboardSend: () -> Void = {}
         var onPasteFileProviders: ([NSItemProvider]) -> Void = { _ in }
         var onPasteFileURLs: ([URL]) -> Void = { _ in }
         var onPasteImageProviders: ([NSItemProvider]) -> Void = { _ in }
@@ -228,12 +240,31 @@ private struct ComposerTextView: UIViewRepresentable {
             onPasteFileProviders(fileProviders)
         }
 
+        override var keyCommands: [UIKeyCommand]? {
+            let sendCommand = UIKeyCommand(
+                title: ComposerKeyboardCommand.title,
+                action: #selector(sendMessageFromKeyboard),
+                input: ComposerKeyboardCommand.input,
+                modifierFlags: ComposerKeyboardCommand.modifierFlags
+            )
+            return (super.keyCommands ?? []) + [sendCommand]
+        }
+
         override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+            if action == #selector(sendMessageFromKeyboard) {
+                return isKeyboardSendEnabled
+            }
+
             if action == #selector(paste(_:)), hasPasteboardContent {
                 return true
             }
 
             return super.canPerformAction(action, withSender: sender)
+        }
+
+        @objc private func sendMessageFromKeyboard() {
+            guard isKeyboardSendEnabled else { return }
+            onKeyboardSend()
         }
 
         override func paste(_ sender: Any?) {
@@ -290,4 +321,10 @@ private struct ComposerTextView: UIViewRepresentable {
             }
         }
     }
+}
+
+enum ComposerKeyboardCommand {
+    static let title = String(localized: "Send Message")
+    static let input = "\r"
+    static let modifierFlags: UIKeyModifierFlags = .command
 }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -311,7 +311,9 @@ struct MessageComposerView: View {
                         inputHeight: $textInputHeight,
                         measuredHeight: $textFieldHeight,
                         isDisabled: isOfflineReadOnly,
+                        isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
                         verticalPadding: textFieldVerticalPadding,
+                        onKeyboardSend: actionButtonTapped,
                         onPasteFileProviders: onPasteFileProviders,
                         onPasteFileURLs: onPasteFileURLs,
                         onPasteImageProviders: onPasteImageProviders,
@@ -606,7 +608,7 @@ struct MessageComposerView: View {
                 onPhotoItemSelected(item)
             }
         }
-        .sheet(isPresented: $showCameraPicker) {
+        .fullScreenCover(isPresented: $showCameraPicker) {
             CameraPickerView { image in
                 deferFocusRestoreUntilUploadCompletes()
                 onPasteImages([image])

--- a/HermesMobile/Features/Chat/ChatGoalControls.swift
+++ b/HermesMobile/Features/Chat/ChatGoalControls.swift
@@ -98,5 +98,6 @@ struct GoalSubmissionSheet: View {
                 }
         }
         .presentationDetents([.medium, .large])
+        .adaptiveFormPresentation()
     }
 }

--- a/HermesMobile/Features/Chat/ChatMessageActions.swift
+++ b/HermesMobile/Features/Chat/ChatMessageActions.swift
@@ -163,5 +163,6 @@ struct EditMessageSheet: View {
             }
         }
         .presentationDetents([.medium, .large])
+        .adaptiveFormPresentation()
     }
 }

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -647,6 +647,7 @@ struct TranscriptMediaPreviewView: View {
                 viewModel.cleanupTemporaryFiles()
             }
         }
+        .adaptivePagePresentation()
     }
 
     private func imageContent(_ image: UIImage) -> some View {

--- a/HermesMobile/Features/Insights/InsightsView.swift
+++ b/HermesMobile/Features/Insights/InsightsView.swift
@@ -14,7 +14,6 @@ struct InsightsView: View {
 
     var body: some View {
         content
-            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Usage Analytics")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/HermesMobile/Features/Memory/MemoryView.swift
+++ b/HermesMobile/Features/Memory/MemoryView.swift
@@ -15,7 +15,6 @@ struct MemoryView: View {
 
     var body: some View {
         content
-            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Memory")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -265,6 +264,7 @@ private struct MemoryEditSheet: View {
                 }
             }
         }
+        .adaptiveFormPresentation()
     }
 }
 

--- a/HermesMobile/Features/SessionList/ProjectCreationSheet.swift
+++ b/HermesMobile/Features/SessionList/ProjectCreationSheet.swift
@@ -149,6 +149,7 @@ private struct ProjectFormSheet: View {
                 nameIsFocused = true
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private var trimmedProjectName: String {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -90,6 +90,7 @@ struct SessionListView: View {
             .sheet(item: $sessionExportShareItem) { item in
                 SessionExportShareSheet(fileURL: item.fileURL)
                     .presentationDetents([.medium, .large])
+                    .adaptiveFormPresentation()
                     .ignoresSafeArea()
                     // The temp file lives in its own UUID directory (see
                     // SessionListViewModel.export); remove the directory once
@@ -239,6 +240,7 @@ struct SessionListView: View {
                     }
                 )
             )
+            .focusedSceneValue(\.hermexSceneActions, sceneActions)
     }
 
     @ViewBuilder
@@ -849,6 +851,32 @@ struct SessionListView: View {
             searchChromeIsExpanded = true
         }
         searchFieldIsFocused = true
+    }
+
+    private var sceneActions: HermexSceneActions {
+        HermexSceneActions(
+            canCreateNewChat: !viewModel.isViewingCachedData && !navigationState.isCreatingNewChat,
+            createNewChat: openNewChatFromKeyboard,
+            searchSessions: openSearchFromKeyboard
+        )
+    }
+
+    private func openNewChatFromKeyboard() {
+        guard !viewModel.isViewingCachedData, !navigationState.isCreatingNewChat else { return }
+        openNewChat()
+    }
+
+    private func openSearchFromKeyboard() {
+        searchFieldIsFocused = false
+
+        if horizontalSizeClass != .regular {
+            navigationState.clearDestination()
+        }
+
+        Task { @MainActor in
+            await Task.yield()
+            openSearch()
+        }
     }
 
     private func handleSearchFieldFocusChange(_ isFocused: Bool) {

--- a/HermesMobile/Features/SessionList/SessionRenameSheet.swift
+++ b/HermesMobile/Features/SessionList/SessionRenameSheet.swift
@@ -57,6 +57,7 @@ struct SessionRenameSheet: View {
                 titleIsFocused = true
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private var trimmedSessionTitle: String {

--- a/HermesMobile/Features/Settings/DefaultModelPickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultModelPickerView.swift
@@ -71,6 +71,7 @@ struct DefaultModelPickerView: View {
                 await loadModels()
             }
         }
+        .adaptiveFormPresentation()
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Settings/DefaultProfilePickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultProfilePickerView.swift
@@ -71,6 +71,7 @@ struct DefaultProfilePickerView: View {
                 }
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private var newProfileButton: some View {
@@ -410,6 +411,7 @@ private struct CreateProfileSheet: View {
                 await loadModels()
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private var modelPicker: some View {

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -2207,6 +2207,7 @@ struct AddServerView: View {
                 }
             }
         }
+        .adaptiveFormPresentation()
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
+++ b/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
@@ -47,6 +47,14 @@ extension View {
         modifier(AdaptiveReadableScrollContentModifier(maxWidth: maxWidth))
     }
 
+    func adaptiveFormPresentation() -> some View {
+        presentationSizing(.form)
+    }
+
+    func adaptivePagePresentation() -> some View {
+        presentationSizing(.page)
+    }
+
     func adaptiveSecondaryNavigationTitle() -> some View {
         modifier(AdaptiveSecondaryNavigationTitleModifier())
     }

--- a/HermesMobile/Features/Skills/SkillsView.swift
+++ b/HermesMobile/Features/Skills/SkillsView.swift
@@ -320,6 +320,7 @@ struct SkillDetailView: View {
                         isLoading: isLoadingFile
                     )
                 }
+                .adaptivePagePresentation()
             }
     }
 

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -15,7 +15,6 @@ struct TasksView: View {
 
     var body: some View {
         content
-            .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.secondaryDestination)
             .navigationTitle("Tasks")
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {
@@ -377,6 +376,7 @@ struct CronJobEditorSheet: View {
                 }
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private var formMessage: String? {

--- a/HermesMobile/Features/Workspace/GitCommitView.swift
+++ b/HermesMobile/Features/Workspace/GitCommitView.swift
@@ -51,6 +51,7 @@ struct GitCommitView: View {
                 }
         }
         .presentationDetents([.large])
+        .adaptivePagePresentation()
         .alert("Discard local changes?", isPresented: $showsDiscardConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Discard Changes", role: .destructive) {

--- a/HermesMobile/Features/Workspace/GitDiffView.swift
+++ b/HermesMobile/Features/Workspace/GitDiffView.swift
@@ -36,6 +36,7 @@ struct GitDiffView: View {
                 }
         }
         .presentationDetents([.medium, .large])
+        .adaptivePagePresentation()
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Workspace/GitTurnChangesCard.swift
+++ b/HermesMobile/Features/Workspace/GitTurnChangesCard.swift
@@ -160,6 +160,7 @@ struct GitTurnDiffSheet: View {
                 }
         }
         .presentationDetents([.medium, .large])
+        .adaptivePagePresentation()
         .sheet(item: $selectedFile) { file in
             GitDiffView(session: session, server: server, file: file, onAPIError: onAPIError)
         }

--- a/HermesMobile/Features/Workspace/GitWorkspaceView.swift
+++ b/HermesMobile/Features/Workspace/GitWorkspaceView.swift
@@ -33,6 +33,7 @@ struct GitWorkspaceView: View {
                 }
         }
         .presentationDetents([.medium, .large])
+        .adaptivePagePresentation()
         .sheet(item: $selectedFile) { file in
             GitDiffView(session: session, server: server, file: file, onAPIError: onAPIError)
         }

--- a/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
+++ b/HermesMobile/Features/Workspace/WorkspaceManagerView.swift
@@ -155,6 +155,7 @@ struct WorkspaceManagerView: View {
                 }
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private func workspaceRow(_ workspace: WorkspaceRoot) -> some View {
@@ -290,6 +291,7 @@ private struct WorkspaceAddSheet: View {
                 suggestions = await viewModel.loadSuggestions(prefix: path)
             }
         }
+        .adaptiveFormPresentation()
     }
 
     private var trimmedPath: String {

--- a/HermesMobile/HermesMobileApp.swift
+++ b/HermesMobile/HermesMobileApp.swift
@@ -1,6 +1,45 @@
 import SwiftUI
 import SwiftData
 
+struct HermexSceneActions {
+    let canCreateNewChat: Bool
+    let createNewChat: () -> Void
+    let searchSessions: () -> Void
+}
+
+private struct HermexSceneActionsKey: FocusedValueKey {
+    typealias Value = HermexSceneActions
+}
+
+extension FocusedValues {
+    var hermexSceneActions: HermexSceneActions? {
+        get { self[HermexSceneActionsKey.self] }
+        set { self[HermexSceneActionsKey.self] = newValue }
+    }
+}
+
+struct HermexCommands: Commands {
+    @FocusedValue(\.hermexSceneActions) private var actions
+
+    var body: some Commands {
+        CommandGroup(replacing: .newItem) {
+            Button("New Chat") {
+                actions?.createNewChat()
+            }
+            .keyboardShortcut("n", modifiers: .command)
+            .disabled(actions?.canCreateNewChat != true)
+        }
+
+        CommandGroup(after: .newItem) {
+            Button("Search Sessions") {
+                actions?.searchSessions()
+            }
+            .keyboardShortcut("f", modifiers: .command)
+            .disabled(actions == nil)
+        }
+    }
+}
+
 @main
 struct HermesMobileApp: App {
     @State private var authManager = AuthManager()
@@ -26,5 +65,9 @@ struct HermesMobileApp: App {
             #endif
         }
         .modelContainer(for: [CachedSession.self, CachedMessage.self])
+        .commands {
+            HermexCommands()
+            SidebarCommands()
+        }
     }
 }

--- a/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
+++ b/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
@@ -1,8 +1,15 @@
 import AVFoundation
+import UIKit
 import XCTest
 @testable import HermesMobile
 
 final class ComposerVoiceDraftComposerTests: XCTestCase {
+    func testComposerSendKeyboardCommandIsDiscoverableCommandReturn() {
+        XCTAssertEqual(ComposerKeyboardCommand.title, "Send Message")
+        XCTAssertEqual(ComposerKeyboardCommand.input, "\r")
+        XCTAssertEqual(ComposerKeyboardCommand.modifierFlags, .command)
+    }
+
     func testComposedDraftUsesTranscriptWhenDraftIsEmpty() {
         XCTAssertEqual(
             ComposerVoiceDraftComposer.composedDraft(baseDraft: "", transcript: "Open the workspace"),


### PR DESCRIPTION
## Summary
- add discoverable New Chat, session search, native sidebar, and composer send keyboard commands
- apply native form/page sizing across sheets, previews, workspace flows, and camera capture
- preserve stable side-by-side layouts for Tasks, Memory, and Insights while the iPad sidebar is visible

## Validation
- `git diff --check`
- full XCTest suite: 1,360 passed, 0 failed
- signed Debug build launched on iPad Pro 13-inch (M5)

## Owner manual checks
- [x] Tasks, Memory, and Insights remain readable with the sidebar expanded
- [x] Sidebar expansion/collapse retains the native side-by-side behavior
- [ ] Verify `⌘N`, `⌘F`, `⌃⌘S`, and `⌘Return` with a hardware keyboard
- [ ] Exercise form sheets, media/file previews, share flows, camera, and nested workspace sheets
- [ ] Exercise portrait, landscape, Split View, Slide Over, and representative Stage Manager sizes
- [ ] Confirm pointer hover, targeting, context menus, and composer focus restoration
- [ ] Confirm representative iPhone flows remain unchanged

Fixes #111

Made with [Cursor](https://cursor.com)