### PR TITLE
fix(chat): eliminate transcript opening jitter

### DIFF
--- a/HermesMobile/Features/Chat/ChatScrollPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatScrollPolicy.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import SwiftUI
 
 /// Pure decision rules for the chat transcript's auto-scroll behavior.
 ///
@@ -8,6 +9,10 @@ import Foundation
 /// interaction prevents streaming layout growth from yanking the viewport
 /// while a manual scroll is still settling.
 enum ChatScrollPolicy {
+    /// Existing transcripts should enter at their latest content as part of the
+    /// scroll view's first layout, before the destination becomes visible.
+    static let initialTranscriptAnchor = UnitPoint.bottom
+
     /// Distance (pt) from the bottom within which we treat the transcript as
     /// pinned to the latest content while idle.
     static let bottomDetectionThreshold: CGFloat = 80
@@ -60,5 +65,14 @@ enum ChatScrollPolicy {
         }
 
         return now < cooldownUntil
+    }
+}
+
+/// Keeps transcript reconciliation and other state-heavy startup work out of
+/// the system navigation transition. Cache preparation remains synchronous so
+/// an available transcript can participate in the destination's first layout.
+enum ChatInitialAppearancePolicy {
+    static func shouldBeginAsyncWork(hasCompletedAppearance: Bool) -> Bool {
+        hasCompletedAppearance
     }
 }

