### PR TITLE
feat(kanban): implement card workflow mutations

### DIFF
--- a/HermesMobile/Features/Kanban/KanbanCardDetailState.swift
+++ b/HermesMobile/Features/Kanban/KanbanCardDetailState.swift
@@ -46,6 +46,7 @@ final class KanbanCardDetailState {
 
     private let client: any KanbanDataClient
     private let onAPIError: (Error) -> Void
+    private let onDetailLoaded: (KanbanCardDetailEnvelope) -> Void
     private var activeDetailLoadID: UUID?
     private var activeMutationID: UUID?
     private var lastReconciledRevision = -1
@@ -55,12 +56,14 @@ final class KanbanCardDetailState {
         cardID: String,
         board: String,
         client: any KanbanDataClient,
-        onAPIError: @escaping (Error) -> Void = { _ in }
+        onAPIError: @escaping (Error) -> Void = { _ in },
+        onDetailLoaded: @escaping (KanbanCardDetailEnvelope) -> Void = { _ in }
     ) {
         self.cardID = cardID
         self.board = board
         self.client = client
         self.onAPIError = onAPIError
+        self.onDetailLoaded = onDetailLoaded
     }
 
     var canSubmitDraft: Bool {
@@ -173,6 +176,7 @@ final class KanbanCardDetailState {
             guard !Task.isCancelled, activeDetailLoadID == loadID, activeMutationID == nil else { return }
             detail = response
             loadState = .loaded
+            onDetailLoaded(response)
         } catch {
             guard activeDetailLoadID == loadID, activeMutationID == nil else { return }
             guard !isCancellation(error) else { return }
@@ -198,6 +202,7 @@ final class KanbanCardDetailState {
             guard !Task.isCancelled, activeMutationID == expectedMutationID else { return }
             detail = response
             loadState = .loaded
+            onDetailLoaded(response)
             if attempt.appears(in: response.comments ?? []) {
                 commentDraft = ""
                 commentSubmission = .succeeded

--- a/HermesMobile/Features/Kanban/KanbanCardDetailView.swift
+++ b/HermesMobile/Features/Kanban/KanbanCardDetailView.swift
@@ -346,13 +346,21 @@ private struct KanbanCardDetailContent: View {
                 case .failed:
                     Label("The server refused or did not apply this update.", systemImage: "exclamationmark.circle")
                         .foregroundStyle(.red)
-                    Button("Try Again") { retryMutation(for: card) }
+                    if case .undoArchive = mutation.kind {
+                        EmptyView()
+                    } else {
+                        Button("Try Again") { retryMutation(for: card) }
+                    }
                 case .outcomeUncertain:
                     Label("Outcome Uncertain", systemImage: "questionmark.circle")
                         .foregroundStyle(.orange)
                     Text("Refresh the Card to check the server result before trying again.")
                         .font(.footnote)
-                    Button("Refresh") { Task { await featureModel.checkUncertainMutation(for: card) } }
+                    if case .undoArchive = mutation.kind {
+                        EmptyView()
+                    } else {
+                        Button("Refresh") { Task { await featureModel.checkUncertainMutation(for: card) } }
+                    }
                 }
                 if featureModel.hasAvailableArchiveUndo,
                    featureModel.archiveUndo?.cardID == card.cardID {

--- a/HermesMobile/Features/Kanban/KanbanCardDetailView.swift
+++ b/HermesMobile/Features/Kanban/KanbanCardDetailView.swift
@@ -27,6 +27,8 @@ private struct KanbanCardDetailContent: View {
     @Bindable var state: KanbanCardDetailState
     @State private var showsOperationalHistory = false
     @State private var cardEditor: KanbanCardEditorState?
+    @State private var pendingRunningAction: KanbanPendingCardAction?
+    @State private var selectedPrerequisiteID: String?
     @FocusState private var commentFieldIsFocused: Bool
 
     var body: some View {
@@ -67,12 +69,15 @@ private struct KanbanCardDetailContent: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
                 Button("Edit") {
                     guard let detail = state.detail else { return }
                     cardEditor = featureModel.makeEditCardEditorState(detail: detail)
                 }
                 .disabled(!featureModel.canMutateCards || state.loadState != .loaded)
+                if let card = state.detail?.card {
+                    cardActionsMenu(card)
+                }
             }
         }
         .sheet(item: $cardEditor) { editor in
@@ -85,6 +90,22 @@ private struct KanbanCardDetailContent: View {
                 }
             )
         }
+        .alert(
+            "Leave Running?",
+            isPresented: Binding(
+                get: { pendingRunningAction != nil },
+                set: { if !$0 { pendingRunningAction = nil } }
+            ),
+            presenting: pendingRunningAction
+        ) { pending in
+            Button("Cancel", role: .cancel) { pendingRunningAction = nil }
+            Button("Continue", role: .destructive) {
+                pendingRunningAction = nil
+                perform(pending.action, for: pending.card, confirmingRunningExit: true)
+            }
+        } message: { _ in
+            Text("Leaving Running may clear the Card's claim and worker state.")
+        }
     }
 
     private var detailList: some View {
@@ -96,8 +117,10 @@ private struct KanbanCardDetailContent: View {
             }
 
             if let card = state.detail?.card {
-                descriptionSection(card)
-                metadataSection(card)
+                let displayedCard = featureModel.displayedCard(card)
+                descriptionSection(displayedCard)
+                metadataSection(displayedCard)
+                mutationSection(displayedCard)
             }
             commentsSection
             dependenciesSection
@@ -242,14 +265,182 @@ private struct KanbanCardDetailContent: View {
 
     private var dependenciesSection: some View {
         Section("Dependencies") {
-            dependencyGroup(
+            prerequisiteGroup(
                 title: KanbanCountFormatter.prerequisites(state.detail?.links?.prerequisites?.count ?? 0),
-                ids: state.detail?.links?.prerequisites ?? []
+                card: state.detail?.card,
+                canonicalIDs: state.detail?.links?.prerequisites ?? []
             )
             dependencyGroup(
                 title: KanbanCountFormatter.dependents(state.detail?.links?.dependents?.count ?? 0),
                 ids: state.detail?.links?.dependents ?? []
             )
+        }
+    }
+
+    @ViewBuilder
+    private func prerequisiteGroup(title: String, card: KanbanCard?, canonicalIDs: [String]) -> some View {
+        if let card, let cardID = card.cardID {
+            let ids = featureModel.displayedPrerequisites(for: cardID, canonical: canonicalIDs)
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title).font(.headline)
+                ForEach(ids, id: \.self) { prerequisiteID in
+                    HStack {
+                        Text(verbatim: prerequisiteID)
+                            .font(.body.monospaced())
+                            .textSelection(.enabled)
+                        Spacer()
+                        Button("Remove", systemImage: "minus.circle", role: .destructive) {
+                            Task {
+                                await featureModel.removePrerequisite(prerequisiteID, from: card)
+                                await state.refresh()
+                            }
+                        }
+                        .labelStyle(.iconOnly)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .disabled(!featureModel.canMutateCard(card) || featureModel.isMutatingCard(cardID))
+                        .accessibilityLabel(Text("Remove \(prerequisiteID) as Prerequisite"))
+                    }
+                }
+
+                Picker("Add Prerequisite", selection: $selectedPrerequisiteID) {
+                    Text("Choose Card").tag(String?.none)
+                    ForEach(featureModel.allCards.filter { option in
+                        guard let optionID = option.cardID else { return false }
+                        return optionID != cardID && !ids.contains(optionID)
+                    }, id: \.cardID) { option in
+                        Text(option.title ?? option.cardID ?? String(localized: "Card"))
+                            .tag(option.cardID)
+                    }
+                }
+                Button("Add Prerequisite") {
+                    guard let prerequisiteID = selectedPrerequisiteID else { return }
+                    selectedPrerequisiteID = nil
+                    Task {
+                        await featureModel.addPrerequisite(prerequisiteID, to: card)
+                        await state.refresh()
+                    }
+                }
+                .disabled(
+                    selectedPrerequisiteID == nil
+                        || !featureModel.canMutateCard(card)
+                        || featureModel.isMutatingCard(cardID)
+                )
+                .frame(minHeight: 44)
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder
+    private func mutationSection(_ card: KanbanCard) -> some View {
+        if let mutation = featureModel.mutationState(for: card.cardID) {
+            Section("Update") {
+                switch mutation.phase {
+                case .updating:
+                    Label("Updating task...", systemImage: "arrow.triangle.2.circlepath")
+                case .checkingResult:
+                    Label("Checking Result", systemImage: "arrow.triangle.2.circlepath")
+                case .succeeded:
+                    Label("Updated", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                case .failed:
+                    Label("The server refused or did not apply this update.", systemImage: "exclamationmark.circle")
+                        .foregroundStyle(.red)
+                    Button("Try Again") { retryMutation(for: card) }
+                case .outcomeUncertain:
+                    Label("Outcome Uncertain", systemImage: "questionmark.circle")
+                        .foregroundStyle(.orange)
+                    Text("Refresh the Card to check the server result before trying again.")
+                        .font(.footnote)
+                    Button("Refresh") { Task { await featureModel.checkUncertainMutation(for: card) } }
+                }
+                if featureModel.hasAvailableArchiveUndo,
+                   featureModel.archiveUndo?.cardID == card.cardID {
+                    if mutation.phase == .outcomeUncertain,
+                       case .undoArchive = mutation.kind {
+                        Button("Refresh") {
+                            Task { await featureModel.checkUncertainMutation(for: card) }
+                        }
+                    } else {
+                        Button(mutation.phase == .failed ? "Try Again" : "Undo Archive") {
+                            Task { await featureModel.undoArchive() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func cardActionsMenu(_ card: KanbanCard) -> some View {
+        Menu {
+            let destinations = featureModel.moveDestinations(for: card)
+            if !destinations.isEmpty {
+                Menu("Move") {
+                    ForEach(destinations, id: \.self) { destination in
+                        Button(KanbanStatusPresentation(destination).title) {
+                            request(.move(destination), for: card)
+                        }
+                    }
+                }
+            }
+            if card.status?.rawValue == "blocked" {
+                Button("Unblock") { request(.unblock, for: card) }
+            } else if card.status?.rawValue != "archived" {
+                Button("Block") { request(.block, for: card) }
+            }
+            if card.status?.rawValue != "done", card.status?.rawValue != "archived" {
+                Button("Complete") { request(.complete, for: card) }
+            }
+            if card.status?.rawValue != "archived" {
+                Button("Archive", role: .destructive) { request(.archive, for: card) }
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .disabled(!featureModel.canMutateCard(card) || featureModel.isMutatingCard(card.cardID))
+        .accessibilityLabel(Text("Card Actions"))
+    }
+
+    private func request(_ action: KanbanCardAction, for card: KanbanCard) {
+        if card.status?.rawValue == "running" {
+            pendingRunningAction = KanbanPendingCardAction(card: card, action: action)
+        } else {
+            perform(action, for: card)
+        }
+    }
+
+    private func perform(
+        _ action: KanbanCardAction,
+        for card: KanbanCard,
+        confirmingRunningExit: Bool = false
+    ) {
+        Task {
+            switch action {
+            case let .move(status):
+                await featureModel.moveCard(card, to: status, confirmingRunningExit: confirmingRunningExit)
+            case .block:
+                await featureModel.blockCard(card, reason: nil, confirmingRunningExit: confirmingRunningExit)
+            case .unblock: await featureModel.unblockCard(card)
+            case .complete:
+                await featureModel.completeCard(card, confirmingRunningExit: confirmingRunningExit)
+            case .archive:
+                await featureModel.archiveCard(card, confirmingRunningExit: confirmingRunningExit)
+            }
+            await state.refresh()
+        }
+    }
+
+    private func retryMutation(for card: KanbanCard) {
+        guard card.status?.rawValue == "running",
+              let mutation = featureModel.mutationState(for: card.cardID) else {
+            Task { await featureModel.retryMutation(for: card) }
+            return
+        }
+        switch mutation.kind {
+        case let .status(status): request(status == "done" ? .complete : .move(status), for: card)
+        case .block: request(.block, for: card)
+        case .archive: request(.archive, for: card)
+        default: Task { await featureModel.retryMutation(for: card) }
         }
     }
 

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -17,6 +17,44 @@ enum KanbanReadCapabilityWarning: Hashable, Sendable {
     case profileHistoryUnavailable
 }
 
+enum KanbanCardMutationPhase: Equatable, Sendable {
+    case updating
+    case checkingResult
+    case succeeded
+    case failed
+    case outcomeUncertain
+
+    var isInFlight: Bool { self == .updating || self == .checkingResult }
+}
+
+enum KanbanCardMutationKind: Equatable, Sendable {
+    case status(String)
+    case block(String?)
+    case unblock
+    case addPrerequisite(String)
+    case removePrerequisite(String)
+    case archive(previousStatus: String)
+    case undoArchive(status: String)
+}
+
+struct KanbanCardMutationState: Equatable, Sendable {
+    let kind: KanbanCardMutationKind
+    let phase: KanbanCardMutationPhase
+}
+
+struct KanbanArchiveUndo: Equatable, Sendable {
+    let cardID: String
+    let cardTitle: String
+    let previousStatus: String
+    let expiresAt: Date
+    let card: KanbanCard
+}
+
+private struct KanbanPendingDependencyChange {
+    let prerequisiteID: String
+    let isAdding: Bool
+}
+
 struct KanbanLiveUpdateTiming: Sendable {
     let coalescingDelay: Duration
     let reconnectDelays: [Duration]
@@ -56,6 +94,8 @@ final class KanbanFeatureState {
     private(set) var loadedDetailIsStale = false
     private(set) var liveCursor = 0
     private(set) var detailRefreshRevision = 0
+    private(set) var cardMutationStates: [String: KanbanCardMutationState] = [:]
+    private(set) var archiveUndo: KanbanArchiveUndo?
 
     private(set) var selectedBoardSlug: String?
     var selectedStatus = "triage"
@@ -72,6 +112,7 @@ final class KanbanFeatureState {
     private let client: any KanbanDataClient
     private let streamClient: any KanbanEventStreamingClient
     private let timing: KanbanLiveUpdateTiming
+    private let archiveUndoLifetime: TimeInterval
     private let sleep: @MainActor @Sendable (Duration) async throws -> Void
     private let onAPIError: (Error) -> Void
     private var isVisible = false
@@ -82,12 +123,18 @@ final class KanbanFeatureState {
     private var reconnectTask: Task<Void, Never>?
     private var coalescingTask: Task<Void, Never>?
     private var pollingTask: Task<Void, Never>?
+    private var activeCardMutationIDs: [String: UUID] = [:]
+    private var pendingOptimisticStatuses: [String: String] = [:]
+    private var uncertainProtectedCards: [String: KanbanCard] = [:]
+    private var pendingDependencyChanges: [String: KanbanPendingDependencyChange] = [:]
+    private var archiveUndoTask: Task<Void, Never>?
 
     init(
         server: URL,
         client: (any KanbanDataClient)? = nil,
         streamClient: (any KanbanEventStreamingClient)? = nil,
         timing: KanbanLiveUpdateTiming = .production,
+        archiveUndoLifetime: TimeInterval = 8,
         sleep: @escaping @MainActor @Sendable (Duration) async throws -> Void = { duration in
             try await Task.sleep(for: duration)
         },
@@ -97,6 +144,7 @@ final class KanbanFeatureState {
         self.client = client ?? APIClient(baseURL: server)
         self.streamClient = streamClient ?? KanbanEventStreamClient()
         self.timing = timing
+        self.archiveUndoLifetime = archiveUndoLifetime
         self.sleep = sleep
         self.onAPIError = onAPIError
     }
@@ -117,8 +165,12 @@ final class KanbanFeatureState {
 
     var canMutateCards: Bool {
         canAddComments
-            && report?.warnings.isEmpty == true
             && Set(KanbanCardEditorState.createStatuses).isSubset(of: Set(configuration?.columns ?? []))
+    }
+
+    var hasAvailableArchiveUndo: Bool {
+        guard let archiveUndo else { return false }
+        return archiveUndo.expiresAt > Date()
     }
 
     var selectedBoard: KanbanBoard? {
@@ -183,7 +235,230 @@ final class KanbanFeatureState {
         searchMatchedCards.count { $0.status?.rawValue == status }
     }
 
+    func canMutateCard(_ card: KanbanCard) -> Bool {
+        guard canMutateCards,
+              normalizedOptional(card.cardID) != nil,
+              let status = card.status?.rawValue else { return false }
+        return Self.liveStatuses.contains(status) || status == "archived"
+    }
+
+    func isMutatingCard(_ cardID: String?) -> Bool {
+        guard let cardID = normalizedOptional(cardID) else { return false }
+        return activeCardMutationIDs[cardID] != nil
+    }
+
+    func mutationState(for cardID: String?) -> KanbanCardMutationState? {
+        guard let cardID = normalizedOptional(cardID) else { return nil }
+        return cardMutationStates[cardID]
+    }
+
+    func moveDestinations(for card: KanbanCard) -> [String] {
+        guard canMutateCard(card) else { return [] }
+        let ordinaryDestinations = Set(["triage", "todo", "ready"])
+        return (configuration?.columns ?? [])
+            .filter { ordinaryDestinations.contains($0) && $0 != card.status?.rawValue }
+    }
+
+    func displayedPrerequisites(for cardID: String, canonical: [String]) -> [String] {
+        guard let change = pendingDependencyChanges[cardID] else { return canonical }
+        var result = canonical.filter { $0 != change.prerequisiteID }
+        if change.isAdding { result.append(change.prerequisiteID) }
+        return Array(Set(result)).sorted()
+    }
+
+    func displayedCard(_ canonical: KanbanCard) -> KanbanCard {
+        guard let cardID = normalizedOptional(canonical.cardID),
+              let status = pendingOptimisticStatuses[cardID] else { return canonical }
+        return canonical.replacingStatus(status)
+    }
+
+    func moveCard(
+        _ card: KanbanCard,
+        to status: String,
+        confirmingRunningExit: Bool = false
+    ) async {
+        guard status != "running", moveDestinations(for: card).contains(status) else { return }
+        await performStatusMutation(
+            card,
+            status: status,
+            kind: .status(status),
+            confirmingRunningExit: confirmingRunningExit
+        )
+    }
+
+    func completeCard(_ card: KanbanCard, confirmingRunningExit: Bool = false) async {
+        guard card.status?.rawValue != "done", card.status?.rawValue != "archived" else { return }
+        await performStatusMutation(
+            card,
+            status: "done",
+            kind: .status("done"),
+            confirmingRunningExit: confirmingRunningExit
+        )
+    }
+
+    func archiveCard(_ card: KanbanCard, confirmingRunningExit: Bool = false) async {
+        guard let previousStatus = card.status?.rawValue, previousStatus != "archived" else { return }
+        await performStatusMutation(
+            card,
+            status: "archived",
+            kind: .archive(previousStatus: previousStatus),
+            confirmingRunningExit: confirmingRunningExit
+        )
+    }
+
+    func blockCard(
+        _ card: KanbanCard,
+        reason: String?,
+        confirmingRunningExit: Bool = false
+    ) async {
+        guard canMutateCard(card), card.status?.rawValue != "blocked", card.status?.rawValue != "archived" else { return }
+        let reason = normalizedOptional(reason)
+        await performStatusMutation(
+            card,
+            status: "blocked",
+            kind: .block(reason),
+            confirmingRunningExit: confirmingRunningExit
+        ) { [client, selectedBoardSlug] cardID in
+            guard let board = selectedBoardSlug else { throw CancellationError() }
+            return try await client.blockKanbanCard(
+                KanbanCardActionRequest(cardID: cardID, board: board, reason: reason)
+            )
+        }
+    }
+
+    func unblockCard(_ card: KanbanCard) async {
+        guard canMutateCard(card), card.status?.rawValue == "blocked" else { return }
+        await performStatusMutation(card, status: "ready", kind: .unblock) { [client, selectedBoardSlug] cardID in
+            guard let board = selectedBoardSlug else { throw CancellationError() }
+            return try await client.unblockKanbanCard(
+                KanbanCardActionRequest(cardID: cardID, board: board, reason: nil)
+            )
+        }
+    }
+
+    func addPrerequisite(_ prerequisiteID: String, to card: KanbanCard) async {
+        await mutatePrerequisite(prerequisiteID, card: card, isAdding: true)
+    }
+
+    func removePrerequisite(_ prerequisiteID: String, from card: KanbanCard) async {
+        await mutatePrerequisite(prerequisiteID, card: card, isAdding: false)
+    }
+
+    func undoArchive() async {
+        guard hasAvailableArchiveUndo,
+              let undo = archiveUndo,
+              let board = selectedBoardSlug else {
+            archiveUndo = nil
+            return
+        }
+        archiveUndoTask?.cancel()
+        do {
+            let detail = try await client.kanbanCardDetail(
+                KanbanCardDetailRequest(cardID: undo.cardID, board: board)
+            )
+            try KanbanCardDetailValidator.validate(detail, requestedCardID: undo.cardID)
+            guard let card = detail.card, card.status?.rawValue == "archived" else {
+                archiveUndo = nil
+                if let card = detail.card { replaceCardInSnapshot(card) }
+                cardMutationStates[undo.cardID] = KanbanCardMutationState(
+                    kind: .undoArchive(status: undo.previousStatus), phase: .failed
+                )
+                detailRefreshRevision &+= 1
+                return
+            }
+            archiveUndo = nil
+            await performStatusMutation(
+                card,
+                status: undo.previousStatus,
+                kind: .undoArchive(status: undo.previousStatus)
+            )
+            if let phase = cardMutationStates[undo.cardID]?.phase,
+               phase == .failed || phase == .outcomeUncertain {
+                archiveUndo = recoveryUndo(from: undo, card: card)
+            }
+        } catch {
+            forwardAuthentication(error)
+            archiveUndo = recoveryUndo(from: undo, card: undo.card)
+            cardMutationStates[undo.cardID] = KanbanCardMutationState(
+                kind: .undoArchive(status: undo.previousStatus), phase: .outcomeUncertain
+            )
+        }
+    }
+
+    func retryMutation(for card: KanbanCard) async {
+        guard let cardID = normalizedOptional(card.cardID),
+              let mutation = cardMutationStates[cardID],
+              mutation.phase == .failed else { return }
+        switch mutation.kind {
+        case let .status(status):
+            await performStatusMutation(card, status: status, kind: mutation.kind)
+        case let .block(reason):
+            await blockCard(card, reason: reason)
+        case .unblock:
+            await unblockCard(card)
+        case let .addPrerequisite(prerequisiteID):
+            await addPrerequisite(prerequisiteID, to: card)
+        case let .removePrerequisite(prerequisiteID):
+            await removePrerequisite(prerequisiteID, from: card)
+        case .archive:
+            await archiveCard(card)
+        case let .undoArchive(status):
+            await performStatusMutation(card, status: status, kind: mutation.kind)
+        }
+    }
+
+    func checkUncertainMutation(for card: KanbanCard) async {
+        guard let cardID = normalizedOptional(card.cardID),
+              let mutation = cardMutationStates[cardID],
+              mutation.phase == .outcomeUncertain,
+              activeCardMutationIDs[cardID] == nil,
+              let board = selectedBoardSlug else { return }
+        cardMutationStates[cardID] = KanbanCardMutationState(
+            kind: mutation.kind,
+            phase: .checkingResult
+        )
+        do {
+            let detail = try await client.kanbanCardDetail(
+                KanbanCardDetailRequest(cardID: cardID, board: board)
+            )
+            try KanbanCardDetailValidator.validate(detail, requestedCardID: cardID)
+            guard let authoritative = detail.card else { throw KanbanMutationSettlementError.unexpectedStatus }
+            uncertainProtectedCards[cardID] = nil
+            replaceCardInSnapshot(authoritative)
+            let succeeded: Bool
+            switch mutation.kind {
+            case let .status(status), let .undoArchive(status):
+                succeeded = authoritative.status?.rawValue == status
+            case .block:
+                succeeded = authoritative.status?.rawValue == "blocked"
+            case .unblock:
+                succeeded = authoritative.status?.rawValue == "ready"
+            case .archive:
+                succeeded = authoritative.status?.rawValue == "archived"
+            case let .addPrerequisite(prerequisiteID):
+                succeeded = detail.links?.prerequisites?.contains(prerequisiteID) == true
+            case let .removePrerequisite(prerequisiteID):
+                succeeded = detail.links?.prerequisites?.contains(prerequisiteID) != true
+            }
+            cardMutationStates[cardID] = KanbanCardMutationState(
+                kind: mutation.kind,
+                phase: succeeded ? .succeeded : .failed
+            )
+            if case .undoArchive = mutation.kind, succeeded { archiveUndo = nil }
+            detailRefreshRevision &+= 1
+        } catch {
+            forwardAuthentication(error)
+            if isNotFound(error) { uncertainProtectedCards[cardID] = nil }
+            cardMutationStates[cardID] = KanbanCardMutationState(
+                kind: mutation.kind,
+                phase: isNotFound(error) ? .failed : .outcomeUncertain
+            )
+        }
+    }
+
     func load() async {
+        archiveUndoTask?.cancel()
+        archiveUndo = nil
         resetLiveUpdates(clearCursor: true)
         let loadID = UUID()
         activeLoadID = loadID
@@ -268,7 +543,11 @@ final class KanbanFeatureState {
     }
 
     func selectBoard(_ slug: String) async {
-        guard boards.contains(where: { normalized($0.slug) == slug }), slug != selectedBoardSlug else { return }
+        guard activeCardMutationIDs.isEmpty,
+              boards.contains(where: { normalized($0.slug) == slug }),
+              slug != selectedBoardSlug else { return }
+        archiveUndoTask?.cancel()
+        archiveUndo = nil
         resetLiveUpdates(clearCursor: true)
         selectedBoardSlug = slug
         snapshot = nil
@@ -397,6 +676,385 @@ final class KanbanFeatureState {
         _ = await refreshBoard(usingCursor: false, refreshSupplementary: true)
     }
 
+    private func performStatusMutation(
+        _ card: KanbanCard,
+        status: String,
+        kind: KanbanCardMutationKind,
+        confirmingRunningExit: Bool = false,
+        write: ((String) async throws -> KanbanCardMutationEnvelope)? = nil
+    ) async {
+        guard status != "running",
+              card.status?.rawValue != "running" || confirmingRunningExit,
+              canMutateCard(card),
+              let cardID = normalizedOptional(card.cardID),
+              activeCardMutationIDs[cardID] == nil,
+              let board = selectedBoardSlug else { return }
+
+        let baseline = cardInSnapshot(cardID) ?? card
+        uncertainProtectedCards[cardID] = nil
+        let mutationID = UUID()
+        activeCardMutationIDs[cardID] = mutationID
+        pendingOptimisticStatuses[cardID] = status
+        cardMutationStates[cardID] = KanbanCardMutationState(kind: kind, phase: .updating)
+        replaceCardInSnapshot(baseline.replacingStatus(status))
+
+        do {
+            let response: KanbanCardMutationEnvelope
+            if let write {
+                response = try await write(cardID)
+            } else {
+                response = try await client.setKanbanCardStatus(
+                    KanbanCardStatusRequest(cardID: cardID, board: board, status: status)
+                )
+            }
+            guard activeCardMutationIDs[cardID] == mutationID else { return }
+            let authoritative = try KanbanCardMutationValidator.validate(response, expectedCardID: cardID)
+            guard authoritative.status?.rawValue == status else {
+                throw KanbanMutationSettlementError.unexpectedStatus
+            }
+            settleSuccessfulStatusMutation(
+                authoritative,
+                baseline: baseline,
+                kind: kind,
+                mutationID: mutationID
+            )
+        } catch {
+            guard activeCardMutationIDs[cardID] == mutationID else { return }
+            guard !isCancellation(error) else {
+                restoreFailedOptimisticMutation(cardID: cardID, baseline: baseline, kind: kind, phase: .failed)
+                return
+            }
+            forwardAuthentication(error)
+            if isDefinitiveWriteFailure(error) {
+                restoreFailedOptimisticMutation(cardID: cardID, baseline: baseline, kind: kind, phase: .failed)
+            } else {
+                cardMutationStates[cardID] = KanbanCardMutationState(kind: kind, phase: .checkingResult)
+                await reconcileStatusMutation(
+                    cardID: cardID,
+                    expectedStatus: status,
+                    baseline: baseline,
+                    kind: kind,
+                    mutationID: mutationID
+                )
+            }
+        }
+    }
+
+    private func reconcileStatusMutation(
+        cardID: String,
+        expectedStatus: String,
+        baseline: KanbanCard,
+        kind: KanbanCardMutationKind,
+        mutationID: UUID
+    ) async {
+        guard let board = selectedBoardSlug else { return }
+        do {
+            let detail = try await client.kanbanCardDetail(
+                KanbanCardDetailRequest(cardID: cardID, board: board)
+            )
+            try KanbanCardDetailValidator.validate(detail, requestedCardID: cardID)
+            guard activeCardMutationIDs[cardID] == mutationID, let authoritative = detail.card else { return }
+            if authoritative.status?.rawValue == expectedStatus {
+                settleSuccessfulStatusMutation(
+                    authoritative,
+                    baseline: baseline,
+                    kind: kind,
+                    mutationID: mutationID
+                )
+            } else {
+                restoreFailedOptimisticMutation(
+                    cardID: cardID,
+                    baseline: authoritative,
+                    kind: kind,
+                    phase: .failed
+                )
+            }
+        } catch {
+            guard activeCardMutationIDs[cardID] == mutationID else { return }
+            forwardAuthentication(error)
+            if isNotFound(error) {
+                removeCardFromSnapshot(cardID)
+                finishMutation(cardID: cardID, kind: kind, phase: .failed)
+            } else {
+                restoreFailedOptimisticMutation(
+                    cardID: cardID,
+                    baseline: baseline,
+                    kind: kind,
+                    phase: .outcomeUncertain
+                )
+            }
+        }
+    }
+
+    private func settleSuccessfulStatusMutation(
+        _ authoritative: KanbanCard,
+        baseline: KanbanCard,
+        kind: KanbanCardMutationKind,
+        mutationID: UUID
+    ) {
+        guard let cardID = normalizedOptional(authoritative.cardID),
+              activeCardMutationIDs[cardID] == mutationID else { return }
+        pendingOptimisticStatuses[cardID] = nil
+        replaceCardInSnapshot(authoritative)
+        finishMutation(cardID: cardID, kind: kind, phase: .succeeded)
+        if case let .archive(previousStatus) = kind {
+            offerArchiveUndo(
+                card: authoritative,
+                title: baseline.title,
+                previousStatus: previousStatus
+            )
+        }
+    }
+
+    private func mutatePrerequisite(_ prerequisiteID: String, card: KanbanCard, isAdding: Bool) async {
+        guard canMutateCard(card),
+              let cardID = normalizedOptional(card.cardID),
+              let prerequisiteID = normalizedOptional(prerequisiteID),
+              prerequisiteID != cardID,
+              activeCardMutationIDs[cardID] == nil,
+              let board = selectedBoardSlug else { return }
+
+        let kind: KanbanCardMutationKind = isAdding
+            ? .addPrerequisite(prerequisiteID)
+            : .removePrerequisite(prerequisiteID)
+        let request = KanbanDependencyMutationRequest(
+            board: board,
+            prerequisiteID: prerequisiteID,
+            dependentID: cardID
+        )
+        let mutationID = UUID()
+        activeCardMutationIDs[cardID] = mutationID
+        pendingDependencyChanges[cardID] = KanbanPendingDependencyChange(
+            prerequisiteID: prerequisiteID,
+            isAdding: isAdding
+        )
+        cardMutationStates[cardID] = KanbanCardMutationState(kind: kind, phase: .updating)
+
+        do {
+            let response = try await (isAdding
+                ? client.addKanbanDependency(request)
+                : client.removeKanbanDependency(request))
+            guard activeCardMutationIDs[cardID] == mutationID else { return }
+            try KanbanDependencyMutationValidator.validate(response, request: request)
+            cardMutationStates[cardID] = KanbanCardMutationState(kind: kind, phase: .checkingResult)
+            await reconcileDependencyMutation(
+                request: request,
+                shouldExist: isAdding,
+                kind: kind,
+                mutationID: mutationID
+            )
+        } catch {
+            guard activeCardMutationIDs[cardID] == mutationID else { return }
+            forwardAuthentication(error)
+            if isDefinitiveWriteFailure(error) {
+                pendingDependencyChanges[cardID] = nil
+                finishMutation(cardID: cardID, kind: kind, phase: .failed)
+            } else {
+                cardMutationStates[cardID] = KanbanCardMutationState(kind: kind, phase: .checkingResult)
+                await reconcileDependencyMutation(
+                    request: request,
+                    shouldExist: isAdding,
+                    kind: kind,
+                    mutationID: mutationID
+                )
+            }
+        }
+    }
+
+    private func reconcileDependencyMutation(
+        request: KanbanDependencyMutationRequest,
+        shouldExist: Bool,
+        kind: KanbanCardMutationKind,
+        mutationID: UUID
+    ) async {
+        let cardID = request.dependentID
+        do {
+            let detail = try await client.kanbanCardDetail(
+                KanbanCardDetailRequest(cardID: cardID, board: request.board)
+            )
+            try KanbanCardDetailValidator.validate(detail, requestedCardID: cardID)
+            guard activeCardMutationIDs[cardID] == mutationID else { return }
+            let exists = detail.links?.prerequisites?.contains(request.prerequisiteID) == true
+            pendingDependencyChanges[cardID] = nil
+            finishMutation(
+                cardID: cardID,
+                kind: kind,
+                phase: exists == shouldExist ? .succeeded : .failed
+            )
+        } catch {
+            guard activeCardMutationIDs[cardID] == mutationID else { return }
+            forwardAuthentication(error)
+            pendingDependencyChanges[cardID] = nil
+            finishMutation(
+                cardID: cardID,
+                kind: kind,
+                phase: isNotFound(error) ? .failed : .outcomeUncertain
+            )
+        }
+    }
+
+    private func offerArchiveUndo(card: KanbanCard, title: String?, previousStatus: String) {
+        guard let cardID = normalizedOptional(card.cardID) else { return }
+        archiveUndoTask?.cancel()
+        let undo = KanbanArchiveUndo(
+            cardID: cardID,
+            cardTitle: normalizedOptional(title) ?? cardID,
+            previousStatus: previousStatus,
+            expiresAt: Date().addingTimeInterval(archiveUndoLifetime),
+            card: card
+        )
+        archiveUndo = undo
+        archiveUndoTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: .seconds(self.archiveUndoLifetime))
+            guard !Task.isCancelled, self.archiveUndo == undo else { return }
+            self.archiveUndo = nil
+        }
+    }
+
+    private func recoveryUndo(from undo: KanbanArchiveUndo, card: KanbanCard) -> KanbanArchiveUndo {
+        KanbanArchiveUndo(
+            cardID: undo.cardID,
+            cardTitle: undo.cardTitle,
+            previousStatus: undo.previousStatus,
+            expiresAt: .distantFuture,
+            card: card
+        )
+    }
+
+    private func restoreFailedOptimisticMutation(
+        cardID: String,
+        baseline: KanbanCard,
+        kind: KanbanCardMutationKind,
+        phase: KanbanCardMutationPhase
+    ) {
+        pendingOptimisticStatuses[cardID] = nil
+        uncertainProtectedCards[cardID] = phase == .outcomeUncertain ? baseline : nil
+        replaceCardInSnapshot(baseline)
+        finishMutation(cardID: cardID, kind: kind, phase: phase)
+    }
+
+    private func finishMutation(
+        cardID: String,
+        kind: KanbanCardMutationKind,
+        phase: KanbanCardMutationPhase
+    ) {
+        activeCardMutationIDs[cardID] = nil
+        if phase != .outcomeUncertain { uncertainProtectedCards[cardID] = nil }
+        cardMutationStates[cardID] = KanbanCardMutationState(kind: kind, phase: phase)
+        detailRefreshRevision &+= 1
+    }
+
+    private func cardInSnapshot(_ cardID: String) -> KanbanCard? {
+        allCards.first { normalizedOptional($0.cardID) == cardID }
+    }
+
+    private func replaceCardInSnapshot(_ card: KanbanCard) {
+        guard let snapshot, let cardID = normalizedOptional(card.cardID),
+              let destination = normalizedOptional(card.status?.rawValue) else { return }
+        var destinationFound = false
+        var columns = (snapshot.columns ?? []).map { column in
+            var cards = (column.cards ?? []).filter { normalizedOptional($0.cardID) != cardID }
+            if column.name == destination {
+                cards.append(card)
+                destinationFound = true
+            }
+            return KanbanColumn(name: column.name, cards: cards)
+        }
+        if !destinationFound, destination != "archived" || includeArchived {
+            columns.append(KanbanColumn(name: destination, cards: [card]))
+        }
+        self.snapshot = snapshotReplacingColumns(snapshot, columns: columns)
+    }
+
+    private func removeCardFromSnapshot(_ cardID: String) {
+        guard let snapshot else { return }
+        let columns = (snapshot.columns ?? []).map { column in
+            KanbanColumn(
+                name: column.name,
+                cards: (column.cards ?? []).filter { normalizedOptional($0.cardID) != cardID }
+            )
+        }
+        self.snapshot = snapshotReplacingColumns(snapshot, columns: columns)
+    }
+
+    private func applyingPendingOptimism(to response: KanbanBoardSnapshot) -> KanbanBoardSnapshot {
+        var result = response
+        for card in uncertainProtectedCards.values {
+            result = snapshotReplacing(card, in: result)
+        }
+        for (cardID, status) in pendingOptimisticStatuses {
+            guard let card = (result.columns ?? []).flatMap({ $0.cards ?? [] }).first(where: {
+                normalizedOptional($0.cardID) == cardID
+            }) ?? cardInSnapshot(cardID) else { continue }
+            result = snapshotReplacing(card.replacingStatus(status), in: result)
+        }
+        return result
+    }
+
+    private func snapshotReplacing(_ card: KanbanCard, in snapshot: KanbanBoardSnapshot) -> KanbanBoardSnapshot {
+        guard let cardID = normalizedOptional(card.cardID),
+              let destination = normalizedOptional(card.status?.rawValue) else { return snapshot }
+        var destinationFound = false
+        var columns = (snapshot.columns ?? []).map { column in
+            var cards = (column.cards ?? []).filter { normalizedOptional($0.cardID) != cardID }
+            if column.name == destination {
+                cards.append(card)
+                destinationFound = true
+            }
+            return KanbanColumn(name: column.name, cards: cards)
+        }
+        if !destinationFound, destination != "archived" || includeArchived {
+            columns.append(KanbanColumn(name: destination, cards: [card]))
+        }
+        return snapshotReplacingColumns(snapshot, columns: columns)
+    }
+
+    private func snapshotReplacingColumns(
+        _ snapshot: KanbanBoardSnapshot,
+        columns: [KanbanColumn]
+    ) -> KanbanBoardSnapshot {
+        KanbanBoardSnapshot(
+            columns: columns,
+            tenants: snapshot.tenants,
+            assignees: snapshot.assignees,
+            filters: snapshot.filters,
+            changed: snapshot.changed,
+            latestEventID: snapshot.latestEventID,
+            readOnly: snapshot.readOnly
+        )
+    }
+
+    private func isDefinitiveWriteFailure(_ error: Error) -> Bool {
+        guard let apiError = error as? APIError else { return error is KanbanRequestError }
+        switch apiError {
+        case .unauthorized, .invalidServerURL:
+            return true
+        case let .http(statusCode, _):
+            return (400..<500).contains(statusCode) && statusCode != 408
+        case .network, .decoding:
+            return false
+        }
+    }
+
+    private func isNotFound(_ error: Error) -> Bool {
+        guard case let APIError.http(statusCode, _) = error else { return false }
+        return statusCode == 404
+    }
+
+    private func isCancellation(_ error: Error) -> Bool {
+        if Task.isCancelled || error is CancellationError { return true }
+        if case let APIError.network(underlying) = error {
+            return (underlying as? URLError)?.code == .cancelled
+        }
+        return false
+    }
+
+    private func normalizedOptional(_ value: String?) -> String? {
+        let value = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value?.isEmpty == false ? value : nil
+    }
+
     private var searchMatchedCards: [KanbanCard] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return allCards }
@@ -433,7 +1091,7 @@ final class KanbanFeatureState {
                 // A cursor refresh may return the minimal unchanged envelope.
             } else {
                 let report = try validateBrowsingSnapshot(response, board: board)
-                snapshot = response
+                snapshot = applyingPendingOptimism(to: response)
                 detailRefreshRevision &+= 1
                 self.report = report
                 state = report.isPartial ? .partial : .compatible
@@ -776,4 +1434,8 @@ final class KanbanFeatureState {
         Array(Set(values.compactMap { normalized($0) }))
             .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }
+}
+
+private enum KanbanMutationSettlementError: Error {
+    case unexpectedStatus
 }

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -125,6 +125,7 @@ final class KanbanFeatureState {
     private var pollingTask: Task<Void, Never>?
     private var activeCardMutationIDs: [String: UUID] = [:]
     private var pendingOptimisticStatuses: [String: String] = [:]
+    private var settledDetailStatuses: [String: String] = [:]
     private var uncertainProtectedCards: [String: KanbanCard] = [:]
     private var pendingDependencyChanges: [String: KanbanPendingDependencyChange] = [:]
     private var archiveUndoTask: Task<Void, Never>?
@@ -268,8 +269,18 @@ final class KanbanFeatureState {
 
     func displayedCard(_ canonical: KanbanCard) -> KanbanCard {
         guard let cardID = normalizedOptional(canonical.cardID),
-              let status = pendingOptimisticStatuses[cardID] else { return canonical }
+              let status = pendingOptimisticStatuses[cardID] ?? settledDetailStatuses[cardID] else {
+            return canonical
+        }
         return canonical.replacingStatus(status)
+    }
+
+    func acknowledgeLoadedCardDetail(_ detail: KanbanCardDetailEnvelope) {
+        guard let cardID = normalizedOptional(detail.card?.cardID),
+              activeCardMutationIDs[cardID] == nil,
+              cardMutationStates[cardID]?.phase == .succeeded else { return }
+        settledDetailStatuses[cardID] = nil
+        pendingDependencyChanges[cardID] = nil
     }
 
     func moveCard(
@@ -378,6 +389,16 @@ final class KanbanFeatureState {
             }
         } catch {
             forwardAuthentication(error)
+            if isNotFound(error) {
+                archiveUndo = nil
+                uncertainProtectedCards[undo.cardID] = nil
+                removeCardFromSnapshot(undo.cardID)
+                cardMutationStates[undo.cardID] = KanbanCardMutationState(
+                    kind: .undoArchive(status: undo.previousStatus), phase: .failed
+                )
+                detailRefreshRevision &+= 1
+                return
+            }
             archiveUndo = recoveryUndo(from: undo, card: undo.card)
             cardMutationStates[undo.cardID] = KanbanCardMutationState(
                 kind: .undoArchive(status: undo.previousStatus), phase: .outcomeUncertain
@@ -448,7 +469,11 @@ final class KanbanFeatureState {
             detailRefreshRevision &+= 1
         } catch {
             forwardAuthentication(error)
-            if isNotFound(error) { uncertainProtectedCards[cardID] = nil }
+            if isNotFound(error) {
+                uncertainProtectedCards[cardID] = nil
+                removeCardFromSnapshot(cardID)
+                if case .undoArchive = mutation.kind { archiveUndo = nil }
+            }
             cardMutationStates[cardID] = KanbanCardMutationState(
                 kind: mutation.kind,
                 phase: isNotFound(error) ? .failed : .outcomeUncertain
@@ -459,6 +484,7 @@ final class KanbanFeatureState {
     func load() async {
         archiveUndoTask?.cancel()
         archiveUndo = nil
+        clearSettledMutationPresentation()
         resetLiveUpdates(clearCursor: true)
         let loadID = UUID()
         activeLoadID = loadID
@@ -548,6 +574,7 @@ final class KanbanFeatureState {
               slug != selectedBoardSlug else { return }
         archiveUndoTask?.cancel()
         archiveUndo = nil
+        clearSettledMutationPresentation()
         resetLiveUpdates(clearCursor: true)
         selectedBoardSlug = slug
         snapshot = nil
@@ -638,7 +665,10 @@ final class KanbanFeatureState {
             cardID: cardID,
             board: board,
             client: client,
-            onAPIError: onAPIError
+            onAPIError: onAPIError,
+            onDetailLoaded: { [weak self] detail in
+                self?.acknowledgeLoadedCardDetail(detail)
+            }
         )
     }
 
@@ -692,6 +722,7 @@ final class KanbanFeatureState {
 
         let baseline = cardInSnapshot(cardID) ?? card
         uncertainProtectedCards[cardID] = nil
+        settledDetailStatuses[cardID] = nil
         let mutationID = UUID()
         activeCardMutationIDs[cardID] = mutationID
         pendingOptimisticStatuses[cardID] = status
@@ -795,6 +826,7 @@ final class KanbanFeatureState {
         guard let cardID = normalizedOptional(authoritative.cardID),
               activeCardMutationIDs[cardID] == mutationID else { return }
         pendingOptimisticStatuses[cardID] = nil
+        settledDetailStatuses[cardID] = authoritative.status?.rawValue
         replaceCardInSnapshot(authoritative)
         finishMutation(cardID: cardID, kind: kind, phase: .succeeded)
         if case let .archive(previousStatus) = kind {
@@ -875,12 +907,9 @@ final class KanbanFeatureState {
             try KanbanCardDetailValidator.validate(detail, requestedCardID: cardID)
             guard activeCardMutationIDs[cardID] == mutationID else { return }
             let exists = detail.links?.prerequisites?.contains(request.prerequisiteID) == true
-            pendingDependencyChanges[cardID] = nil
-            finishMutation(
-                cardID: cardID,
-                kind: kind,
-                phase: exists == shouldExist ? .succeeded : .failed
-            )
+            let succeeded = exists == shouldExist
+            if !succeeded { pendingDependencyChanges[cardID] = nil }
+            finishMutation(cardID: cardID, kind: kind, phase: succeeded ? .succeeded : .failed)
         } catch {
             guard activeCardMutationIDs[cardID] == mutationID else { return }
             forwardAuthentication(error)
@@ -929,6 +958,7 @@ final class KanbanFeatureState {
         phase: KanbanCardMutationPhase
     ) {
         pendingOptimisticStatuses[cardID] = nil
+        settledDetailStatuses[cardID] = nil
         uncertainProtectedCards[cardID] = phase == .outcomeUncertain ? baseline : nil
         replaceCardInSnapshot(baseline)
         finishMutation(cardID: cardID, kind: kind, phase: phase)
@@ -943,6 +973,15 @@ final class KanbanFeatureState {
         if phase != .outcomeUncertain { uncertainProtectedCards[cardID] = nil }
         cardMutationStates[cardID] = KanbanCardMutationState(kind: kind, phase: phase)
         detailRefreshRevision &+= 1
+    }
+
+    private func clearSettledMutationPresentation() {
+        let activeCardIDs = Set(activeCardMutationIDs.keys)
+        cardMutationStates = cardMutationStates.filter { activeCardIDs.contains($0.key) }
+        pendingOptimisticStatuses = pendingOptimisticStatuses.filter { activeCardIDs.contains($0.key) }
+        settledDetailStatuses = settledDetailStatuses.filter { activeCardIDs.contains($0.key) }
+        pendingDependencyChanges = pendingDependencyChanges.filter { activeCardIDs.contains($0.key) }
+        uncertainProtectedCards = uncertainProtectedCards.filter { activeCardIDs.contains($0.key) }
     }
 
     private func cardInSnapshot(_ cardID: String) -> KanbanCard? {

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -1,11 +1,32 @@
 import SwiftUI
 
+enum KanbanCardAction: Equatable {
+    case move(String)
+    case block
+    case unblock
+    case complete
+    case archive
+}
+
+struct KanbanPendingCardAction: Identifiable, Equatable {
+    let id = UUID()
+    let card: KanbanCard
+    let action: KanbanCardAction
+
+    static func == (lhs: KanbanPendingCardAction, rhs: KanbanPendingCardAction) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
 struct KanbanStatusFocusView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Bindable var model: KanbanFeatureState
     @State private var showsFilters = false
     @State private var visibleModel: KanbanFeatureState?
     @State private var cardEditor: KanbanCardEditorState?
+    @State private var pendingRunningAction: KanbanPendingCardAction?
+    @AccessibilityFocusState private var focusedCardID: String?
+    @AccessibilityFocusState private var archiveUndoIsFocused: Bool
 
     var body: some View {
         Group {
@@ -61,10 +82,26 @@ struct KanbanStatusFocusView: View {
         }
         .onChange(of: ObjectIdentifier(model)) { _, _ in
             activateCurrentModel()
-            Task { await model.setSceneActive(scenePhase == .active) }
+            updateSceneActivity(scenePhase)
         }
         .onChange(of: scenePhase) { _, phase in
-            Task { await model.setSceneActive(phase == .active) }
+            updateSceneActivity(phase)
+        }
+        .alert(
+            "Leave Running?",
+            isPresented: Binding(
+                get: { pendingRunningAction != nil },
+                set: { if !$0 { pendingRunningAction = nil } }
+            ),
+            presenting: pendingRunningAction
+        ) { pending in
+            Button("Cancel", role: .cancel) { pendingRunningAction = nil }
+            Button("Continue", role: .destructive) {
+                pendingRunningAction = nil
+                perform(pending.action, for: pending.card, confirmingRunningExit: true)
+            }
+        } message: { _ in
+            Text("Leaving Running may clear the Card's claim and worker state.")
         }
     }
 
@@ -76,6 +113,11 @@ struct KanbanStatusFocusView: View {
         visibleModel?.setVisible(false)
         visibleModel = model
         model.setVisible(true)
+    }
+
+    private func updateSceneActivity(_ phase: ScenePhase) {
+        let isActive = phase == .active
+        Task { await model.setSceneActive(isActive) }
     }
 
     private var loadingContent: some View {
@@ -102,10 +144,55 @@ struct KanbanStatusFocusView: View {
             if model.refreshFailed {
                 refreshErrorBanner
             }
+            if model.hasAvailableArchiveUndo, let undo = model.archiveUndo {
+                archiveUndoBanner(undo)
+            }
             statusSelector
             Divider()
             cardList
         }
+    }
+
+    private func archiveUndoBanner(_ undo: KanbanArchiveUndo) -> some View {
+        let recoveryPhase = model.mutationState(for: undo.cardID)?.phase
+        return HStack {
+            Label(
+                recoveryPhase == .outcomeUncertain
+                    ? String(localized: "Outcome Uncertain")
+                    : recoveryPhase == .failed
+                        ? String(localized: "Update failed")
+                        : String(localized: "Archived"),
+                systemImage: recoveryPhase == nil ? "archivebox" : "exclamationmark.circle"
+            )
+                .lineLimit(2)
+            Spacer()
+            if recoveryPhase == .outcomeUncertain {
+                Button("Refresh") {
+                    Task { await model.checkUncertainMutation(for: undo.card) }
+                }
+                .fontWeight(.semibold)
+            } else {
+                Button(recoveryPhase == .failed ? "Try Again" : "Undo") {
+                    Task { await model.undoArchive() }
+                }
+                .fontWeight(.semibold)
+            }
+        }
+        .font(.footnote)
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.secondary.opacity(0.1))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(
+            Text(
+                String.localizedStringWithFormat(
+                    String(localized: "%@, %@"),
+                    undo.cardTitle,
+                    String(localized: "Archived")
+                )
+            )
+        )
+        .accessibilityFocused($archiveUndoIsFocused)
     }
 
     private var offlineBanner: some View {
@@ -236,12 +323,147 @@ struct KanbanStatusFocusView: View {
     }
 
     private func cardNavigationLink(_ card: KanbanCard) -> some View {
-        NavigationLink {
-            if let cardID = card.cardID {
-                KanbanCardDetailView(featureModel: model, cardID: cardID)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                NavigationLink {
+                    if let cardID = card.cardID {
+                        KanbanCardDetailView(featureModel: model, cardID: cardID)
+                    }
+                } label: {
+                    KanbanCardSummaryView(card: card)
+                }
+                cardActionsMenu(card)
+            }
+            mutationStatus(for: card)
+        }
+        .accessibilityFocused($focusedCardID, equals: card.cardID)
+    }
+
+    private func cardActionsMenu(_ card: KanbanCard) -> some View {
+        Menu {
+            let destinations = model.moveDestinations(for: card)
+            if !destinations.isEmpty {
+                Menu("Move") {
+                    ForEach(destinations, id: \.self) { destination in
+                        Button(KanbanStatusPresentation(destination).title) {
+                            request(.move(destination), for: card)
+                        }
+                    }
+                }
+            }
+            if card.status?.rawValue == "blocked" {
+                Button("Unblock") { request(.unblock, for: card) }
+            } else if card.status?.rawValue != "archived" {
+                Button("Block") { request(.block, for: card) }
+            }
+            if card.status?.rawValue != "done", card.status?.rawValue != "archived" {
+                Button("Complete") { request(.complete, for: card) }
+            }
+            if card.status?.rawValue != "archived" {
+                Button("Archive", role: .destructive) { request(.archive, for: card) }
             }
         } label: {
-            KanbanCardSummaryView(card: card)
+            Image(systemName: "ellipsis.circle")
+                .frame(minWidth: 44, minHeight: 44)
+        }
+        .disabled(!model.canMutateCard(card) || model.isMutatingCard(card.cardID))
+        .accessibilityLabel(Text("Card Actions"))
+    }
+
+    @ViewBuilder
+    private func mutationStatus(for card: KanbanCard) -> some View {
+        if let mutation = model.mutationState(for: card.cardID) {
+            switch mutation.phase {
+            case .updating:
+                Label("Updating task...", systemImage: "arrow.triangle.2.circlepath")
+                    .font(.footnote).foregroundStyle(.secondary)
+            case .checkingResult:
+                Label("Checking Result", systemImage: "arrow.triangle.2.circlepath")
+                    .font(.footnote).foregroundStyle(.secondary)
+            case .succeeded:
+                Label("Updated", systemImage: "checkmark.circle.fill")
+                    .font(.footnote).foregroundStyle(.green)
+            case .failed:
+                HStack {
+                    Label("Update failed", systemImage: "exclamationmark.circle")
+                        .foregroundStyle(.red)
+                    Button("Try Again") { retryMutation(for: card) }
+                }
+                .font(.footnote)
+            case .outcomeUncertain:
+                HStack {
+                    Label("Outcome Uncertain", systemImage: "questionmark.circle")
+                        .foregroundStyle(.orange)
+                    Button("Refresh") { Task { await model.checkUncertainMutation(for: card) } }
+                }
+                .font(.footnote)
+            }
+        }
+    }
+
+    private func request(_ action: KanbanCardAction, for card: KanbanCard) {
+        if card.status?.rawValue == "running" {
+            pendingRunningAction = KanbanPendingCardAction(card: card, action: action)
+        } else {
+            perform(action, for: card)
+        }
+    }
+
+    private func perform(
+        _ action: KanbanCardAction,
+        for card: KanbanCard,
+        confirmingRunningExit: Bool = false
+    ) {
+        Task {
+            switch action {
+            case let .move(status):
+                await model.moveCard(card, to: status, confirmingRunningExit: confirmingRunningExit)
+                if model.mutationState(for: card.cardID)?.phase == .succeeded {
+                    model.selectedStatus = status
+                    await Task.yield()
+                    focusedCardID = card.cardID
+                }
+            case .block:
+                await model.blockCard(card, reason: nil, confirmingRunningExit: confirmingRunningExit)
+                if model.mutationState(for: card.cardID)?.phase == .succeeded {
+                    model.selectedStatus = "blocked"
+                    await Task.yield()
+                    focusedCardID = card.cardID
+                }
+            case .unblock:
+                await model.unblockCard(card)
+                if model.mutationState(for: card.cardID)?.phase == .succeeded {
+                    model.selectedStatus = "ready"
+                    await Task.yield()
+                    focusedCardID = card.cardID
+                }
+            case .complete:
+                await model.completeCard(card, confirmingRunningExit: confirmingRunningExit)
+                if model.mutationState(for: card.cardID)?.phase == .succeeded {
+                    model.selectedStatus = "done"
+                    await Task.yield()
+                    focusedCardID = card.cardID
+                }
+            case .archive:
+                await model.archiveCard(card, confirmingRunningExit: confirmingRunningExit)
+                if model.hasAvailableArchiveUndo {
+                    archiveUndoIsFocused = true
+                }
+            }
+        }
+    }
+
+    private func retryMutation(for card: KanbanCard) {
+        guard card.status?.rawValue == "running",
+              let mutation = model.mutationState(for: card.cardID) else {
+            Task { await model.retryMutation(for: card) }
+            return
+        }
+        switch mutation.kind {
+        case let .status(status): request(status == "done" ? .complete : .move(status), for: card)
+        case .block: request(.block, for: card)
+        case .archive: request(.archive, for: card)
+        default: Task { await model.retryMutation(for: card) }
         }
     }
 

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -155,14 +155,16 @@ struct KanbanStatusFocusView: View {
 
     private func archiveUndoBanner(_ undo: KanbanArchiveUndo) -> some View {
         let recoveryPhase = model.mutationState(for: undo.cardID)?.phase
+        let statusText = recoveryPhase == .outcomeUncertain
+            ? String(localized: "Outcome Uncertain")
+            : recoveryPhase == .failed
+                ? String(localized: "Update failed")
+                : String(localized: "Archived")
+        let hasRecoveryError = recoveryPhase == .outcomeUncertain || recoveryPhase == .failed
         return HStack {
             Label(
-                recoveryPhase == .outcomeUncertain
-                    ? String(localized: "Outcome Uncertain")
-                    : recoveryPhase == .failed
-                        ? String(localized: "Update failed")
-                        : String(localized: "Archived"),
-                systemImage: recoveryPhase == nil ? "archivebox" : "exclamationmark.circle"
+                statusText,
+                systemImage: hasRecoveryError ? "exclamationmark.circle" : "archivebox"
             )
                 .lineLimit(2)
             Spacer()
@@ -188,7 +190,7 @@ struct KanbanStatusFocusView: View {
                 String.localizedStringWithFormat(
                     String(localized: "%@, %@"),
                     undo.cardTitle,
-                    String(localized: "Archived")
+                    statusText
                 )
             )
         )

--- a/HermesMobile/Models/Kanban.swift
+++ b/HermesMobile/Models/Kanban.swift
@@ -35,6 +35,36 @@ struct KanbanEditCardRequest: Equatable, Sendable {
     }
 }
 
+struct KanbanCardStatusRequest: Equatable, Sendable {
+    let cardID: String
+    let board: String
+    let status: String
+
+    var queryItems: [URLQueryItem] {
+        [URLQueryItem(name: "board", value: board)]
+    }
+}
+
+struct KanbanCardActionRequest: Equatable, Sendable {
+    let cardID: String
+    let board: String
+    let reason: String?
+
+    var queryItems: [URLQueryItem] {
+        [URLQueryItem(name: "board", value: board)]
+    }
+}
+
+struct KanbanDependencyMutationRequest: Equatable, Sendable {
+    let board: String
+    let prerequisiteID: String
+    let dependentID: String
+
+    var queryItems: [URLQueryItem] {
+        [URLQueryItem(name: "board", value: board)]
+    }
+}
+
 struct KanbanCardDetailRequest: Equatable, Sendable {
     let cardID: String
     let board: String
@@ -273,6 +303,24 @@ struct KanbanBoardSnapshot: Decodable, Equatable, Sendable {
         case latestEventID = "latestEventId"
     }
 
+    init(
+        columns: [KanbanColumn]?,
+        tenants: [String]?,
+        assignees: [String]?,
+        filters: KanbanAppliedFilters?,
+        changed: Bool?,
+        latestEventID: Int?,
+        readOnly: Bool?
+    ) {
+        self.columns = columns
+        self.tenants = tenants
+        self.assignees = assignees
+        self.filters = filters
+        self.changed = changed
+        self.latestEventID = latestEventID
+        self.readOnly = readOnly
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         columns = try? container.decodeIfPresent([KanbanColumn].self, forKey: .columns)
@@ -292,6 +340,11 @@ struct KanbanColumn: Decodable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case name
         case cards = "tasks"
+    }
+
+    init(name: String?, cards: [KanbanCard]?) {
+        self.name = name
+        self.cards = cards
     }
 
     init(from decoder: Decoder) throws {
@@ -334,6 +387,50 @@ struct KanbanCard: Decodable, Equatable, Sendable {
         case workerID = "workerPid"
     }
 
+    init(
+        cardID: String?,
+        title: String?,
+        status: KanbanStatus?,
+        assignee: String?,
+        body: String?,
+        tenant: String?,
+        priority: Int?,
+        commentCount: Int?,
+        linkCounts: KanbanLinkCounts?,
+        ageSeconds: Double?,
+        createdAt: String?,
+        updatedAt: String?,
+        workspaceKind: String?,
+        workspacePath: String?,
+        skills: [String]?,
+        maxRuntimeSeconds: Int?,
+        currentRunID: String?,
+        claimLock: String?,
+        claimExpires: String?,
+        workerID: String?
+    ) {
+        self.cardID = cardID
+        self.title = title
+        self.status = status
+        self.assignee = assignee
+        self.body = body
+        self.tenant = tenant
+        self.priority = priority
+        self.commentCount = commentCount
+        self.linkCounts = linkCounts
+        self.ageSeconds = ageSeconds
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.workspaceKind = workspaceKind
+        self.workspacePath = workspacePath
+        self.skills = skills
+        self.maxRuntimeSeconds = maxRuntimeSeconds
+        self.currentRunID = currentRunID
+        self.claimLock = claimLock
+        self.claimExpires = claimExpires
+        self.workerID = workerID
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         cardID = container.decodeLossyStringIfPresent(forKey: .cardID)
@@ -370,6 +467,31 @@ struct KanbanCard: Decodable, Equatable, Sendable {
         default:
             return .none
         }
+    }
+
+    func replacingStatus(_ status: String) -> KanbanCard {
+        KanbanCard(
+            cardID: cardID,
+            title: title,
+            status: KanbanStatus(rawValue: status),
+            assignee: assignee,
+            body: body,
+            tenant: tenant,
+            priority: priority,
+            commentCount: commentCount,
+            linkCounts: linkCounts,
+            ageSeconds: ageSeconds,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            workspaceKind: workspaceKind,
+            workspacePath: workspacePath,
+            skills: skills,
+            maxRuntimeSeconds: maxRuntimeSeconds,
+            currentRunID: status == "running" ? currentRunID : nil,
+            claimLock: status == "running" ? claimLock : nil,
+            claimExpires: status == "running" ? claimExpires : nil,
+            workerID: status == "running" ? workerID : nil
+        )
     }
 }
 
@@ -410,6 +532,47 @@ struct KanbanCardMutationEnvelope: Decodable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         card = try? container.decodeIfPresent(KanbanCard.self, forKey: .card)
         readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+struct KanbanDependencyMutationEnvelope: Decodable, Equatable, Sendable {
+    let ok: Bool?
+    let changed: Bool?
+    let prerequisiteID: String?
+    let dependentID: String?
+    let readOnly: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case ok, changed, readOnly
+        case prerequisiteID = "parentId"
+        case dependentID = "childId"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ok = container.decodeLossyBoolIfPresent(forKey: .ok)
+        changed = container.decodeLossyBoolIfPresent(forKey: .changed)
+        prerequisiteID = container.decodeLossyStringIfPresent(forKey: .prerequisiteID)
+        dependentID = container.decodeLossyStringIfPresent(forKey: .dependentID)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+enum KanbanDependencyMutationValidator {
+    static func validate(
+        _ envelope: KanbanDependencyMutationEnvelope,
+        request: KanbanDependencyMutationRequest
+    ) throws {
+        guard envelope.ok == true,
+              normalized(envelope.prerequisiteID) == normalized(request.prerequisiteID),
+              normalized(envelope.dependentID) == normalized(request.dependentID) else {
+            throw KanbanContractViolation.missingCardIdentity
+        }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 }
 

--- a/HermesMobile/Networking/APIClient+Kanban.swift
+++ b/HermesMobile/Networking/APIClient+Kanban.swift
@@ -12,6 +12,11 @@ protocol KanbanDataClient: Sendable {
     func addKanbanComment(_ request: KanbanAddCommentRequest) async throws -> KanbanAddCommentResponse
     func createKanbanCard(_ request: KanbanCreateCardRequest) async throws -> KanbanCardMutationEnvelope
     func editKanbanCard(_ request: KanbanEditCardRequest) async throws -> KanbanCardMutationEnvelope
+    func setKanbanCardStatus(_ request: KanbanCardStatusRequest) async throws -> KanbanCardMutationEnvelope
+    func blockKanbanCard(_ request: KanbanCardActionRequest) async throws -> KanbanCardMutationEnvelope
+    func unblockKanbanCard(_ request: KanbanCardActionRequest) async throws -> KanbanCardMutationEnvelope
+    func addKanbanDependency(_ request: KanbanDependencyMutationRequest) async throws -> KanbanDependencyMutationEnvelope
+    func removeKanbanDependency(_ request: KanbanDependencyMutationRequest) async throws -> KanbanDependencyMutationEnvelope
 }
 
 extension KanbanDataClient {
@@ -34,6 +39,26 @@ extension KanbanDataClient {
     func editKanbanCard(_ request: KanbanEditCardRequest) async throws -> KanbanCardMutationEnvelope {
         throw KanbanUnsupportedClientMethod.editCard
     }
+
+    func setKanbanCardStatus(_ request: KanbanCardStatusRequest) async throws -> KanbanCardMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.cardStatus
+    }
+
+    func blockKanbanCard(_ request: KanbanCardActionRequest) async throws -> KanbanCardMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.blockCard
+    }
+
+    func unblockKanbanCard(_ request: KanbanCardActionRequest) async throws -> KanbanCardMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.unblockCard
+    }
+
+    func addKanbanDependency(_ request: KanbanDependencyMutationRequest) async throws -> KanbanDependencyMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.addDependency
+    }
+
+    func removeKanbanDependency(_ request: KanbanDependencyMutationRequest) async throws -> KanbanDependencyMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.removeDependency
+    }
 }
 
 private enum KanbanUnsupportedClientMethod: Error {
@@ -42,6 +67,11 @@ private enum KanbanUnsupportedClientMethod: Error {
     case addComment
     case createCard
     case editCard
+    case cardStatus
+    case blockCard
+    case unblockCard
+    case addDependency
+    case removeDependency
 }
 
 extension APIClient: KanbanDataClient {
@@ -101,6 +131,49 @@ extension APIClient: KanbanDataClient {
         )
     }
 
+    func setKanbanCardStatus(_ request: KanbanCardStatusRequest) async throws -> KanbanCardMutationEnvelope {
+        guard request.status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() != "running" else {
+            throw KanbanRequestError.runningStatusRequiresDispatcher
+        }
+        return try await kanbanJSON(
+            endpoint: .kanbanCardStatus(request),
+            method: "PATCH",
+            body: KanbanStatusBody(status: request.status)
+        )
+    }
+
+    func blockKanbanCard(_ request: KanbanCardActionRequest) async throws -> KanbanCardMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanBlockCard(request),
+            method: "POST",
+            body: KanbanActionBody(reason: request.reason)
+        )
+    }
+
+    func unblockKanbanCard(_ request: KanbanCardActionRequest) async throws -> KanbanCardMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanUnblockCard(request),
+            method: "POST",
+            body: KanbanActionBody(reason: nil)
+        )
+    }
+
+    func addKanbanDependency(_ request: KanbanDependencyMutationRequest) async throws -> KanbanDependencyMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanAddDependency(request),
+            method: "POST",
+            body: KanbanDependencyBody(request: request)
+        )
+    }
+
+    func removeKanbanDependency(_ request: KanbanDependencyMutationRequest) async throws -> KanbanDependencyMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanRemoveDependency(request),
+            method: "POST",
+            body: KanbanDependencyBody(request: request)
+        )
+    }
+
     nonisolated func kanbanEventsStreamURL(_ request: KanbanEventsStreamRequest) -> URL {
         Endpoint.kanbanEventsStream(request).url(relativeTo: baseURL)
     }
@@ -141,6 +214,35 @@ extension APIClient: KanbanDataClient {
 
 private struct KanbanCommentBody: Encodable {
     let body: String
+}
+
+enum KanbanRequestError: Error, Equatable {
+    case runningStatusRequiresDispatcher
+}
+
+private struct KanbanStatusBody: Encodable {
+    let status: String
+}
+
+private struct KanbanActionBody: Encodable {
+    let reason: String?
+
+    enum CodingKeys: CodingKey { case reason }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(reason, forKey: .reason)
+    }
+}
+
+private struct KanbanDependencyBody: Encodable {
+    let parentID: String
+    let childID: String
+
+    init(request: KanbanDependencyMutationRequest) {
+        parentID = request.prerequisiteID
+        childID = request.dependentID
+    }
 }
 
 private struct KanbanCreateCardBody: Encodable {

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -105,6 +105,11 @@ enum Endpoint {
     case kanbanAddComment(KanbanAddCommentRequest)
     case kanbanCreateCard(KanbanCreateCardRequest)
     case kanbanEditCard(KanbanEditCardRequest)
+    case kanbanCardStatus(KanbanCardStatusRequest)
+    case kanbanBlockCard(KanbanCardActionRequest)
+    case kanbanUnblockCard(KanbanCardActionRequest)
+    case kanbanAddDependency(KanbanDependencyMutationRequest)
+    case kanbanRemoveDependency(KanbanDependencyMutationRequest)
     case memory
     case memoryWrite
     case skills
@@ -324,6 +329,16 @@ enum Endpoint {
             return "/api/kanban/tasks"
         case let .kanbanEditCard(request):
             return "/api/kanban/tasks/\(request.cardID)"
+        case let .kanbanCardStatus(request):
+            return "/api/kanban/tasks/\(request.cardID)"
+        case let .kanbanBlockCard(request):
+            return "/api/kanban/tasks/\(request.cardID)/block"
+        case let .kanbanUnblockCard(request):
+            return "/api/kanban/tasks/\(request.cardID)/unblock"
+        case .kanbanAddDependency:
+            return "/api/kanban/links"
+        case .kanbanRemoveDependency:
+            return "/api/kanban/links/delete"
         case .memory:
             return "/api/memory"
         case .memoryWrite:
@@ -462,6 +477,12 @@ enum Endpoint {
             return request.queryItems
         case let .kanbanEditCard(request):
             return request.queryItems
+        case let .kanbanCardStatus(request):
+            return request.queryItems
+        case let .kanbanBlockCard(request), let .kanbanUnblockCard(request):
+            return request.queryItems
+        case let .kanbanAddDependency(request), let .kanbanRemoveDependency(request):
+            return request.queryItems
         case let .reasoning(model, provider):
             var items: [URLQueryItem] = []
             if let model, !model.isEmpty {
@@ -495,6 +516,12 @@ enum Endpoint {
             url = kanbanTaskURL(relativeTo: baseURL, cardID: request.cardID, suffix: "/comments")
         case let .kanbanEditCard(request):
             url = kanbanTaskURL(relativeTo: baseURL, cardID: request.cardID)
+        case let .kanbanCardStatus(request):
+            url = kanbanTaskURL(relativeTo: baseURL, cardID: request.cardID)
+        case let .kanbanBlockCard(request):
+            url = kanbanTaskURL(relativeTo: baseURL, cardID: request.cardID, suffix: "/block")
+        case let .kanbanUnblockCard(request):
+            url = kanbanTaskURL(relativeTo: baseURL, cardID: request.cardID, suffix: "/unblock")
         default:
             url = baseURL.appending(path: path)
         }

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -111234,6 +111234,300 @@
         "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "檢視全部" } },
         "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "查看全部" } }
       }
+    },
+    "Add Prerequisite" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "إضافة متطلب سابق" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Voraussetzung hinzufügen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Añadir requisito previo" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajouter un prérequis" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הוספת תנאי מוקדם" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Aggiungi prerequisito" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "前提条件を追加" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "전제 조건 추가" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Vereiste toevoegen" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Dodaj wymaganie wstępne" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Adicionar pré-requisito" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Добавить предварительное условие" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Önkoşul ekle" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "پیشگی شرط شامل کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "新增先決條件" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "添加先决条件" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "新增先決條件" } }
+      }
+    },
+    "Block" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "حظر" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Blockieren" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Bloquear" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Bloquer" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "חסימה" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Blocca" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロック" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "차단" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Blokkeren" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Zablokuj" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Bloquear" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Заблокировать" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Engelle" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بلاک کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "封鎖" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "阻止" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "封鎖" } }
+      }
+    },
+    "Card Actions" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "إجراءات البطاقة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Kartenaktionen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Acciones de la tarjeta" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Actions de la carte" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "פעולות כרטיס" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Azioni scheda" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "カードの操作" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "카드 작업" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Kaartacties" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Akcje karty" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Ações do cartão" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Действия с картой" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Kart eylemleri" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "کارڈ کی کارروائیاں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "卡片操作" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "卡片操作" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "卡片操作" } }
+      }
+    },
+    "Choose Card" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "اختر بطاقة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Karte auswählen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Elegir tarjeta" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Choisir une carte" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "בחירת כרטיס" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Scegli scheda" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "カードを選択" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "카드 선택" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Kaart kiezen" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Wybierz kartę" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Escolher cartão" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Выберите карту" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Kart seç" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "کارڈ منتخب کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "選擇卡片" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "选择卡片" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "選擇卡片" } }
+      }
+    },
+    "Leave Running?" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "هل تريد مغادرة قيد التشغيل؟" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Status „Wird ausgeführt“ verlassen?" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "¿Salir de En ejecución?" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Quitter En cours ?" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "לצאת ממצב פועל?" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Uscire da In esecuzione?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "実行中を終了しますか？" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "실행 중 상태를 벗어나시겠습니까?" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Actief verlaten?" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Opuścić stan Uruchomione?" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Sair de Em execução?" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Выйти из состояния «Выполняется»?" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Çalışıyor durumundan çıkılsın mı?" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "جاری حالت سے نکلیں؟" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "離開「執行中」？" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "离开“运行中”？" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "離開「執行中」？" } }
+      }
+    },
+    "Leaving Running may clear the Card's claim and worker state." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "قد تؤدي مغادرة قيد التشغيل إلى مسح حالة مطالبة البطاقة والعامل." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Beim Verlassen von „Wird ausgeführt“ können Anspruch und Worker-Status der Karte gelöscht werden." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Salir de En ejecución puede borrar la asignación y el estado del proceso de la tarjeta." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Quitter En cours peut effacer la revendication et l’état du worker de la carte." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "יציאה ממצב פועל עלולה לנקות את התביעה ואת מצב העובד של הכרטיס." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Uscire da In esecuzione può cancellare la rivendicazione e lo stato del worker della scheda." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "実行中を終了すると、カードのクレームとワーカー状態が消去される場合があります。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "실행 중 상태를 벗어나면 카드의 클레임 및 작업자 상태가 지워질 수 있습니다." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Als u Actief verlaat, kunnen de claim en workerstatus van de kaart worden gewist." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Opuszczenie stanu Uruchomione może wyczyścić przejęcie i stan procesu karty." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Sair de Em execução pode limpar a reivindicação e o estado do worker do cartão." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "При выходе из состояния «Выполняется» данные захвата и состояние исполнителя карты могут быть очищены." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Çalışıyor durumundan çıkmak Kartın sahiplenme ve çalışan durumunu temizleyebilir." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "جاری حالت سے نکلنے پر کارڈ کا کلیم اور ورکر کی حالت صاف ہو سکتی ہے۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "離開「執行中」可能會清除卡片的認領及工作程序狀態。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "离开“运行中”可能会清除卡片的认领和工作进程状态。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "離開「執行中」可能會清除卡片的認領及工作程序狀態。" } }
+      }
+    },
+    "Move" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "نقل" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Verschieben" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Mover" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Déplacer" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "העברה" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Sposta" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "移動" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이동" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Verplaatsen" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Przenieś" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Mover" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Переместить" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Taşı" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "منتقل کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "移動" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "移动" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "移動" } }
+      }
+    },
+    "Refresh the Card to check the server result before trying again." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "حدّث البطاقة للتحقق من نتيجة الخادم قبل المحاولة مرة أخرى." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Aktualisiere die Karte, um das Serverergebnis zu prüfen, bevor du es erneut versuchst." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Actualiza la tarjeta para comprobar el resultado del servidor antes de volver a intentarlo." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Actualisez la carte pour vérifier le résultat du serveur avant de réessayer." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "יש לרענן את הכרטיס כדי לבדוק את תוצאת השרת לפני ניסיון נוסף." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Aggiorna la scheda per verificare il risultato del server prima di riprovare." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "再試行する前にカードを更新してサーバーの結果を確認してください。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "다시 시도하기 전에 카드를 새로 고쳐 서버 결과를 확인하세요." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Vernieuw de kaart om het serverresultaat te controleren voordat u het opnieuw probeert." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Odśwież kartę, aby sprawdzić wynik serwera przed ponowną próbą." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Atualize o cartão para verificar o resultado do servidor antes de tentar novamente." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Обновите карту, чтобы проверить результат сервера перед повторной попыткой." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Tekrar denemeden önce sunucu sonucunu kontrol etmek için Kartı yenileyin." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "دوبارہ کوشش سے پہلے سرور کا نتیجہ جانچنے کے لیے کارڈ ریفریش کریں۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "再次嘗試前，請重新整理卡片以檢查伺服器結果。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重试前，请刷新卡片以检查服务器结果。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "再次嘗試前，請重新整理卡片以檢查伺服器結果。" } }
+      }
+    },
+    "Remove %@ as Prerequisite" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "إزالة %@ كمتطلب سابق" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "%@ als Voraussetzung entfernen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Quitar %@ como requisito previo" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Retirer %@ des prérequis" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הסרת %@ כתנאי מוקדם" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Rimuovi %@ come prerequisito" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%@ を前提条件から削除" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "%@을(를) 전제 조건에서 제거" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "%@ als vereiste verwijderen" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Usuń %@ jako wymaganie wstępne" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Remover %@ como pré-requisito" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Удалить %@ из предварительных условий" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "%@ öğesini önkoşul olmaktan çıkar" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "%@ کو پیشگی شرط سے ہٹائیں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "移除 %@ 作為先決條件" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "移除 %@ 作为先决条件" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "移除 %@ 作為先決條件" } }
+      }
+    },
+    "The server refused or did not apply this update." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "رفض الخادم هذا التحديث أو لم يطبقه." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Der Server hat dieses Update abgelehnt oder nicht angewendet." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "El servidor rechazó o no aplicó esta actualización." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Le serveur a refusé ou n’a pas appliqué cette mise à jour." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "השרת סירב לעדכון הזה או לא החיל אותו." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Il server ha rifiutato o non ha applicato questo aggiornamento." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "サーバーがこの更新を拒否したか、適用しませんでした。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "서버가 이 업데이트를 거부했거나 적용하지 않았습니다." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "De server heeft deze update geweigerd of niet toegepast." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Serwer odrzucił lub nie zastosował tej aktualizacji." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "O servidor recusou ou não aplicou esta atualização." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Сервер отклонил или не применил это обновление." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Sunucu bu güncellemeyi reddetti veya uygulamadı." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "سرور نے یہ اپ ڈیٹ مسترد کر دی یا لاگو نہیں کی۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "伺服器拒絕或未套用此更新。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "服务器拒绝或未应用此更新。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "伺服器拒絕或未套用此更新。" } }
+      }
+    },
+    "Unblock" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "إلغاء الحظر" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Blockierung aufheben" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Desbloquear" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Débloquer" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "ביטול חסימה" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Sblocca" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ブロック解除" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "차단 해제" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Deblokkeren" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Odblokuj" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Desbloquear" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Разблокировать" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Engeli kaldır" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بلاک ختم کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "解除封鎖" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "解除阻止" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "解除封鎖" } }
+      }
+    },
+    "Undo" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تراجع" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Rückgängig" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Deshacer" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Annuler" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "ביטול" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Annulla" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "元に戻す" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "실행 취소" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Ongedaan maken" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Cofnij" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Desfazer" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Отменить" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Geri al" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "واپس کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "還原" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "撤销" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "還原" } }
+      }
+    },
+    "Undo Archive" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تراجع عن الأرشفة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Archivierung rückgängig machen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Deshacer archivado" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Annuler l’archivage" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "ביטול העברה לארכיון" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Annulla archiviazione" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アーカイブを元に戻す" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보관 취소" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Archiveren ongedaan maken" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Cofnij archiwizację" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Desfazer arquivamento" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Отменить архивацию" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Arşivlemeyi geri al" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "آرکائیو واپس کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "還原封存" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "撤销归档" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "還原封存" } }
+      }
+    },
+    "Update failed" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "فشل التحديث" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Update fehlgeschlagen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Error al actualizar" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Échec de la mise à jour" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "העדכון נכשל" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Aggiornamento non riuscito" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "更新に失敗しました" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "업데이트 실패" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Bijwerken mislukt" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Aktualizacja nie powiodła się" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Falha na atualização" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Не удалось обновить" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Güncelleme başarısız" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "اپ ڈیٹ ناکام ہو گئی" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "更新失敗" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更新失败" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "更新失敗" } }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -311,6 +311,81 @@ final class APIClientKanbanTests: APIClientTestCase {
         XCTAssertThrowsError(try KanbanCardMutationValidator.validate(malformed))
     }
 
