### PR TITLE
feat(kanban): add hidden compatibility shell

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -265,6 +265,12 @@
 		C23400000000000000000001 /* StreamingLabReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000002 /* StreamingLabReplay.swift */; };
 		C23400000000000000000003 /* StreamingLabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000004 /* StreamingLabView.swift */; };
 		C23400000000000000000005 /* StreamingLabReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000006 /* StreamingLabReplayTests.swift */; };
+		C14900000000000000000001 /* Kanban.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14900000000000000000002 /* Kanban.swift */; };
+		C14900000000000000000003 /* APIClient+Kanban.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14900000000000000000004 /* APIClient+Kanban.swift */; };
+		C14900000000000000000005 /* KanbanFeatureState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14900000000000000000006 /* KanbanFeatureState.swift */; };
+		C14900000000000000000007 /* KanbanLabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14900000000000000000008 /* KanbanLabView.swift */; };
+		C14900000000000000000009 /* APIClientKanbanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1490000000000000000000A /* APIClientKanbanTests.swift */; };
+		C1490000000000000000000B /* KanbanFeatureStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1490000000000000000000C /* KanbanFeatureStateTests.swift */; };
 		C21300000000000000000007 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = C21300000000000000000008 /* MarkdownUI */; };
 		B5A220000000000000000005 /* ChatMarkerMessageClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A220000000000000000006 /* ChatMarkerMessageClassifierTests.swift */; };
 		B5A100000000000000000004 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000014 /* PrivacyInfo.xcprivacy */; };
@@ -612,6 +618,12 @@
 		C23400000000000000000002 /* StreamingLabReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabReplay.swift; sourceTree = "<group>"; };
 		C23400000000000000000004 /* StreamingLabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabView.swift; sourceTree = "<group>"; };
 		C23400000000000000000006 /* StreamingLabReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabReplayTests.swift; sourceTree = "<group>"; };
+		C14900000000000000000002 /* Kanban.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kanban.swift; sourceTree = "<group>"; };
+		C14900000000000000000004 /* APIClient+Kanban.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Kanban.swift"; sourceTree = "<group>"; };
+		C14900000000000000000006 /* KanbanFeatureState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanFeatureState.swift; sourceTree = "<group>"; };
+		C14900000000000000000008 /* KanbanLabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanLabView.swift; sourceTree = "<group>"; };
+		C1490000000000000000000A /* APIClientKanbanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientKanbanTests.swift; sourceTree = "<group>"; };
+		C1490000000000000000000C /* KanbanFeatureStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanFeatureStateTests.swift; sourceTree = "<group>"; };
 		B5A220000000000000000006 /* ChatMarkerMessageClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMarkerMessageClassifierTests.swift; sourceTree = "<group>"; };
 		B5A100000000000000000017 /* HermesShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HermesShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A04500000000000000000010 /* AgentRunActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunActivityAttributes.swift; sourceTree = "<group>"; };
@@ -777,6 +789,8 @@
 				C21200000000000000000006 /* ChatViewModelStreamingPaceTests.swift */,
 				C21300000000000000000006 /* StreamingTextFadeTests.swift */,
 				C23400000000000000000006 /* StreamingLabReplayTests.swift */,
+				C1490000000000000000000A /* APIClientKanbanTests.swift */,
+				C1490000000000000000000C /* KanbanFeatureStateTests.swift */,
 				C1A042000000000000000006 /* ClarificationTests.swift */,
 				1A2B3C4D5E6F7000000000F4 /* CacheStoreTests.swift */,
 				C04400000000000000000004 /* CacheFallbackPolicyTests.swift */,
@@ -839,6 +853,7 @@
 				C04000000000000000000017 /* APIClient+Memory.swift */,
 				C04000000000000000000018 /* APIClient+Skills.swift */,
 				C04000000000000000000019 /* APIClient+Upload.swift */,
+				C14900000000000000000004 /* APIClient+Kanban.swift */,
 				1A2B3C4D5E6F7000000000B8 /* Endpoints.swift */,
 				C03250000000000000F102 /* APIClient+Transcribe.swift */,
 				C03260000000000000F101 /* APIClient+TTS.swift */,
@@ -877,6 +892,7 @@
 				3F91D2A54B9A4F66A2C01011 /* Cron.swift */,
 				1A2B3C4D5E6F70000000201 /* Memory.swift */,
 				1A2B3C4D5E6F70000000211 /* Skills.swift */,
+				C14900000000000000000002 /* Kanban.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -895,6 +911,7 @@
 				1A2B3C4D5E6F70000000216 /* Skills */,
 				1A2B3C4D5E6F70000000206 /* Memory */,
 				B50E1CE3A8912B92B1924714 /* Insights */,
