### PR TITLE
Make transcript file cards fully tappable

### DIFF
--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -408,48 +408,47 @@ private struct TranscriptMediaFileExportView: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "doc")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Color(.secondaryLabel))
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(reference.displayName)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color(.label))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                Text(isExporting
-                     ? String(localized: "Loading…")
-                     : String(localized: "Tap to download"))
-                    .font(.caption2)
+        Button {
+            Task { await exportFile() }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "doc")
+                    .font(.system(size: 16, weight: .semibold))
                     .foregroundStyle(Color(.secondaryLabel))
-                    .lineLimit(1)
-            }
 
-            Spacer(minLength: 8)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(reference.displayName)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color(.label))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
 
-            Button {
-                Task { await exportFile() }
-            } label: {
+                    Text(isExporting
+                         ? String(localized: "Loading…")
+                         : String(localized: "Tap to download"))
+                        .font(.caption2)
+                        .foregroundStyle(Color(.secondaryLabel))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
                 Image(systemName: "square.and.arrow.down")
                     .font(.system(size: 15, weight: .semibold))
             }
-            .buttonStyle(.chatTactile(.icon))
-            .disabled(isExporting)
-            .accessibilityLabel(String(localized: "Download \(reference.displayName)"))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: 240, alignment: .leading)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color(.separator).opacity(0.35), lineWidth: 0.5)
+            )
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .frame(maxWidth: 240, alignment: .leading)
-        .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color(.separator).opacity(0.35), lineWidth: 0.5)
-        )
-        .accessibilityElement(children: .contain)
+        .buttonStyle(.chatTactile(.thumbnail))
+        .disabled(isExporting)
+        .accessibilityLabel(String(localized: "Download \(reference.displayName)"))
         .fileExporter(
             isPresented: $isFileExporterPresented,
             document: exportDocument,


### PR DESCRIPTION
## Summary

- make the entire generic transcript file card trigger its existing download action
- keep the loading, disabled, error, filename, and content-type behavior unchanged
- use the existing tactile thumbnail button style for full-card feedback

## Root cause

PR #118 added authenticated downloads for unsupported `MEDIA:` file types, but only the small trailing download icon was a button. The surrounding card still said “Tap to download,” so tapping the filename or card background did nothing.

## User impact

Users can tap anywhere on an agent-generated generic file card to load the file and open the iOS Save-to-Files exporter.

## Validation

- focused `TranscriptMediaParserTests`: 15 passed, 0 failed
- complete `HermesMobile` XCTest suite: 1,369 passed, 0 failed, 0 skipped
- signed Debug Simulator build: succeeded
- installed and launched on iPhone 17 / iOS 26.5 Simulator

The final end-to-end tap against a live agent-generated file remains a manual Simulator check.
