### PR TITLE
Chat: use shared brain icon for Thinking cards

### DIFF
--- a/HermesMobile/Features/Chat/ReasoningBlockView.swift
+++ b/HermesMobile/Features/Chat/ReasoningBlockView.swift
@@ -56,8 +56,9 @@ struct ReasoningBlockView: View {
 
     private func header(summary: String) -> some View {
         HStack(alignment: usesStackedHeader ? .top : .center, spacing: 8) {
-            Image(systemName: "brain.head.profile")
-                .font(.system(size: 14, weight: .semibold))
+            Image("LucideBrain")
+                .resizable()
+                .scaledToFit()
                 .foregroundStyle(.secondary)
                 .frame(width: 18, height: 18)
 


### PR DESCRIPTION
## Summary
- replace the Thinking card SF Symbol with the shared `LucideBrain` asset
- preserve the existing icon frame, tint, layout, interaction, and accessibility behavior
- leave ordinary tool-call icons unchanged

## Validation
- `git diff --check`
- full XCTest suite on iPhone 17 (iOS 26.5)
- signed Debug build installed and launched on iPhone 17
- owner manually verified collapsed and expanded Thinking states

## Owner manual checks
- confirmed Thinking icon matches the Sessions Memory row
- confirmed collapsed and expanded states render correctly
- confirmed ordinary tool-call icons remain unchanged

Fixes #127