+				C1490000000000000000000D /* Kanban */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -913,6 +930,15 @@
 				1A2B3C4D5E6F7000000000B6 /* OnboardingViewModel.swift */,
 			);
 			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		C1490000000000000000000D /* Kanban */ = {
+			isa = PBXGroup;
+			children = (
+				C14900000000000000000006 /* KanbanFeatureState.swift */,
+				C14900000000000000000008 /* KanbanLabView.swift */,
+			);
+			path = Kanban;
 			sourceTree = "<group>";
 		};
 		C09300000000000000000010 /* Shared */ = {
@@ -1402,6 +1428,10 @@
 				C04000000000000000000007 /* APIClient+Memory.swift in Sources */,
 				C04000000000000000000008 /* APIClient+Skills.swift in Sources */,
 				C04000000000000000000009 /* APIClient+Upload.swift in Sources */,
+				C14900000000000000000001 /* Kanban.swift in Sources */,
+				C14900000000000000000003 /* APIClient+Kanban.swift in Sources */,
+				C14900000000000000000005 /* KanbanFeatureState.swift in Sources */,
+				C14900000000000000000007 /* KanbanLabView.swift in Sources */,
 				1A2B3C4D5E6F7000000000A8 /* Endpoints.swift in Sources */,
 				C03250000000000000B101 /* TranscribeResponse.swift in Sources */,
 				C03250000000000000B102 /* APIClient+Transcribe.swift in Sources */,
@@ -1610,6 +1640,8 @@
 				C21200000000000000000005 /* ChatViewModelStreamingPaceTests.swift in Sources */,
 				C21300000000000000000005 /* StreamingTextFadeTests.swift in Sources */,
 				C23400000000000000000005 /* StreamingLabReplayTests.swift in Sources */,
+				C14900000000000000000009 /* APIClientKanbanTests.swift in Sources */,
+				C1490000000000000000000B /* KanbanFeatureStateTests.swift in Sources */,
 				C1A042000000000000000005 /* ClarificationTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000F2 /* CacheStoreTests.swift in Sources */,
 				C04400000000000000000003 /* CacheFallbackPolicyTests.swift in Sources */,

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -72,6 +72,9 @@ final class KanbanFeatureState {
             self.report = report
             state = report.isPartial ? .partial : .compatible
         } catch is CancellationError {
+            guard activeLoadID == loadID else { return }
+            report = nil
+            state = .idle
             return
         } catch {
             guard isCurrent(loadID) else { return }

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Observation
+
+enum KanbanCompatibilityState: Equatable {
+    case idle
+    case checking
+    case compatible
+    case partial
+    case authenticationRequired
+    case networkUnavailable
+    case serverUnavailable
+    case incompatibleContract
+}
+
+/// Server-bound, read-only compatibility state. It deliberately owns no
+/// persisted data and starts no live-update work; those arrive in later Kanban
+/// slices after this handshake has established a safe contract.
+@MainActor
+@Observable
+final class KanbanFeatureState {
+    let server: URL
+    private(set) var state: KanbanCompatibilityState = .idle
+    private(set) var report: KanbanCompatibilityReport?
+    private(set) var isLoading = false
+    private var activeLoadID: UUID?
+
+    private let client: any KanbanDataClient
+    private let onAPIError: (Error) -> Void
+
+    init(
+        server: URL,
+        client: (any KanbanDataClient)? = nil,
+        onAPIError: @escaping (Error) -> Void = { _ in }
+    ) {
+        self.server = server
+        self.client = client ?? APIClient(baseURL: server)
+        self.onAPIError = onAPIError
+    }
+
+    func load() async {
+        let loadID = UUID()
+        activeLoadID = loadID
+        isLoading = true
+        state = .checking
+        report = nil
+        defer {
+            if activeLoadID == loadID {
+                isLoading = false
+            }
+        }
+
+        do {
+            // Ordered exactly as the compatibility specification requires. These
+            // are all GETs: no probes, previews, or alternate request shapes.
+            let configuration = try await client.kanbanConfiguration()
+            guard isCurrent(loadID) else { return }
+            let boards = try await client.kanbanBoards()
+            guard isCurrent(loadID) else { return }
+            guard let currentBoard = boards.current?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !currentBoard.isEmpty else {
+                throw KanbanContractViolation.missingCurrentBoard
+            }
+            let snapshot = try await client.kanbanBoard(board: currentBoard)
+            guard isCurrent(loadID) else { return }
+
+            let report = try KanbanCompatibilityValidator.validate(
+                configuration: configuration,
+                boardsResponse: boards,
+                snapshot: snapshot
+            )
+            guard isCurrent(loadID) else { return }
+            self.report = report
+            state = report.isPartial ? .partial : .compatible
+        } catch is CancellationError {
+            return
+        } catch {
+            guard isCurrent(loadID) else { return }
+            report = nil
+            state = Self.classify(error)
+            if case APIError.unauthorized = error {
+                onAPIError(error)
+            }
+        }
+    }
+
+    func retry() async {
+        await load()
+    }
+
+    private func isCurrent(_ loadID: UUID) -> Bool {
+        activeLoadID == loadID && !Task.isCancelled
+    }
+
+    private static func classify(_ error: Error) -> KanbanCompatibilityState {
+        if error is KanbanContractViolation || error is KanbanResponseError {
+            return .incompatibleContract
+        }
+        guard let apiError = error as? APIError else {
+            return .networkUnavailable
+        }
+        switch apiError {
+        case .unauthorized:
+            return .authenticationRequired
+        case .network:
+            return .networkUnavailable
+        case let .http(statusCode, _):
+            return [502, 503, 504].contains(statusCode) ? .serverUnavailable : .incompatibleContract
+        case .decoding, .invalidServerURL:
+            return .incompatibleContract
+        }
+    }
+}

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -1,0 +1,106 @@
+#if DEBUG
+import SwiftUI
+
+/// Debug-only fixture for reviewing compatibility copy and retry states. It
+/// deliberately has no client or server URL, so exercising it cannot read or
+/// mutate an authenticated Kanban server.
+struct KanbanLabView: View {
+    @State private var scenario: KanbanLabScenario = .compatible
+    @State private var retryCount = 0
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("State", selection: $scenario) {
+                    ForEach(KanbanLabScenario.allCases) { scenario in
+                        Text(scenario.title).tag(scenario)
+                    }
+                }
+            } header: {
+                Text("Fixture")
+            } footer: {
+                Text("This lab uses local fixtures only. It never contacts or changes a Kanban server.")
+            }
+
+            Section("Compatibility") {
+                stateContent
+            }
+        }
+        .navigationTitle("Kanban Lab")
+    }
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch scenario {
+        case .compatible:
+            Label("This server is compatible with Kanban.", systemImage: "checkmark.circle")
+                .foregroundStyle(.green)
+        case .partial:
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Kanban is available with limited capabilities.", systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+                Text("Some server values are unsupported. Editing remains unavailable.")
+            }
+        case .authentication:
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Sign in is required for Kanban.", systemImage: "lock")
+                Text("Return to the server login screen, then try again.")
+            }
+        case .network:
+            retryContent(
+                title: "Kanban could not reach the server.",
+                detail: "Known Kanban data remains unavailable until a connection succeeds."
+            )
+        case .serverUnavailable:
+            retryContent(
+                title: "The Kanban server is unavailable.",
+                detail: "Check that the Hermes server is awake, then try again."
+            )
+        case .incompatible:
+            retryContent(
+                title: "This server's Kanban response is incompatible with Hermex.",
+                detail: "No Kanban changes were made."
+            )
+        }
+    }
+
+    private func retryContent(title: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+            Text(detail)
+            Button("Try Again") {
+                retryCount += 1
+            }
+            .accessibilityHint("Simulates a retry without contacting a server.")
+            if retryCount > 0 {
+                Text("Retry simulated.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private enum KanbanLabScenario: String, CaseIterable, Identifiable {
+    case compatible
+    case partial
+    case authentication
+    case network
+    case serverUnavailable
+    case incompatible
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .compatible: "Compatible"
+        case .partial: "Partial"
+        case .authentication: "Authentication"
+        case .network: "Network"
+        case .serverUnavailable: "Server unavailable"
+        case .incompatible: "Incompatible"
+        }
+    }
+}
+#endif

