### PR TITLE
fix(chat): bound cached transcript on reopen

### DIFF
--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -1199,7 +1199,8 @@ final class ChatViewModel {
                     let cachedMessages = try CacheStore.cachedMessages(
                         serverURL: server,
                         sessionID: sessionID,
-                        in: modelContext
+                        in: modelContext,
+                        limit: Self.messagePageLimit
                     )
                     reloadedMessages = Self.mergingLoadedMessages(
                         loadedMessages,
@@ -1272,7 +1273,8 @@ final class ChatViewModel {
                     let cachedMessages = try CacheStore.cachedMessages(
                         serverURL: server,
                         sessionID: sessionID,
-                        in: modelContext
+                        in: modelContext,
+                        limit: Self.messagePageLimit
                     )
                     if !cachedMessages.isEmpty {
                         clearCompressionAnchorMetadata()
@@ -1371,7 +1373,8 @@ final class ChatViewModel {
             cachedMessages = try CacheStore.cachedMessages(
                 serverURL: server,
                 sessionID: sessionID,
-                in: modelContext
+                in: modelContext,
+                limit: Self.messagePageLimit
             )
         } catch {
             // A cache read failure must not block the normal network load; fall back

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -25,20 +25,36 @@ enum CacheStore {
         serverURL: URL,
         sessionID: String,
         in context: ModelContext,
+        limit: Int? = nil,
         now: Date = Date()
     ) throws -> [ChatMessage] {
+        if let limit, limit <= 0 {
+            return []
+        }
+
         let serverURLString = serverURL.absoluteString
-        let descriptor = FetchDescriptor<CachedMessage>(
+        var descriptor = FetchDescriptor<CachedMessage>(
             predicate: #Predicate { cachedMessage in
                 cachedMessage.serverURLString == serverURLString
                     && cachedMessage.sessionID == sessionID
-            }
+                    && cachedMessage.expiresAt > now
+            },
+            sortBy: [
+                SortDescriptor(
+                    \CachedMessage.sortIndex,
+                    order: limit == nil ? .forward : .reverse
+                )
+            ]
         )
+        if let limit {
+            descriptor.fetchLimit = limit
+        }
 
-        return try context.fetch(descriptor)
-            .filter { $0.expiresAt > now }
-            .sorted { $0.sortIndex < $1.sortIndex }
-            .map(ChatMessage.init(cachedMessage:))
+        let cachedMessages = try context.fetch(descriptor)
+        if limit != nil {
+            return cachedMessages.reversed().map(ChatMessage.init(cachedMessage:))
+        }
+        return cachedMessages.map(ChatMessage.init(cachedMessage:))
     }
 
     @MainActor

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -3234,6 +3234,39 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testPrepareInitialMessageLoadBoundsLargeCachedTranscriptToNewestPage() throws {
+        let context = try makeContext()
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
+        let cachedMessages = (0..<75).map { index in
+            ChatMessage(
+                role: index.isMultiple(of: 2) ? "user" : "assistant",
+                content: "Cached message \(index)",
+                timestamp: Double(1_770_000_000 + index),
+                messageId: "cached-\(index)"
+            )
+        }
+        try CacheStore.cacheMessages(
+            cachedMessages,
+            serverURL: serverURL,
+            sessionID: "session-abc",
+            in: context
+        )
+
+        let viewModel = try makeViewModel { request in
+            XCTFail("Cache preparation must not start a request: \(request.url?.absoluteString ?? "nil")")
+            throw URLError(.badURL)
+        }
+
+        viewModel.prepareInitialMessageLoad(modelContext: context)
+
+        XCTAssertEqual(viewModel.messages.count, 50)
+        XCTAssertEqual(viewModel.messages.first?.content, "Cached message 25")
+        XCTAssertEqual(viewModel.messages.last?.content, "Cached message 74")
+        XCTAssertTrue(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isViewingCachedData)
+    }
+
+    @MainActor
     func testLoadMessagesKeepsTranscriptEmptyDuringNetworkWhenCacheIsEmpty() async throws {
         let context = try makeContext()
 


### PR DESCRIPTION
## Linked issue

Fixes #163

## What changed

- Added an optional newest-row limit to `CacheStore.cachedMessages` so SwiftData applies the bound before materializing cached models.
- Applied the existing 50-message mobile page budget to cache-first paint, offline fallback, and optimistic-message reconciliation.
- Restored chronological order after the newest-first limited fetch.
- Added a regression test that caches 75 rows and verifies reopening publishes only rows 25–74.

This addresses a path that bypassed normal `/api/session?msg_limit=50` pagination: after **Load earlier** cached an accumulated transcript, reopening synchronously published every cached row on `@MainActor` before the network reconcile. A measured tool-heavy session had 448 raw rows and about 1.27 MB of message content, which could make the app appear hung while its eager transcript stack built the cache-first view.

This is complementary to #32 / PR #33. That work targets lazy transcript rendering and scrolling; this PR prevents cache-first and offline reads from loading an unbounded transcript in the first place.

AI usage: built with Hermes Agent (OpenAI GPT-5.6 Sol).

## How it was tested

- Full `PR CI` workflow on the exact PR commit in the fork mirror: **1,390 passed, 0 failed** on iPhone 17 simulator; `Build and Test` and `CI Gate` both succeeded ([run](https://github.com/andyylin/hermex/actions/runs/29421613427)).
- Regression test `testPrepareInitialMessageLoadBoundsLargeCachedTranscriptToNewestPage` — passed.
- `swiftc -frontend -parse` on all three changed Swift files — passed on macOS 26.5.2 Command Line Tools.
- `git diff --check` — passed.
- `scripts/check-swift-file-sizes` — passed (warning-only existing oversized files).
- Upstream `PR CI` still awaits the repository's first-time-fork workflow approval; the mirror ran the same workflow at exact commit `80c28ac6ad9e7a24f78ba46ed2707520aec52597`.
- Manual simulator reopen check — not run locally because neither available Mac has full Xcode/Simulator installed.

## Checklist

- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`) — not available locally; the full macOS PR workflow passed on the exact commit in GitHub Actions.
- [x] New/changed `Codable` models decode tolerantly (no `Codable` model changes).
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked).
- [x] No invented API endpoints or JSON shapes (no API or JSON changes).
