### PR TITLE
Chat: Use Liquid Glass for the scroll-to-bottom button

### DIFF
--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -673,12 +673,12 @@ private struct ChatScrollToBottomButton: View {
             Image(systemName: "arrow.down")
                 .font(.system(size: 13, weight: .semibold))
                 .frame(width: 32, height: 32)
-                .background(backgroundColor)
-                .foregroundStyle(foregroundColor)
-                .clipShape(Circle())
-                .overlay(
-                    Circle()
-                        .stroke(Color(.separator).opacity(colorScheme == .dark ? 0.35 : 0.18), lineWidth: 0.5)
+                .foregroundStyle(.primary)
+                .adaptiveGlass(
+                    .regular,
+                    isInteractive: true,
+                    fallbackMaterial: .regularMaterial,
+                    in: Circle()
                 )
                 .chatMinimumHitTarget(in: Circle())
         }
@@ -696,14 +696,6 @@ private struct ChatScrollToBottomButton: View {
         ))
         .padding(.bottom, bottomPadding)
         .accessibilityLabel("Scroll to latest message")
-    }
-
-    private var backgroundColor: Color {
-        colorScheme == .dark ? .white : .black
-    }
-
-    private var foregroundColor: Color {
-        colorScheme == .dark ? .black : .white
     }
 }
 


### PR DESCRIPTION
Fixes #120

## Summary
- replace the scroll-to-bottom button’s solid circle with the shared adaptive-glass surface
- use regular interactive Liquid Glass when supported, with established material and opaque accessibility fallbacks
- preserve the existing size, hit target, placement, behavior, tactile interaction, and accessibility label

## Validation
- `git diff --check`
- full XCTest suite: 1,363 passed, 0 failed
- signed Debug build succeeded and launched on the configured iPhone 17 simulator

## Owner manual checks
- [x] Button appears while scrolled above the latest message
- [x] Signed simulator build launches and the updated control works
- [ ] Recheck light and dark mode if desired
- [ ] Recheck glass-disabled material fallback if desired
- [ ] Recheck Reduce Transparency opaque fallback if desired
