### PR TITLE
Add Copy Deeplink to session export menu

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -23,6 +23,21 @@ enum SessionRowActionPolicy {
     static func canExport(_ session: SessionSummary, isViewingCachedData: Bool) -> Bool {
         !isViewingCachedData && hasServerSessionID(session)
     }
+
+    static func deepLinkURL(
+        for session: SessionSummary,
+        isViewingCachedData: Bool,
+        isMutating: Bool
+    ) -> URL? {
+        guard !isMutating,
+              canExport(session, isViewingCachedData: isViewingCachedData),
+              let sessionID = session.sessionId
+        else {
+            return nil
+        }
+
+        return HermesDeepLink.sessionURL(sessionID: sessionID)
+    }
 }
 
 enum SessionListMotion {
@@ -727,6 +742,18 @@ struct SessionRowContextMenu: View {
                 actions.export(session, .json)
             } label: {
                 Label("Export as JSON", systemImage: "curlybraces")
+            }
+
+            if let deepLinkURL = SessionRowActionPolicy.deepLinkURL(
+                for: session,
+                isViewingCachedData: isViewingCachedData,
+                isMutating: isMutating
+            ) {
+                Button {
+                    UIPasteboard.general.string = deepLinkURL.absoluteString
+                } label: {
+                    Label("Copy Deeplink", systemImage: "doc.on.doc")
+                }
             }
         } label: {
             Label("Export", systemImage: "square.and.arrow.up")

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -20828,6 +20828,112 @@
         }
       }
     },
+    "Copy Deeplink" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نسخ الرابط العميق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deep-Link kopieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Copiar enlace profundo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Copier le lien profond"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "העתק קישור עומק"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Copia il link diretto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ディープリンクをコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "딥 링크 복사"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deep link kopiëren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kopiuj link bezpośredni"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Copiar link profundo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Копировать диплинк"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Derin bağlantıyı kopyala"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ڈیپ لنک کاپی کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "複製深層連結"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "复制深度链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "複製深層連結"
+          }
+        }
+      }
+    },
     "Copy Full Title" : {
       "localizations" : {
         "ar" : {

--- a/HermesMobileTests/LiveActivityTests.swift
+++ b/HermesMobileTests/LiveActivityTests.swift
@@ -204,6 +204,17 @@ final class LiveActivityTests: XCTestCase {
         XCTAssertNil(HermesDeepLink.sessionID(from: HermesShareDraft.openURL))
     }
 
+    func testSessionDeepLinkURLPercentEncodesSessionID() throws {
+        let sessionID = "session & /?=✓"
+        let url = try XCTUnwrap(HermesDeepLink.sessionURL(sessionID: sessionID))
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+
+        XCTAssertEqual(url.scheme, HermesDeepLink.scheme)
+        XCTAssertEqual(url.host, "session")
+        XCTAssertEqual(components?.queryItems, [URLQueryItem(name: "id", value: sessionID)])
+        XCTAssertFalse(url.absoluteString.contains(sessionID))
+    }
+
     func testChatViewModelLiveActivityLifecycleUsesInjectedManager() async throws {
         let baseURL = URL(string: "https://example.test")!
         let configuration = URLSessionConfiguration.ephemeral

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2286,6 +2286,40 @@ final class SessionListMutationTests: XCTestCase {
         )
     }
 
+    func testCopyDeepLinkUsesExportAvailabilityRules() throws {
+        let session = SessionSummary(sessionId: "session & /?=✓", readOnly: true)
+
+        let url = try XCTUnwrap(
+            SessionRowActionPolicy.deepLinkURL(
+                for: session,
+                isViewingCachedData: false,
+                isMutating: false
+            )
+        )
+        XCTAssertEqual(HermesDeepLink.sessionID(from: url), session.sessionId)
+        XCTAssertNil(
+            SessionRowActionPolicy.deepLinkURL(
+                for: session,
+                isViewingCachedData: true,
+                isMutating: false
+            )
+        )
+        XCTAssertNil(
+            SessionRowActionPolicy.deepLinkURL(
+                for: session,
+                isViewingCachedData: false,
+                isMutating: true
+            )
+        )
+        XCTAssertNil(
+            SessionRowActionPolicy.deepLinkURL(
+                for: SessionSummary(sessionId: nil),
+                isViewingCachedData: false,
+                isMutating: false
+            )
+        )
+    }
+
     func testAutomatedVisibilityShowAllKeepsEveryKind() {
         let visibility = AutomatedSessionVisibility.showAll
         XCTAssertTrue(visibility.shows(SessionSummary(sessionId: "cron_1")))


### PR DESCRIPTION
## Summary

- Add Copy Deeplink below the existing session export formats.
- Reuse the existing Hermex session deep-link generator and copy the URL to the system clipboard.
- Keep the action unavailable for cached data, missing IDs, and in-progress row mutations.

## Validation

- Full XCTest suite: 1,369 passed, 0 failed (iPhone 17 simulator).
- Signed Debug build launched on iPhone 17.
- Owner manually verified copying, pasting, and opening a session deep link.

Fixes #129