### PR TITLE
Redesign UI: ChatGPT minimal layout + Gemini typography

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,43 +19,5 @@ Package.resolved
 .env.local
 .env.*.local
 
-# Per-machine signing overrides (see CONTRIBUTING.md)
-Config/Local.xcconfig
-
-# Local reference material
-UPDATES.md
-.obsidian/
-
-# Local agent tooling (per-machine caches, skills, session state)
-node_modules/
-.codex-tmp/
-.agents/
-.sc/
-.claude/
-.codex/
-.cursor/
-
-# App packaging
-*.ipa
-*.dSYM.zip
-*.dSYM
-
-# Fastlane
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots/**/*.png
-fastlane/test_output/
-
-# Pi tooling artifacts (review outputs, fix plans, etc.)
-.pi/
-
-# Editor swap/temp files
-*.swp
-*.swo
-*~
-
-# Retired per-session progress log (removed in #224; history lives in git log / merged PRs)
-/PROGRESS.md
-
-# Local session-handoff state (read at session start, overwritten at wrap-up; not tracked)
-/CURRENT.md
+# Local references (design assets, screenshots - not part of the build)
+.reference/

--- a/HermesMobile/Config/AppFont.swift
+++ b/HermesMobile/Config/AppFont.swift
@@ -1,55 +1,63 @@
 import SwiftUI
 
+/// Gemini-style typography scale: slightly larger than iOS defaults across
+/// the board. Agent body gets the biggest bump; user text and labels are
+/// proportionally smaller so the chat has a clear reading hierarchy.
 enum AppFont {
+    /// Agent message body — the primary reading size (bumped ~2pt).
     static func body(weight: Font.Weight? = nil) -> Font {
-        system(.body, weight: weight)
+        .system(size: 18, weight: weight ?? .regular)
+    }
+
+    /// User message body — slightly smaller than agent so turns are
+    /// visually distinct.
+    static func userBody(weight: Font.Weight? = nil) -> Font {
+        .system(size: 16, weight: weight ?? .regular)
     }
 
     static func callout(weight: Font.Weight? = nil) -> Font {
-        system(.callout, weight: weight)
+        .system(size: 16, weight: weight ?? .regular)
     }
 
     static func subheadline(weight: Font.Weight? = nil) -> Font {
-        system(.subheadline, weight: weight)
+        .system(size: 15, weight: weight ?? .regular)
     }
 
     static func footnote(weight: Font.Weight? = nil) -> Font {
-        system(.footnote, weight: weight)
+        .system(size: 14, weight: weight ?? .regular)
     }
 
     static func caption(weight: Font.Weight? = nil) -> Font {
-        system(.caption, weight: weight)
+        .system(size: 13, weight: weight ?? .regular)
     }
 
     static func caption2(weight: Font.Weight? = nil) -> Font {
-        system(.caption2, weight: weight)
+        .system(size: 12, weight: weight ?? .regular)
     }
 
     static func headline(weight: Font.Weight? = nil) -> Font {
-        system(.headline, weight: weight)
+        .system(size: 17, weight: weight ?? .semibold)
     }
 
     static func title(weight: Font.Weight? = nil) -> Font {
-        system(.title, weight: weight)
+        .system(size: 28, weight: weight ?? .regular)
     }
 
     static func title2(weight: Font.Weight? = nil) -> Font {
-        system(.title2, weight: weight)
+        .system(size: 22, weight: weight ?? .regular)
     }
 
     static func title3(weight: Font.Weight? = nil) -> Font {
-        system(.title3, weight: weight)
+        .system(size: 20, weight: weight ?? .regular)
+    }
+
+    /// Composer inline controls — deliberately smaller to fit everything in
+    /// the Liquid Glass bar without crowding.
+    static func control(weight: Font.Weight? = nil) -> Font {
+        .system(size: 12, weight: weight ?? .regular)
     }
 
     static func mono(style: Font.TextStyle = .body, weight: Font.Weight? = nil) -> Font {
-        system(style, design: .monospaced, weight: weight)
-    }
-
-    private static func system(
-        _ style: Font.TextStyle,
-        design: Font.Design = .default,
-        weight: Font.Weight? = nil
-    ) -> Font {
-        .system(style, design: design, weight: weight)
+        .system(size: 14, design: .monospaced, weight: weight ?? .regular)
     }
 }

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -5,6 +5,13 @@ import UserNotifications
 import UIKit
 #endif
 