--- a/HermesMobile/Features/Chat/ChatScrollPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatScrollPolicy.swift
@@ -13,6 +13,13 @@ enum ChatScrollPolicy {
     /// scroll view's first layout, before the destination becomes visible.
     static let initialTranscriptAnchor = UnitPoint.bottom
 
+    /// Rich Markdown can finish measuring after the scroll view's initial
+    /// layout. Keep those size changes bottom-pinned only while the app still
+    /// owns follow-latest intent; return nil as soon as the reader scrolls away.
+    static func sizeChangeAnchor(shouldFollowLatestMessage: Bool) -> UnitPoint? {
+        shouldFollowLatestMessage ? .bottom : nil
+    }
+
     /// Distance (pt) from the bottom within which we treat the transcript as
     /// pinned to the latest content while idle.
     static let bottomDetectionThreshold: CGFloat = 80

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -124,6 +124,12 @@ struct ChatTranscriptView: View {
                         ChatScrollPolicy.initialTranscriptAnchor,
                         for: .initialOffset
                     )
+                    .defaultScrollAnchor(
+                        ChatScrollPolicy.sizeChangeAnchor(
+                            shouldFollowLatestMessage: shouldFollowLatestMessage
+                        ),
+                        for: .sizeChanges
+                    )
                     .frame(width: viewportWidth)
                     .refreshable {
                         if hasOlderMessages {

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -120,6 +120,10 @@ struct ChatTranscriptView: View {
                             contentWidth: contentWidth
                         )
                     }
+                    .defaultScrollAnchor(
+                        ChatScrollPolicy.initialTranscriptAnchor,
+                        for: .initialOffset
+                    )
                     .frame(width: viewportWidth)
                     .refreshable {
                         if hasOlderMessages {
@@ -154,9 +158,6 @@ struct ChatTranscriptView: View {
                 }
                 .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: showsScrollToBottomButton)
                 .background(Color(.systemBackground))
-                .onAppear {
-                    onScrollToLatestContent(proxy, false)
-                }
                 .onChange(of: messages.count) {
                     guard shouldFollowLatestMessage else { return }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -572,30 +572,8 @@ struct ChatView: View {
         .navigationTitle(displayTitle)
         .navigationBarTitleDisplayMode(.inline)
         .accessibilityIdentifier("chat-detail:\(viewModel.displayTitle)")
-        .task {
-            viewModel.setShowsLiveActivityResponseExcerpts(showsLiveActivityResponseExcerpts)
-            if loadsInitialMessages {
-                await loadMessages(appliesInitialFocus: false)
-            }
-            if initialAttachments.isEmpty {
-                isInitialComposerFocusContentReady = true
-                applyInitialComposerFocusPolicyIfNeeded()
-            }
-            await viewModel.loadComposerConfiguration()
-            await viewModel.refreshApprovalBypassState()
-            await uploadInitialAttachmentsIfNeeded()
-            isInitialComposerFocusContentReady = true
-            applyInitialComposerFocusPolicyIfNeeded()
-            if let lastError = viewModel.lastError {
-                onAPIError(lastError)
-            }
-        }
-        .task(id: gitAvailabilityTaskID) {
-            let availabilityViewModel = GitWorkspaceAvailabilityViewModel(session: session, server: server)
-            await MainActor.run {
-                gitAvailabilityViewModel = availabilityViewModel
-            }
-            await availabilityViewModel.loadIfNeeded()
+        .task(id: didCompleteInitialAppearance) {
+            await handleInitialAppearanceTask()
         }
         .onChange(of: scenePhase) {
                 handleScenePhaseChange(scenePhase)
@@ -813,10 +791,6 @@ struct ChatView: View {
             )
             .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
         }
-    }
-
-    private var gitAvailabilityTaskID: String {
-        "\(session.id)|\(server.absoluteString)"
     }
 
     private var gitWriteAvailability: GitWriteAvailability {
@@ -1322,6 +1296,49 @@ struct ChatView: View {
 
     private var latestTranscriptMessageRole: String? {
         transcriptMessages.last?.message.role
+    }
+
+    private func prepareInitialAppearance() {
+        viewModel.setShowsLiveActivityResponseExcerpts(showsLiveActivityResponseExcerpts)
+        if loadsInitialMessages {
+            viewModel.prepareInitialMessageLoad(modelContext: modelContext)
+        }
+    }
+
+    private func handleInitialAppearanceTask() async {
+        guard ChatInitialAppearancePolicy.shouldBeginAsyncWork(
+            hasCompletedAppearance: didCompleteInitialAppearance
+        ) else {
+            prepareInitialAppearance()
+            return
+        }
+
+        await performInitialAsyncWork()
+        await loadInitialGitAvailability()
+    }
+
+    private func performInitialAsyncWork() async {
+        if loadsInitialMessages {
+            await loadMessages(appliesInitialFocus: false)
+        }
+        if initialAttachments.isEmpty {
+            isInitialComposerFocusContentReady = true
+            applyInitialComposerFocusPolicyIfNeeded()
+        }
+        await viewModel.loadComposerConfiguration()
+        await viewModel.refreshApprovalBypassState()
+        await uploadInitialAttachmentsIfNeeded()
+        isInitialComposerFocusContentReady = true
+        applyInitialComposerFocusPolicyIfNeeded()
+        if let lastError = viewModel.lastError {
+            onAPIError(lastError)
+        }
+    }
+
+    private func loadInitialGitAvailability() async {
+        let availabilityViewModel = GitWorkspaceAvailabilityViewModel(session: session, server: server)
+        gitAvailabilityViewModel = availabilityViewModel
+        await availabilityViewModel.loadIfNeeded()
     }
 
     private var goalControlMenu: some View {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1313,8 +1313,9 @@ struct ChatView: View {
             return
         }
 
-        await performInitialAsyncWork()
-        await loadInitialGitAvailability()
+        async let chatStartup: Void = performInitialAsyncWork()
+        async let gitAvailability: Void = loadInitialGitAvailability()
+        _ = await (chatStartup, gitAvailability)
     }
 
     private func performInitialAsyncWork() async {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1306,10 +1306,11 @@ struct ChatView: View {
     }
 
     private func handleInitialAppearanceTask() async {
+        prepareInitialAppearance()
+
         guard ChatInitialAppearancePolicy.shouldBeginAsyncWork(
             hasCompletedAppearance: didCompleteInitialAppearance
         ) else {
-            prepareInitialAppearance()
             return
         }
 
@@ -1319,16 +1320,25 @@ struct ChatView: View {
     }
 
     private func performInitialAsyncWork() async {
+        guard !Task.isCancelled else { return }
+
         if loadsInitialMessages {
             await loadMessages(appliesInitialFocus: false)
+            guard !Task.isCancelled else { return }
         }
         if initialAttachments.isEmpty {
             isInitialComposerFocusContentReady = true
             applyInitialComposerFocusPolicyIfNeeded()
         }
         await viewModel.loadComposerConfiguration()
+        guard !Task.isCancelled else { return }
+
         await viewModel.refreshApprovalBypassState()
+        guard !Task.isCancelled else { return }
+
         await uploadInitialAttachmentsIfNeeded()
+        guard !Task.isCancelled else { return }
+
         isInitialComposerFocusContentReady = true
         applyInitialComposerFocusPolicyIfNeeded()
         if let lastError = viewModel.lastError {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -235,6 +235,7 @@ final class ChatViewModel {
     /// render, so the view re-pins to the bottom on this token *without* animation —
     /// otherwise the height growth produces a visible scroll jump.
     private(set) var cacheFirstReconcileScrollToken = 0
+    private var hasPrimedInitialCachedMessages = false
     @ObservationIgnored private var pendingStreamingScrollTriggerTask: Task<Void, Never>?
     @ObservationIgnored private var pendingAssistantTokenChunks: [String] = []
     @ObservationIgnored private var pendingReasoningChunks: [String] = []
@@ -1165,12 +1166,16 @@ final class ChatViewModel {
         // render the cached messages immediately so the loading skeleton never shows.
         let previousMessages = messages
         let previousMessagesOffset = messagesOffset
+        let usesPrimedInitialCache = hasPrimedInitialCachedMessages && !previousMessages.isEmpty
+        hasPrimedInitialCachedMessages = false
         let cacheFirstPlaceholder: [ChatMessage]
         if previousMessages.isEmpty, let modelContext {
             cacheFirstPlaceholder = renderCachedMessagesBeforeReload(
                 sessionID: sessionID,
                 modelContext: modelContext
             )
+        } else if usesPrimedInitialCache {
+            cacheFirstPlaceholder = previousMessages
         } else {
             cacheFirstPlaceholder = []
         }
@@ -1330,6 +1335,23 @@ final class ChatViewModel {
                 errorMessage = error.localizedDescription
             }
         }
+    }
+
+    /// Performs only the fast, local portion of an existing session's first
+    /// load. The network reconcile is intentionally started by `ChatView` after
+    /// its navigation appearance completes so rendering a richer transcript
+    /// cannot stall the system push animation.
+    func prepareInitialMessageLoad(modelContext: ModelContext) {
+        guard let sessionID else { return }
+
+        isLoading = true
+        guard messages.isEmpty else { return }
+
+        let cachedMessages = renderCachedMessagesBeforeReload(
+            sessionID: sessionID,
+            modelContext: modelContext
+        )
+        hasPrimedInitialCachedMessages = !cachedMessages.isEmpty
     }
 
     /// Cache-first render (#289): on a cold session open, paint the cached transcript

--- a/HermesMobile/Features/Chat/ContextWindowIndicatorView.swift
+++ b/HermesMobile/Features/Chat/ContextWindowIndicatorView.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+struct ContextWindowIndicatorPresentation: Equatable {
+    let percentage: Double?
+
+    init(snapshot: ContextWindowSnapshot?) {
+        percentage = snapshot?.percentage
+    }
+
+    var percentageLabel: String {
+        guard let percentage else { return "–" }
+        return "\(Int(percentage * 100))"
+    }
+
+    var isInteractive: Bool {
+        percentage != nil
+    }
+}
+
 struct ContextWindowIndicatorView: View {
     let snapshot: ContextWindowSnapshot?
 
@@ -9,13 +26,13 @@ struct ContextWindowIndicatorView: View {
     private let tapTargetSize: CGFloat = 44
 
     var body: some View {
-        if let snapshot, let percentage = snapshot.percentage {
-            Button(action: { showPopover = true }) {
-                ZStack {
-                    Circle()
-                        .stroke(trackColor, lineWidth: 3)
-                        .frame(width: ringSize, height: ringSize)
+        Button(action: showContextDetails) {
+            ZStack {
+                Circle()
+                    .stroke(trackColor, lineWidth: 3)
+                    .frame(width: ringSize, height: ringSize)
 
+                if let percentage = presentation.percentage {
                     Circle()
                         .trim(from: 0, to: CGFloat(min(percentage, 1.0)))
                         .stroke(
@@ -24,28 +41,42 @@ struct ContextWindowIndicatorView: View {
                         )
                         .frame(width: ringSize, height: ringSize)
                         .rotationEffect(.degrees(-90))
-
-                    Text("\(Int(percentage * 100))")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(.primary)
                 }
-                .frame(width: ringSize, height: ringSize)
-                .adaptiveGlass(
-                    .regular,
-                    isInteractive: true,
-                    fallbackMaterial: .ultraThinMaterial,
-                    in: Circle()
-                )
-                .frame(width: tapTargetSize, height: tapTargetSize)
-                .contentShape(Circle())
+
+                Text(presentation.percentageLabel)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(presentation.isInteractive ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
             }
-            .buttonStyle(.plain)
-            .popover(isPresented: $showPopover) {
+            .frame(width: ringSize, height: ringSize)
+            .adaptiveGlass(
+                .regular,
+                isInteractive: presentation.isInteractive,
+                fallbackMaterial: .ultraThinMaterial,
+                in: Circle()
+            )
+            .frame(width: tapTargetSize, height: tapTargetSize)
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!presentation.isInteractive)
+        .accessibilityLabel(presentation.isInteractive ? "Context usage" : "Context usage loading")
+        .accessibilityValue(presentation.isInteractive ? "\(presentation.percentageLabel) percent" : "")
+        .popover(isPresented: $showPopover) {
+            if let snapshot {
                 ContextWindowPopover(snapshot: snapshot)
                     .presentationCompactAdaptation(.none)
                     .presentationBackground(.clear)
             }
         }
+    }
+
+    private var presentation: ContextWindowIndicatorPresentation {
+        ContextWindowIndicatorPresentation(snapshot: snapshot)
+    }
+
+    private func showContextDetails() {
+        guard presentation.isInteractive else { return }
+        showPopover = true
     }
 
     private var trackColor: Color {

--- a/HermesMobileTests/ChatScrollPolicyTests.swift
+++ b/HermesMobileTests/ChatScrollPolicyTests.swift
@@ -2,6 +2,15 @@ import XCTest
 @testable import HermesMobile
 
 final class ChatScrollPolicyTests: XCTestCase {
+    func testExistingTranscriptUsesBottomAsItsInitialLayoutAnchor() {
+        XCTAssertEqual(ChatScrollPolicy.initialTranscriptAnchor, .bottom)
+    }
+
+    func testInitialAsyncWorkWaitsForNavigationAppearanceCompletion() {
+        XCTAssertFalse(ChatInitialAppearancePolicy.shouldBeginAsyncWork(hasCompletedAppearance: false))
+        XCTAssertTrue(ChatInitialAppearancePolicy.shouldBeginAsyncWork(hasCompletedAppearance: true))
+    }
+
     func testBottomThresholdLoosensWhileStreaming() {
         XCTAssertEqual(
             ChatScrollPolicy.bottomThreshold(isStreaming: false),

--- a/HermesMobileTests/ChatScrollPolicyTests.swift
+++ b/HermesMobileTests/ChatScrollPolicyTests.swift
@@ -6,6 +6,14 @@ final class ChatScrollPolicyTests: XCTestCase {
         XCTAssertEqual(ChatScrollPolicy.initialTranscriptAnchor, .bottom)
     }
 
+    func testTranscriptSizeChangesStayBottomAnchoredOnlyWhileFollowingLatest() {
+        XCTAssertEqual(
+            ChatScrollPolicy.sizeChangeAnchor(shouldFollowLatestMessage: true),
+            .bottom
+        )
+        XCTAssertNil(ChatScrollPolicy.sizeChangeAnchor(shouldFollowLatestMessage: false))
+    }
+
     func testInitialAsyncWorkWaitsForNavigationAppearanceCompletion() {
         XCTAssertFalse(ChatInitialAppearancePolicy.shouldBeginAsyncWork(hasCompletedAppearance: false))
         XCTAssertTrue(ChatInitialAppearancePolicy.shouldBeginAsyncWork(hasCompletedAppearance: true))

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -3208,6 +3208,32 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testPrepareInitialMessageLoadPrimesCacheWithoutStartingNetwork() throws {
+        let context = try makeContext()
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
+        try CacheStore.cacheMessages(
+            [
+                ChatMessage(role: "user", content: "Cached question", timestamp: 1_770_000_001, messageId: "cached-user"),
+                ChatMessage(role: "assistant", content: "Cached answer", timestamp: 1_770_000_002, messageId: "cached-assistant")
+            ],
+            serverURL: serverURL,
+            sessionID: "session-abc",
+            in: context
+        )
+
+        let viewModel = try makeViewModel { request in
+            XCTFail("Cache preparation must not start a request: \(request.url?.absoluteString ?? "nil")")
+            throw URLError(.badURL)
+        }
+
+        viewModel.prepareInitialMessageLoad(modelContext: context)
+
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), ["Cached question", "Cached answer"])
+        XCTAssertTrue(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isViewingCachedData)
+    }
+
+    @MainActor
     func testLoadMessagesKeepsTranscriptEmptyDuringNetworkWhenCacheIsEmpty() async throws {
         let context = try makeContext()
 

--- a/HermesMobileTests/ContextWindowIndicatorTests.swift
+++ b/HermesMobileTests/ContextWindowIndicatorTests.swift
@@ -2,6 +2,30 @@ import XCTest
 @testable import HermesMobile
 
 final class ContextWindowIndicatorTests: XCTestCase {
+    func testPresentationProvidesNonInteractivePlaceholderBeforeSnapshotLoads() {
+        let presentation = ContextWindowIndicatorPresentation(snapshot: nil)
+
+        XCTAssertEqual(presentation.percentageLabel, "–")
+        XCTAssertFalse(presentation.isInteractive)
+        XCTAssertNil(presentation.percentage)
+    }
+
+    func testPresentationBecomesInteractiveWhenPercentageLoads() {
+        let snapshot = ContextWindowSnapshot(
+            contextLength: 100_000,
+            thresholdTokens: nil,
+            lastPromptTokens: 25_000,
+            inputTokens: nil,
+            outputTokens: nil,
+            estimatedCost: nil
+        )
+        let presentation = ContextWindowIndicatorPresentation(snapshot: snapshot)
+
+        XCTAssertEqual(presentation.percentageLabel, "25")
+        XCTAssertTrue(presentation.isInteractive)
+        XCTAssertEqual(presentation.percentage, 0.25)
+    }
+
     func testCompactIndicatorWithValidData() {
         let snapshot = ContextWindowSnapshot(
             contextLength: 128_000,


### PR DESCRIPTION
Fixes #134

## Summary

- place existing transcripts at their latest content during the scroll view's initial layout instead of visibly scrolling there after presentation
- defer the network transcript reconcile and other state-heavy startup work until the native navigation appearance completes
- reserve the context-ring layout slot immediately so usage data cannot shift the composer or transcript when it arrives
- keep rich Markdown size changes bottom-anchored while follow-latest intent is active, without affecting readers who scroll away

## Validation

- full XCTest suite on iPhone 17: 1,379 passed, 0 failed, 0 skipped
- `git diff --check`
- signed Debug build installed and launched on iPhone 17
- frame-level recording check for “Upper Body Workout Analysis and Obsidian Comparison”: eliminated the previously measured 509-pixel adjacent-frame snap

## Owner manual checks

- short text-only session opens and immediately reopens smoothly
- long rich-Markdown session with tables and code blocks opens and immediately reopens smoothly
- transcript, composer, top bar, and context ring no longer shift after presentation
- ordinary scrolling away from the bottom remains user-controlled
