### PR TITLE
NetBird instructions and more generic terms for private networks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ read the [Code of Conduct](CODE_OF_CONDUCT.md).
 - To actually use the app you need your own
   [hermes-webui](https://github.com/nesquena/hermes-webui) server — the app is
   a client only. See the [README](README.md#you-need-your-own-server) for
-  reachable-server options (Cloudflare Tunnel, reverse proxy, Tailscale, or
+  reachable-server options (Cloudflare Tunnel, reverse proxy, Tailscale, NetBird, or
   `http://localhost:8787` for simulator-only testing).
 
 ## Running tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,7 +59,7 @@ cd hermes-webui
 
 2. Run it with Docker or directly with Python, following the upstream README.
 
-For simulator-only testing, `http://localhost:8787` can work when the server is running on the same Mac. For physical-device testing, use HTTPS or a Tailscale `100.64.0.0/10` IP; TestFlight builds include a scoped ATS exception for that Tailscale range.
+For simulator-only testing, `http://localhost:8787` can work when the server is running on the same Mac. For physical-device testing, use HTTPS or a supported Tailscale/NetBird IP in `100.64.0.0/10`; TestFlight builds include a scoped ATS exception for that private-network range.
 
 ## Example Server Setup (macOS + launchd)
 

--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -81,7 +81,7 @@
 		C15210000000000000000002 /* OnboardingWelcomePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000002 /* OnboardingWelcomePage.swift */; };
 		C15210000000000000000003 /* OnboardingFeaturesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000003 /* OnboardingFeaturesPage.swift */; };
 		C15210000000000000000004 /* OnboardingAgentPromptPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000004 /* OnboardingAgentPromptPage.swift */; };
-		C15210000000000000000005 /* OnboardingTailscalePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000005 /* OnboardingTailscalePage.swift */; };
+		C15210000000000000000005 /* OnboardingPrivateNetworkPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000005 /* OnboardingPrivateNetworkPage.swift */; };
 		C15210000000000000000006 /* OnboardingConnectPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000006 /* OnboardingConnectPage.swift */; };
 		C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000007 /* OnboardingFlowTests.swift */; };
 		C0391000000000000000000F /* SessionListMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000F /* SessionListMutationTests.swift */; };
@@ -420,7 +420,7 @@
 		C15200000000000000000002 /* OnboardingWelcomePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomePage.swift; sourceTree = "<group>"; };
 		C15200000000000000000003 /* OnboardingFeaturesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFeaturesPage.swift; sourceTree = "<group>"; };
 		C15200000000000000000004 /* OnboardingAgentPromptPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAgentPromptPage.swift; sourceTree = "<group>"; };
-		C15200000000000000000005 /* OnboardingTailscalePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTailscalePage.swift; sourceTree = "<group>"; };
+		C15200000000000000000005 /* OnboardingPrivateNetworkPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPrivateNetworkPage.swift; sourceTree = "<group>"; };
 		C15200000000000000000006 /* OnboardingConnectPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConnectPage.swift; sourceTree = "<group>"; };
 		C15200000000000000000007 /* OnboardingFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowTests.swift; sourceTree = "<group>"; };
 		C0390000000000000000000F /* SessionListMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListMutationTests.swift; sourceTree = "<group>"; };
@@ -947,7 +947,7 @@
 				C15200000000000000000004 /* OnboardingAgentPromptPage.swift */,
 				C15200000000000000000003 /* OnboardingFeaturesPage.swift */,
 				C15200000000000000000001 /* OnboardingFlowPolicy.swift */,
-				C15200000000000000000005 /* OnboardingTailscalePage.swift */,
+				C15200000000000000000005 /* OnboardingPrivateNetworkPage.swift */,
 				C15200000000000000000002 /* OnboardingWelcomePage.swift */,
 				1A2B3C4D5E6F70000000411 /* OnboardingComponents.swift */,
 				1A2B3C4D5E6F7000000000B6 /* OnboardingViewModel.swift */,
@@ -1479,7 +1479,7 @@
 				C15210000000000000000004 /* OnboardingAgentPromptPage.swift in Sources */,
 				C15210000000000000000003 /* OnboardingFeaturesPage.swift in Sources */,
 				C15210000000000000000001 /* OnboardingFlowPolicy.swift in Sources */,
