### PR TITLE
fix(chat): serialize foreground stream recovery

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -95,7 +95,8 @@ final class ChatStreamCoordinator {
     // Foreground activation and view appearance can both request recovery for the
     // same suspended stream. Share one recovery task so a late load cannot
     // re-suspend a live connection or let a caller continue before recovery ends.
-    private var reconnectTask: Task<Void, Never>?
+    // The identifier prevents a superseded task from clearing a newer recovery.
+    private var reconnectTask: (id: UUID, task: Task<Void, Never>)?
     // Bumped whenever the active run starts or finalizes. Captured before an async
     // transcript load so a concurrent cancel/completion during the load can't be
     // double-finalized (PR #266 review #2).
@@ -140,6 +141,10 @@ final class ChatStreamCoordinator {
     ) {
         hasCompletedCurrentResponse = false
         runGeneration &+= 1
+        // A newly started stream must not inherit a prior stream's in-flight
+        // recovery task. The old task can finish harmlessly, but its identity
+        // check prevents it from clearing a later recovery.
+        reconnectTask = nil
         activeStreamID = streamID
         isConnectionSuspended = false
         if replayAfterSeq == nil {
@@ -244,16 +249,18 @@ final class ChatStreamCoordinator {
     func reconnectIfNeeded(modelContext: ModelContext? = nil) async {
         guard activeStreamID != nil, isConnectionSuspended else { return }
         if let reconnectTask {
-            await reconnectTask.value
+            await reconnectTask.task.value
             return
         }
 
+        let reconnectTaskID = UUID()
         let reconnectTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.performReconnectIfNeeded(modelContext: modelContext)
+            guard self.reconnectTask?.id == reconnectTaskID else { return }
             self.reconnectTask = nil
         }
-        self.reconnectTask = reconnectTask
+        self.reconnectTask = (id: reconnectTaskID, task: reconnectTask)
         await reconnectTask.value
     }
 

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -99,9 +99,11 @@ final class ChatStreamCoordinator {
     private var reconnectTask: (
         id: UUID,
         streamID: String,
+        runGeneration: Int,
         modelContext: ModelContext?,
         task: Task<Void, Never>
     )?
+    private var reconnectTranscriptLoadTaskID: UUID?
     // Bumped whenever the active run starts or finalizes. Captured before an async
     // transcript load so a concurrent cancel/completion during the load can't be
     // double-finalized (PR #266 review #2).
@@ -265,72 +267,110 @@ final class ChatStreamCoordinator {
         }
 
         let reconnectTaskID = UUID()
+        let reconnectGeneration = runGeneration
         let reconnectTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.performReconnectIfNeeded(reconnectTaskID: reconnectTaskID)
+            await self.performReconnectIfNeeded(
+                reconnectTaskID: reconnectTaskID,
+                streamID: activeStreamID,
+                runGeneration: reconnectGeneration
+            )
             guard self.reconnectTask?.id == reconnectTaskID else { return }
             self.reconnectTask = nil
         }
         self.reconnectTask = (
             id: reconnectTaskID,
             streamID: activeStreamID,
+            runGeneration: reconnectGeneration,
             modelContext: modelContext,
             task: reconnectTask
         )
         await reconnectTask.value
     }
 
-    private func performReconnectIfNeeded(reconnectTaskID: UUID) async {
-        guard let activeStreamID, isConnectionSuspended else { return }
-
-        let generation = runGeneration
+    private func performReconnectIfNeeded(
+        reconnectTaskID: UUID,
+        streamID: String,
+        runGeneration: Int
+    ) async {
+        guard reconnectTaskIsCurrent(
+            reconnectTaskID: reconnectTaskID,
+            streamID: streamID,
+            runGeneration: runGeneration
+        ) else { return }
 
         do {
-            let response = try await client.chatStreamStatus(streamID: activeStreamID)
-            guard self.activeStreamID == activeStreamID, isConnectionSuspended else { return }
+            let response = try await client.chatStreamStatus(streamID: streamID)
+            guard reconnectTaskIsCurrent(
+                reconnectTaskID: reconnectTaskID,
+                streamID: streamID,
+                runGeneration: runGeneration
+            ) else { return }
 
             if response.active == true {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
-                guard self.activeStreamID == activeStreamID, isConnectionSuspended else { return }
+                let completedLoad = await loadMessagesForReconnect(reconnectTaskID: reconnectTaskID)
+                guard completedLoad,
+                      reconnectTaskIsCurrent(
+                          reconnectTaskID: reconnectTaskID,
+                          streamID: streamID,
+                          runGeneration: runGeneration
+                      )
+                else { return }
 
-                let streamIDToResume = activeStreamID
                 if delegate?.streamCoordinatorStreamingAssistantMessageID == nil {
-                    restoreSnapshotIfAvailable(streamID: streamIDToResume)
+                    restoreSnapshotIfAvailable(streamID: streamID)
                 }
                 if delegate?.streamCoordinatorStreamingAssistantMessageID == nil {
                     delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
                 }
                 isConnectionSuspended = false
-                start(streamID: streamIDToResume)
+                start(streamID: streamID)
             } else if response.replayAvailable == true {
+                guard reconnectTaskIsCurrent(
+                    reconnectTaskID: reconnectTaskID,
+                    streamID: streamID,
+                    runGeneration: runGeneration
+                ) else { return }
                 let replayAfterSeq = Self.runJournalReplayAfterSeq(from: lastEventID) ?? 0
-                self.activeStreamID = activeStreamID
                 isConnectionSuspended = false
-                start(streamID: activeStreamID, replayAfterSeq: replayAfterSeq)
+                start(streamID: streamID, replayAfterSeq: replayAfterSeq)
             } else {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
-                // Bail if a concurrent completion/cancel/new run finalized or
-                // replaced this run during the load (see canFinalizeRunAfterLoad).
-                guard canFinalizeRunAfterLoad(streamID: activeStreamID, capturedGeneration: generation) else { return }
+                let completedLoad = await loadMessagesForReconnect(reconnectTaskID: reconnectTaskID)
+                guard completedLoad,
+                      reconnectTaskOwnsFinalization(
+                          reconnectTaskID: reconnectTaskID,
+                          streamID: streamID,
+                          runGeneration: runGeneration
+                      ),
+                      canFinalizeRunAfterLoad(streamID: streamID, capturedGeneration: runGeneration)
+                else { return }
 
-                // #246: the server reports the run is over. Finalize it (and end
-                // the Live Activity) instead of re-arming and leaving it dangling
-                // on "running" when no assistant reply surfaced.
-                finalizeInactiveStream(streamID: activeStreamID)
+                finalizeInactiveStream(streamID: streamID)
             }
         } catch {
             if (error as? APIError)?.indicatesMissingStream == true,
-               self.activeStreamID == activeStreamID,
-               isConnectionSuspended {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
-                guard canFinalizeRunAfterLoad(streamID: activeStreamID, capturedGeneration: generation) else { return }
-                finalizeInactiveStream(streamID: activeStreamID)
+               reconnectTaskIsCurrent(
+                   reconnectTaskID: reconnectTaskID,
+                   streamID: streamID,
+                   runGeneration: runGeneration
+               ) {
+                let completedLoad = await loadMessagesForReconnect(reconnectTaskID: reconnectTaskID)
+                guard completedLoad,
+                      reconnectTaskOwnsFinalization(
+                          reconnectTaskID: reconnectTaskID,
+                          streamID: streamID,
+                          runGeneration: runGeneration
+                      ),
+                      canFinalizeRunAfterLoad(streamID: streamID, capturedGeneration: runGeneration)
+                else { return }
+                finalizeInactiveStream(streamID: streamID)
                 return
             }
-            guard !Task.isCancelled,
-                  self.activeStreamID == activeStreamID,
-                  isConnectionSuspended
-            else { return }
+            guard reconnectTaskIsCurrent(
+                reconnectTaskID: reconnectTaskID,
+                streamID: streamID,
+                runGeneration: runGeneration
+            ) else { return }
             delegate?.streamCoordinatorDidReceiveRecoveryError(error)
         }
     }
@@ -711,21 +751,72 @@ final class ChatStreamCoordinator {
         delegate?.streamCoordinatorDidStartConnection(isReplay: isReplay)
     }
 
+    private func loadMessagesForReconnect(reconnectTaskID: UUID) async -> Bool {
+        guard reconnectTask?.id == reconnectTaskID else { return false }
+        reconnectTranscriptLoadTaskID = reconnectTaskID
+        await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
+        let completedLoad = reconnectTranscriptLoadTaskID == reconnectTaskID
+        if completedLoad {
+            reconnectTranscriptLoadTaskID = nil
+        }
+        return completedLoad
+    }
+
+    private func reconnectTaskIsCurrent(
+        reconnectTaskID: UUID,
+        streamID: String,
+        runGeneration: Int
+    ) -> Bool {
+        guard !Task.isCancelled,
+              let reconnectTask,
+              reconnectTask.id == reconnectTaskID,
+              reconnectTask.streamID == streamID,
+              reconnectTask.runGeneration == runGeneration,
+              self.runGeneration == runGeneration,
+              activeStreamID == streamID,
+              isConnectionSuspended
+        else { return false }
+        return true
+    }
+
+    private func reconnectTaskOwnsFinalization(
+        reconnectTaskID: UUID,
+        streamID: String,
+        runGeneration: Int
+    ) -> Bool {
+        guard !Task.isCancelled,
+              let reconnectTask,
+              reconnectTask.id == reconnectTaskID,
+              reconnectTask.streamID == streamID,
+              reconnectTask.runGeneration == runGeneration,
+              self.runGeneration == runGeneration
+        else { return false }
+        return activeStreamID == streamID || activeStreamID == nil
+    }
+
     private func recoveryModelContext(for reconnectTaskID: UUID) -> ModelContext? {
         guard reconnectTask?.id == reconnectTaskID else { return nil }
         return reconnectTask?.modelContext
     }
 
     private func invalidateReconnectTask() {
-        reconnectTask?.task.cancel()
         reconnectTask = nil
+        reconnectTranscriptLoadTaskID = nil
     }
 
     private func invalidateReconnectTaskIfItDoesNotMatchCurrentStream() {
-        guard isConnectionSuspended,
-              let activeStreamID,
-              reconnectTask?.streamID == activeStreamID
+        guard let reconnectTask,
+              reconnectTask.runGeneration == runGeneration
         else {
+            invalidateReconnectTask()
+            return
+        }
+
+        if activeStreamID == nil, reconnectTranscriptLoadTaskID == reconnectTask.id {
+            return
+        }
+
+        guard isConnectionSuspended, activeStreamID == reconnectTask.streamID else {
             invalidateReconnectTask()
             return
         }

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -96,7 +96,7 @@ final class ChatStreamCoordinator {
     // same suspended stream. Share one recovery task so a late load cannot
     // re-suspend a live connection or let a caller continue before recovery ends.
     // The identifier prevents a superseded task from clearing a newer recovery.
-    private var reconnectTask: (id: UUID, task: Task<Void, Never>)?
+    private var reconnectTask: (id: UUID, streamID: String, task: Task<Void, Never>)?
     // Bumped whenever the active run starts or finalizes. Captured before an async
     // transcript load so a concurrent cancel/completion during the load can't be
     // double-finalized (PR #266 review #2).
@@ -132,6 +132,7 @@ final class ChatStreamCoordinator {
     func prepareForNewResponse() {
         hasCompletedCurrentResponse = false
         isConnectionSuspended = false
+        invalidateReconnectTask()
     }
 
     func start(
@@ -142,9 +143,9 @@ final class ChatStreamCoordinator {
         hasCompletedCurrentResponse = false
         runGeneration &+= 1
         // A newly started stream must not inherit a prior stream's in-flight
-        // recovery task. The old task can finish harmlessly, but its identity
-        // check prevents it from clearing a later recovery.
-        reconnectTask = nil
+        // recovery task. Cancel the old recovery; its identity check still keeps
+        // a late completion from clearing a later recovery.
+        invalidateReconnectTask()
         activeStreamID = streamID
         isConnectionSuspended = false
         if replayAfterSeq == nil {
@@ -208,6 +209,7 @@ final class ChatStreamCoordinator {
         usedCacheFallback: Bool
     ) {
         hasCompletedCurrentResponse = false
+        defer { invalidateReconnectTaskIfItDoesNotMatchCurrentStream() }
 
         if usedCacheFallback {
             activeStreamID = nil
@@ -247,7 +249,7 @@ final class ChatStreamCoordinator {
     }
 
     func reconnectIfNeeded(modelContext: ModelContext? = nil) async {
-        guard activeStreamID != nil, isConnectionSuspended else { return }
+        guard let activeStreamID, isConnectionSuspended else { return }
         if let reconnectTask {
             await reconnectTask.task.value
             return
@@ -260,7 +262,7 @@ final class ChatStreamCoordinator {
             guard self.reconnectTask?.id == reconnectTaskID else { return }
             self.reconnectTask = nil
         }
-        self.reconnectTask = (id: reconnectTaskID, task: reconnectTask)
+        self.reconnectTask = (id: reconnectTaskID, streamID: activeStreamID, task: reconnectTask)
         await reconnectTask.value
     }
 
@@ -311,6 +313,10 @@ final class ChatStreamCoordinator {
                 finalizeInactiveStream(streamID: activeStreamID)
                 return
             }
+            guard !Task.isCancelled,
+                  self.activeStreamID == activeStreamID,
+                  isConnectionSuspended
+            else { return }
             delegate?.streamCoordinatorDidReceiveRecoveryError(error)
         }
     }
@@ -609,6 +615,7 @@ final class ChatStreamCoordinator {
 
     private func completeCurrentResponse(needsTranscriptRefresh: Bool) {
         runGeneration &+= 1
+        invalidateReconnectTask()
         liveActivityManager.end(status: .complete, activity: String(localized: "Response complete"), errorSummary: nil)
         delegate?.streamCoordinatorRemoveSnapshot(streamID: activeStreamID)
         delegate?.streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: true)
@@ -659,6 +666,7 @@ final class ChatStreamCoordinator {
 
     private func finishStream() {
         runGeneration &+= 1
+        invalidateReconnectTask()
         let completedNormally = hasCompletedCurrentResponse
         let finishedStreamID = activeStreamID
         streamClient.stop()
@@ -687,6 +695,21 @@ final class ChatStreamCoordinator {
         self.recoveryState = recoveryState
         isReplayConnection = isReplay
         delegate?.streamCoordinatorDidStartConnection(isReplay: isReplay)
+    }
+
+    private func invalidateReconnectTask() {
+        reconnectTask?.task.cancel()
+        reconnectTask = nil
+    }
+
+    private func invalidateReconnectTaskIfItDoesNotMatchCurrentStream() {
+        guard isConnectionSuspended,
+              let activeStreamID,
+              reconnectTask?.streamID == activeStreamID
+        else {
+            invalidateReconnectTask()
+            return
+        }
     }
 
     private func resetRecoveryState() {

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -92,6 +92,10 @@ final class ChatStreamCoordinator {
     private(set) var lastProgressDate: Date?
     private var lastRecoveryStatusCheckDate: Date?
     private(set) var isReplayConnection = false
+    // Foreground activation and view appearance can both request recovery for the
+    // same suspended stream. Share one recovery task so a late load cannot
+    // re-suspend a live connection or let a caller continue before recovery ends.
+    private var reconnectTask: Task<Void, Never>?
     // Bumped whenever the active run starts or finalizes. Captured before an async
     // transcript load so a concurrent cancel/completion during the load can't be
     // double-finalized (PR #266 review #2).
@@ -238,7 +242,24 @@ final class ChatStreamCoordinator {
     }
 
     func reconnectIfNeeded(modelContext: ModelContext? = nil) async {
+        guard activeStreamID != nil, isConnectionSuspended else { return }
+        if let reconnectTask {
+            await reconnectTask.value
+            return
+        }
+
+        let reconnectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performReconnectIfNeeded(modelContext: modelContext)
+            self.reconnectTask = nil
+        }
+        self.reconnectTask = reconnectTask
+        await reconnectTask.value
+    }
+
+    private func performReconnectIfNeeded(modelContext: ModelContext?) async {
         guard let activeStreamID, isConnectionSuspended else { return }
+
         let generation = runGeneration
 
         do {

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -96,7 +96,12 @@ final class ChatStreamCoordinator {
     // same suspended stream. Share one recovery task so a late load cannot
     // re-suspend a live connection or let a caller continue before recovery ends.
     // The identifier prevents a superseded task from clearing a newer recovery.
-    private var reconnectTask: (id: UUID, streamID: String, task: Task<Void, Never>)?
+    private var reconnectTask: (
+        id: UUID,
+        streamID: String,
+        modelContext: ModelContext?,
+        task: Task<Void, Never>
+    )?
     // Bumped whenever the active run starts or finalizes. Captured before an async
     // transcript load so a concurrent cancel/completion during the load can't be
     // double-finalized (PR #266 review #2).
@@ -250,7 +255,11 @@ final class ChatStreamCoordinator {
 
     func reconnectIfNeeded(modelContext: ModelContext? = nil) async {
         guard let activeStreamID, isConnectionSuspended else { return }
-        if let reconnectTask {
+        if var reconnectTask {
+            if reconnectTask.modelContext == nil, let modelContext {
+                reconnectTask.modelContext = modelContext
+                self.reconnectTask = reconnectTask
+            }
             await reconnectTask.task.value
             return
         }
@@ -258,15 +267,20 @@ final class ChatStreamCoordinator {
         let reconnectTaskID = UUID()
         let reconnectTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.performReconnectIfNeeded(modelContext: modelContext)
+            await self.performReconnectIfNeeded(reconnectTaskID: reconnectTaskID)
             guard self.reconnectTask?.id == reconnectTaskID else { return }
             self.reconnectTask = nil
         }
-        self.reconnectTask = (id: reconnectTaskID, streamID: activeStreamID, task: reconnectTask)
+        self.reconnectTask = (
+            id: reconnectTaskID,
+            streamID: activeStreamID,
+            modelContext: modelContext,
+            task: reconnectTask
+        )
         await reconnectTask.value
     }
 
-    private func performReconnectIfNeeded(modelContext: ModelContext?) async {
+    private func performReconnectIfNeeded(reconnectTaskID: UUID) async {
         guard let activeStreamID, isConnectionSuspended else { return }
 
         let generation = runGeneration
@@ -276,7 +290,7 @@ final class ChatStreamCoordinator {
             guard self.activeStreamID == activeStreamID, isConnectionSuspended else { return }
 
             if response.active == true {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
+                await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
                 guard self.activeStreamID == activeStreamID, isConnectionSuspended else { return }
 
                 let streamIDToResume = activeStreamID
@@ -294,7 +308,7 @@ final class ChatStreamCoordinator {
                 isConnectionSuspended = false
                 start(streamID: activeStreamID, replayAfterSeq: replayAfterSeq)
             } else {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
+                await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
                 // Bail if a concurrent completion/cancel/new run finalized or
                 // replaced this run during the load (see canFinalizeRunAfterLoad).
                 guard canFinalizeRunAfterLoad(streamID: activeStreamID, capturedGeneration: generation) else { return }
@@ -308,7 +322,7 @@ final class ChatStreamCoordinator {
             if (error as? APIError)?.indicatesMissingStream == true,
                self.activeStreamID == activeStreamID,
                isConnectionSuspended {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
+                await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
                 guard canFinalizeRunAfterLoad(streamID: activeStreamID, capturedGeneration: generation) else { return }
                 finalizeInactiveStream(streamID: activeStreamID)
                 return
@@ -695,6 +709,11 @@ final class ChatStreamCoordinator {
         self.recoveryState = recoveryState
         isReplayConnection = isReplay
         delegate?.streamCoordinatorDidStartConnection(isReplay: isReplay)
+    }
+
+    private func recoveryModelContext(for reconnectTaskID: UUID) -> ModelContext? {
+        guard reconnectTask?.id == reconnectTaskID else { return nil }
+        return reconnectTask?.modelContext
     }
 
     private func invalidateReconnectTask() {

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -124,6 +124,48 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testForegroundReconnectStartsNewRecoveryAfterStreamReplacement() async throws {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            if statusRequestCount.increment() == 1 {
+                firstStatusStarted.fulfill()
+                _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-old")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        coordinator.start(streamID: "stream-new")
+        coordinator.suspendActiveStreamConnection()
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(coordinator.activeStreamID, "stream-new")
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(coordinator.activeStreamID, "stream-new")
+        XCTAssertEqual(streamClient.startedURLs.count, 3)
+    }
+
+    @MainActor
     func testForegroundReconnectActiveStreamDoesNotRestartAfterReplacementDuringLoad() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -207,6 +207,49 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testForegroundReconnectDoesNotResumeSupersededSameStreamGeneration() async throws {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
+                firstStatusStarted.fulfill()
+                _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await secondReconnect.value
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(streamClient.startedURLs.count, 3)
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+    }
+
+    @MainActor
     func testForegroundReconnectStartsNewRecoveryAfterSessionLoadReplacesStream() async throws {
         let firstStatusStarted = expectation(description: "first stream status request started")
         let secondStatusStarted = expectation(description: "second stream status request started")

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -104,12 +104,14 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         }
         await fulfillment(of: [firstStatusStarted], timeout: 1)
 
+        let secondReconnectStarted = expectation(description: "second reconnect request started")
         let secondReconnectReturned = CoordinatorLockedCounter()
         let secondReconnect = Task { @MainActor in
+            secondReconnectStarted.fulfill()
             await coordinator.reconnectIfNeeded()
             _ = secondReconnectReturned.increment()
         }
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await fulfillment(of: [secondReconnectStarted], timeout: 1)
 
         XCTAssertEqual(statusRequestCount.value, 1)
         XCTAssertEqual(secondReconnectReturned.value, 0)
@@ -124,17 +126,56 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testJoiningReconnectUsesNonNilModelContextBeforeTranscriptReload() async throws {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            firstStatusStarted.fulfill()
+            _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+        let modelContext = try makeModelContext()
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        let joiningReconnectStarted = expectation(description: "joining reconnect request started")
+        let secondReconnect = Task { @MainActor in
+            joiningReconnectStarted.fulfill()
+            await coordinator.reconnectIfNeeded(modelContext: modelContext)
+        }
+        await fulfillment(of: [joiningReconnectStarted], timeout: 1)
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(delegate.loadMessageReceivedModelContextValues, [true])
+    }
+
+    @MainActor
     func testForegroundReconnectStartsNewRecoveryAfterStreamReplacement() async throws {
         let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
         let releaseFirstStatus = DispatchSemaphore(value: 0)
         let statusRequestCount = CoordinatorLockedCounter()
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()
         let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
             XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
-            if statusRequestCount.increment() == 1 {
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
                 firstStatusStarted.fulfill()
                 _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
             }
             return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
         }
@@ -151,7 +192,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         let secondReconnect = Task { @MainActor in
             await coordinator.reconnectIfNeeded()
         }
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await secondReconnect.value
 
         XCTAssertEqual(statusRequestCount.value, 2)
         XCTAssertEqual(coordinator.activeStreamID, "stream-new")
@@ -159,7 +201,6 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
 
         releaseFirstStatus.signal()
         await firstReconnect.value
-        await secondReconnect.value
 
         XCTAssertEqual(coordinator.activeStreamID, "stream-new")
         XCTAssertEqual(streamClient.startedURLs.count, 3)
@@ -168,15 +209,19 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     @MainActor
     func testForegroundReconnectStartsNewRecoveryAfterSessionLoadReplacesStream() async throws {
         let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
         let releaseFirstStatus = DispatchSemaphore(value: 0)
         let statusRequestCount = CoordinatorLockedCounter()
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()
         let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
             XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
-            if statusRequestCount.increment() == 1 {
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
                 firstStatusStarted.fulfill()
                 _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
             }
             return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
         }
@@ -197,7 +242,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         let secondReconnect = Task { @MainActor in
             await coordinator.reconnectIfNeeded()
         }
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await secondReconnect.value
 
         XCTAssertEqual(statusRequestCount.value, 2)
         XCTAssertEqual(coordinator.activeStreamID, "stream-new")
@@ -205,21 +251,24 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
 
         releaseFirstStatus.signal()
         await firstReconnect.value
-        await secondReconnect.value
     }
 
     @MainActor
     func testForegroundReconnectStartsNewRecoveryAfterPriorStreamFinishesAndNewSessionLoads() async throws {
         let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
         let releaseFirstStatus = DispatchSemaphore(value: 0)
         let statusRequestCount = CoordinatorLockedCounter()
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()
         let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
             XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
-            if statusRequestCount.increment() == 1 {
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
                 firstStatusStarted.fulfill()
                 _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
             }
             return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
         }
@@ -241,7 +290,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         let secondReconnect = Task { @MainActor in
             await coordinator.reconnectIfNeeded()
         }
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await secondReconnect.value
 
         XCTAssertEqual(statusRequestCount.value, 2)
         XCTAssertEqual(coordinator.activeStreamID, "stream-new")
@@ -249,7 +299,6 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
 
         releaseFirstStatus.signal()
         await firstReconnect.value
-        await secondReconnect.value
     }
 
     @MainActor
@@ -739,6 +788,16 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(delegate.finishCount, 1)
     }
 
+    private func makeModelContext() throws -> ModelContext {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: CachedSession.self,
+            CachedMessage.self,
+            configurations: configuration
+        )
+        return ModelContext(container)
+    }
+
     @MainActor
     private func makeCoordinator(
         streamClient: CoordinatorSpySSEStreamingClient? = nil,
@@ -791,6 +850,7 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
     var streamCoordinatorStreamingAssistantMessageID: String?
 
     private(set) var loadMessagesCount = 0
+    private(set) var loadMessageReceivedModelContextValues: [Bool] = []
     private(set) var startMonitoringCount = 0
     private(set) var stopMonitoringClearPromptValues: [Bool] = []
     private(set) var saveSnapshotCount = 0
@@ -815,6 +875,7 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
 
     func streamCoordinatorLoadMessages(modelContext: ModelContext?) async {
         loadMessagesCount += 1
+        loadMessageReceivedModelContextValues.append(modelContext != nil)
         await onLoadMessages?()
     }
 

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -166,6 +166,93 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testForegroundReconnectStartsNewRecoveryAfterSessionLoadReplacesStream() async throws {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            if statusRequestCount.increment() == 1 {
+                firstStatusStarted.fulfill()
+                _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-old")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        let preparation = coordinator.prepareForSessionLoad()
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-new",
+            preparation: preparation,
+            usedCacheFallback: false
+        )
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(coordinator.activeStreamID, "stream-new")
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+        await secondReconnect.value
+    }
+
+    @MainActor
+    func testForegroundReconnectStartsNewRecoveryAfterPriorStreamFinishesAndNewSessionLoads() async throws {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            if statusRequestCount.increment() == 1 {
+                firstStatusStarted.fulfill()
+                _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-old")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        streamClient.emit(.streamEnd)
+        let preparation = coordinator.prepareForSessionLoad()
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-new",
+            preparation: preparation,
+            usedCacheFallback: false
+        )
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(coordinator.activeStreamID, "stream-new")
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+        await secondReconnect.value
+    }
+
+    @MainActor
     func testForegroundReconnectActiveStreamDoesNotRestartAfterReplacementDuringLoad() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -81,6 +81,49 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testConcurrentForegroundReconnectRequestsShareOneRecoveryAttempt() async throws {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            if statusRequestCount.increment() == 1 {
+                firstStatusStarted.fulfill()
+                _ = releaseFirstStatus.wait(timeout: .now() + 2)
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        let secondReconnectReturned = CoordinatorLockedCounter()
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+            _ = secondReconnectReturned.increment()
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(statusRequestCount.value, 1)
+        XCTAssertEqual(secondReconnectReturned.value, 0)
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(secondReconnectReturned.value, 1)
+        XCTAssertEqual(delegate.loadMessagesCount, 1)
+        XCTAssertEqual(streamClient.startedURLs.count, 2)
+    }
+
+    @MainActor
     func testForegroundReconnectActiveStreamDoesNotRestartAfterReplacementDuringLoad() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()
@@ -745,6 +788,24 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
         guard !trimmed.isEmpty else { return false }
         pendingSteerLeftovers.append(trimmed)
         return true
+    }
+}
+
+private final class CoordinatorLockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
     }
 }
 


### PR DESCRIPTION
## linked issue

not linked. this is a focused fix for a reproduced app-side foreground/reconnect failure.

## what changed

- serialize suspended-stream foreground recovery in `ChatStreamCoordinator`
- make concurrent reconnect callers await one status check, transcript reload, snapshot restore, and SSE restart
- add regression coverage for overlapping foreground reconnect requests

this prevents a lifecycle race where returning to Hermex while a chat stream is reconnecting can run recovery twice and merge live reasoning/tool-call presentation into one block.

## how it was tested

- `git diff --check`
- regression coverage added: `testConcurrentForegroundReconnectRequestsShareOneRecoveryAttempt`
- full XCTest: pending PR CI on macOS

local XCTest could not run because this Linux checkout has no `xcodebuild` or `swift`.

## checklist

- [ ] full test suite passes in PR CI
- [x] no changed `Codable` models
- [x] no new third-party dependencies
- [x] no invented API endpoints or JSON shapes

AI-assisted implementation and review.