--- a/HermesMobile/HermesMobileApp.swift
+++ b/HermesMobile/HermesMobileApp.swift
@@ -55,6 +55,10 @@ struct HermesMobileApp: App {
                 NavigationStack {
                     StreamingLabView()
                 }
+            } else if ProcessInfo.processInfo.arguments.contains("--kanban-lab") {
+                NavigationStack {
+                    KanbanLabView()
+                }
             } else {
                 ContentView(authManager: authManager)
                     .preferredColorScheme(AppTheme.storedValue(appThemeRawValue).colorScheme)

--- a/HermesMobile/Models/Kanban.swift
+++ b/HermesMobile/Models/Kanban.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+/// Tolerant read-only boundary for the independently-versioned Kanban bridge.
+/// Every upstream field stays optional so an added or renamed server field never
+/// prevents the rest of the shell from decoding.
+struct KanbanConfiguration: Decodable, Equatable, Sendable {
+    let columns: [String]?
+    let assignees: [String]?
+    let defaultTenant: String?
+    let laneByProfile: Bool?
+    let includeArchivedByDefault: Bool?
+    let renderMarkdown: Bool?
+    let readOnly: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case columns, assignees, defaultTenant, laneByProfile, includeArchivedByDefault, renderMarkdown, readOnly
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        columns = (try? container.decodeIfPresent([String].self, forKey: .columns)) ?? nil
+        assignees = (try? container.decodeIfPresent([String].self, forKey: .assignees)) ?? nil
+        defaultTenant = container.decodeLossyStringIfPresent(forKey: .defaultTenant)
+        laneByProfile = container.decodeLossyBoolIfPresent(forKey: .laneByProfile)
+        includeArchivedByDefault = container.decodeLossyBoolIfPresent(forKey: .includeArchivedByDefault)
+        renderMarkdown = container.decodeLossyBoolIfPresent(forKey: .renderMarkdown)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+struct KanbanBoardsResponse: Decodable, Equatable, Sendable {
+    let boards: [KanbanBoard]?
+    let current: String?
+    let readOnly: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case boards, current, readOnly
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        boards = (try? container.decodeIfPresent([KanbanBoard].self, forKey: .boards)) ?? nil
+        current = container.decodeLossyStringIfPresent(forKey: .current)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+struct KanbanBoard: Decodable, Equatable, Sendable {
+    let slug: String?
+    let name: String?
+    let description: String?
+    let icon: String?
+    let color: String?
+    let isCurrent: Bool?
+    let total: Int?
+    let readOnly: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case slug, name, description, icon, color, isCurrent, total, readOnly
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        slug = container.decodeLossyStringIfPresent(forKey: .slug)
+        name = container.decodeLossyStringIfPresent(forKey: .name)
+        description = container.decodeLossyStringIfPresent(forKey: .description)
+        icon = container.decodeLossyStringIfPresent(forKey: .icon)
+        color = container.decodeLossyStringIfPresent(forKey: .color)
+        isCurrent = container.decodeLossyBoolIfPresent(forKey: .isCurrent)
+        total = container.decodeLossyIntIfPresent(forKey: .total)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+struct KanbanBoardSnapshot: Decodable, Equatable, Sendable {
+    let columns: [KanbanColumn]?
+    let changed: Bool?
+    let latestEventID: Int?
+    let readOnly: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case columns, changed, latestEventID, readOnly
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        columns = (try? container.decodeIfPresent([KanbanColumn].self, forKey: .columns)) ?? nil
+        changed = container.decodeLossyBoolIfPresent(forKey: .changed)
+        latestEventID = container.decodeLossyIntIfPresent(forKey: .latestEventID)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+struct KanbanColumn: Decodable, Equatable, Sendable {
+    let name: String?
+    let cards: [KanbanCard]?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case cards = "tasks"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = container.decodeLossyStringIfPresent(forKey: .name)
+        cards = (try? container.decodeIfPresent([KanbanCard].self, forKey: .cards)) ?? nil
+    }
+}
+
+struct KanbanCard: Decodable, Equatable, Sendable {
+    let cardID: String?
+    let title: String?
+    let status: KanbanStatus?
+    let assignee: String?
+
+    enum CodingKeys: String, CodingKey {
+        case cardID = "id"
+        case title
+        case status
+        case assignee
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        cardID = container.decodeLossyStringIfPresent(forKey: .cardID)
+        title = container.decodeLossyStringIfPresent(forKey: .title)
+        status = container.decodeLossyStringIfPresent(forKey: .status).map(KanbanStatus.init(rawValue:))
+        assignee = container.decodeLossyStringIfPresent(forKey: .assignee)
+    }
+}
+
+/// Retains an unknown server Status rather than turning it into a decoding
+/// failure. Future mutation slices can use `isSupported` to keep it read-only.
+struct KanbanStatus: Equatable, Hashable, Sendable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    var isSupported: Bool {
+        ["triage", "todo", "blocked", "ready", "running", "done", "archived"].contains(rawValue.lowercased())
+    }
+}
+
+struct KanbanCompatibilityReport: Equatable, Sendable {
+    let board: KanbanBoard
+    let warnings: [KanbanCompatibilityWarning]
+
+    var isPartial: Bool { !warnings.isEmpty }
+}
+
+enum KanbanCompatibilityWarning: Equatable, Sendable {
+    case readOnly
+    case writeCapabilityUnavailable
+    case unsupportedStatus(String)
+}
+
+enum KanbanContractViolation: Error, Equatable, LocalizedError, Sendable {
+    case missingConfigurationColumns
+    case missingCurrentBoard
+    case missingBoardIdentity
+    case missingBoardSnapshot
+    case missingColumnStatus
+    case missingCardIdentity
+    case missingCardStatus
+
+    var errorDescription: String? {
+        String(localized: "This server's Kanban response is incompatible with Hermex.")
+    }
+}
+
+enum KanbanResponseError: Error, Equatable, LocalizedError, Sendable {
+    case nonJSONContentType
+
+    var errorDescription: String? {
+        String(localized: "This server's Kanban response is incompatible with Hermex.")
+    }
+}
+
+enum KanbanCompatibilityValidator {
+    static func validate(
+        configuration: KanbanConfiguration,
+        boardsResponse: KanbanBoardsResponse,
+        snapshot: KanbanBoardSnapshot
+    ) throws -> KanbanCompatibilityReport {
+        let configuredStatuses = try nonEmptyValues(configuration.columns, missing: .missingConfigurationColumns)
+        let currentBoardSlug = try nonEmpty(boardsResponse.current, missing: .missingCurrentBoard)
+        let boards = boardsResponse.boards ?? []
+        guard let board = boards.first(where: { normalized($0.slug) == currentBoardSlug }) else {
+            throw KanbanContractViolation.missingBoardIdentity
+        }
+        guard snapshot.changed == true, let columns = snapshot.columns, !columns.isEmpty else {
+            throw KanbanContractViolation.missingBoardSnapshot
+        }
+
+        var warnings: [KanbanCompatibilityWarning] = []
+        if configuration.readOnly == true || boardsResponse.readOnly == true || snapshot.readOnly == true {
+            warnings.append(.readOnly)
+        }
+        if configuration.readOnly == nil || boardsResponse.readOnly == nil || snapshot.readOnly == nil {
+            warnings.append(.writeCapabilityUnavailable)
+        }
+
+        for column in columns {
+            let status = try nonEmpty(column.name, missing: .missingColumnStatus)
+            for card in column.cards ?? [] {
+                _ = try nonEmpty(card.cardID, missing: .missingCardIdentity)
+                let cardStatus = try nonEmpty(card.status?.rawValue, missing: .missingCardStatus)
+                if !configuredStatuses.contains(cardStatus), !warnings.contains(.unsupportedStatus(cardStatus)) {
+                    warnings.append(.unsupportedStatus(cardStatus))
+                }
+            }
+            if !configuredStatuses.contains(status), !warnings.contains(.unsupportedStatus(status)) {
+                warnings.append(.unsupportedStatus(status))
+            }
+        }
+
+        return KanbanCompatibilityReport(board: board, warnings: warnings)
+    }
+
+    private static func nonEmptyValues(
+        _ values: [String]?,
+        missing: KanbanContractViolation
+    ) throws -> Set<String> {
+        let normalizedValues = Set((values ?? []).compactMap(normalized))
+        guard !normalizedValues.isEmpty else { throw missing }
+        return normalizedValues
+    }
+
+    private static func nonEmpty(_ value: String?, missing: KanbanContractViolation) throws -> String {
+        guard let normalized = normalized(value) else { throw missing }
+        return normalized
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/HermesMobile/Models/Kanban.swift
+++ b/HermesMobile/Models/Kanban.swift
@@ -18,8 +18,8 @@ struct KanbanConfiguration: Decodable, Equatable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        columns = (try? container.decodeIfPresent([String].self, forKey: .columns)) ?? nil
-        assignees = (try? container.decodeIfPresent([String].self, forKey: .assignees)) ?? nil
+        columns = try? container.decodeIfPresent([String].self, forKey: .columns)
+        assignees = try? container.decodeIfPresent([String].self, forKey: .assignees)
         defaultTenant = container.decodeLossyStringIfPresent(forKey: .defaultTenant)
         laneByProfile = container.decodeLossyBoolIfPresent(forKey: .laneByProfile)
         includeArchivedByDefault = container.decodeLossyBoolIfPresent(forKey: .includeArchivedByDefault)
@@ -39,7 +39,7 @@ struct KanbanBoardsResponse: Decodable, Equatable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        boards = (try? container.decodeIfPresent([KanbanBoard].self, forKey: .boards)) ?? nil
+        boards = try? container.decodeIfPresent([KanbanBoard].self, forKey: .boards)
         current = container.decodeLossyStringIfPresent(forKey: .current)
         readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
     }
@@ -84,7 +84,7 @@ struct KanbanBoardSnapshot: Decodable, Equatable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        columns = (try? container.decodeIfPresent([KanbanColumn].self, forKey: .columns)) ?? nil
+        columns = try? container.decodeIfPresent([KanbanColumn].self, forKey: .columns)
         changed = container.decodeLossyBoolIfPresent(forKey: .changed)
         latestEventID = container.decodeLossyIntIfPresent(forKey: .latestEventID)
         readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
@@ -103,7 +103,7 @@ struct KanbanColumn: Decodable, Equatable, Sendable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = container.decodeLossyStringIfPresent(forKey: .name)
-        cards = (try? container.decodeIfPresent([KanbanCard].self, forKey: .cards)) ?? nil
+        cards = try? container.decodeIfPresent([KanbanCard].self, forKey: .cards)
     }
 }
 

--- a/HermesMobile/Networking/APIClient+Kanban.swift
+++ b/HermesMobile/Networking/APIClient+Kanban.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+protocol KanbanDataClient: Sendable {
+    func kanbanConfiguration() async throws -> KanbanConfiguration
+    func kanbanBoards() async throws -> KanbanBoardsResponse
+    func kanbanBoard(board: String) async throws -> KanbanBoardSnapshot
+}
+
+extension APIClient: KanbanDataClient {
+    func kanbanConfiguration() async throws -> KanbanConfiguration {
+        try await kanbanJSON(endpoint: .kanbanConfig)
+    }
+
+    func kanbanBoards() async throws -> KanbanBoardsResponse {
+        try await kanbanJSON(endpoint: .kanbanBoards)
+    }
+
+    func kanbanBoard(board: String) async throws -> KanbanBoardSnapshot {
+        try await kanbanJSON(endpoint: .kanbanBoard(board: board))
+    }
+
+    private func kanbanJSON<Response: Decodable>(endpoint: Endpoint) async throws -> Response {
+        let (data, response) = try await sendDataReturningResponse(
+            endpoint: endpoint,
+            method: "GET",
+            encodedBody: nil
+        )
+        let contentType = response.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
+        guard contentType.hasPrefix("application/json") else {
+            throw KanbanResponseError.nonJSONContentType
+        }
+        return try decode(Response.self, from: data)
+    }
+}

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -93,6 +93,9 @@ enum Endpoint {
     case cronStatus(jobID: String?)
     case cronOutput(jobID: String, limit: Int?)
     case cronDeliveryOptions
+    case kanbanConfig
+    case kanbanBoards
+    case kanbanBoard(board: String)
     case memory
     case memoryWrite
     case skills
@@ -288,6 +291,12 @@ enum Endpoint {
             return "/api/crons/output"
         case .cronDeliveryOptions:
             return "/api/crons/delivery-options"
+        case .kanbanConfig:
+            return "/api/kanban/config"
+        case .kanbanBoards:
+            return "/api/kanban/boards"
+        case .kanbanBoard:
+            return "/api/kanban/board"
         case .memory:
             return "/api/memory"
         case .memoryWrite:
@@ -408,6 +417,8 @@ enum Endpoint {
                 items.append(URLQueryItem(name: "limit", value: "\(limit)"))
             }
             return items
+        case let .kanbanBoard(board):
+            return [URLQueryItem(name: "board", value: board)]
         case let .reasoning(model, provider):
             var items: [URLQueryItem] = []
             if let model, !model.isEmpty {

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -35,7 +35,7 @@ final class APIClientKanbanTests: APIClientTestCase {
         XCTAssertEqual(board.columns?.first?.cards?.first?.cardID, "card-1")
     }
 
-    func testKanbanCarriesConfiguredCustomHeadersAndUsesCookieEnabledSession() async throws {
+    func testKanbanCarriesConfiguredCustomHeaders() async throws {
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-Hermes-Proxy"), "enabled")
             XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
@@ -43,24 +43,9 @@ final class APIClientKanbanTests: APIClientTestCase {
             XCTAssertNil(request.value(forHTTPHeaderField: "Referer"))
             return apiTestJSONResponse(Self.configurationJSON, for: request)
         }
-        let cookieStorage = HTTPCookieStorage()
-        cookieStorage.setCookie(try XCTUnwrap(HTTPCookie(properties: [
-            .domain: "example.test",
-            .path: "/",
-            .name: "session",
-            .value: "abc",
-            .secure: "TRUE"
-        ])))
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.httpCookieStorage = cookieStorage
-        configuration.httpCookieAcceptPolicy = .always
-        configuration.httpShouldSetCookies = true
         configuration.protocolClasses = [MockURLProtocol.self]
         let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
-        // URLProtocol does not receive URLSession's jar-injected Cookie header
-        // consistently across simulator runtimes. Verify the session's configured
-        // jar separately; production requests use URLSession's normal cookie path.
-        XCTAssertEqual(cookieStorage.cookies(for: serverURL)?.map(\.value), ["abc"])
         let client = APIClient(
             baseURL: serverURL,
             session: URLSession(configuration: configuration),

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -54,6 +54,8 @@ final class APIClientKanbanTests: APIClientTestCase {
         ])))
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpCookieStorage = cookieStorage
+        configuration.httpCookieAcceptPolicy = .always
+        configuration.httpShouldSetCookies = true
         configuration.protocolClasses = [MockURLProtocol.self]
         let client = APIClient(
             baseURL: URL(string: "https://example.test")!,

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -35,10 +35,9 @@ final class APIClientKanbanTests: APIClientTestCase {
         XCTAssertEqual(board.columns?.first?.cards?.first?.cardID, "card-1")
     }
 
-    func testKanbanCarriesConfiguredCustomHeadersAndCookieJar() async throws {
+    func testKanbanCarriesConfiguredCustomHeadersAndUsesCookieEnabledSession() async throws {
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-Hermes-Proxy"), "enabled")
-            XCTAssertEqual(request.value(forHTTPHeaderField: "Cookie"), "session=abc")
             XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
             XCTAssertNil(request.value(forHTTPHeaderField: "Origin"))
             XCTAssertNil(request.value(forHTTPHeaderField: "Referer"))
@@ -57,8 +56,13 @@ final class APIClientKanbanTests: APIClientTestCase {
         configuration.httpCookieAcceptPolicy = .always
         configuration.httpShouldSetCookies = true
         configuration.protocolClasses = [MockURLProtocol.self]
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
+        // URLProtocol does not receive URLSession's jar-injected Cookie header
+        // consistently across simulator runtimes. Verify the session's configured
+        // jar separately; production requests use URLSession's normal cookie path.
+        XCTAssertEqual(cookieStorage.cookies(for: serverURL)?.map(\.value), ["abc"])
         let client = APIClient(
-            baseURL: URL(string: "https://example.test")!,
+            baseURL: serverURL,
             session: URLSession(configuration: configuration),
             customHeaderProvider: { [CustomHeader(name: "X-Hermes-Proxy", value: "enabled")] }
         )

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import HermesMobile
+
+final class APIClientKanbanTests: APIClientTestCase {
+    func testCompatibilityHandshakeUsesOnlyVerifiedGETRequests() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "Origin"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "Referer"))
+            XCTAssertNil(request.httpBody)
+
+            switch request.url?.path {
+            case "/api/kanban/config":
+                XCTAssertNil(request.url?.query)
+                return apiTestJSONResponse(Self.configurationJSON, for: request)
+            case "/api/kanban/boards":
+                XCTAssertNil(request.url?.query)
+                return apiTestJSONResponse(Self.boardsJSON, for: request)
+            case "/api/kanban/board":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                XCTAssertEqual(components?.queryItems, [URLQueryItem(name: "board", value: "main board")])
+                return apiTestJSONResponse(Self.boardJSON, for: request)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+
+        _ = try await client.kanbanConfiguration()
+        _ = try await client.kanbanBoards()
+        let board = try await client.kanbanBoard(board: "main board")
+
+        XCTAssertEqual(board.changed, true)
+        XCTAssertEqual(board.columns?.first?.cards?.first?.cardID, "card-1")
+    }
+
+    func testKanbanCarriesConfiguredCustomHeadersAndCookieJar() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Hermes-Proxy"), "enabled")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Cookie"), "session=abc")
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "Origin"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "Referer"))
+            return apiTestJSONResponse(Self.configurationJSON, for: request)
+        }
+        let cookieStorage = HTTPCookieStorage()
+        cookieStorage.setCookie(try XCTUnwrap(HTTPCookie(properties: [
+            .domain: "example.test",
+            .path: "/",
+            .name: "session",
+            .value: "abc",
+            .secure: "TRUE"
+        ])))
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieStorage = cookieStorage
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let client = APIClient(
+            baseURL: URL(string: "https://example.test")!,
+            session: URLSession(configuration: configuration),
+            customHeaderProvider: { [CustomHeader(name: "X-Hermes-Proxy", value: "enabled")] }
+        )
+
+        _ = try await client.kanbanConfiguration()
+    }
+
+    func testNonJSONAndMalformedJSONAreNotAcceptedAsKanban() async throws {
+        let nonJSONClient = makeClient { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html"]
+            )!
+            return (response, Data("<html>login</html>".utf8))
+        }
+        await XCTAssertThrowsErrorAsync(try await nonJSONClient.kanbanConfiguration()) { error in
+            XCTAssertEqual(error as? KanbanResponseError, .nonJSONContentType)
+        }
+
+        let malformedClient = makeClient { request in
+            apiTestJSONResponse("{not valid json", for: request)
+        }
+        await XCTAssertThrowsErrorAsync(try await malformedClient.kanbanConfiguration()) { error in
+            guard case APIError.decoding = error else {
+                return XCTFail("Expected decoding error, got \(error)")
+            }
+        }
+    }
+
+    func testTolerantModelsKeepUnknownStatusAndIgnoreUnknownFields() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let snapshot = try decoder.decode(KanbanBoardSnapshot.self, from: Data("""
+        {
+          "changed": true,
+          "columns": [{
+            "name": "future-status",
+            "tasks": [{"id": "card-1", "status": "future-status", "new_field": {"nested": true}}]
+          }],
+          "new_envelope_field": 17
+        }
+        """.utf8))
+
+        XCTAssertEqual(snapshot.columns?.first?.cards?.first?.status?.rawValue, "future-status")
+        XCTAssertFalse(snapshot.columns?.first?.cards?.first?.status?.isSupported ?? true)
+    }
+
+    func testSemanticValidationRejectsMissingSafetyCriticalDataAndMarksUnknownStatusPartial() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let configuration = try decoder.decode(KanbanConfiguration.self, from: Data(Self.configurationJSON.utf8))
+        let boards = try decoder.decode(KanbanBoardsResponse.self, from: Data(Self.boardsJSON.utf8))
+        let snapshot = try decoder.decode(KanbanBoardSnapshot.self, from: Data(Self.boardJSON.utf8))
+
+        let report = try KanbanCompatibilityValidator.validate(
+            configuration: configuration,
+            boardsResponse: boards,
+            snapshot: snapshot
+        )
+        XCTAssertFalse(report.isPartial)
+
+        let missingCurrent = try decoder.decode(KanbanBoardsResponse.self, from: Data(#"{"boards": []}"#.utf8))
+        XCTAssertThrowsError(
+            try KanbanCompatibilityValidator.validate(
+                configuration: configuration,
+                boardsResponse: missingCurrent,
+                snapshot: snapshot
+            )
+        ) { error in
+            XCTAssertEqual(error as? KanbanContractViolation, .missingCurrentBoard)
+        }
+
+        let futureSnapshot = try decoder.decode(KanbanBoardSnapshot.self, from: Data("""
+        {"changed":true,"columns":[{"name":"future","tasks":[{"id":"card-1","status":"future"}]}]}
+        """.utf8))
+        let partialReport = try KanbanCompatibilityValidator.validate(
+            configuration: configuration,
+            boardsResponse: boards,
+            snapshot: futureSnapshot
+        )
+        XCTAssertEqual(partialReport.warnings, [.unsupportedStatus("future")])
+    }
+
+    private static let configurationJSON = """
+    {"columns":["triage","todo","ready"],"assignees":["work"],"read_only":false}
+    """
+
+    private static let boardsJSON = """
+    {"boards":[{"slug":"main board","name":"Main","is_current":true,"total":1}],"current":"main board","read_only":false}
+    """
+
+    private static let boardJSON = """
+    {"changed":true,"latest_event_id":7,"read_only":false,"columns":[{"name":"triage","tasks":[{"id":"card-1","title":"Safe read","status":"triage"}]}]}
+    """
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ errorHandler: (Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected an error, but none was thrown")
+    } catch {
+        errorHandler(error)
+    }
+}

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -132,7 +132,7 @@ final class APIClientKanbanTests: APIClientTestCase {
         }
 
         let futureSnapshot = try decoder.decode(KanbanBoardSnapshot.self, from: Data("""
-        {"changed":true,"columns":[{"name":"future","tasks":[{"id":"card-1","status":"future"}]}]}
+        {"changed":true,"read_only":false,"columns":[{"name":"future","tasks":[{"id":"card-1","status":"future"}]}]}
         """.utf8))
         let partialReport = try KanbanCompatibilityValidator.validate(
             configuration: configuration,
@@ -140,6 +140,29 @@ final class APIClientKanbanTests: APIClientTestCase {
             snapshot: futureSnapshot
         )
         XCTAssertEqual(partialReport.warnings, [.unsupportedStatus("future")])
+
+        let incompleteSnapshot = try decoder.decode(KanbanBoardSnapshot.self, from: Data("""
+        {"read_only":false,"columns":[{"name":"triage","tasks":[]}]}
+        """.utf8))
+        XCTAssertThrowsError(
+            try KanbanCompatibilityValidator.validate(
+                configuration: configuration,
+                boardsResponse: boards,
+                snapshot: incompleteSnapshot
+            )
+        ) { error in
+            XCTAssertEqual(error as? KanbanContractViolation, .missingBoardSnapshot)
+        }
+
+        let caseMismatchedSnapshot = try decoder.decode(KanbanBoardSnapshot.self, from: Data("""
+        {"changed":true,"read_only":false,"columns":[{"name":"TRIAGE","tasks":[{"id":"card-1","status":"TRIAGE"}]}]}
+        """.utf8))
+        let exactStatusReport = try KanbanCompatibilityValidator.validate(
+            configuration: configuration,
+            boardsResponse: boards,
+            snapshot: caseMismatchedSnapshot
+        )
+        XCTAssertEqual(exactStatusReport.warnings, [.unsupportedStatus("TRIAGE")])
     }
 
     private static let configurationJSON = """

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import HermesMobile
+
+@MainActor
+final class KanbanFeatureStateTests: XCTestCase {
+    func testCompatibleHandshakeIsOrderedAndBoundToItsServer() async {
+        let client = KanbanClientStub()
+        let firstServer = URL(string: "https://first.example.test")!
+        let secondServer = URL(string: "https://second.example.test")!
+        let first = KanbanFeatureState(server: firstServer, client: client)
+        let second = KanbanFeatureState(server: secondServer, client: client)
+
+        await first.load()
+
+        XCTAssertEqual(first.state, .compatible)
+        XCTAssertEqual(first.server, firstServer)
+        XCTAssertEqual(second.state, .idle)
+        XCTAssertEqual(second.server, secondServer)
+        let calls = await client.calls()
+        XCTAssertEqual(calls, [.configuration, .boards, .board("main")])
+    }
+
+    func testAuthenticationForwardsToExistingHandler() async {
+        let client = KanbanClientStub(configurationResult: .failure(APIError.unauthorized))
+        var forwardedErrors: [Error] = []
+        let state = KanbanFeatureState(
+            server: URL(string: "https://example.test")!,
+            client: client,
+            onAPIError: { forwardedErrors.append($0) }
+        )
+
+        await state.load()
+
+        XCTAssertEqual(state.state, .authenticationRequired)
+        XCTAssertEqual(forwardedErrors.count, 1)
+        XCTAssertTrue(forwardedErrors.first is APIError)
+    }
+
+    func testNetworkServerAndContractFailuresStayDistinct() async {
+        let network = KanbanFeatureState(
+            server: URL(string: "https://example.test")!,
+            client: KanbanClientStub(configurationResult: .failure(APIError.network(underlying: URLError(.notConnectedToInternet))))
+        )
+        await network.load()
+        XCTAssertEqual(network.state, .networkUnavailable)
+
+        let server = KanbanFeatureState(
+            server: URL(string: "https://example.test")!,
+            client: KanbanClientStub(configurationResult: .failure(APIError.http(statusCode: 503, body: nil)))
+        )
+        await server.load()
+        XCTAssertEqual(server.state, .serverUnavailable)
+
+        let contract = KanbanFeatureState(
+            server: URL(string: "https://example.test")!,
+            client: KanbanClientStub(configurationResult: .failure(KanbanResponseError.nonJSONContentType))
+        )
+        await contract.load()
+        XCTAssertEqual(contract.state, .incompatibleContract)
+    }
+
+    func testStaleHandshakeCompletionCannotReplaceNewerResult() async {
+        let client = DeferredFirstConfigurationClient()
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+
+        let firstLoad = Task { await state.load() }
+        await client.waitForFirstConfiguration()
+
+        await state.load()
+        XCTAssertEqual(state.state, .compatible)
+
+        await client.resumeFirstConfiguration()
+        await firstLoad.value
+
+        XCTAssertEqual(state.state, .compatible)
+        XCTAssertFalse(state.isLoading)
+    }
+}
+
+private actor KanbanClientStub: KanbanDataClient {
+    enum Call: Equatable { case configuration, boards, board(String) }
+
+    private let configurationResult: Result<KanbanConfiguration, Error>
+    private let boardsResult: Result<KanbanBoardsResponse, Error>
+    private let boardResult: Result<KanbanBoardSnapshot, Error>
+    private var recordedCalls: [Call] = []
+
+    init(
+        configurationResult: Result<KanbanConfiguration, Error> = .success(KanbanFixtures.configuration),
+        boardsResult: Result<KanbanBoardsResponse, Error> = .success(KanbanFixtures.boards),
+        boardResult: Result<KanbanBoardSnapshot, Error> = .success(KanbanFixtures.snapshot)
+    ) {
+        self.configurationResult = configurationResult
+        self.boardsResult = boardsResult
+        self.boardResult = boardResult
+    }
+
+    func kanbanConfiguration() throws -> KanbanConfiguration {
+        recordedCalls.append(.configuration)
+        return try configurationResult.get()
+    }
+
+    func kanbanBoards() throws -> KanbanBoardsResponse {
+        recordedCalls.append(.boards)
+        return try boardsResult.get()
+    }
+
+    func kanbanBoard(board: String) throws -> KanbanBoardSnapshot {
+        recordedCalls.append(.board(board))
+        return try boardResult.get()
+    }
+
+    func calls() -> [Call] { recordedCalls }
+}
+
+private actor DeferredFirstConfigurationClient: KanbanDataClient {
+    private var configurationCalls = 0
+    private var continuation: CheckedContinuation<KanbanConfiguration, Error>?
+
+    func kanbanConfiguration() async throws -> KanbanConfiguration {
+        configurationCalls += 1
+        if configurationCalls == 1 {
+            return try await withCheckedThrowingContinuation { continuation = $0 }
+        }
+        return KanbanFixtures.configuration
+    }
+
+    func kanbanBoards() throws -> KanbanBoardsResponse { KanbanFixtures.boards }
+    func kanbanBoard(board: String) throws -> KanbanBoardSnapshot { KanbanFixtures.snapshot }
+
+    func waitForFirstConfiguration() async {
+        while continuation == nil {
+            await Task.yield()
+        }
+    }
+
+    func resumeFirstConfiguration() {
+        continuation?.resume(returning: KanbanFixtures.configuration)
+        continuation = nil
+    }
+}
+
+private enum KanbanFixtures {
+    static let configuration = decode(KanbanConfiguration.self, #"{"columns":["triage"],"read_only":false}"#)
+    static let boards = decode(KanbanBoardsResponse.self, #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#)
+    static let snapshot = decode(KanbanBoardSnapshot.self, #"{"changed":true,"read_only":false,"columns":[{"name":"triage","tasks":[]}]}"#)
+
+    private static func decode<T: Decodable>(_ type: T.Type, _ json: String) -> T {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try! decoder.decode(T.self, from: Data(json.utf8))
+    }
+}

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -59,6 +59,19 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(contract.state, .incompatibleContract)
     }
 
+    func testCancelledHandshakeReturnsToIdle() async {
+        let state = KanbanFeatureState(
+            server: URL(string: "https://example.test")!,
+            client: KanbanClientStub(configurationResult: .failure(CancellationError()))
+        )
+
+        await state.load()
+
+        XCTAssertEqual(state.state, .idle)
+        XCTAssertFalse(state.isLoading)
+        XCTAssertNil(state.report)
+    }
+
     func testStaleHandshakeCompletionCannotReplaceNewerResult() async {
         let client = DeferredFirstConfigurationClient()
         let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)


### PR DESCRIPTION
Fixes #149

## Summary
- Add tolerant Kanban wire/domain models and the non-mutating config → boards → board compatibility handshake.
- Distinguish compatible, partial, authentication, network, server-unavailable, and incompatible-contract states through a server-bound data-client seam.
- Add a Debug-only `--kanban-lab`; ordinary Debug and Release navigation remain unchanged.

## Validation
- `git diff --check`
- Focused Kanban XCTest suites
- Full XCTest suite on iPhone 17 (iOS 26.4.1)
- Signed Debug build

## Owner manual checks
1. Launch the signed Debug build with `--kanban-lab`.
2. Verify Compatible, Partial, Authentication, Network, Server unavailable, and Incompatible fixtures.
3. Tap Try Again in a retry state and verify the local retry confirmation.
4. Launch normally and confirm Kanban is absent from ordinary navigation.

Note: the local simulator service accepted the signed build but did not launch an app process after boot; retry the manual check on a healthy simulator.