-				C15210000000000000000005 /* OnboardingTailscalePage.swift in Sources */,
+				C15210000000000000000005 /* OnboardingPrivateNetworkPage.swift in Sources */,
 				C15210000000000000000002 /* OnboardingWelcomePage.swift in Sources */,
 				1A2B3C4D5E6F70000000410 /* OnboardingComponents.swift in Sources */,
 				1A2B3C4D5E6F7000000000A6 /* OnboardingViewModel.swift in Sources */,

--- a/HermesMobile/Features/Onboarding/OnboardingAgentPromptPage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingAgentPromptPage.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct OnboardingAgentPromptPage: View {
     @Binding var hasCopiedAgentPrompt: Bool
+    @Binding var privateNetworkProvider: PrivateNetworkProvider
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -10,11 +11,13 @@ struct OnboardingAgentPromptPage: View {
                     stepNumber: 1,
                     icon: "terminal",
                     title: String(localized: "Set up Hermes Web UI"),
-                    description: String(localized: "Send this prompt to your Hermes Agent. It installs Hermes Web UI, enables password auth, and configures Tailscale access.")
+                    description: String(localized: "Choose your private network, then send the setup prompt to your Hermes Agent.")
                 )
 
+                OnboardingNetworkProviderPicker(selection: $privateNetworkProvider)
+
                 OnboardingAgentPromptCard(
-                    prompt: OnboardingFlowPolicy.agentSetupPrompt,
+                    prompt: privateNetworkProvider.setupPrompt,
                     hasCopied: $hasCopiedAgentPrompt
                 )
             }
@@ -23,5 +26,8 @@ struct OnboardingAgentPromptPage: View {
             .padding(.bottom, 16)
         }
         .scrollBounceBehavior(.basedOnSize)
+        .onChange(of: privateNetworkProvider) {
+            hasCopiedAgentPrompt = false
+        }
     }
 }

--- a/HermesMobile/Features/Onboarding/OnboardingComponents.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingComponents.swift
@@ -270,6 +270,46 @@ struct OnboardingAgentPromptCard: View {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(Color.white.opacity(0.1), lineWidth: 1)
         )
+        .onChange(of: prompt) {
+            didCopyRecently = false
+        }
+    }
+}
+
+struct OnboardingNetworkProviderPicker: View {
+    @Binding var selection: PrivateNetworkProvider
+
+    private let accent = Color(red: 1.0, green: 0.74, blue: 0.10)
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(PrivateNetworkProvider.allCases) { provider in
+                Button {
+                    selection = provider
+                } label: {
+                    Text(provider.rawValue)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(selection == provider ? Color.black : Color.white.opacity(0.72))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(
+                            selection == provider ? accent : Color.clear,
+                            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(selection == provider ? .isSelected : [])
+            }
+        }
+        .padding(4)
+        .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 11, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Private network")
+        .accessibilityHint("Changes the setup prompt and iPhone installation instructions.")
     }
 }
 