+    func testWorkflowAndDependencyMutationsUseExactVerifiedContracts() async throws {
+        var requestIndex = 0
+        let client = makeClient { request in
+            defer { requestIndex += 1 }
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            XCTAssertEqual(components?.queryItems, [URLQueryItem(name: "board", value: "release board")])
+            let data = try XCTUnwrap(apiTestBodyData(from: request))
+            let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+            switch requestIndex {
+            case 0:
+                XCTAssertEqual(request.httpMethod, "PATCH")
+                XCTAssertEqual(components?.path, "/api/kanban/tasks/CARD-1")
+                XCTAssertEqual(body as NSDictionary, ["status": "done"])
+                return apiTestJSONResponse(#"{"task":{"id":"CARD-1","status":"done"},"read_only":false}"#, for: request)
+            case 1:
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(components?.path, "/api/kanban/tasks/CARD-1/block")
+                XCTAssertEqual(body as NSDictionary, ["reason": "Waiting for review"])
+                return apiTestJSONResponse(#"{"task":{"id":"CARD-1","status":"blocked"},"read_only":false}"#, for: request)
+            case 2:
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(components?.path, "/api/kanban/tasks/CARD-1/unblock")
+                XCTAssertTrue(body.isEmpty)
+                return apiTestJSONResponse(#"{"task":{"id":"CARD-1","status":"ready"},"read_only":false}"#, for: request)
+            case 3:
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(components?.path, "/api/kanban/links")
+                XCTAssertEqual(body as NSDictionary, ["parent_id": "CARD-0", "child_id": "CARD-1"])
+                return apiTestJSONResponse(#"{"ok":true,"parent_id":"CARD-0","child_id":"CARD-1","read_only":false}"#, for: request)
+            default:
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(components?.path, "/api/kanban/links/delete")
+                XCTAssertEqual(body as NSDictionary, ["parent_id": "CARD-0", "child_id": "CARD-1"])
+                return apiTestJSONResponse(#"{"ok":true,"changed":true,"parent_id":"CARD-0","child_id":"CARD-1","read_only":false}"#, for: request)
+            }
+        }
+
+        let status = try await client.setKanbanCardStatus(
+            KanbanCardStatusRequest(cardID: "CARD-1", board: "release board", status: "done")
+        )
+        let blocked = try await client.blockKanbanCard(
+            KanbanCardActionRequest(cardID: "CARD-1", board: "release board", reason: "Waiting for review")
+        )
+        let unblocked = try await client.unblockKanbanCard(
+            KanbanCardActionRequest(cardID: "CARD-1", board: "release board", reason: nil)
+        )
+        let dependency = KanbanDependencyMutationRequest(
+            board: "release board", prerequisiteID: "CARD-0", dependentID: "CARD-1"
+        )
+        let linked = try await client.addKanbanDependency(dependency)
+        let unlinked = try await client.removeKanbanDependency(dependency)
+
+        XCTAssertEqual(status.card?.status?.rawValue, "done")
+        XCTAssertEqual(blocked.card?.status?.rawValue, "blocked")
+        XCTAssertEqual(unblocked.card?.status?.rawValue, "ready")
+        XCTAssertNoThrow(try KanbanDependencyMutationValidator.validate(linked, request: dependency))
+        XCTAssertNoThrow(try KanbanDependencyMutationValidator.validate(unlinked, request: dependency))
+    }
+
+    func testRunningEntryIsRejectedBeforeRequestConstruction() async {
+        let client = makeClient { _ in
+            XCTFail("Running must never reach URLSession")
+            throw URLError(.badURL)
+        }
+
+        await XCTAssertThrowsErrorAsync(
+            try await client.setKanbanCardStatus(
+                KanbanCardStatusRequest(cardID: "CARD-1", board: "main", status: " Running ")
+            )
+        ) { error in
+            XCTAssertEqual(error as? KanbanRequestError, .runningStatusRequiresDispatcher)
+        }
+    }
+
     func testCardDetailDecodesExpandedAndMinimalEnvelopesTolerantly() throws {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -453,6 +453,135 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(requestCount, 2, "Checking an uncertain Undo must not repeat the write.")
     }
 
+    func testSuccessfulStatusPresentationPersistsUntilFreshDetailLoads() async throws {
+        let client = ImmediateMutationClient(
+            statusResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"done"}}"#))
+            ],
+            detailResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"done"}}"#))
+            ]
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let staleCard = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+        let detailState = try XCTUnwrap(state.makeCardDetailState(cardID: "CARD-1"))
+
+        await state.completeCard(staleCard)
+
+        XCTAssertEqual(state.displayedCard(staleCard).status?.rawValue, "done")
+        await state.refresh()
+        XCTAssertEqual(
+            state.allCards.first { $0.cardID == "CARD-1" }?.status?.rawValue,
+            "todo",
+            "A settled detail overlay must not mask a later authoritative Board refresh."
+        )
+        XCTAssertEqual(state.displayedCard(staleCard).status?.rawValue, "done")
+        await detailState.load()
+        let laterCanonical: KanbanCardDetailEnvelope = mutationDecode(
+            #"{"task":{"id":"CARD-1","status":"ready"}}"#
+        )
+        XCTAssertEqual(
+            state.displayedCard(try XCTUnwrap(laterCanonical.card)).status?.rawValue,
+            "ready",
+            "A successful detail load must retire the settled status overlay."
+        )
+    }
+
+    func testSuccessfulDependencyPresentationPersistsUntilFreshDetailLoads() async throws {
+        let confirmed: KanbanCardDetailEnvelope = mutationDecode(
+            #"{"task":{"id":"CARD-1","status":"todo"},"links":{"parents":["CARD-2"]}}"#
+        )
+        let client = ImmediateMutationClient(detailResults: [.success(confirmed), .success(confirmed)])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+        let detailState = try XCTUnwrap(state.makeCardDetailState(cardID: "CARD-1"))
+
+        await state.addPrerequisite("CARD-2", to: card)
+
+        XCTAssertEqual(state.displayedPrerequisites(for: "CARD-1", canonical: []), ["CARD-2"])
+        await detailState.load()
+        XCTAssertEqual(
+            state.displayedPrerequisites(for: "CARD-1", canonical: []),
+            [],
+            "A successful detail load must retire the settled dependency overlay."
+        )
+    }
+
+    func testUndoArchiveNotFoundDuringPrefetchClearsRecoveryOffer() async throws {
+        let client = ImmediateMutationClient(
+            statusResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"archived"}}"#))
+            ],
+            detailResults: [.failure(APIError.http(statusCode: 404, body: nil))]
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.archiveCard(card)
+        await state.undoArchive()
+
+        XCTAssertFalse(state.hasAvailableArchiveUndo)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .failed)
+    }
+
+    func testUndoArchiveNotFoundDuringUncertainCheckClearsRecoveryOffer() async throws {
+        let network = APIError.network(underlying: URLError(.networkConnectionLost))
+        let client = ImmediateMutationClient(
+            statusResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"archived"}}"#)),
+                .failure(network)
+            ],
+            detailResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"archived"}}"#)),
+                .failure(network),
+                .failure(APIError.http(statusCode: 404, body: nil))
+            ]
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.archiveCard(card)
+        await state.undoArchive()
+        let recoveryCard = try XCTUnwrap(state.archiveUndo?.card)
+        await state.checkUncertainMutation(for: recoveryCard)
+
+        XCTAssertFalse(state.hasAvailableArchiveUndo)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .failed)
+    }
+
+    func testFullLoadAndBoardSwitchClearSettledMutationPresentation() async throws {
+        let boards: KanbanBoardsResponse = mutationDecode(
+            #"{"boards":[{"slug":"main"},{"slug":"release"}],"current":"main","read_only":false}"#
+        )
+        let client = ImmediateMutationClient(
+            boards: boards,
+            statusResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"done"}}"#)),
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"done"}}"#))
+            ]
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        var card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.completeCard(card)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .succeeded)
+        await state.load()
+        XCTAssertNil(state.mutationState(for: card.cardID))
+        XCTAssertEqual(state.displayedCard(card).status?.rawValue, "todo")
+
+        card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+        await state.completeCard(card)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .succeeded)
+        await state.selectBoard("release")
+        XCTAssertNil(state.mutationState(for: card.cardID))
+        XCTAssertEqual(state.displayedCard(card).status?.rawValue, "todo")
+    }
+
     private func waitUntil(
         timeout: Duration = .seconds(1),
         condition: @escaping @Sendable () async -> Bool
@@ -595,6 +724,7 @@ private actor DeferredMutationClient: KanbanDataClient {
 
 private actor ImmediateMutationClient: KanbanDataClient {
     private let snapshot: KanbanBoardSnapshot
+    private let boards: KanbanBoardsResponse
     private var statusResults: [Result<KanbanCardMutationEnvelope, Error>]
     private var detailResults: [Result<KanbanCardDetailEnvelope, Error>]
     private let dependencyResult: Result<KanbanDependencyMutationEnvelope, Error>
@@ -604,6 +734,9 @@ private actor ImmediateMutationClient: KanbanDataClient {
 
     init(
         snapshot: KanbanBoardSnapshot = mutationSnapshot(),
+        boards: KanbanBoardsResponse = mutationDecode(
+            #"{"boards":[{"slug":"main"}],"current":"main","read_only":false}"#
+        ),
         statusResults: [Result<KanbanCardMutationEnvelope, Error>] = [],
         detailResults: [Result<KanbanCardDetailEnvelope, Error>] = [],
         dependencyResult: Result<KanbanDependencyMutationEnvelope, Error> = .success(
@@ -611,6 +744,7 @@ private actor ImmediateMutationClient: KanbanDataClient {
         )
     ) {
         self.snapshot = snapshot
+        self.boards = boards
         self.statusResults = statusResults
         self.detailResults = detailResults
         self.dependencyResult = dependencyResult
@@ -620,7 +754,7 @@ private actor ImmediateMutationClient: KanbanDataClient {
         mutationDecode(#"{"columns":["triage","todo","ready","running","blocked","done"],"read_only":false}"#)
     }
     func kanbanBoards() -> KanbanBoardsResponse {
-        mutationDecode(#"{"boards":[{"slug":"main"}],"current":"main","read_only":false}"#)
+        boards
     }
     func kanbanBoard(_ request: KanbanBoardRequest) -> KanbanBoardSnapshot { snapshot }
     func kanbanStats(board: String) -> KanbanStats { mutationDecode("{}") }

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -270,6 +270,201 @@ final class KanbanFeatureStateTests: XCTestCase {
             .none, .warning, .critical
         ])
     }
+
+    func testCardMutationsAreOptimisticSerializedPerCardAndConcurrentAcrossCards() async throws {
+        let client = DeferredMutationClient()
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let firstCard = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+        let secondCard = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-2" })
+
+        let firstWrite = Task { await state.moveCard(firstCard, to: "ready") }
+        try await waitUntil { await client.statusRequestCount == 1 }
+        XCTAssertEqual(state.allCards.first { $0.cardID == "CARD-1" }?.status?.rawValue, "ready")
+        XCTAssertEqual(state.mutationState(for: "CARD-1")?.phase, .updating)
+
+        // A canonical refresh that still carries the old status must not erase
+        // the pending optimistic status.
+        await state.refresh()
+        XCTAssertEqual(state.allCards.first { $0.cardID == "CARD-1" }?.status?.rawValue, "ready")
+
+        let duplicateWrite = Task { await state.completeCard(firstCard) }
+        let unrelatedWrite = Task { await state.moveCard(secondCard, to: "todo") }
+        try await waitUntil { await client.statusRequestCount == 2 }
+        let firstCardRequestCount = await client.requestCount(for: "CARD-1")
+        let maximumConcurrentWrites = await client.maximumConcurrentWrites
+        XCTAssertEqual(firstCardRequestCount, 1)
+        XCTAssertEqual(maximumConcurrentWrites, 2)
+
+        await client.finish(cardID: "CARD-1", status: "ready")
+        await client.finish(cardID: "CARD-2", status: "todo")
+        await firstWrite.value
+        await duplicateWrite.value
+        await unrelatedWrite.value
+
+        XCTAssertEqual(state.mutationState(for: "CARD-1")?.phase, .succeeded)
+        XCTAssertEqual(state.mutationState(for: "CARD-2")?.phase, .succeeded)
+    }
+
+    func testAmbiguousMutationRequiresReconciliationBeforeTryAgain() async throws {
+        let network = APIError.network(underlying: URLError(.networkConnectionLost))
+        let client = ImmediateMutationClient(
+            statusResults: [.failure(network)],
+            detailResults: [
+                .failure(network),
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"done"}}"#))
+            ]
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.completeCard(card)
+
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .outcomeUncertain)
+        var statusRequestCount = await client.statusRequestCount
+        XCTAssertEqual(statusRequestCount, 1)
+        await state.refresh()
+        XCTAssertEqual(
+            state.allCards.first { $0.cardID == card.cardID }?.status?.rawValue,
+            "todo",
+            "An ordinary refresh must preserve the recoverable Card until uncertainty is explicitly checked."
+        )
+        await state.checkUncertainMutation(for: card)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .succeeded)
+        statusRequestCount = await client.statusRequestCount
+        XCTAssertEqual(statusRequestCount, 1, "A result check must never repeat the write.")
+    }
+
+    func testArchiveUndoUsesFreshAuthoritativeStateAndDependencyRefusalsPersist() async throws {
+        let client = ImmediateMutationClient(
+            statusResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","title":"First","status":"archived"}}"#)),
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","title":"First","status":"todo"}}"#))
+            ],
+            detailResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","title":"First","status":"archived"}}"#))
+            ],
+            dependencyResult: .failure(APIError.http(statusCode: 409, body: #"{"error":"cycle"}"#))
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.archiveCard(card)
+        XCTAssertTrue(state.hasAvailableArchiveUndo)
+        XCTAssertFalse(state.allCards.contains { $0.cardID == card.cardID })
+
+        await state.undoArchive()
+        XCTAssertEqual(state.allCards.first { $0.cardID == card.cardID }?.status?.rawValue, "todo")
+        let detailRequestCount = await client.detailRequestCount
+        XCTAssertEqual(detailRequestCount, 1, "Undo must read current authoritative state first.")
+
+        let restored = try XCTUnwrap(state.allCards.first { $0.cardID == card.cardID })
+        await state.addPrerequisite("CARD-2", to: restored)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .failed)
+        let dependencyRequestCount = await client.dependencyRequestCount
+        XCTAssertEqual(dependencyRequestCount, 1)
+    }
+
+    func testUnknownStatusAndRunningDestinationCannotConstructWrites() async throws {
+        let client = ImmediateMutationClient(snapshot: mutationSnapshot(status: "future"))
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        XCTAssertFalse(state.canMutateCard(card))
+        await state.moveCard(card, to: "running")
+        let statusRequestCount = await client.statusRequestCount
+        XCTAssertEqual(statusRequestCount, 0)
+    }
+
+    func testArchiveUndoExpiresWithoutIssuingAnotherWrite() async throws {
+        let client = ImmediateMutationClient(statusResults: [
+            .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"archived"}}"#))
+        ])
+        let state = KanbanFeatureState(
+            server: URL(string: "https://example.test")!,
+            client: client,
+            archiveUndoLifetime: 0.01
+        )
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.archiveCard(card)
+        XCTAssertTrue(state.hasAvailableArchiveUndo)
+        try await Task.sleep(for: .milliseconds(30))
+
+        XCTAssertFalse(state.hasAvailableArchiveUndo)
+        let statusRequestCount = await client.statusRequestCount
+        XCTAssertEqual(statusRequestCount, 1)
+    }
+
+    func testRunningExitRequiresExplicitConfirmationBeforeWriteConstruction() async throws {
+        let client = ImmediateMutationClient(
+            snapshot: mutationSnapshot(status: "running"),
+            statusResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"done"}}"#))
+            ]
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.completeCard(card)
+        var requestCount = await client.statusRequestCount
+        XCTAssertEqual(requestCount, 0)
+
+        await state.completeCard(card, confirmingRunningExit: true)
+        requestCount = await client.statusRequestCount
+        XCTAssertEqual(requestCount, 1)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .succeeded)
+    }
+
+    func testUncertainArchiveUndoStaysRecoverableAndChecksBeforeAnotherWrite() async throws {
+        let network = APIError.network(underlying: URLError(.networkConnectionLost))
+        let client = ImmediateMutationClient(
+            statusResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"archived"}}"#)),
+                .failure(network)
+            ],
+            detailResults: [
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"archived"}}"#)),
+                .failure(network),
+                .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"todo"}}"#))
+            ]
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.archiveCard(card)
+        await state.undoArchive()
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .outcomeUncertain)
+        XCTAssertTrue(state.hasAvailableArchiveUndo)
+        var requestCount = await client.statusRequestCount
+        XCTAssertEqual(requestCount, 2)
+
+        let recoveryCard = try XCTUnwrap(state.archiveUndo?.card)
+        await state.checkUncertainMutation(for: recoveryCard)
+        XCTAssertEqual(state.mutationState(for: card.cardID)?.phase, .succeeded)
+        XCTAssertFalse(state.hasAvailableArchiveUndo)
+        requestCount = await client.statusRequestCount
+        XCTAssertEqual(requestCount, 2, "Checking an uncertain Undo must not repeat the write.")
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: @escaping @Sendable () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return }
+            await Task.yield()
+        }
+        XCTFail("Condition was not met before timeout")
+    }
 }
 
 private enum KanbanEventsNotStubbed: Error { case unexpectedCall }