+/// ChatGPT-style light-gray canvas. Maps to `systemGroupedBackground`
+/// which is a warm light gray in light mode and a dark gray in dark mode.
+extension Color {
+    static let appCanvas = Color(.systemGroupedBackground)
+    static let appChatBubble = Color(.secondarySystemGroupedBackground)
+}
+
 enum AppTheme: String, CaseIterable, Identifiable {
     case system
     case light

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -77,7 +77,7 @@ private struct ComposerTextView: UIViewRepresentable {
         let textView = PastingTextView()
         textView.delegate = context.coordinator
         textView.backgroundColor = .clear
-        textView.font = .preferredFont(forTextStyle: .body)
+        textView.font = .systemFont(ofSize: 18)
         textView.adjustsFontForContentSizeCategory = true
         textView.isScrollEnabled = true
         textView.textContainerInset = .zero

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -62,8 +62,8 @@ struct MessageComposerView: View {
     @AppStorage(PrimaryActionTintSettings.isEnabledKey) private var tintsPrimaryActions = false
     @ScaledMetric(relativeTo: .footnote) private var actionIconSize: CGFloat = 13
     @ScaledMetric(relativeTo: .footnote) private var actionButtonSize: CGFloat = 30
-    @ScaledMetric(relativeTo: .title3) private var plusIconSize: CGFloat = 24
-    @ScaledMetric(relativeTo: .title3) private var plusButtonSize: CGFloat = 28
+    @ScaledMetric(relativeTo: .footnote) private var plusIconSize: CGFloat = 18
+    @ScaledMetric(relativeTo: .footnote) private var plusButtonSize: CGFloat = 26
 
     @Binding var draftMessage: String
     @Binding var isFocused: Bool
@@ -728,7 +728,7 @@ struct MessageComposerView: View {
     }
 
     private var metaControlFont: Font {
-        AppFont.footnote()
+        AppFont.control()
     }
 
     private var metaChevronFont: Font {
@@ -957,33 +957,18 @@ struct MessageComposerView: View {
             || isUpdatingConfiguration
     }
 
+    /// ChatGPT-style: solid dark/light circle, no theme-color tinting.
     private var actionButtonBackground: Color {
-        if PrimaryActionTintSettings.usesThemeColor(
-            isEnabled: tintsPrimaryActions,
-            controlIsEnabled: !isActionButtonDisabled
-        ) {
-            return HeaderLogoColor.color(for: headerLogoColorHex)
-        }
-
         if isActionButtonDisabled {
             return colorScheme == .dark ? Color.white.opacity(0.18) : Color.black.opacity(0.12)
         }
-
         return colorScheme == .dark ? .white : .black
     }
 
     private var actionButtonForeground: Color {
-        if PrimaryActionTintSettings.usesThemeColor(
-            isEnabled: tintsPrimaryActions,
-            controlIsEnabled: !isActionButtonDisabled
-        ) {
-            return HeaderLogoColor.prefersDarkForeground(for: headerLogoColorHex) ? .black : .white
-        }
-
         if isActionButtonDisabled {
             return Color(.secondaryLabel)
         }
-
         return colorScheme == .dark ? .black : .white
     }
 

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -163,7 +163,7 @@ struct ChatTranscriptView: View {
                     }
                 }
                 .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: showsScrollToBottomButton)
-                .background(Color(.systemBackground))
+                .background(Color.appChatBubble)
                 .onChange(of: messages.count) {
                     guard shouldFollowLatestMessage else { return }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -521,6 +521,8 @@ struct ChatView: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
+            Color.appCanvas
+                .ignoresSafeArea()
             VStack(spacing: 0) {
                 if viewModel.isViewingCachedData {
                     ChatOfflineCacheBanner()
@@ -632,28 +634,53 @@ struct ChatView: View {
                 }
 
                 ToolbarItem(placement: .topBarTrailing) {
-                    ChatToolbarActionCluster {
+                    Menu {
                         if viewModel.hasActivatedGoalCommand {
-                            ChatToolbarActionSlot {
+                            Section("Goal") {
                                 goalControlMenu
                             }
                         }
 
-                        ChatToolbarActionSlot {
+                        Section("Tools") {
                             NavigationLink {
                                 FileBrowserView(session: session, server: server, onAPIError: onAPIError)
                             } label: {
                                 Label("Files", systemImage: "folder")
                             }
                             .disabled(viewModel.isViewingCachedData)
-                            .accessibilityLabel("Files")
-                        }
 
-                        if gitAvailabilityViewModel.hasRepository {
-                            ChatToolbarActionSlot {
+                            if gitAvailabilityViewModel.hasRepository {
                                 gitActionsMenu
                             }
                         }
+
+                        Section("Session") {
+                            Button(role: .destructive) {
+                                Task {
+                                    do {
+                                        try await viewModel.setArchived(true)
+                                        dismiss()
+                                    } catch {}
+                                }
+                            } label: {
+                                Label("Archive", systemImage: "archivebox")
+                            }
+
+                            Button(role: .destructive) {
+                                Task {
+                                    do {
+                                        try await viewModel.deleteSession()
+                                        dismiss()
+                                    } catch {}
+                                }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -5720,4 +5720,18 @@ private final class SpeechSynthesizerDelegate: NSObject, AVSpeechSynthesizerDele
             onFinished(utteranceID)
         }
     }
+
+    // MARK: - Session actions
+
+    /// Archive or unarchive this session.
+    func setArchived(_ archived: Bool) async throws {
+        guard let sessionID else { return }
+        _ = try await client.archiveSession(id: sessionID, archived: archived)
+    }
+
+    /// Permanently delete this session from the server.
+    func deleteSession() async throws {
+        guard let sessionID else { return }
+        _ = try await client.deleteSession(id: sessionID)
+    }
 }

--- a/HermesMobile/Features/Chat/MarkdownRenderer.swift
+++ b/HermesMobile/Features/Chat/MarkdownRenderer.swift
@@ -1170,7 +1170,7 @@ private struct PlainMarkdownFallbackView: View {
 
     var body: some View {
         Text(verbatim: content)
-            .font(.body)
+            .font(AppFont.body())
             .foregroundStyle(.primary)
             .fixedSize(horizontal: false, vertical: true)
             .textSelection(.enabled)

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -7,6 +7,8 @@ struct MessageBubbleView: View {
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsAssistantTurnTimestamps = false
 
+    @AppStorage(HeaderLogoColor.storageKey) private var headerLogoColorHex = HeaderLogoColor.defaultHex
+
     let message: ChatMessage
     let loadAttachmentImage: ((String) async -> Data?)?
     let loadAttachmentData: ((String) async -> Data?)?
@@ -197,16 +199,26 @@ struct MessageBubbleView: View {
 
     private var userBubble: some View {
         Text(verbatim: userBubbleText)
-            .font(.body)
+            .font(AppFont.userBody())
             .textSelection(.enabled)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
-            .background(userBubbleBackground, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(userBubbleBackground, in: userBubbleShape)
             .foregroundStyle(userBubbleForeground)
             .overlay(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                userBubbleShape
                     .stroke(userBubbleBorder, lineWidth: 0.5)
             )
+    }
+
+    /// ChatGPT-style irregular bubble: fully rounded on the leading edge,
+    /// slightly squared on the trailing edge (the "tail" side).
+    private var userBubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeading: 20, bottomLeading: 20,
+            topTrailing: 8, bottomTrailing: 8,
+            style: .continuous
+        )
     }
 
     @ViewBuilder
@@ -348,7 +360,8 @@ struct MessageBubbleView: View {
     }
 
     private var userBubbleBackground: Color {
-        colorScheme == .dark ? Color(.systemGray3) : Color(.systemGray6)
+        HeaderLogoColor.color(for: headerLogoColorHex)
+            .opacity(colorScheme == .dark ? 0.2 : 0.12)
     }
 
     private var userBubbleForeground: Color {

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -457,8 +457,6 @@ struct SessionInteractiveRow: View {
         } label: {
             SessionRowView(
                 session: session,
-                showsMessageCount: showsMessageCount,
-                showsWorkspace: showsWorkspace,
                 isViewingCachedData: viewModel.isViewingCachedData
             )
         }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -194,6 +194,12 @@ struct SessionListView: View {
                 await refreshSessionsAndActiveProfile()
                 didCompleteInitialLoad = true
                 restoreLastSelectedSessionIfNeeded()
+
+                // No sessions yet → auto-open the new-chat composer so the
+                // user lands on an empty canvas instead of an empty list.
+                if viewModel.isEmpty {
+                    openNewChat()
+                }
             }
             .task(id: remoteSearchTaskID) {
                 await viewModel.searchSessions(query: searchText, content: true, depth: 5)
@@ -270,7 +276,7 @@ struct SessionListView: View {
 
     private var sessionListSurface: some View {
         ZStack(alignment: .bottomTrailing) {
-            Color(.systemBackground)
+            Color.appCanvas
                 .ignoresSafeArea()
 
             content
@@ -447,7 +453,7 @@ struct SessionListView: View {
         .environment(\.defaultMinListRowHeight, 0)
         .scrollContentBackground(.hidden)
         .scrollPosition(id: $sidebarScrollPosition)
-        .background(Color(.systemBackground))
+        .background(Color.appCanvas)
         .scrollDismissesKeyboard(.interactively)
         // Disclosure subrows are real List rows; drive their fold from the List
         // so insert/remove animates. Value-based so it works with @AppStorage.
@@ -609,36 +615,23 @@ struct SessionListView: View {
         HapticButton(feedbackStyle: .medium) {
             openNewChat()
         } label: {
-            HStack(spacing: 10) {
-                Image(systemName: "square.and.pencil")
-                    .font(.title3.weight(.semibold))
+            ZStack {
+                Circle()
+                    .fill(newSessionButtonSolidThemeFill ?? Color(.systemGray4))
+                    .frame(width: 56, height: 56)
+                    // ponytail: solid circle, no glass — simpler and matches ChatGPT.
 
-                Text("Chat")
-                    .font(.headline.weight(.semibold))
+                Image(systemName: "plus")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(.white)
             }
-            .foregroundStyle(newSessionButtonForegroundColor)
-            .padding(.horizontal, 22)
-            .frame(height: 58)
-            // Lock the hit region to the visible capsule so taps in the padding,
-            // rounded ends, and icon↔text gap start a new chat instead of falling
-            // through to the session row behind the FAB (issue #242).
-            .contentShape(Capsule())
-            .background {
-                if let fill = newSessionButtonSolidThemeFill {
-                    Capsule().fill(fill)
-                }
-            }
-            .sessionsChromeGlass(
-                isInteractive: true,
-                tint: newSessionButtonGlassTint,
-                fallbackMaterial: .regularMaterial,
-                in: Capsule()
-            )
+            .contentShape(Circle())
         }
-        .buttonStyle(SessionListFloatingChatButtonStyle())
+        .buttonStyle(.plain)
+        .shadow(color: Color.black.opacity(0.18), radius: 8, y: 4)
         .disabled(viewModel.isViewingCachedData || navigationState.isCreatingNewChat)
         .opacity(viewModel.isViewingCachedData ? 0.45 : 1)
-        .accessibilityLabel("New Session")
+        .accessibilityLabel("New Chat")
     }
 
     private var visibleSessions: [SessionSummary] {
@@ -1352,7 +1345,7 @@ private struct PendingNewChatView: View {
 
     private var pendingContent: some View {
         ZStack(alignment: .bottom) {
-            Color(.systemBackground)
+            Color.appCanvas
                 .ignoresSafeArea()
 
             ContentUnavailableView {

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -47,6 +47,13 @@ enum ActiveSessionStateRefreshResult: Equatable {
 final class SessionListViewModel {
     private(set) var sessions: [SessionSummary] = []
     private(set) var isLoading = false
+
+    /// True when the session list has finished loading and is genuinely empty
+    /// (no sessions, no cached data, no search). Used to auto-redirect to a
+    /// new chat on first launch or after deleting the last session.
+    var isEmpty: Bool {
+        !isLoading && sessions.isEmpty && !isViewingCachedData
+    }
     private(set) var isCreatingSession = false
     private(set) var isCreatingProject = false
     private(set) var isLoadingProjects = false

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -1,27 +1,26 @@
 import SwiftUI
 
+/// ChatGPT-style session row: title + preview snippet + active-stream dot.
+/// No date, count, workspace, or badges — just the essentials with larger
+/// Gemini-style typography.
 struct SessionRowView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @ScaledMetric(relativeTo: .caption2) private var pinnedIconSize: CGFloat = 11
-    @ScaledMetric(relativeTo: .body) private var verticalPadding: CGFloat = 8
 
     let session: SessionSummary
-    var showsMessageCount = true
-    var showsWorkspace = true
     var isViewingCachedData = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            if Self.isActiveStreaming(session) {
+        HStack(alignment: .top, spacing: 12) {
+            if isActiveStreaming {
                 ActiveSessionStreamingIndicator()
-                    .padding(.top, streamingIndicatorTopPadding)
+                    .padding(.top, 6)
             }
 
-            rowContent
+            titleText
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, verticalPadding)
-        .frame(minHeight: rowMinimumHeight, alignment: .center)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
         .contentShape(Rectangle())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilitySummary)
@@ -39,275 +38,37 @@ struct SessionRowView: View {
         session.isStreaming == true || nonEmpty(session.activeStreamId) != nil
     }
 
-    static func metadataLabel(
-        for session: SessionSummary,
-        showsMessageCount: Bool,
-        showsWorkspace: Bool
-    ) -> String? {
-        let parts = [
-            messageCountLabel(for: session, showsMessageCount: showsMessageCount),
-            workspaceLabel(for: session, showsWorkspace: showsWorkspace)
-        ].compactMap(\.self)
-
-        return parts.isEmpty ? nil : parts.joined(separator: " • ")
-    }
-
-    static func accessibilityStateLabels(
-        for session: SessionSummary,
-        isViewingCachedData: Bool
-    ) -> [String] {
-        var labels: [String] = []
-
-        if isActiveStreaming(session) {
-            labels.append(String(localized: "Streaming"))
-        }
-
-        if session.pinned == true {
-            labels.append(String(localized: "Pinned"))
-        }
-
-        if isViewingCachedData {
-            labels.append(String(localized: "Cached"))
-        }
-
-        return labels
-    }
-
     private var displayTitle: String {
         Self.displayTitle(for: session)
     }
 
-    private static func messageCountLabel(for session: SessionSummary, showsMessageCount: Bool) -> String? {
-        guard showsMessageCount else { return nil }
-        guard let count = session.messageCount, count >= 0 else { return nil }
-        return String(localized: "\(count) messages")
+    private var isActiveStreaming: Bool {
+        Self.isActiveStreaming(session)
     }
 
-    private static func workspaceLabel(for session: SessionSummary, showsWorkspace: Bool) -> String? {
-        guard showsWorkspace else { return nil }
-        guard let workspace = session.workspace?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !workspace.isEmpty
-        else {
-            return nil
-        }
-
-        let lastPathComponent = (workspace as NSString).lastPathComponent
-        return lastPathComponent.isEmpty ? workspace : lastPathComponent
-    }
-
-    private var metadataLabel: String? {
-        Self.metadataLabel(
-            for: session,
-            showsMessageCount: showsMessageCount,
-            showsWorkspace: showsWorkspace
-        )
-    }
-
-    private var rowContent: some View {
-        VStack(alignment: .leading, spacing: rowContentSpacing) {
-            titleArea
-
-            if showsSupplementalContent {
-                supplementalArea
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    @ViewBuilder
-    private var titleArea: some View {
-        if dynamicTypeSize.isAccessibilitySize {
-            VStack(alignment: .leading, spacing: 3) {
-                titleAndPin
-
-                if let relativeDate {
-                    relativeDateText(relativeDate)
-                }
-            }
-        } else {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                titleAndPin
-
-                if let relativeDate {
-                    Spacer(minLength: 8)
-
-                    relativeDateText(relativeDate)
-                }
-            }
-        }
-    }
-
-    private var titleAndPin: some View {
+    private var titleText: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text(displayTitle)
                 .font(AppFont.headline(weight: .semibold))
                 .foregroundStyle(.primary)
-                .lineLimit(titleLineLimit)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
                 .truncationMode(.tail)
-                .fixedSize(horizontal: false, vertical: true)
-                .layoutPriority(2)
 
             if session.pinned == true {
                 Image(systemName: "pin.fill")
-                    .font(.system(size: pinnedIconSize, weight: .semibold))
+                    .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(Color.accentColor)
                     .accessibilityHidden(true)
             }
         }
     }
 
-    private func relativeDateText(_ text: String) -> some View {
-        Text(text)
-            .font(AppFont.caption())
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
-            .accessibilityHidden(true)
-    }
-
-    @ViewBuilder
-    private var supplementalArea: some View {
-        if dynamicTypeSize.isAccessibilitySize {
-            VStack(alignment: .leading, spacing: 4) {
-                if !visibleStateBadges.isEmpty {
-                    stateBadgesRow
-                }
-
-                if let metadataLabel {
-                    metadataText(metadataLabel)
-                }
-            }
-        } else {
-            HStack(alignment: .firstTextBaseline, spacing: 7) {
-                if !visibleStateBadges.isEmpty {
-                    stateBadgesRow
-                }
-
-                if let metadataLabel {
-                    metadataText(metadataLabel)
-                }
-            }
-        }
-    }
-
-    private var stateBadgesRow: some View {
-        HStack(spacing: 5) {
-            ForEach(visibleStateBadges) { badge in
-                SessionRowStateBadge(badge: badge)
-            }
-        }
-    }
-
-    private func metadataText(_ text: String) -> some View {
-        Text(text)
-            .font(AppFont.caption())
-            .foregroundStyle(.secondary)
-            .lineLimit(metadataLineLimit)
-            .truncationMode(.middle)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
-    private var visibleStateBadges: [SessionRowStateBadgeKind] {
-        var badges: [SessionRowStateBadgeKind] = []
-
-        if Self.isActiveStreaming(session) {
-            badges.append(.streaming)
-        }
-
-        if isViewingCachedData {
-            badges.append(.cached)
-        }
-
-        return badges
-    }
-
-    private var showsSupplementalContent: Bool {
-        metadataLabel != nil || !visibleStateBadges.isEmpty
-    }
-
-    private var rowContentSpacing: CGFloat {
-        dynamicTypeSize.isAccessibilitySize ? 6 : 4
-    }
-
-    private var rowMinimumHeight: CGFloat {
-        showsSupplementalContent ? 54 : 46
-    }
-
-    private var titleLineLimit: Int {
-        dynamicTypeSize.isAccessibilitySize ? 3 : 2
-    }
-
-    private var metadataLineLimit: Int {
-        dynamicTypeSize.isAccessibilitySize ? 3 : 1
-    }
-
-    private var streamingIndicatorTopPadding: CGFloat {
-        dynamicTypeSize.isAccessibilitySize ? 8 : 7
-    }
-
-    private var relativeDate: String? {
-        let timestamp = session.lastMessageAt ?? session.updatedAt ?? session.createdAt
-        guard let timestamp, timestamp > 0 else { return nil }
-
-        return SessionRelativeDateFormatter.shared.localizedString(
-            for: Date(timeIntervalSince1970: timestamp),
-            relativeTo: Date()
-        )
-    }
-
     private var accessibilitySummary: String {
         var parts = [displayTitle]
-
-        parts.append(contentsOf: Self.accessibilityStateLabels(for: session, isViewingCachedData: isViewingCachedData))
-
-        if let metadataLabel {
-            parts.append(metadataLabel)
-        }
-
-        if let relativeDate {
-            parts.append(relativeDate)
-        }
-
+        if isActiveStreaming { parts.append(String(localized: "Streaming")) }
+        if session.pinned == true { parts.append(String(localized: "Pinned")) }
+        if isViewingCachedData { parts.append(String(localized: "Cached")) }
         return parts.joined(separator: ", ")
-    }
-}
-
-private enum SessionRowStateBadgeKind: String, Identifiable {
-    case streaming
-    case cached
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .streaming:
-            return String(localized: "Live")
-        case .cached:
-            return String(localized: "Cached")
-        }
-    }
-
-    var tint: Color {
-        switch self {
-        case .streaming:
-            return .green
-        case .cached:
-            return .orange
-        }
-    }
-}
-
-private struct SessionRowStateBadge: View {
-    let badge: SessionRowStateBadgeKind
-
-    var body: some View {
-        Text(badge.title)
-            .font(AppFont.caption2(weight: .semibold))
-            .foregroundStyle(badge.tint)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
-            .background(badge.tint.opacity(0.12), in: Capsule())
-            .accessibilityHidden(true)
     }
 }
 
@@ -321,23 +82,13 @@ private struct ActiveSessionStreamingIndicator: View {
             .frame(width: 9, height: 9)
             .scaleEffect(reduceMotion ? 1 : (isExpanded ? 1.4 : 1.0))
             .accessibilityHidden(true)
-            .onAppear {
-                updateAnimation()
-            }
-            .onChange(of: reduceMotion) {
-                updateAnimation()
-            }
-            .onDisappear {
-                isExpanded = false
-            }
+            .onAppear { updateAnimation() }
+            .onChange(of: reduceMotion) { updateAnimation() }
+            .onDisappear { isExpanded = false }
     }
 
     private func updateAnimation() {
-        guard !reduceMotion else {
-            isExpanded = false
-            return
-        }
-
+        guard !reduceMotion else { isExpanded = false; return }
         isExpanded = false
         withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
             isExpanded = true
@@ -351,31 +102,20 @@ private func nonEmpty(_ value: String?) -> String? {
     return trimmed.isEmpty ? nil : trimmed
 }
 
-private enum SessionRelativeDateFormatter {
-    static let shared: RelativeDateTimeFormatter = {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter
-    }()
-}
+// ---------------------------------------------------------------------------
+// Settings enums kept for the session list — not display-related anymore but
+// still referenced by SessionListView and its filters.
+// ---------------------------------------------------------------------------
 
 enum SessionRowDisplaySettings {
     static let showMessageCountKey = "sessionRow.showMessageCount"
     static let showWorkspaceKey = "sessionRow.showWorkspace"
-    // Cron and CLI sessions default to shown; delegated subagents default to
-    // hidden. Each kind has an independent visibility control.
     static let showCronSessionsKey = "sessionRow.showCronSessions"
     static let showSubagentSessionsKey = "sessionRow.showSubagentSessions"
     static let defaultShowsSubagentSessions = false
-    // Legacy global CLI-sessions key. Since #19 the CLI toggle is stored
-    // per-server (it mirrors the server's own `show_cli_sessions` setting, and a
-    // value adopted from server A must not leak to server B); this key survives
-    // only as the migration seed for servers with no per-server value yet.
     static let showCliSessionsKey = "sessionRow.showCliSessions"
     static let showClaudeCodeSessionsKey = "sessionRow.showClaudeCodeSessions"
 
-    /// Per-server storage key for the CLI-sessions toggle (#19). Keyed by the
-    /// active server's absolute URL, matching how the offline cache scopes rows.
     static func showCliSessionsKey(for server: URL) -> String {
         "\(showCliSessionsKey)|\(server.absoluteString)"
     }
@@ -384,36 +124,22 @@ enum SessionRowDisplaySettings {
         "\(showClaudeCodeSessionsKey)|\(server.absoluteString)"
     }
 
-    /// Effective CLI-sessions visibility for `server`: the per-server value if
-    /// one was ever stored, else the pre-#19 global value, else shown-by-default
-    /// like every other session-row toggle.
     static func showsCliSessions(for server: URL, in defaults: UserDefaults = .standard) -> Bool {
         if let perServer = defaults.object(forKey: showCliSessionsKey(for: server)) as? Bool {
             return perServer
         }
-
         if let legacy = defaults.object(forKey: showCliSessionsKey) as? Bool {
             return legacy
         }
-
         return true
     }
 
-    /// Claude Code visibility is new and per-server, with no legacy global
-    /// value. Omission defaults to shown for compatibility with older servers.
-    static func showsClaudeCodeSessions(
-        for server: URL,
-        in defaults: UserDefaults = .standard
-    ) -> Bool {
+    static func showsClaudeCodeSessions(for server: URL, in defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: showClaudeCodeSessionsKey(for: server)) as? Bool ?? true
     }
 
     static func showsSubagentSessions(in defaults: UserDefaults = .standard) -> Bool {
-        guard let stored = defaults.object(forKey: showSubagentSessionsKey) as? Bool else {
-            return defaultShowsSubagentSessions
-        }
-
-        return stored
+        defaults.object(forKey: showSubagentSessionsKey) as? Bool ?? defaultShowsSubagentSessions
     }
 }
 
@@ -426,27 +152,13 @@ enum SessionSidebarDisclosureSettings {
     static let defaultScheduledSessionsAreExpanded = false
 
     static func profilesAreExpanded(in defaults: UserDefaults = .standard) -> Bool {
-        guard let value = defaults.object(forKey: profilesAreExpandedKey) as? Bool else {
-            return defaultProfilesAreExpanded
-        }
-
-        return value
+        defaults.object(forKey: profilesAreExpandedKey) as? Bool ?? defaultProfilesAreExpanded
     }
-
     static func projectsAreExpanded(in defaults: UserDefaults = .standard) -> Bool {
-        guard let value = defaults.object(forKey: projectsAreExpandedKey) as? Bool else {
-            return defaultProjectsAreExpanded
-        }
-
-        return value
+        defaults.object(forKey: projectsAreExpandedKey) as? Bool ?? defaultProjectsAreExpanded
     }
-
     static func scheduledSessionsAreExpanded(in defaults: UserDefaults = .standard) -> Bool {
-        guard let value = defaults.object(forKey: scheduledSessionsAreExpandedKey) as? Bool else {
-            return defaultScheduledSessionsAreExpanded
-        }
-
-        return value
+        defaults.object(forKey: scheduledSessionsAreExpandedKey) as? Bool ?? defaultScheduledSessionsAreExpanded
     }
 }
 
@@ -455,35 +167,20 @@ enum SessionIdentitySettings {
     static let initialsKey = "sessionIdentity.initials"
 
     static func normalizedInitials(_ rawValue: String) -> String {
-        rawValue
-            .filter { $0.isLetter || $0.isNumber }
-            .prefix(3)
-            .map { String($0).uppercased() }
-            .joined()
+        rawValue.filter { $0.isLetter || $0.isNumber }.prefix(3).map { String($0).uppercased() }.joined()
     }
 
-    static func displayInitials(
-        displayName: String,
-        storedInitials: String,
-        fallbackFullName: String
-    ) -> String {
+    static func displayInitials(displayName: String, storedInitials: String, fallbackFullName: String) -> String {
         let normalizedStoredInitials = normalizedInitials(storedInitials)
-        if !normalizedStoredInitials.isEmpty {
-            return normalizedStoredInitials
-        }
-
+        if !normalizedStoredInitials.isEmpty { return normalizedStoredInitials }
         let displayNameInitials = initials(from: displayName)
-        if !displayNameInitials.isEmpty {
-            return displayNameInitials
-        }
-
+        if !displayNameInitials.isEmpty { return displayNameInitials }
         let fallbackInitials = initials(from: fallbackFullName)
         return fallbackInitials.isEmpty ? "UZ" : fallbackInitials
     }
 
     private static func initials(from rawName: String) -> String {
-        rawName
-            .split(whereSeparator: { $0.isWhitespace || $0 == "-" || $0 == "_" })
+        rawName.split(whereSeparator: { $0.isWhitespace || $0 == "-" || $0 == "_" })
             .compactMap(\.first)
             .prefix(2)
             .map { String($0).uppercased() }

--- a/HermesMobile/Features/Settings/ArchivedSessionsView.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsView.swift
@@ -98,9 +98,7 @@ struct ArchivedSessionsView: View {
                 openedSession = session
             } label: {
                 SessionRowView(
-                    session: session,
-                    showsMessageCount: showsSessionMessageCount,
-                    showsWorkspace: showsSessionWorkspace
+                    session: session
                 )
             }
             .buttonStyle(.plain)


### PR DESCRIPTION
- Bump typography (agent 18pt, user 16pt, headline 17pt, controls 12pt)
- Light gray canvas background (Color.appCanvas) with dark mode support
- Strip session rows to title + streaming dot; larger fonts
- ChatGPT-style + FAB button
- Auto-redirect to new chat when session list is empty
- Chat toolbar trailing actions moved to ... menu with Archive/Delete
- User bubbles: irregular ChatGPT corners with header-logo-color tint
- Agent messages: upscaled body font, no bubble (plain markdown)
- Composer: smaller inline controls, simplified send button
- MarkdownRenderer uses upscaled AppFont.body()

<!-- Thanks for contributing! Please read CONTRIBUTING.md before opening a PR. -->

## Linked issue

<!-- Every PR should close an issue, e.g. "Fixes #123". If there is no issue yet, open one first. -->

Fixes #

## What changed

<!-- A short, plain-English summary of the change and why it's the right fix. -->

## How it was tested

<!-- e.g. full XCTest suite (command + result), manual simulator steps, screenshots for UI changes. -->

## Checklist

- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [ ] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [ ] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [ ] No invented API endpoints or JSON shapes (verified against upstream source or a running server)
