### PR TITLE
Skills: remove leading hammer icon from rows

### DIFF
--- a/HermesMobile/Features/Skills/SkillsView.swift
+++ b/HermesMobile/Features/Skills/SkillsView.swift
@@ -160,7 +160,6 @@ private struct SkillCategorySection: View {
 
                     if index < skills.count - 1 {
                         Divider()
-                            .padding(.leading, 58)
                     }
                 }
             }
@@ -185,13 +184,7 @@ private struct SkillRow: View {
     var onToggle: ((Bool) -> Void)? = nil
 
     var body: some View {
-        HStack(alignment: .top, spacing: 14) {
-            Image(systemName: "hammer")
-                .font(.system(size: 17, weight: .medium))
-                .foregroundStyle(.primary)
-                .frame(width: 40, height: 40)
-                .background(Color(.tertiarySystemFill).opacity(0.7), in: Circle())
-
+        HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 4) {
                 Text(displayName)
                     .font(.body.weight(.semibold))


### PR DESCRIPTION
Fixes #122

## Summary
- remove the decorative hammer and circular background from populated skill rows
- let names, descriptions, and tags use the freed horizontal space
- align row dividers with the updated content edge
- preserve the empty-state hammer and existing row interactions

## Validation
- `git diff --check`
- `xcodebuildmcp simulator test --output jsonl` (1,363 passed, 0 failed)
- `xcodebuildmcp simulator build-and-run --output jsonl` (signed Debug build installed and launched on iPhone 17)

## Owner manual checks
- open Skills and inspect multiple categories and long descriptions
- search for a skill
- open a skill detail view
- exercise available toggles and confirm disabled styling
- confirm the empty “No Skills” state still uses its hammer icon