@@ -357,6 +552,117 @@ private actor DeferredFirstConfigurationClient: KanbanDataClient {
         continuation?.resume(returning: KanbanFixtures.configuration)
         continuation = nil
     }
+}
+
+private actor DeferredMutationClient: KanbanDataClient {
+    private var continuations: [String: CheckedContinuation<KanbanCardMutationEnvelope, Never>] = [:]
+    private var requests: [KanbanCardStatusRequest] = []
+    private var concurrentWrites = 0
+    private(set) var maximumConcurrentWrites = 0
+
+    var statusRequestCount: Int { requests.count }
+
+    func requestCount(for cardID: String) -> Int {
+        requests.count { $0.cardID == cardID }
+    }
+
+    func kanbanConfiguration() -> KanbanConfiguration {
+        mutationDecode(#"{"columns":["triage","todo","ready","running","blocked","done"],"read_only":false}"#)
+    }
+    func kanbanBoards() -> KanbanBoardsResponse {
+        mutationDecode(#"{"boards":[{"slug":"main"}],"current":"main","read_only":false}"#)
+    }
+    func kanbanBoard(_ request: KanbanBoardRequest) -> KanbanBoardSnapshot { mutationSnapshot() }
+    func kanbanStats(board: String) -> KanbanStats { mutationDecode("{}") }
+    func kanbanAssignees(board: String) -> KanbanAssigneeHistory { mutationDecode("{}") }
+
+    func setKanbanCardStatus(_ request: KanbanCardStatusRequest) async -> KanbanCardMutationEnvelope {
+        requests.append(request)
+        concurrentWrites += 1
+        maximumConcurrentWrites = max(maximumConcurrentWrites, concurrentWrites)
+        return await withCheckedContinuation { continuation in
+            continuations[request.cardID] = continuation
+        }
+    }
+
+    func finish(cardID: String, status: String) {
+        concurrentWrites -= 1
+        continuations.removeValue(forKey: cardID)?.resume(
+            returning: mutationDecode(#"{"task":{"id":"\#(cardID)","status":"\#(status)"}}"#)
+        )
+    }
+}
+
+private actor ImmediateMutationClient: KanbanDataClient {
+    private let snapshot: KanbanBoardSnapshot
+    private var statusResults: [Result<KanbanCardMutationEnvelope, Error>]
+    private var detailResults: [Result<KanbanCardDetailEnvelope, Error>]
+    private let dependencyResult: Result<KanbanDependencyMutationEnvelope, Error>
+    private(set) var statusRequestCount = 0
+    private(set) var detailRequestCount = 0
+    private(set) var dependencyRequestCount = 0
+
+    init(
+        snapshot: KanbanBoardSnapshot = mutationSnapshot(),
+        statusResults: [Result<KanbanCardMutationEnvelope, Error>] = [],
+        detailResults: [Result<KanbanCardDetailEnvelope, Error>] = [],
+        dependencyResult: Result<KanbanDependencyMutationEnvelope, Error> = .success(
+            mutationDecode(#"{"ok":true,"parent_id":"CARD-2","child_id":"CARD-1"}"#)
+        )
+    ) {
+        self.snapshot = snapshot
+        self.statusResults = statusResults
+        self.detailResults = detailResults
+        self.dependencyResult = dependencyResult
+    }
+
+    func kanbanConfiguration() -> KanbanConfiguration {
+        mutationDecode(#"{"columns":["triage","todo","ready","running","blocked","done"],"read_only":false}"#)
+    }
+    func kanbanBoards() -> KanbanBoardsResponse {
+        mutationDecode(#"{"boards":[{"slug":"main"}],"current":"main","read_only":false}"#)
+    }
+    func kanbanBoard(_ request: KanbanBoardRequest) -> KanbanBoardSnapshot { snapshot }
+    func kanbanStats(board: String) -> KanbanStats { mutationDecode("{}") }
+    func kanbanAssignees(board: String) -> KanbanAssigneeHistory { mutationDecode("{}") }
+
+    func kanbanCardDetail(_ request: KanbanCardDetailRequest) throws -> KanbanCardDetailEnvelope {
+        detailRequestCount += 1
+        return try detailResults.removeFirst().get()
+    }
+
+    func setKanbanCardStatus(_ request: KanbanCardStatusRequest) throws -> KanbanCardMutationEnvelope {
+        statusRequestCount += 1
+        return try statusResults.removeFirst().get()
+    }
+
+    func addKanbanDependency(
+        _ request: KanbanDependencyMutationRequest
+    ) throws -> KanbanDependencyMutationEnvelope {
+        dependencyRequestCount += 1
+        return try dependencyResult.get()
+    }
+}
+
+private func mutationSnapshot(status: String = "todo") -> KanbanBoardSnapshot {
+    mutationDecode("""
+    {
+      "changed":true,
+      "read_only":false,
+      "columns":[
+        {"name":"triage","tasks":[{"id":"CARD-2","title":"Second","status":"triage"}]},
+        {"name":"\(status)","tasks":[{"id":"CARD-1","title":"First","status":"\(status)"}]},
+        {"name":"ready","tasks":[]},
+        {"name":"done","tasks":[]}
+      ]
+    }
+    """)
+}
+
+private func mutationDecode<T: Decodable>(_ json: String) -> T {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return try! decoder.decode(T.self, from: Data(json.utf8))
 }
 
 private actor BrowsingClient: KanbanDataClient {


### PR DESCRIPTION
## Summary

- add verified status, block, unblock, archive, and dependency mutation contracts
- coordinate per-card optimistic updates with uncertain-outcome recovery and archive Undo
- expose accessible Card actions, Running-exit confirmation, dependency controls, and localized feedback
- add focused API and feature-state coverage

## Validation

- Full XCTest suite: 1,456 passed, 0 failed, 0 skipped
- Focused API/state suite: 38 passed, 0 failed, 0 skipped
- Kanban-focused suite: 70 passed, 0 failed, 0 skipped
- `git diff --check`
- `jq empty HermesMobile/Resources/Localizable.xcstrings`
- signed Debug build, install, and launch on iPhone 17 simulator

## Owner manual checks

- exercised the card workflow in Kanban Lab
- owner result: seems to work fine

Fixes #154