--- a/HermesMobile/Features/Onboarding/OnboardingConnectPage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingConnectPage.swift
@@ -30,7 +30,7 @@ struct OnboardingConnectPage: View {
                         .font(.title3.weight(.bold))
                         .foregroundStyle(.white)
 
-                    Text("Enter the Tailscale URL your agent returned, for example `http://<tailnet-ip>:8787`.")
+                    Text("Enter the private-network URL your agent returned, for example `http://<server-ip>:8787`.")
                         .font(.footnote)
                         .foregroundStyle(.white.opacity(0.5))
                         .fixedSize(horizontal: false, vertical: true)

--- a/HermesMobile/Features/Onboarding/OnboardingFeaturesPage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingFeaturesPage.swift
@@ -4,11 +4,11 @@ struct OnboardingFeaturesPage: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private let features: [(icon: String, color: Color, title: String, subtitle: String)] = [
-        ("bubble.left.and.bubble.right.fill", Color(red: 1.0, green: 0.74, blue: 0.10), String(localized: "Chat with your Hermes agent from iPhone"), String(localized: "Drive conversations from anywhere on your tailnet.")),
+        ("bubble.left.and.bubble.right.fill", Color(red: 1.0, green: 0.74, blue: 0.10), String(localized: "Chat with your Hermes agent from iPhone"), String(localized: "Drive conversations from anywhere on your private network.")),
         ("list.bullet.rectangle.portrait.fill", .green, String(localized: "Manage sessions, tasks, and files remotely"), String(localized: "Browse workspaces and stay on top of agent work.")),
         ("mic.fill", .purple, String(localized: "Voice input and mobile-friendly composer controls"), String(localized: "Compose naturally with touch-first controls.")),
         ("checkmark.shield.fill", .cyan, String(localized: "Review approvals and clarifications inline"), String(localized: "Respond to agent prompts without switching apps.")),
-        ("server.rack", .orange, String(localized: "Self-hosted: your machine, your tailnet"), String(localized: "Your Hermes Web UI stays on hardware you control."))
+        ("server.rack", .orange, String(localized: "Self-hosted on your private network"), String(localized: "Your Hermes Web UI stays on hardware you control."))
     ]
 
     var body: some View {
@@ -19,7 +19,7 @@ struct OnboardingFeaturesPage: View {
                         .font(.system(size: dynamicTypeSize.isAccessibilitySize ? 26 : 28, weight: .bold))
                         .foregroundStyle(.white)
 
-                    Text("Your Hermes agent, reachable from iPhone over Tailscale.")
+                    Text("Your Hermes agent, securely reachable from your iPhone.")
                         .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.45))
                         .multilineTextAlignment(.center)

--- a/HermesMobile/Features/Onboarding/OnboardingFlowPolicy.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingFlowPolicy.swift
@@ -1,14 +1,65 @@
 import Foundation
 
+enum PrivateNetworkProvider: String, CaseIterable, Identifiable {
+    case tailscale = "Tailscale"
+    case netBird = "NetBird"
+
+    var id: Self { self }
+
+    var setupPrompt: String {
+        switch self {
+        case .tailscale:
+            return OnboardingFlowPolicy.tailscaleSetupPrompt
+        case .netBird:
+            return OnboardingFlowPolicy.netBirdSetupPrompt
+        }
+    }
+
+    var appStoreURL: URL {
+        switch self {
+        case .tailscale:
+            return URL(string: "itms-apps://apps.apple.com/us/app/tailscale/id1470499037")!
+        case .netBird:
+            return URL(string: "itms-apps://apps.apple.com/us/app/netbird-p2p-vpn/id6469329339")!
+        }
+    }
+
+    var appStoreFallbackURL: URL {
+        switch self {
+        case .tailscale:
+            return URL(string: "https://apps.apple.com/us/app/tailscale/id1470499037")!
+        case .netBird:
+            return URL(string: "https://apps.apple.com/us/app/netbird-p2p-vpn/id6469329339")!
+        }
+    }
+
+    var iphoneSetupSteps: [String] {
+        switch self {
+        case .tailscale:
+            return [
+                String(localized: "Install Tailscale from the App Store."),
+                String(localized: "Sign in with the same account you used on your server."),
+                String(localized: "Keep Tailscale connected while using Hermex.")
+            ]
+        case .netBird:
+            return [
+                String(localized: "Install NetBird from the App Store."),
+                String(localized: "Add the same NetBird account or management server used by your server."),
+                String(localized: "Keep NetBird connected while using Hermex.")
+            ]
+        }
+    }
+}
+
 enum OnboardingFlowPolicy {
     static let pageCount = 5
     static let connectPageIndex = 4
     static let agentPromptPageIndex = 2
 
-    static let agentSetupPrompt = """
+    static let tailscaleSetupPrompt = """
 Set up Hermes Web UI on this machine for access from my iPhone via Tailscale.
 
-Clone and install https://github.com/nesquena/hermes-webui — it's a Node.js web app. Install dependencies and start it on port 8787.
+Clone and install https://github.com/nesquena/hermes-webui. Follow its current installation instructions and start it on port 8787.
 Enable password authentication by setting the HERMES_WEBUI_PASSWORD environment variable. Generate a secure random password and save it — I'll need it for the iPhone app.
 Install Tailscale on this machine. Search the web for the correct install method for this OS if you're unsure. Authenticate to my Tailscale account — if this requires opening a URL or an auth key, tell me exactly what to do.
 Make the WebUI reachable over Tailscale:
@@ -23,9 +74,23 @@ Reply with:
 Do not use Cloudflare. Optimize for Tailscale + iPhone.
 """
 
-    static let tailscaleAppStoreURL = URL(string: "itms-apps://apps.apple.com/us/app/tailscale/id1470499037")!
+    static let netBirdSetupPrompt = """
+Set up Hermes Web UI on this machine for access from my iPhone via NetBird.
 
-    static let tailscaleAppStoreFallbackURL = URL(string: "https://apps.apple.com/us/app/tailscale/id1470499037")!
+Clone and install https://github.com/nesquena/hermes-webui. Follow its current installation instructions and start it on port 8787.
+Enable password authentication by setting the HERMES_WEBUI_PASSWORD environment variable. Generate a secure random password and save it — I'll need it for the iPhone app.
+Install NetBird on this machine using the current official instructions for this OS. Connect it to my NetBird network with `netbird up`. If authentication requires a browser login, setup key, or self-hosted management URL, tell me exactly what I need to provide or do; do not guess credentials.
+Make the WebUI reachable over NetBird:
+- Bind the server to 0.0.0.0 instead of localhost so it listens on the NetBird interface. Before doing this, confirm password auth is active — never expose an unauthenticated WebUI.
+- Check the host firewall and NetBird access policy. Allow my iPhone peer to reach TCP port 8787, but do not expose the port publicly. If you cannot change my NetBird policy, give me the exact policy change I need to make.
+Set up auto-start appropriate for this OS so the WebUI and NetBird survive reboots.
+Verify it works: find the server's NetBird IPv4 address using `netbird status` or `ip addr show wt0`, then run `curl http://<netbird-ip>:8787/health` with that address. It should return a success response.
+Reply with:
+- The exact server URL I enter in Hermex
+- The password
+- Any setup steps I still need to do on my iPhone
+Do not use Cloudflare. Optimize for NetBird + iPhone.
+"""
 
     static func primaryButtonTitle(for page: Int) -> String {
         switch page {

--- a/HermesMobile/Features/Onboarding/OnboardingPrivateNetworkPage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingPrivateNetworkPage.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
-struct OnboardingTailscalePage: View {
+struct OnboardingPrivateNetworkPage: View {
     @Environment(\.openURL) private var openURL
+    @Binding var privateNetworkProvider: PrivateNetworkProvider
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -9,17 +10,19 @@ struct OnboardingTailscalePage: View {
                 OnboardingStepHeader(
                     stepNumber: 2,
                     icon: "iphone.and.arrow.forward",
-                    title: String(localized: "Install Tailscale on iPhone"),
-                    description: String(localized: "Install Tailscale on your iPhone and sign into the same tailnet as your server. Your agent will reply with the exact URL to use on the next screen.")
+                    title: String(localized: "Connect your iPhone"),
+                    description: String(localized: "Install your chosen private-network app on your iPhone. Your agent will reply with the exact URL to use on the next screen.")
                 )
 
-                VStack(alignment: .leading, spacing: 14) {
-                    tailscaleStep(number: "1", text: String(localized: "Install Tailscale from the App Store."))
-                    tailscaleStep(number: "2", text: String(localized: "Sign in with the same account you used on your server."))
-                    tailscaleStep(number: "3", text: String(localized: "Keep Tailscale connected while using Hermex."))
+                OnboardingNetworkProviderPicker(selection: $privateNetworkProvider)
 
-                    Button(action: openTailscaleInAppStore) {
-                        Label("Get Tailscale on the App Store", systemImage: "arrow.up.forward.square")
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(Array(privateNetworkProvider.iphoneSetupSteps.enumerated()), id: \.offset) { index, step in
+                        networkStep(number: String(index + 1), text: step)
+                    }
+
+                    Button(action: openProviderInAppStore) {
+                        Label("Get \(privateNetworkProvider.rawValue) on the App Store", systemImage: "arrow.up.forward.square")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(Color(red: 1.0, green: 0.74, blue: 0.10))
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -32,7 +35,7 @@ struct OnboardingTailscalePage: View {
                             )
                     }
                     .buttonStyle(.plain)
-                    .accessibilityHint("Opens the Tailscale page in the App Store.")
+                    .accessibilityHint("Opens the selected private-network app in the App Store.")
                 }
             }
             .padding(.horizontal, 28)
@@ -42,14 +45,14 @@ struct OnboardingTailscalePage: View {
         .scrollBounceBehavior(.basedOnSize)
     }
 
-    private func openTailscaleInAppStore() {
-        openURL(OnboardingFlowPolicy.tailscaleAppStoreURL, completion: { accepted in
+    private func openProviderInAppStore() {
+        openURL(privateNetworkProvider.appStoreURL, completion: { accepted in
             guard !accepted else { return }
-            openURL(OnboardingFlowPolicy.tailscaleAppStoreFallbackURL)
+            openURL(privateNetworkProvider.appStoreFallbackURL)
         })
     }
 
-    private func tailscaleStep(number: String, text: String) -> some View {
+    private func networkStep(number: String, text: String) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Text(number)
                 .font(.caption.weight(.bold))

--- a/HermesMobile/Features/Onboarding/OnboardingView.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingView.swift
@@ -5,6 +5,7 @@ struct OnboardingView: View {
     @State private var viewModel: OnboardingViewModel
     @State private var currentPage: Int
     @State private var hasCopiedAgentPrompt = false
+    @State private var privateNetworkProvider: PrivateNetworkProvider = .tailscale
     @State private var hasBypassedCopyReminder = false
     @State private var isShowingCopyReminder = false
     @FocusState private var focusedField: OnboardingConnectField?
@@ -47,10 +48,13 @@ struct OnboardingView: View {
                     OnboardingFeaturesPage()
                         .tag(1)
 
-                    OnboardingAgentPromptPage(hasCopiedAgentPrompt: $hasCopiedAgentPrompt)
+                    OnboardingAgentPromptPage(
+                        hasCopiedAgentPrompt: $hasCopiedAgentPrompt,
+                        privateNetworkProvider: $privateNetworkProvider
+                    )
                         .tag(2)
 
-                    OnboardingTailscalePage()
+                    OnboardingPrivateNetworkPage(privateNetworkProvider: $privateNetworkProvider)
                         .tag(3)
 
                     OnboardingConnectPage(
@@ -83,7 +87,7 @@ struct OnboardingView: View {
                 advanceToNextPage()
             }
         } message: {
-            Text("Copy the agent setup prompt on your desktop before continuing so Hermes Web UI and Tailscale are configured correctly.")
+            Text("Copy the agent setup prompt before continuing so Hermes Web UI and your private network are configured correctly.")
         }
     }
 

--- a/HermesMobile/Features/Onboarding/OnboardingWelcomePage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingWelcomePage.swift
@@ -74,14 +74,14 @@ struct OnboardingWelcomePage: View {
                         .minimumScaleFactor(0.86)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    Text("Connect to your self-hosted Web UI over Tailscale.")
+                    Text("Connect securely to your self-hosted Web UI from anywhere.")
                         .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.58))
                         .fixedSize(horizontal: false, vertical: true)
 
                     HStack(spacing: 8) {
                         HeroBadge(systemImage: "lock.shield.fill", title: String(localized: "Password protected"))
-                        HeroBadge(systemImage: "network", title: String(localized: "Tailscale ready"))
+                        HeroBadge(systemImage: "network", title: String(localized: "Private network ready"))
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/HermesMobile/Networking/APIError.swift
+++ b/HermesMobile/Networking/APIError.swift
@@ -10,7 +10,7 @@ enum APIError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidServerURL:
-            return String(localized: "Enter a valid server URL, for example https://hermes.yourdomain.com or http://<server-tailscale-ip>:8787.")
+            return String(localized: "Enter a valid server URL, for example https://hermes.yourdomain.com or http://<private-network-ip>:8787.")
         case .network(let underlying):
             return Self.networkMessage(for: underlying)
         case .http(let statusCode, let body):
@@ -157,7 +157,7 @@ private extension APIError {
              .serverCertificateNotYetValid:
             return String(localized: "The HTTPS connection failed. Check the server URL and certificate.")
         case .appTransportSecurityRequiresSecureConnection:
-            return String(localized: "iOS blocked this insecure HTTP connection. Use HTTPS, or use a Tailscale IP in the 100.64.0.0/10 range.")
+            return String(localized: "iOS blocked this insecure HTTP connection. Use HTTPS, or use a private-network IP in the supported 100.64.0.0/10 range.")
         case .cancelled:
             return String(localized: "The request was cancelled.")
         default:

--- a/HermesMobileTests/APIClientAuthAndErrorTests.swift
+++ b/HermesMobileTests/APIClientAuthAndErrorTests.swift
@@ -31,7 +31,7 @@ final class APIClientAuthAndErrorTests: APIClientTestCase {
     }
 
     @MainActor
-    func testAuthManagerConnectsToNoPasswordTailscaleServerWithoutLogin() async throws {
+    func testAuthManagerConnectsToNoPasswordPrivateNetworkServerWithoutLogin() async throws {
         let keychain = InMemoryKeychainStore()
         let client = MockAuthAPIClient(authStatus: AuthStatusResponse(authEnabled: false, loggedIn: false))
         var requestedURLs: [URL] = []
@@ -216,7 +216,7 @@ final class APIClientAuthAndErrorTests: APIClientTestCase {
 
         XCTAssertEqual(
             error.localizedDescription,
-            "iOS blocked this insecure HTTP connection. Use HTTPS, or use a Tailscale IP in the 100.64.0.0/10 range."
+            "iOS blocked this insecure HTTP connection. Use HTTPS, or use a private-network IP in the supported 100.64.0.0/10 range."
         )
     }
 }

--- a/HermesMobileTests/OnboardingFlowTests.swift
+++ b/HermesMobileTests/OnboardingFlowTests.swift
@@ -81,8 +81,8 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertFalse(OnboardingFlowPolicy.showsServerShortcut(for: OnboardingFlowPolicy.connectPageIndex))
     }
 
-    func testAgentSetupPromptIncludesTailscaleRequirements() {
-        let prompt = OnboardingFlowPolicy.agentSetupPrompt
+    func testTailscaleSetupPromptIncludesProviderRequirements() {
+        let prompt = PrivateNetworkProvider.tailscale.setupPrompt
 
         XCTAssertTrue(prompt.contains("hermes-webui"))
         XCTAssertTrue(prompt.contains("HERMES_WEBUI_PASSWORD"))
@@ -92,15 +92,43 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertTrue(prompt.contains("Hermex"))
     }
 
-    func testTailscaleAppStoreURLUsesITMSDeepLink() {
+    func testNetBirdSetupPromptIncludesProviderRequirements() {
+        let prompt = PrivateNetworkProvider.netBird.setupPrompt
+
+        XCTAssertTrue(prompt.contains("hermes-webui"))
+        XCTAssertTrue(prompt.contains("HERMES_WEBUI_PASSWORD"))
+        XCTAssertTrue(prompt.contains("netbird up"))
+        XCTAssertTrue(prompt.contains("ip addr show wt0"))
+        XCTAssertTrue(prompt.contains("curl http://<netbird-ip>:8787/health"))
+        XCTAssertTrue(prompt.contains("NetBird access policy"))
+        XCTAssertTrue(prompt.contains("Do not use Cloudflare. Optimize for NetBird + iPhone."))
+        XCTAssertTrue(prompt.contains("Hermex"))
+    }
+
+    func testProviderAppStoreURLsUseITMSDeepLinks() {
         XCTAssertEqual(
-            OnboardingFlowPolicy.tailscaleAppStoreURL.absoluteString,
+            PrivateNetworkProvider.tailscale.appStoreURL.absoluteString,
             "itms-apps://apps.apple.com/us/app/tailscale/id1470499037"
         )
         XCTAssertEqual(
-            OnboardingFlowPolicy.tailscaleAppStoreFallbackURL.absoluteString,
+            PrivateNetworkProvider.tailscale.appStoreFallbackURL.absoluteString,
             "https://apps.apple.com/us/app/tailscale/id1470499037"
         )
+        XCTAssertEqual(
+            PrivateNetworkProvider.netBird.appStoreURL.absoluteString,
+            "itms-apps://apps.apple.com/us/app/netbird-p2p-vpn/id6469329339"
+        )
+        XCTAssertEqual(
+            PrivateNetworkProvider.netBird.appStoreFallbackURL.absoluteString,
+            "https://apps.apple.com/us/app/netbird-p2p-vpn/id6469329339"
+        )
+    }
+
+    func testProviderSetupStepsUseSelectedProvider() {
+        XCTAssertTrue(PrivateNetworkProvider.tailscale.iphoneSetupSteps.joined().contains("Tailscale"))
+        XCTAssertFalse(PrivateNetworkProvider.tailscale.iphoneSetupSteps.joined().contains("NetBird"))
+        XCTAssertTrue(PrivateNetworkProvider.netBird.iphoneSetupSteps.joined().contains("NetBird"))
+        XCTAssertFalse(PrivateNetworkProvider.netBird.iphoneSetupSteps.joined().contains("Tailscale"))
     }
 
     func testConnectPageIndexIsFinalPagerPage() {

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -20,7 +20,7 @@ If anything in this spec is ambiguous, **stop and ask the human owner before gue
 ## 1. Project summary
 
 ### 1.1 What we're building
-A native iOS app (SwiftUI, iOS 18+, iPhone only) that lets the user drive a self-hosted Hermes AI agent from their phone. The user runs the `hermes-webui` Python server on a machine they control and connects from the phone via Cloudflare Tunnel (or Tailscale).
+A native iOS app (SwiftUI, iOS 18+, iPhone only) that lets the user drive a self-hosted Hermes AI agent from their phone. The user runs the `hermes-webui` Python server on a machine they control and connects from the phone via HTTPS or a supported private mesh network (Tailscale or NetBird).
 
 ### 1.2 What it is NOT
 - ❌ Not a webview wrapper around the existing browser UI.
@@ -28,7 +28,7 @@ A native iOS app (SwiftUI, iOS 18+, iPhone only) that lets the user drive a self
 - ❌ Not a hosted service — every user brings their own server.
 
 ### 1.3 Why it exists
-The `hermes-webui` browser UI works on mobile via Cloudflare Tunnel/Tailscale, but a native client gives:
+The `hermes-webui` browser UI works on mobile via an HTTPS tunnel or private mesh network, but a native client gives:
 - A real iOS app icon, lifecycle, and Keychain-backed auth.
 - Native streaming chat with proper SwiftUI rendering (no PWA quirks).
 - Offline read-only cache of recent sessions.
@@ -59,7 +59,7 @@ The server owns execution. The app owns mobile interaction quality.
 | # | Decision | Value |
 |---|---|---|
 | 1 | v1 feature scope | **Expanded pre-polish scope** (login, sessions, chat with streaming, conversation actions, composer attachments/config, read-only tasks/skills/memory, limited usage analytics, workspace browser, file viewer with syntax highlighting, settings; **no push, no terminal, no file editing in v1**) |
-| 2 | Hosting models documented | **Cloudflare Tunnel (primary)** and **Tailscale (secondary)** |
+| 2 | Hosting models documented | **Cloudflare Tunnel (primary)** and **Tailscale or NetBird (private-network alternatives)** |
 | 3 | Upstream strategy | **Pin to upstream tags** for v1; revisit forking later if API churn becomes painful |
 | 4 | Auth method | **Password only** for v1 (no OAuth) |
 | 5 | Target | iOS 18+, iPhone only, portrait + landscape |
@@ -356,7 +356,7 @@ Each phase ends in a working, committable state. Run on the simulator after ever
 - [x] Add a `README.md` that points at this spec.
 - [x] Write a one-page `DEVELOPMENT.md` with:
   - **Primary test target:** the developer's own HTTPS-exposed `hermes-webui` instance (needs the password). Works from simulator AND a physical device.
-  - **Local-only fallback**: clone `nesquena/hermes-webui`, run via Docker OR `python3 server.py` from the repo. Note: physical-device testing against `http://localhost:8787` requires either a Tailscale IP or an ATS exception.
+  - **Local-only fallback**: clone `nesquena/hermes-webui`, run via Docker OR `python3 server.py` from the repo. Note: physical-device testing against `http://localhost:8787` requires a supported private-network IP or an ATS exception.
   - How to verify the server is up before debugging the app: `curl https://<your-server>/health`.
 
 ### Phase 1 — Onboarding + auth (1–2 days)
@@ -702,7 +702,7 @@ Document it as the recommended path.
 **Pros:** real HTTPS, accessible from anywhere, no VPN client on the phone.
 **Cons:** publicly reachable URL — if the password leaks, anyone can hit your agent. Recommended hardening: add a Cloudflare Access policy in front of the hostname.
 
-### 9.2 Tailscale (alternative — if you don't want a public hostname)
+### 9.2 Tailscale (private-network alternative)
 1. Install Tailscale on the server and the iPhone, sign both into the same account.
 2. On the server, start hermes-webui bound to all interfaces with auth:
    ```bash
@@ -715,6 +715,21 @@ Document it as the recommended path.
 
 **Pros:** zero config, encrypted via WireGuard, no public exposure.
 **Cons:** must install Tailscale on both ends; plain HTTP requires ATS exception.
+
+### 9.3 NetBird (private-network alternative)
+1. Install NetBird on the server and iPhone, then connect both peers to the same NetBird account or self-hosted management server.
+2. Start `hermes-webui` bound to all interfaces with password authentication:
+   ```bash
+   HERMES_WEBUI_HOST=0.0.0.0 HERMES_WEBUI_PASSWORD=your-secret ./start.sh
+   ```
+3. Confirm the server peer's NetBird address with `netbird status` or, on Linux, `ip addr show wt0`.
+4. Ensure the NetBird access policy and the server's host firewall allow the iPhone peer to reach TCP port 8787. Do not expose the port publicly.
+5. In Hermex, enter `http://<netbird-ip>:8787` and the password.
+
+**Caveat for the iOS app:** plain HTTP is supported only for private-network IPv4 addresses in the app's scoped `100.64.0.0/10` ATS exception. NetBird deployments using a custom IPv4 range or IPv6 should put Hermes Web UI behind HTTPS instead of broadening the exception.
+
+**Pros:** encrypted WireGuard mesh, no public exposure, supports NetBird-managed and self-hosted control planes.
+**Cons:** must install NetBird on both ends and configure an access policy; plain HTTP is limited by the scoped ATS exception.
 
 ---
 
@@ -771,7 +786,7 @@ The app is "v1 done" when:
 - [ ] An internal TestFlight tester can install it and, given their server URL and password, can: log in, see their sessions, open a session, use session/message action menus, send a message with configured composer options and attachments, watch the response stream, browse workspace files, view a file, open read-only tasks/skills/memory, and view limited session-based usage analytics.
 - [ ] All §8 pre-TestFlight phases 0–12 complete.
 - [ ] Zero crashes in 30 minutes of normal use on iPhone 13 or newer running iOS 18+.
-- [ ] README documents Cloudflare Tunnel (primary) and Tailscale (alternative) setup end-to-end.
+- [ ] README documents Cloudflare Tunnel (primary) and Tailscale/NetBird (private-network alternatives) setup end-to-end.
 - [ ] Contract tests pass against the upstream tag pinned in `UPSTREAM_TESTED_SHA`.
 - [x] No third-party dependencies beyond the locked list in §5.
 
@@ -816,6 +831,8 @@ Stop and ask before guessing:
 - Pinned local upstream copy: `.codex-tmp/hermes-webui/` (read-only; see `CONTRACT_TESTS.md`)
 - Cloudflare Tunnel docs: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
 - Tailscale download: https://tailscale.com/download
+- NetBird install docs: https://docs.netbird.io/get-started/install
+- NetBird mobile apps: https://docs.netbird.io/get-started/install/mobile
 - LDSwiftEventSource: https://github.com/launchdarkly/swift-eventsource
 - swift-markdown-ui: https://github.com/gonzalezreal/swift-markdown-ui
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Self-hosting the server, securing it, and keeping it reachable are your responsi
 ### Making the server reachable
 
 - **HTTPS via a tunnel or reverse proxy (recommended).** Expose the server through Cloudflare Tunnel or any reverse proxy that terminates real TLS at a hostname you own. Real HTTPS keeps iOS App Transport Security happy with no exceptions. On a publicly reachable hostname the password is your only app-level defense — set a strong one.
-- **Tailscale.** Run the server bound to all interfaces with a password, install Tailscale on both the server and the iPhone, and connect to `http://<tailnet-ip>:8787`. The app allows plain HTTP only for Tailscale's `100.64.0.0/10` device range.
+- **Private mesh network.** Run the server bound to all interfaces with a password, install either Tailscale or NetBird on both the server and iPhone, and connect to `http://<private-network-ip>:8787`. Confirm the mesh access policy and host firewall allow the iPhone to reach TCP port 8787. Plain HTTP is supported only for addresses in the app's scoped `100.64.0.0/10` range; use HTTPS for custom ranges or IPv6.
 - **Simulator-only local testing** can use `http://localhost:8787` when the server runs on the same Mac.
 
 ### Troubleshooting the connection
@@ -76,7 +76,7 @@ If connection testing fails, check these first:
 
 1. The machine hosting `hermes-webui` is awake.
 2. `hermes-webui` is running and serving `/health` (`curl https://<your-server>/health`).
-3. The tunnel, reverse proxy, or Tailscale route is connected.
+3. The tunnel, reverse proxy, or private mesh network is connected.
 4. The server URL and password are correct.
 
 ## Building from source


### PR DESCRIPTION
<!-- Thanks for contributing! Please read CONTRIBUTING.md before opening a PR. -->

## Linked issue

Fixes #170

Fixes #

## What changed

- Made private-network onboarding provider-neutral where instructions do not depend on a specific
service.
- Added a shared Tailscale/NetBird selector to the setup-prompt and iPhone setup pages.
- Added provider-specific setup prompts, iPhone instructions, and App Store links.
- Added NetBird guidance covering installation, authentication, access policies, firewall
configuration, automatic startup, address discovery, and health verification.
- Updated relevant documentation, error messages, and onboarding tests.
- Preserved the existing Tailscale flow without changing API or authentication behavior.

## How it was tested
This PR was written on a Linux system and tested with xtool on a physical iPhone 16e running iOS 27 Developer Beta 3 

The full XCTest suite was not run because this environment does not provide the Xcode simulator
workflow required by the project. The temporary xtool build adapter and generated artifacts are
not included in the PR.

<img width="1170" height="2532" alt="IMG_3451" src="https://github.com/user-attachments/assets/864d4623-6a74-4396-a3f3-33260a2fbff1" />

## Checklist
- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [ ] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [X] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [X] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

This PR was written by GPT-5.6-Sol through Codex and human-written changes.