### PR TITLE
Sessions: add scheduled sessions disclosure

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -309,7 +309,6 @@ struct SessionSidebarUtilityRows: View {
 }
 
 struct SessionListRowsSection: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let viewModel: SessionListViewModel
 
     let sessions: [SessionSummary]
@@ -320,6 +319,7 @@ struct SessionListRowsSection: View {
     let showsWorkspace: Bool
     let selectedSessionID: String?
     let actions: SessionListRowActions
+    var suppressEmptyState = false
 
     var body: some View {
         sessionsHeaderRow
@@ -331,7 +331,7 @@ struct SessionListRowsSection: View {
         } else if let errorMessage = viewModel.errorMessage, viewModel.sessions.isEmpty {
             sessionsErrorRow(message: errorMessage)
                 .sessionsScreenListRow()
-        } else if sessions.isEmpty {
+        } else if sessions.isEmpty && !suppressEmptyState {
             SessionListStatusRow(
                 title: emptyTitle,
                 description: emptyDescription,
@@ -341,7 +341,14 @@ struct SessionListRowsSection: View {
                 .sessionsScreenListRow()
         } else {
             ForEach(sessions) { session in
-                sessionListRow(for: session)
+                SessionInteractiveRow(
+                    viewModel: viewModel,
+                    session: session,
+                    showsMessageCount: showsMessageCount,
+                    showsWorkspace: showsWorkspace,
+                    selectedSessionID: selectedSessionID,
+                    actions: actions
+                )
             }
         }
     }
@@ -418,7 +425,18 @@ struct SessionListRowsSection: View {
         return (String(localized: "Could not load sessions"), fallbackMessage)
     }
 
-    private func sessionListRow(for session: SessionSummary) -> some View {
+}
+
+struct SessionInteractiveRow: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let viewModel: SessionListViewModel
+    let session: SessionSummary
+    let showsMessageCount: Bool
+    let showsWorkspace: Bool
+    let selectedSessionID: String?
+    let actions: SessionListRowActions
+
+    var body: some View {
         Button {
             actions.open(session)
         } label: {
@@ -498,6 +516,130 @@ struct SessionListRowsSection: View {
         SessionRowActionPolicy.offersMutationActions(for: session)
             && !viewModel.isViewingCachedData
             && hasServerSessionID(session)
+    }
+}
+
+struct ScheduledSessionsDisclosure: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let viewModel: SessionListViewModel
+    let sessions: [SessionSummary]
+    let totalCount: Int
+    let isSearchActive: Bool
+    let showsMessageCount: Bool
+    let showsWorkspace: Bool
+    let selectedSessionID: String?
+    @Binding var userIsExpanded: Bool
+    let actions: SessionListRowActions
+    let viewAll: () -> Void
+
+    private var isExpanded: Bool { isSearchActive || userIsExpanded }
+    private var displayedSessions: [SessionSummary] {
+        isSearchActive ? sessions : Array(sessions.prefix(5))
+    }
+
+    var body: some View {
+        SidebarDisclosureButton(
+            title: String(localized: "Scheduled sessions"),
+            assetImage: "LucideCalendarClock",
+            isExpanded: isExpanded
+        ) {
+            guard !isSearchActive else { return }
+            userIsExpanded.toggle()
+        } accessory: {
+            Text("\(totalCount)")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(.thinMaterial, in: Capsule())
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, isSearchActive ? 16 : 12)
+        .sessionsScreenListRow()
+
+        if isExpanded {
+            ForEach(displayedSessions) { session in
+                SessionInteractiveRow(
+                    viewModel: viewModel,
+                    session: session,
+                    showsMessageCount: showsMessageCount,
+                    showsWorkspace: showsWorkspace,
+                    selectedSessionID: selectedSessionID,
+                    actions: actions
+                )
+                .transition(SessionListMotion.disclosureContentTransition(reduceMotion: reduceMotion))
+            }
+
+            if !isSearchActive && sessions.count > 5 {
+                HapticButton(action: viewAll) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "magnifyingglass")
+                            .frame(width: 24)
+                        Text("View all")
+                            .font(.subheadline.weight(.medium))
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.forward")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 24)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .sessionsScreenListRow()
+                .transition(SessionListMotion.disclosureContentTransition(reduceMotion: reduceMotion))
+            }
+        }
+    }
+}
+
+struct ScheduledSessionsView: View {
+    let viewModel: SessionListViewModel
+    let showsMessageCount: Bool
+    let showsWorkspace: Bool
+    let selectedSessionID: String?
+    let actions: SessionListRowActions
+
+    @State private var searchText = ""
+
+    var body: some View {
+        List {
+            if sessions.isEmpty {
+                SessionListStatusRow(
+                    title: searchText.isEmpty
+                        ? String(localized: "No sessions yet")
+                        : String(localized: "No matching sessions"),
+                    description: searchText.isEmpty
+                        ? nil
+                        : String(localized: "Try another search or project filter."),
+                    systemImage: "calendar.badge.clock"
+                )
+                .padding(.horizontal, 24)
+                .sessionsScreenListRow()
+            } else {
+                ForEach(sessions) { session in
+                    SessionInteractiveRow(
+                        viewModel: viewModel,
+                        session: session,
+                        showsMessageCount: showsMessageCount,
+                        showsWorkspace: showsWorkspace,
+                        selectedSessionID: selectedSessionID,
+                        actions: actions
+                    )
+                }
+            }
+        }
+        .listStyle(.plain)
+        .environment(\.defaultMinListRowHeight, 0)
+        .scrollContentBackground(.hidden)
+        .navigationTitle("Scheduled sessions")
+        .searchable(text: $searchText, prompt: "Search sessions")
+    }
+
+    private var sessions: [SessionSummary] {
+        viewModel.visibleSessions(searchText: searchText, selectedProjectID: nil)
+            .filter { $0.isCronSession && $0.archived != true }
     }
 }
 

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -603,6 +603,7 @@ struct ScheduledSessionsDisclosure: View {
 
 struct ScheduledSessionsView: View {
     let viewModel: SessionListViewModel
+    let showsCronSessions: Bool
     let showsMessageCount: Bool
     let showsWorkspace: Bool
     let selectedSessionID: String?
@@ -645,7 +646,9 @@ struct ScheduledSessionsView: View {
     }
 
     private var sessions: [SessionSummary] {
-        viewModel.visibleSessions(searchText: searchText, selectedProjectID: nil)
+        guard showsCronSessions else { return [] }
+
+        return viewModel.visibleSessions(searchText: searchText, selectedProjectID: nil)
             .filter { $0.isCronSession && $0.archived != true }
     }
 }

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -556,6 +556,13 @@ struct ScheduledSessionsDisclosure: View {
         .padding(.horizontal, 24)
         .padding(.top, isSearchActive ? 16 : 12)
         .sessionsScreenListRow()
+        .accessibilityLabel(
+            isSearchActive
+                ? String(localized: "Scheduled sessions")
+                : isExpanded
+                    ? String(localized: "Collapse scheduled sessions")
+                    : String(localized: "Expand scheduled sessions")
+        )
 
         if isExpanded {
             ForEach(displayedSessions) { session in

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -397,7 +397,7 @@ struct SessionListView: View {
                 )
             }
 
-            if scheduledSessionGroups.totalScheduledCount > 0 {
+            if scheduledSessionGroups.showsDisclosure(isSearchActive: isSearchingSessions) {
                 ScheduledSessionsDisclosure(
                     viewModel: viewModel,
                     sessions: scheduledSessionGroups.scheduled,

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -40,6 +40,8 @@ struct SessionListView: View {
     private var profilesAreExpanded = SessionSidebarDisclosureSettings.defaultProfilesAreExpanded
     @AppStorage(SessionSidebarDisclosureSettings.projectsAreExpandedKey)
     private var projectsAreExpanded = SessionSidebarDisclosureSettings.defaultProjectsAreExpanded
+    @AppStorage(SessionSidebarDisclosureSettings.scheduledSessionsAreExpandedKey)
+    private var scheduledSessionsAreExpanded = SessionSidebarDisclosureSettings.defaultScheduledSessionsAreExpanded
     @AppStorage(SessionRowDisplaySettings.showMessageCountKey) private var showsSessionMessageCount = true
     @AppStorage(SessionRowDisplaySettings.showWorkspaceKey) private var showsSessionWorkspace = true
     @AppStorage(SessionRowDisplaySettings.showCronSessionsKey) private var showsCronSessions = true
@@ -337,6 +339,16 @@ struct SessionListView: View {
                 InsightsView(server: server, onAPIError: authManager.handleAPIError)
             case .archived:
                 ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
+            case .scheduled:
+                ScheduledSessionsView(
+                    viewModel: viewModel,
+                    showsMessageCount: showsSessionMessageCount,
+                    showsWorkspace: showsSessionWorkspace,
+                    selectedSessionID: horizontalSizeClass == .regular
+                        ? navigationState.selectedSessionID
+                        : nil,
+                    actions: sessionRowActions
+                )
             }
         }
         .adaptiveSecondaryNavigationTitle()
@@ -385,9 +397,26 @@ struct SessionListView: View {
                 )
             }
 
+            if scheduledSessionGroups.totalScheduledCount > 0 {
+                ScheduledSessionsDisclosure(
+                    viewModel: viewModel,
+                    sessions: scheduledSessionGroups.scheduled,
+                    totalCount: scheduledSessionGroups.totalScheduledCount,
+                    isSearchActive: isSearchingSessions,
+                    showsMessageCount: showsSessionMessageCount,
+                    showsWorkspace: showsSessionWorkspace,
+                    selectedSessionID: horizontalSizeClass == .regular
+                        ? navigationState.selectedSessionID
+                        : nil,
+                    userIsExpanded: $scheduledSessionsAreExpanded,
+                    actions: sessionRowActions,
+                    viewAll: { navigationState.select(.scheduled) }
+                )
+            }
+
             SessionListRowsSection(
                 viewModel: viewModel,
-                sessions: visibleSessions,
+                sessions: scheduledSessionGroups.ordinary,
                 emptyTitle: emptySessionsTitle,
                 emptyDescription: emptySessionsDescription,
                 isSearchActive: isSearchingSessions,
@@ -396,7 +425,8 @@ struct SessionListView: View {
                 selectedSessionID: horizontalSizeClass == .regular
                     ? navigationState.selectedSessionID
                     : nil,
-                actions: sessionRowActions
+                actions: sessionRowActions,
+                suppressEmptyState: !scheduledSessionGroups.scheduled.isEmpty
             )
 
             if showsArchivedEntry {
@@ -422,6 +452,7 @@ struct SessionListView: View {
         // so insert/remove animates. Value-based so it works with @AppStorage.
         .animation(SessionListMotion.disclosureAnimation(reduceMotion: reduceMotion), value: profilesAreExpanded)
         .animation(SessionListMotion.disclosureAnimation(reduceMotion: reduceMotion), value: projectsAreExpanded)
+        .animation(SessionListMotion.disclosureAnimation(reduceMotion: reduceMotion), value: scheduledSessionsAreExpanded)
     }
 
     private var header: some View {
@@ -611,6 +642,14 @@ struct SessionListView: View {
 
     private var visibleSessions: [SessionSummary] {
         viewModel.visibleSessions(
+            searchText: searchText,
+            selectedProjectID: selectedProjectID,
+            automatedVisibility: automatedSessionVisibility
+        )
+    }
+
+    private var scheduledSessionGroups: ScheduledSessionGroups {
+        viewModel.scheduledSessionGroups(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
             automatedVisibility: automatedSessionVisibility
@@ -1229,6 +1268,7 @@ enum SessionListUtilityDestination: Hashable, Identifiable {
     case insights
     /// Archived sessions screen (issue #17), also reachable from Settings.
     case archived
+    case scheduled
 
     var id: Self { self }
 }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -342,6 +342,7 @@ struct SessionListView: View {
             case .scheduled:
                 ScheduledSessionsView(
                     viewModel: viewModel,
+                    showsCronSessions: showsCronSessions,
                     showsMessageCount: showsSessionMessageCount,
                     showsWorkspace: showsSessionWorkspace,
                     selectedSessionID: horizontalSizeClass == .regular

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -18,6 +18,20 @@ struct SessionListSection: Identifiable {
     var id: String { kind.rawValue }
 }
 
+struct ScheduledSessionGroups: Equatable {
+    let ordinary: [SessionSummary]
+    let scheduled: [SessionSummary]
+    let totalScheduledCount: Int
+
+    var scheduledPreview: [SessionSummary] {
+        Array(scheduled.prefix(5))
+    }
+
+    var hasAdditionalScheduledSessions: Bool {
+        scheduled.count > scheduledPreview.count
+    }
+}
+
 enum ActiveSessionStateRefreshResult: Equatable {
     case unchanged
     case reloaded
@@ -161,6 +175,31 @@ final class SessionListViewModel {
         }
 
         return sortedLocalMatches + Self.sortedSessions(remoteMatches)
+    }
+
+    func scheduledSessionGroups(
+        searchText: String,
+        selectedProjectID: String?,
+        automatedVisibility: AutomatedSessionVisibility = .showAll
+    ) -> ScheduledSessionGroups {
+        let ordinaryCandidates = visibleSessions(
+            searchText: searchText,
+            selectedProjectID: selectedProjectID,
+            automatedVisibility: automatedVisibility
+        )
+        let scheduledCandidates = visibleSessions(
+            searchText: searchText,
+            selectedProjectID: nil,
+            automatedVisibility: automatedVisibility
+        )
+
+        return ScheduledSessionGroups(
+            ordinary: ordinaryCandidates.filter { !$0.isCronSession },
+            scheduled: scheduledCandidates.filter { $0.isCronSession && $0.archived != true },
+            totalScheduledCount: automatedVisibility.showsCron
+                ? sessions.filter { $0.isCronSession && $0.archived != true }.count
+                : 0
+        )
     }
 
     @discardableResult

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -30,6 +30,10 @@ struct ScheduledSessionGroups: Equatable {
     var hasAdditionalScheduledSessions: Bool {
         scheduled.count > scheduledPreview.count
     }
+
+    func showsDisclosure(isSearchActive: Bool) -> Bool {
+        totalScheduledCount > 0 && (!isSearchActive || !scheduled.isEmpty)
+    }
 }
 
 enum ActiveSessionStateRefreshResult: Equatable {
@@ -189,7 +193,7 @@ final class SessionListViewModel {
         )
         let scheduledCandidates = visibleSessions(
             searchText: searchText,
-            selectedProjectID: nil,
+            selectedProjectID: selectedProjectID,
             automatedVisibility: automatedVisibility
         )
 

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -420,8 +420,10 @@ enum SessionRowDisplaySettings {
 enum SessionSidebarDisclosureSettings {
     static let profilesAreExpandedKey = "sessionSidebar.profilesAreExpanded"
     static let projectsAreExpandedKey = "sessionSidebar.projectsAreExpanded"
+    static let scheduledSessionsAreExpandedKey = "sessionSidebar.scheduledSessionsAreExpanded"
     static let defaultProfilesAreExpanded = false
     static let defaultProjectsAreExpanded = false
+    static let defaultScheduledSessionsAreExpanded = false
 
     static func profilesAreExpanded(in defaults: UserDefaults = .standard) -> Bool {
         guard let value = defaults.object(forKey: profilesAreExpandedKey) as? Bool else {
@@ -434,6 +436,14 @@ enum SessionSidebarDisclosureSettings {
     static func projectsAreExpanded(in defaults: UserDefaults = .standard) -> Bool {
         guard let value = defaults.object(forKey: projectsAreExpandedKey) as? Bool else {
             return defaultProjectsAreExpanded
+        }
+
+        return value
+    }
+
+    static func scheduledSessionsAreExpanded(in defaults: UserDefaults = .standard) -> Bool {
+        guard let value = defaults.object(forKey: scheduledSessionsAreExpandedKey) as? Bool else {
+            return defaultScheduledSessionsAreExpanded
         }
 
         return value

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -109705,6 +109705,48 @@
           }
         }
       }
+    },
+    "Scheduled sessions" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "الجلسات المجدولة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Geplante Sitzungen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Sesiones programadas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Sessions planifiées" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הפעלות מתוזמנות" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Sessioni programmate" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スケジュール済みセッション" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "예약된 세션" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Geplande sessies" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Zaplanowane sesje" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Sessões agendadas" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Запланированные сеансы" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Zamanlanmış oturumlar" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "شیڈول کردہ سیشنز" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "计划会话" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "排程的工作階段" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "已排程的工作階段" } }
+      }
+    },
+    "View all" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "عرض الكل" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Alle anzeigen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Ver todo" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tout afficher" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הצגת הכול" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Mostra tutto" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "すべて表示" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "모두 보기" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Alles bekijken" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Wyświetl wszystko" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Ver tudo" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Показать все" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Tümünü görüntüle" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "سبھی دیکھیں" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "查看全部" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "檢視全部" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "查看全部" } }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -109706,6 +109706,48 @@
         }
       }
     },
+    "Collapse scheduled sessions" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "طي الجلسات المجدولة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Geplante Sitzungen einklappen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Contraer sesiones programadas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Réduire les sessions planifiées" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "כיווץ הפעלות מתוזמנות" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Comprimi sessioni programmate" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スケジュール済みセッションを折りたたむ" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "예약된 세션 접기" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Geplande sessies inklappen" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Zwiń zaplanowane sesje" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Recolher sessões agendadas" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Свернуть запланированные сеансы" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Zamanlanmış oturumları daralt" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "شیڈول کردہ سیشنز سمیٹیں" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "收起计划会话" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "收合排程的工作階段" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "收起已排程的工作階段" } }
+      }
+    },
+    "Expand scheduled sessions" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "توسيع الجلسات المجدولة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Geplante Sitzungen ausklappen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Expandir sesiones programadas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Développer les sessions planifiées" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הרחבת הפעלות מתוזמנות" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Espandi sessioni programmate" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スケジュール済みセッションを展開" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "예약된 세션 펼치기" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Geplande sessies uitklappen" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Rozwiń zaplanowane sesje" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Expandir sessões agendadas" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Развернуть запланированные сеансы" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Zamanlanmış oturumları genişlet" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "شیڈول کردہ سیشنز پھیلائیں" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "展开计划会话" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "展開排程的工作階段" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "展開已排程的工作階段" } }
+      }
+    },
     "Scheduled sessions" : {
       "localizations" : {
         "ar" : { "stringUnit" : { "state" : "translated", "value" : "الجلسات المجدولة" } },

--- a/HermesMobileTests/SessionIdentityTests.swift
+++ b/HermesMobileTests/SessionIdentityTests.swift
@@ -159,22 +159,28 @@ final class SessionSidebarDisclosureSettingsTests: XCTestCase {
     func testDisclosureStatesDefaultToCollapsedWhenUnset() {
         XCTAssertNil(defaults.object(forKey: SessionSidebarDisclosureSettings.profilesAreExpandedKey))
         XCTAssertNil(defaults.object(forKey: SessionSidebarDisclosureSettings.projectsAreExpandedKey))
+        XCTAssertNil(defaults.object(forKey: SessionSidebarDisclosureSettings.scheduledSessionsAreExpandedKey))
         XCTAssertFalse(SessionSidebarDisclosureSettings.profilesAreExpanded(in: defaults))
         XCTAssertFalse(SessionSidebarDisclosureSettings.projectsAreExpanded(in: defaults))
+        XCTAssertFalse(SessionSidebarDisclosureSettings.scheduledSessionsAreExpanded(in: defaults))
     }
 
     func testDisclosureStatesRoundTripThroughUserDefaults() {
         defaults.set(true, forKey: SessionSidebarDisclosureSettings.profilesAreExpandedKey)
         defaults.set(false, forKey: SessionSidebarDisclosureSettings.projectsAreExpandedKey)
+        defaults.set(true, forKey: SessionSidebarDisclosureSettings.scheduledSessionsAreExpandedKey)
 
         XCTAssertTrue(SessionSidebarDisclosureSettings.profilesAreExpanded(in: defaults))
         XCTAssertFalse(SessionSidebarDisclosureSettings.projectsAreExpanded(in: defaults))
+        XCTAssertTrue(SessionSidebarDisclosureSettings.scheduledSessionsAreExpanded(in: defaults))
 
         defaults.set(false, forKey: SessionSidebarDisclosureSettings.profilesAreExpandedKey)
         defaults.set(true, forKey: SessionSidebarDisclosureSettings.projectsAreExpandedKey)
+        defaults.set(false, forKey: SessionSidebarDisclosureSettings.scheduledSessionsAreExpandedKey)
 
         XCTAssertFalse(SessionSidebarDisclosureSettings.profilesAreExpanded(in: defaults))
         XCTAssertTrue(SessionSidebarDisclosureSettings.projectsAreExpanded(in: defaults))
+        XCTAssertFalse(SessionSidebarDisclosureSettings.scheduledSessionsAreExpanded(in: defaults))
     }
 }
 

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2363,6 +2363,78 @@ final class SessionListMutationTests: XCTestCase {
     }
 
     @MainActor
+    func testScheduledSessionGroupsSeparatesAndCapsNewestNonArchivedCronSessions() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/sessions")
+            return apiTestJSONResponse("""
+            {
+              "sessions": [
+                {"session_id":"ordinary","title":"Ordinary","updated_at":50},
+                {"session_id":"cron_1","title":"Scheduled 1","updated_at":10},
+                {"session_id":"cron_2","title":"Scheduled 2","updated_at":20},
+                {"session_id":"cron_3","title":"Scheduled 3","updated_at":30},
+                {"session_id":"cron_4","title":"Scheduled 4","updated_at":40},
+                {"session_id":"cron_5","title":"Scheduled 5","updated_at":50},
+                {"session_id":"cron_6","title":"Scheduled 6","updated_at":60},
+                {"session_id":"cron_7","title":"Scheduled 7","updated_at":70},
+                {"session_id":"cron_archived","title":"Archived scheduled","updated_at":80,"archived":true}
+              ]
+            }
+            """, for: request)
+        }
+
+        await viewModel.load()
+        let groups = viewModel.scheduledSessionGroups(searchText: "", selectedProjectID: nil)
+
+        XCTAssertEqual(groups.ordinary.compactMap(\.sessionId), ["ordinary"])
+        XCTAssertEqual(groups.totalScheduledCount, 7)
+        XCTAssertEqual(
+            groups.scheduled.compactMap(\.sessionId),
+            ["cron_7", "cron_6", "cron_5", "cron_4", "cron_3", "cron_2", "cron_1"]
+        )
+        XCTAssertEqual(
+            groups.scheduledPreview.compactMap(\.sessionId),
+            ["cron_7", "cron_6", "cron_5", "cron_4", "cron_3"]
+        )
+        XCTAssertTrue(groups.hasAdditionalScheduledSessions)
+    }
+
+    @MainActor
+    func testScheduledSessionGroupsRespectCronVisibilityAndSearchWithoutCappingMatches() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/sessions")
+            return apiTestJSONResponse("""
+            {
+              "sessions": [
+                {"session_id":"ordinary","title":"Needle ordinary","updated_at":5},
+                {"session_id":"cron_1","title":"Needle scheduled 1","updated_at":10},
+                {"session_id":"cron_2","title":"Needle scheduled 2","updated_at":20},
+                {"session_id":"cron_3","title":"Needle scheduled 3","updated_at":30},
+                {"session_id":"cron_4","title":"Needle scheduled 4","updated_at":40},
+                {"session_id":"cron_5","title":"Needle scheduled 5","updated_at":50},
+                {"session_id":"cron_6","title":"Needle scheduled 6","updated_at":60}
+              ]
+            }
+            """, for: request)
+        }
+
+        await viewModel.load()
+        let matches = viewModel.scheduledSessionGroups(searchText: "needle", selectedProjectID: nil)
+        XCTAssertEqual(matches.ordinary.compactMap(\.sessionId), ["ordinary"])
+        XCTAssertEqual(matches.scheduled.count, 6)
+        XCTAssertEqual(matches.totalScheduledCount, 6)
+
+        let hidden = viewModel.scheduledSessionGroups(
+            searchText: "",
+            selectedProjectID: nil,
+            automatedVisibility: AutomatedSessionVisibility(showsCron: false, showsCli: true)
+        )
+        XCTAssertTrue(hidden.scheduled.isEmpty)
+        XCTAssertEqual(hidden.totalScheduledCount, 0)
+        XCTAssertEqual(hidden.ordinary.compactMap(\.sessionId), ["ordinary"])
+    }
+
+    @MainActor
     func testVisibleSessionsFiltersCronAndCliIndependently() async throws {
         let viewModel = try makeViewModel { request in
             XCTAssertEqual(request.url?.path, "/api/sessions")

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2468,6 +2468,8 @@ final class SessionListMutationTests: XCTestCase {
 
         XCTAssertEqual(groups.ordinary.compactMap(\.sessionId), ["ordinary-1"])
         XCTAssertEqual(groups.scheduled.compactMap(\.sessionId), ["cron_1"])
+        // The badge is intentionally global even when rows are project-filtered:
+        // issue #125 requires the total number of non-archived scheduled sessions.
         XCTAssertEqual(groups.totalScheduledCount, 2)
     }
 

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2397,6 +2397,7 @@ final class SessionListMutationTests: XCTestCase {
             ["cron_7", "cron_6", "cron_5", "cron_4", "cron_3"]
         )
         XCTAssertTrue(groups.hasAdditionalScheduledSessions)
+        XCTAssertTrue(groups.showsDisclosure(isSearchActive: false))
     }
 
     @MainActor
@@ -2423,6 +2424,14 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertEqual(matches.ordinary.compactMap(\.sessionId), ["ordinary"])
         XCTAssertEqual(matches.scheduled.count, 6)
         XCTAssertEqual(matches.totalScheduledCount, 6)
+        XCTAssertTrue(matches.showsDisclosure(isSearchActive: true))
+
+        let noScheduledMatches = viewModel.scheduledSessionGroups(
+            searchText: "ordinary",
+            selectedProjectID: nil
+        )
+        XCTAssertFalse(noScheduledMatches.showsDisclosure(isSearchActive: true))
+        XCTAssertTrue(noScheduledMatches.showsDisclosure(isSearchActive: false))
 
         let hidden = viewModel.scheduledSessionGroups(
             searchText: "",
@@ -2432,6 +2441,34 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertTrue(hidden.scheduled.isEmpty)
         XCTAssertEqual(hidden.totalScheduledCount, 0)
         XCTAssertEqual(hidden.ordinary.compactMap(\.sessionId), ["ordinary"])
+        XCTAssertFalse(hidden.showsDisclosure(isSearchActive: false))
+    }
+
+    @MainActor
+    func testScheduledSessionGroupsApplyProjectFilterToScheduledAndOrdinaryRows() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/sessions")
+            return apiTestJSONResponse("""
+            {
+              "sessions": [
+                {"session_id":"ordinary-1","title":"Ordinary one","project_id":"project-1"},
+                {"session_id":"ordinary-2","title":"Ordinary two","project_id":"project-2"},
+                {"session_id":"cron_1","title":"Scheduled one","project_id":"project-1"},
+                {"session_id":"cron_2","title":"Scheduled two","project_id":"project-2"}
+              ]
+            }
+            """, for: request)
+        }
+
+        await viewModel.load()
+        let groups = viewModel.scheduledSessionGroups(
+            searchText: "",
+            selectedProjectID: "project-1"
+        )
+
+        XCTAssertEqual(groups.ordinary.compactMap(\.sessionId), ["ordinary-1"])
+        XCTAssertEqual(groups.scheduled.compactMap(\.sessionId), ["cron_1"])
+        XCTAssertEqual(groups.totalScheduledCount, 2)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- separate non-archived scheduled runs from ordinary Sessions rows
- add a persisted, collapsed-by-default Scheduled sessions disclosure with a total badge, five-row preview, and View all navigation
- auto-expand scheduled matches during main search without overwriting the saved disclosure preference
- reuse standard session navigation, swipe actions, context menus, message counts, and workspace display in both scheduled-session surfaces
- add complete localization entries and focused coverage for partitioning, ordering, limits, visibility, search, archived exclusion, and persistence

Fixes #125

## Validation

- `git diff --check`
- focused scheduled-session, disclosure-persistence, and localization tests
- full XCTest suite: 1,366 tests passed on iPhone 17
- signed Debug build succeeded, installed, and launched on iPhone 17

## Owner manual checks

1. Confirm Scheduled sessions visually matches Active Profile and Projects.
2. Expand/collapse it and confirm the state survives relaunch.
3. Check zero, fewer than five, exactly five, and more than five scheduled sessions.
4. Open scheduled sessions and exercise navigation, swipe actions, context menus, message count, and workspace display.
5. Open View all and test its search.
6. Search from Sessions and confirm scheduled matches auto-expand without a five-row cap, then confirm ending search restores the saved disclosure state.
7. Toggle Cron Sessions off and confirm all scheduled-session UI disappears.
8. Confirm archived scheduled sessions appear only in Archived Sessions and the remote-search spinner appears once.
