### PR TITLE
fix(chat): recover interrupted backend streams

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -275,6 +275,14 @@ final class ChatStreamCoordinator {
                 finalizeInactiveStream(streamID: activeStreamID)
             }
         } catch {
+            if (error as? APIError)?.indicatesMissingStream == true,
+               self.activeStreamID == activeStreamID,
+               isConnectionSuspended {
+                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
+                guard canFinalizeRunAfterLoad(streamID: activeStreamID, capturedGeneration: generation) else { return }
+                finalizeInactiveStream(streamID: activeStreamID)
+                return
+            }
             delegate?.streamCoordinatorDidReceiveRecoveryError(error)
         }
     }
@@ -531,6 +539,16 @@ final class ChatStreamCoordinator {
             chatStreamCoordinatorLogger.warning(
                 "Stale stream recovery status check failed category=\(APIError.privacySafeLogCategory(for: error), privacy: .public)"
             )
+
+            if (error as? APIError)?.indicatesMissingStream == true,
+               activeStreamID == expectedStreamID,
+               !isConnectionSuspended {
+                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
+                guard canFinalizeRunAfterLoad(streamID: expectedStreamID, capturedGeneration: generation),
+                      !isConnectionSuspended else { return }
+                finalizeInactiveStream(streamID: expectedStreamID)
+                return
+            }
 
             guard forceReconnect,
                   activeStreamID == expectedStreamID,

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -2112,6 +2112,16 @@ final class ChatViewModel {
                 rollbackOptimisticMessage(id: localMessageID)
                 cacheCurrentMessages(sessionID: sessionID, modelContext: modelContext)
                 restorePendingAttachments(attachmentsToRestoreOnFailure)
+                // The existing run may have started outside this view model. Reconcile
+                // the server transcript first so the SSE tokens attach to the persisted
+                // assistant turn instead of creating a second bubble with only the tail.
+                await loadMessages(modelContext: modelContext)
+                if streamingAssistantMessageID == nil {
+                    _ = restoreActiveStreamSnapshotIfAvailable(streamID: streamID)
+                }
+                if streamingAssistantMessageID == nil {
+                    streamingAssistantMessageID = Self.latestAssistantMessageID(in: messages)
+                }
                 streamCoordinator.start(streamID: streamID)
                 // The server kept the earlier run, not this newly submitted text.
                 // Report an unaccepted send so ChatView restores the draft while

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -2108,6 +2108,13 @@ final class ChatViewModel {
             streamCoordinator.start(streamID: streamID)
             return true
         } catch {
+            if let streamID = (error as? APIError)?.activeStreamID {
+                rollbackOptimisticMessage(id: localMessageID)
+                cacheCurrentMessages(sessionID: sessionID, modelContext: modelContext)
+                restorePendingAttachments(attachmentsToRestoreOnFailure)
+                streamCoordinator.start(streamID: streamID)
+                return true
+            }
             lastError = error
             sendErrorMessage = error.localizedDescription
             rollbackOptimisticMessage(id: localMessageID)

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -2113,7 +2113,10 @@ final class ChatViewModel {
                 cacheCurrentMessages(sessionID: sessionID, modelContext: modelContext)
                 restorePendingAttachments(attachmentsToRestoreOnFailure)
                 streamCoordinator.start(streamID: streamID)
-                return true
+                // The server kept the earlier run, not this newly submitted text.
+                // Report an unaccepted send so ChatView restores the draft while
+                // the coordinator reconnects to the existing response.
+                return false
             }
             lastError = error
             sendErrorMessage = error.localizedDescription

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -2116,12 +2116,10 @@ final class ChatViewModel {
                 // the server transcript first so the SSE tokens attach to the persisted
                 // assistant turn instead of creating a second bubble with only the tail.
                 await loadMessages(modelContext: modelContext)
-                if streamingAssistantMessageID == nil {
-                    _ = restoreActiveStreamSnapshotIfAvailable(streamID: streamID)
-                }
-                if streamingAssistantMessageID == nil {
-                    streamingAssistantMessageID = Self.latestAssistantMessageID(in: messages)
-                }
+                _ = restoreActiveStreamSnapshotIfAvailable(streamID: streamID)
+                streamingAssistantMessageID = TranscriptTurnClassifier
+                    .currentTurnAssistantAnchorIDs(in: messages, messageOffset: messagesOffset)
+                    .first
                 streamCoordinator.start(streamID: streamID)
                 // The server kept the earlier run, not this newly submitted text.
                 // Report an unaccepted send so ChatView restores the draft while

--- a/HermesMobile/Networking/APIError.swift
+++ b/HermesMobile/Networking/APIError.swift
@@ -79,6 +79,16 @@ enum APIError: LocalizedError {
         return Self.serverErrorMessage(from: body)
     }
 
+    var activeStreamID: String? {
+        guard case .http(let statusCode, let body) = self, statusCode == 409 else { return nil }
+        return Self.serverErrorPayload(from: body)?.activeStreamId?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    var indicatesMissingStream: Bool {
+        guard case .http(let statusCode, _) = self else { return false }
+        return statusCode == 404
+    }
+
     /// True for the documented "prompt already expired" respond rejection:
     /// HTTP 409 with `{"stale": true, …}` in the body (issue #25). Used to show
     /// a friendly expired state instead of a generic failure.
@@ -111,6 +121,12 @@ private extension APIError {
         let detail: String?
         let code: String?
         let stale: Bool?
+        let activeStreamId: String?
+
+        enum CodingKeys: String, CodingKey {
+            case error, message, detail, code, stale
+            case activeStreamId = "active_stream_id"
+        }
     }
 
     static func networkMessage(for error: Error) -> String {

--- a/HermesMobile/Networking/APIError.swift
+++ b/HermesMobile/Networking/APIError.swift
@@ -85,8 +85,8 @@ enum APIError: LocalizedError {
     }
 
     var indicatesMissingStream: Bool {
-        guard case .http(let statusCode, _) = self else { return false }
-        return statusCode == 404
+        guard case .http(let statusCode, let body) = self, statusCode == 404 else { return false }
+        return Self.serverErrorMessage(from: body)?.localizedCaseInsensitiveContains("stream not found") == true
     }
 
     /// True for the documented "prompt already expired" respond rejection:

--- a/HermesMobileTests/StreamReconnectContractTests.swift
+++ b/HermesMobileTests/StreamReconnectContractTests.swift
@@ -235,11 +235,21 @@ final class StreamReconnectContractTests: APIClientTestCase {
 
         let didStart = await viewModel.sendMessage("Duplicate request")
 
-        XCTAssertTrue(didStart)
+        XCTAssertFalse(didStart)
         XCTAssertEqual(viewModel.activeStreamID, "stream-existing")
         XCTAssertEqual(viewModel.messages.compactMap(\.content), [])
         XCTAssertNil(viewModel.sendErrorMessage)
         XCTAssertEqual(queryDictionary(of: try XCTUnwrap(streamClient.startedURLs.first))["stream_id"], "stream-existing")
+    }
+
+    func testOnlySpecificMissingStream404IsTerminal() {
+        XCTAssertTrue(
+            APIError.http(statusCode: 404, body: #"{"error":"stream not found"}"#).indicatesMissingStream
+        )
+        XCTAssertFalse(
+            APIError.http(statusCode: 404, body: #"{"error":"endpoint not found"}"#).indicatesMissingStream
+        )
+        XCTAssertFalse(APIError.http(statusCode: 404, body: nil).indicatesMissingStream)
     }
 
     @MainActor

--- a/HermesMobileTests/StreamReconnectContractTests.swift
+++ b/HermesMobileTests/StreamReconnectContractTests.swift
@@ -284,6 +284,66 @@ final class StreamReconnectContractTests: APIClientTestCase {
         )
     }
 
+    @MainActor
+    func testDuplicateStartReconnectDoesNotReusePreviousTurnAssistantAnchor() async throws {
+        let streamClient = ScriptedSSEStreamingClient(connectionScripts: [[
+            .init(.token("new response"), lastEventID: "stream-existing:1")
+        ]])
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return self.jsonResponse(
+                    #"{"error":"session already has an active stream","active_stream_id":"stream-existing"}"#,
+                    statusCode: 409,
+                    for: request
+                )
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "active_stream_id": "stream-existing",
+                    "messages": [
+                      {
+                        "role": "assistant",
+                        "content": "Previous response",
+                        "timestamp": 1770000099,
+                        "message_id": "assistant-previous"
+                      },
+                      {
+                        "role": "user",
+                        "content": "Already accepted",
+                        "timestamp": 1770000100,
+                        "message_id": "user-existing"
+                      }
+                    ]
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Duplicate request")
+
+        XCTAssertFalse(didStart)
+        XCTAssertEqual(
+            viewModel.messages.compactMap(\.content),
+            ["Previous response", "Already accepted"]
+        )
+        XCTAssertNil(viewModel.streamingAssistantMessageID)
+
+        streamClient.playArmedConnectionScript()
+        viewModel.flushPendingStreamingContent()
+        XCTAssertEqual(
+            assistantContents(of: viewModel),
+            ["Previous response", "new response"]
+        )
+    }
+
     func testOnlySpecificMissingStream404IsTerminal() {
         XCTAssertTrue(
             APIError.http(statusCode: 404, body: #"{"error":"stream not found"}"#).indicatesMissingStream

--- a/HermesMobileTests/StreamReconnectContractTests.swift
+++ b/HermesMobileTests/StreamReconnectContractTests.swift
@@ -223,23 +223,65 @@ final class StreamReconnectContractTests: APIClientTestCase {
 
     @MainActor
     func testDuplicateStartReconnectsExistingStreamWithoutKeepingOptimisticMessage() async throws {
-        let streamClient = ScriptedSSEStreamingClient()
+        let streamClient = ScriptedSSEStreamingClient(connectionScripts: [[
+            .init(.token(" continuation"), lastEventID: "stream-existing:1")
+        ]])
         let viewModel = try makeViewModel(streamClient: streamClient) { request in
-            XCTAssertEqual(request.url?.path, "/api/chat/start")
-            return self.jsonResponse(
-                #"{"error":"session already has an active stream","active_stream_id":"stream-existing"}"#,
-                statusCode: 409,
-                for: request
-            )
+            switch request.url?.path {
+            case "/api/chat/start":
+                return self.jsonResponse(
+                    #"{"error":"session already has an active stream","active_stream_id":"stream-existing"}"#,
+                    statusCode: 409,
+                    for: request
+                )
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "active_stream_id": "stream-existing",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "Already accepted",
+                        "timestamp": 1770000100,
+                        "message_id": "user-existing"
+                      },
+                      {
+                        "role": "assistant",
+                        "content": "Partial answer",
+                        "timestamp": 1770000101,
+                        "message_id": "assistant-existing"
+                      }
+                    ]
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
         }
 
         let didStart = await viewModel.sendMessage("Duplicate request")
 
         XCTAssertFalse(didStart)
         XCTAssertEqual(viewModel.activeStreamID, "stream-existing")
-        XCTAssertEqual(viewModel.messages.compactMap(\.content), [])
+        XCTAssertEqual(
+            viewModel.messages.compactMap(\.content),
+            ["Already accepted", "Partial answer"]
+        )
+        XCTAssertEqual(viewModel.streamingAssistantMessageID, "assistant-existing")
         XCTAssertNil(viewModel.sendErrorMessage)
         XCTAssertEqual(queryDictionary(of: try XCTUnwrap(streamClient.startedURLs.first))["stream_id"], "stream-existing")
+
+        streamClient.playArmedConnectionScript()
+        viewModel.flushPendingStreamingContent()
+        XCTAssertEqual(
+            assistantContents(of: viewModel),
+            ["Partial answer continuation"]
+        )
     }
 
     func testOnlySpecificMissingStream404IsTerminal() {

--- a/HermesMobileTests/StreamReconnectContractTests.swift
+++ b/HermesMobileTests/StreamReconnectContractTests.swift
@@ -221,6 +221,72 @@ final class StreamReconnectContractTests: APIClientTestCase {
         XCTAssertEqual(streamClient.droppedEventCount, 0)
     }
 
+    @MainActor
+    func testDuplicateStartReconnectsExistingStreamWithoutKeepingOptimisticMessage() async throws {
+        let streamClient = ScriptedSSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/start")
+            return self.jsonResponse(
+                #"{"error":"session already has an active stream","active_stream_id":"stream-existing"}"#,
+                statusCode: 409,
+                for: request
+            )
+        }
+
+        let didStart = await viewModel.sendMessage("Duplicate request")
+
+        XCTAssertTrue(didStart)
+        XCTAssertEqual(viewModel.activeStreamID, "stream-existing")
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), [])
+        XCTAssertNil(viewModel.sendErrorMessage)
+        XCTAssertEqual(queryDictionary(of: try XCTUnwrap(streamClient.startedURLs.first))["stream_id"], "stream-existing")
+    }
+
+    @MainActor
+    func testMissingStatusAfterDisconnectFinalizesInsteadOfRetryingStaleStream() async throws {
+        let streamClient = ScriptedSSEStreamingClient(connectionScripts: [[
+            .init(.token("Partial"), lastEventID: "stream-123:1"),
+            .init(.transportError("Connection lost"))
+        ]])
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(#"{"session_id":"session-abc","stream_id":"stream-123"}"#, for: request)
+            case "/api/chat/stream/status":
+                return self.jsonResponse(#"{"error":"stream not found"}"#, statusCode: 404, for: request)
+            case "/api/session":
+                return apiTestJSONResponse(#"{"session":{"session_id":"session-abc","title":"Planning","messages":[]}}"#, for: request)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Keep working")
+        XCTAssertTrue(didStart)
+        streamClient.playArmedConnectionScript()
+        try await waitUntil { viewModel.activeStreamID == nil }
+
+        XCTAssertEqual(streamClient.startedURLs.count, 1)
+        XCTAssertFalse(viewModel.isActiveStreamConnectionSuspended)
+        XCTAssertNil(viewModel.sendErrorMessage)
+    }
+
+    private func jsonResponse(
+        _ json: String,
+        statusCode: Int,
+        for request: URLRequest
+    ) -> (HTTPURLResponse, Data) {
+        (
+            HTTPURLResponse(
+                url: request.url!,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!,
+            Data(json.utf8)
+        )
+    }
+
     // MARK: - Helpers
 
     @MainActor


### PR DESCRIPTION
## Summary

- treat a 404 stream-status response as terminal and reconcile from the server transcript
- reconnect to the existing stream when `/api/chat/start` returns a 409 with `active_stream_id`
- roll back the duplicate optimistic message and restore pending attachments before reconnecting
- add contract coverage for both backend-interruption paths

## Why

After a backend restart, a stale stream ID may return 404 instead of an inactive status envelope. Treating that as a generic recovery error leaves the client suspended or causes later reconnect attempts against a stream that no longer exists.

A start request can also race with an already-active server run. Hermes WebUI returns HTTP 409 with `active_stream_id`; reconnecting to that run is safer than surfacing a generic error or resending the message.

## API contract

Verified against `nesquena/hermes-webui` commit `54520ef35b1b2c4751807cf4f50bb9826bd4f9db`.

The duplicate-start envelope is:

```json
{
  "error": "session already has an active stream",
  "active_stream_id": "<stream-id>"
}
```

## Testing

- Targeted `StreamReconnectContractTests`: passed, 5/5
- Full `HermesMobile` XCTest suite on iPhone 17 simulator: passed
