### PR TITLE
fix: make setup prompt use safe Tailscale Serve defaults

### DIFF
--- a/HermesMobile/Features/Onboarding/OnboardingAgentPromptPage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingAgentPromptPage.swift
@@ -10,7 +10,7 @@ struct OnboardingAgentPromptPage: View {
                     stepNumber: 1,
                     icon: "terminal",
                     title: String(localized: "Set up Hermes Web UI"),
-                    description: String(localized: "Send this prompt to your Hermes Agent. It installs Hermes Web UI, enables password auth, and configures Tailscale access.")
+                    description: String(localized: "Send this prompt to your Hermes Agent. It audits existing state, keeps Hermes Web UI on localhost, and configures private HTTPS with Tailscale Serve.")
                 )
 
                 OnboardingAgentPromptCard(

--- a/HermesMobile/Features/Onboarding/OnboardingConnectPage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingConnectPage.swift
@@ -30,7 +30,7 @@ struct OnboardingConnectPage: View {
                         .font(.title3.weight(.bold))
                         .foregroundStyle(.white)
 
-                    Text("Enter the Tailscale URL your agent returned, for example `http://<tailnet-ip>:8787`.")
+                    Text("Enter the exact HTTPS Tailscale Serve URL your agent returned, for example `https://server.tailnet-name.ts.net`.")
                         .font(.footnote)
                         .foregroundStyle(.white.opacity(0.5))
                         .fixedSize(horizontal: false, vertical: true)
@@ -40,7 +40,7 @@ struct OnboardingConnectPage: View {
                     OnboardingField(systemImage: "link", title: String(localized: "Server URL")) {
                         ZStack(alignment: .leading) {
                             if viewModel.serverURLString.isEmpty {
-                                Text(verbatim: "http://100.64.0.1:8787")
+                                Text(verbatim: "https://server.tailnet-name.ts.net")
                                     .foregroundStyle(.white.opacity(0.38))
                                     .allowsHitTesting(false)
                             }

--- a/HermesMobile/Features/Onboarding/OnboardingFlowPolicy.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingFlowPolicy.swift
@@ -8,18 +8,32 @@ enum OnboardingFlowPolicy {
     static let agentSetupPrompt = """
 Set up Hermes Web UI on this machine for access from my iPhone via Tailscale.
 
-Clone and install https://github.com/nesquena/hermes-webui — it's a Node.js web app. Install dependencies and start it on port 8787.
-Enable password authentication by setting the HERMES_WEBUI_PASSWORD environment variable. Generate a secure random password and save it — I'll need it for the iPhone app.
-Install Tailscale on this machine. Search the web for the correct install method for this OS if you're unsure. Authenticate to my Tailscale account — if this requires opening a URL or an auth key, tell me exactly what to do.
-Make the WebUI reachable over Tailscale:
-- Try tailscale serve --bg 8787 first (gives HTTPS + nice hostname).
-- If Tailscale Serve is disabled on my tailnet, fall back: bind the server to 0.0.0.0 instead of localhost so it listens on the tailnet interface. Before doing this, confirm password auth is active — never expose an unauthenticated WebUI.
-Set up auto-start appropriate for this OS so the WebUI survives reboots.
-Verify it works: curl http://$(tailscale ip -4):8787/health should return a success response.
-Reply with:
-- The exact server URL I enter in Hermex
-- The password
-- Any setup steps I still need to do on my iPhone
+Hermes Web UI uses the Python standard library + vanilla JavaScript. Use only Python's standard library and the repository's existing frontend; do not add dependencies.
+
+Inventory before changing anything:
+- Locate any existing hermes-webui checkout, configuration, launcher, service, and running process. Reuse and preserve working state instead of reinstalling it.
+- Check who owns port 8787 with `lsof -nP -iTCP:8787 -sTCP:LISTEN` (or the OS equivalent). Do not kill an unknown process; stop and report the owner or conflict.
+- Run `command -v tailscale`, `tailscale version`, and `tailscale status`. If Tailscale is installed, do not reinstall it. Only if `command -v tailscale` reports that Tailscale is absent, install it using the correct method for this OS, then rerun `tailscale version`, `tailscale status`, and the authentication check before proceeding. If it is installed but not running or authenticated, explain the exact user action required.
+- Run `tailscale serve status` and `tailscale funnel status` before changing routes. Preserve every existing Serve and Funnel route. Do not run tailscale serve reset, remove routes, or overwrite an occupied HTTPS listener or path.
+
+Set up or repair Hermes Web UI safely:
+- Clone https://github.com/nesquena/hermes-webui only if no usable checkout exists. Inspect its README and use a supported launcher: `python3 bootstrap.py` or `./ctl.sh`.
+- Keep the WebUI bound to `127.0.0.1:8787`.
+- Preserve every existing line in `.env`; only add or update the `HERMES_WEBUI_PASSWORD` entry, and never truncate or replace the file. Preserve an existing password; if none exists, generate a secure random one. Set `umask 077` before creating a new `.env`. Whether `.env` already existed or is new, inspect its permissions and run `chmod 600 .env`. Do not print the full .env or expose unrelated secrets.
+- Reuse an existing service when present. Do not configure auto-start yourself. Propose the exact OS-appropriate commands and steps around the verified launcher, then wait for me to run them. Do not touch `~/Library/LaunchAgents/` or restart Mac services.
+
+Expose only the localhost service through private Tailscale HTTPS:
+- First confirm from `tailscale serve status` and `tailscale funnel status` that HTTPS port 443 at the root path is unused. Run `tailscale serve --bg 8787` only if HTTPS port 443 at the root path is free. Never enable Funnel.
+- If Tailscale requires HTTPS consent, show me the consent URL and explain the certificate-transparency disclosure before continuing.
+- If the root listener or route is already occupied, do not reset or replace it. Stop and report the exact conflict and safe options.
+
+Verify in this order:
+1. Confirm localhost health with `curl --fail http://127.0.0.1:8787/health`.
+2. Read back `tailscale serve status`, identify the actual ts.net HTTPS URL, and verify that exact URL's `/health` endpoint with `curl --fail https://<actual-ts.net-hostname>/health`.
+
+Treat binding to `0.0.0.0` or using a Tailscale IP over plain HTTP as an explicit manual fallback only. Explain the additional exposure and require my confirmation. Do not automate it.
+
+Reply with the exact HTTPS URL, password, launcher, and both health-check results, plus any remaining action required on my iPhone. Do not include the full `.env` contents.
 Do not use Cloudflare. Optimize for Tailscale + iPhone.
 """
 

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -31590,108 +31590,108 @@
         }
       }
     },
-    "Enter the Tailscale URL your agent returned, for example `http://<tailnet-ip>:8787`." : {
+    "Enter the exact HTTPS Tailscale Serve URL your agent returned, for example `https://server.tailnet-name.ts.net`." : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "أدخل عنوان Tailscale URL الذي أعاده عميلك، على سبيل المثال `http://<tailnet-ip>:8787`."
+            "value" : "أدخل عنوان HTTPS الدقيق لـ Tailscale Serve الذي أعاده وكيلك، على سبيل المثال `https://server.tailnet-name.ts.net`."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Gib die Tailscale-URL ein, die dein Agent zurückgegeben hat, zum Beispiel `http://<tailnet-ip>:8787`."
+            "value" : "Gib die genaue HTTPS-URL von Tailscale Serve ein, die dein Agent zurückgegeben hat, zum Beispiel `https://server.tailnet-name.ts.net`."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Introduce la URL de Tailscale que devolvió tu agente, por ejemplo `http://<tailnet-ip>:8787`."
+            "value" : "Introduce la URL HTTPS exacta de Tailscale Serve que devolvió tu agente, por ejemplo `https://server.tailnet-name.ts.net`."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Saisissez l'URL Tailscale renvoyée par votre agent, par exemple `http://<ip-tailnet>:8787`."
+            "value" : "Saisissez l'URL HTTPS Tailscale Serve exacte renvoyée par votre agent, par exemple `https://server.tailnet-name.ts.net`."
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "הזן את כתובת ה-URL של Tailscale שהסוכן שלך החזיר, לדוגמה `http://<tailnet-ip>:8787`."
+            "value" : "הזן את כתובת ה-HTTPS המדויקת של Tailscale Serve שהסוכן שלך החזיר, לדוגמה `https://server.tailnet-name.ts.net`."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Inserisci l'URL Tailscale restituito dal tuo agente, ad esempio `http://<tailnet-ip>:8787`."
+            "value" : "Inserisci l'URL HTTPS esatto di Tailscale Serve restituito dal tuo agente, ad esempio `https://server.tailnet-name.ts.net`."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "エージェントが返したTailscale URLを入力してください。例：`http://<tailnet-ip>:8787`。"
+            "value" : "エージェントが返した正確な Tailscale Serve の HTTPS URL を入力してください。例：`https://server.tailnet-name.ts.net`。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "에이전트가 반환한 Tailscale URL을 입력하세요. 예: `http://<tailnet-ip>:8787`."
+            "value" : "에이전트가 반환한 정확한 Tailscale Serve HTTPS URL을 입력하세요. 예: `https://server.tailnet-name.ts.net`."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Voer de Tailscale-URL in die uw agent heeft teruggegeven, bijvoorbeeld `http://<tailnet-ip>:8787`."
+            "value" : "Voer de exacte HTTPS-URL van Tailscale Serve in die uw agent heeft teruggegeven, bijvoorbeeld `https://server.tailnet-name.ts.net`."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Wprowadź URL Tailscale zwrócony przez agenta, na przykład `http://<tailnet-ip>:8787`."
+            "value" : "Wprowadź dokładny adres HTTPS Tailscale Serve zwrócony przez agenta, na przykład `https://server.tailnet-name.ts.net`."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Digite a URL do Tailscale que seu agente retornou, por exemplo `http://<tailnet-ip>:8787`."
+            "value" : "Digite a URL HTTPS exata do Tailscale Serve que seu agente retornou, por exemplo `https://server.tailnet-name.ts.net`."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Введите URL Tailscale, который вернул ваш агент, например `http://<tailnet-ip>:8787`."
+            "value" : "Введите точный HTTPS-адрес Tailscale Serve, который вернул ваш агент, например `https://server.tailnet-name.ts.net`."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Ajanınızın döndürdüğü Tailscale URL'sini girin, örneğin `http://<tailnet-ip>:8787`."
+            "value" : "Ajanınızın döndürdüğü tam Tailscale Serve HTTPS URL'sini girin, örneğin `https://server.tailnet-name.ts.net`."
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "وہ Tailscale URL درج کریں جو آپ کے ایجنٹ نے واپس کیا، مثلاً `http://<tailnet-ip>:8787`۔"
+            "value" : "وہ درست Tailscale Serve HTTPS URL درج کریں جو آپ کے ایجنٹ نے واپس کیا، مثلاً `https://server.tailnet-name.ts.net`۔"
           }
         },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "請輸入你的代理返回的 Tailscale URL，例如 `http://<tailnet-ip>:8787`。"
+            "value" : "請輸入代理傳回的確切 Tailscale Serve HTTPS URL，例如 `https://server.tailnet-name.ts.net`。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "请输入你的智能体返回的 Tailscale URL，例如 `http://<tailnet-ip>:8787`。"
+            "value" : "请输入智能体返回的确切 Tailscale Serve HTTPS URL，例如 `https://server.tailnet-name.ts.net`。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "請輸入你的代理人傳回的 Tailscale URL，例如 `http://<tailnet-ip>:8787`。"
+            "value" : "請輸入代理人傳回的確切 Tailscale Serve HTTPS URL，例如 `https://server.tailnet-name.ts.net`。"
           }
         }
       }
@@ -69172,108 +69172,108 @@
         }
       }
     },
-    "Send this prompt to your Hermes Agent. It installs Hermes Web UI, enables password auth, and configures Tailscale access." : {
+    "Send this prompt to your Hermes Agent. It audits existing state, keeps Hermes Web UI on localhost, and configures private HTTPS with Tailscale Serve." : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "أرسل هذا المُوجّه إلى وكيل Hermes الخاص بك. فهو يثبّت Hermes Web UI، ويفعّل مصادقة كلمة المرور، ويهيّئ الوصول عبر Tailscale."
+            "value" : "أرسل هذا المُوجّه إلى وكيل Hermes الخاص بك. فهو يراجع الحالة الحالية، ويبقي Hermes Web UI على المضيف المحلي، ويهيّئ HTTPS خاصًا باستخدام Tailscale Serve."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Sende diesen Prompt an deinen Hermes Agent. Er installiert Hermes Web UI, aktiviert die Passwort-Authentifizierung und konfiguriert den Tailscale-Zugriff."
+            "value" : "Sende diesen Prompt an deinen Hermes Agent. Er prüft den bestehenden Zustand, hält Hermes Web UI auf localhost und konfiguriert privates HTTPS mit Tailscale Serve."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Envía esta indicación a tu agente Hermes. Instala Hermes Web UI, activa la autenticación con contraseña y configura el acceso de Tailscale."
+            "value" : "Envía esta indicación a tu agente Hermes. Audita el estado existente, mantiene Hermes Web UI en localhost y configura HTTPS privado con Tailscale Serve."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Envoyez cette invite à votre agent Hermes. Elle installe Hermes Web UI, active l'authentification par mot de passe et configure l'accès Tailscale."
+            "value" : "Envoyez cette invite à votre agent Hermes. Elle vérifie l'état existant, conserve Hermes Web UI sur localhost et configure un HTTPS privé avec Tailscale Serve."
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "שלח הנחיה זו לסוכן Hermes שלך. היא מתקינה את Hermes Web UI, מפעילה אימות בסיסמה ומגדירה גישה דרך Tailscale."
+            "value" : "שלח הנחיה זו לסוכן Hermes שלך. היא בודקת את המצב הקיים, משאירה את Hermes Web UI ב-localhost ומגדירה HTTPS פרטי עם Tailscale Serve."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Invia questo prompt al tuo agente Hermes. Installa Hermes Web UI, abilita l'autenticazione con password e configura l'accesso Tailscale."
+            "value" : "Invia questo prompt al tuo agente Hermes. Verifica lo stato esistente, mantiene Hermes Web UI su localhost e configura HTTPS privato con Tailscale Serve."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "このプロンプトを Hermes エージェントに送信してください。Hermes Web UI のインストール、パスワード認証の有効化、Tailscale アクセスの設定を行います。"
+            "value" : "このプロンプトを Hermes エージェントに送信してください。既存の状態を確認し、Hermes Web UI を localhost に保ち、Tailscale Serve でプライベート HTTPS を設定します。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "이 프롬프트를 Hermes 에이전트에게 보내세요. Hermes Web UI를 설치하고 비밀번호 인증을 활성화하며 Tailscale 접근을 구성해요."
+            "value" : "이 프롬프트를 Hermes 에이전트에게 보내세요. 기존 상태를 점검하고 Hermes Web UI를 localhost에 유지하며 Tailscale Serve로 비공개 HTTPS를 구성해요."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Verzend deze prompt naar uw Hermes-agent. Deze installeert Hermes Web UI, schakelt wachtwoordverificatie in en configureert Tailscale-toegang."
+            "value" : "Verzend deze prompt naar uw Hermes-agent. Deze controleert de bestaande staat, houdt Hermes Web UI op localhost en configureert privé-HTTPS met Tailscale Serve."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Wyślij ten monit do swojego agenta Hermes. Instaluje Hermes Web UI, włącza uwierzytelnianie hasłem i konfiguruje dostęp przez Tailscale."
+            "value" : "Wyślij ten monit do swojego agenta Hermes. Sprawdza istniejący stan, pozostawia Hermes Web UI na localhost i konfiguruje prywatny HTTPS przez Tailscale Serve."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Envie este prompt ao seu Hermes Agent. Ele instala a Hermes Web UI, ativa a autenticação por senha e configura o acesso ao Tailscale."
+            "value" : "Envie este prompt ao seu Hermes Agent. Ele audita o estado existente, mantém a Hermes Web UI no localhost e configura HTTPS privado com o Tailscale Serve."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Отправьте этот промпт вашему агенту Hermes. Он устанавливает Hermes Web UI, включает аутентификацию по паролю и настраивает доступ через Tailscale."
+            "value" : "Отправьте этот промпт вашему агенту Hermes. Он проверит текущее состояние, оставит Hermes Web UI на localhost и настроит приватный HTTPS через Tailscale Serve."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Bu istemi Hermes Aracınıza gönderin. Hermes Web UI'yi yükler, parola kimlik doğrulamasını etkinleştirir ve Tailscale erişimini yapılandırır."
+            "value" : "Bu istemi Hermes Aracınıza gönderin. Mevcut durumu denetler, Hermes Web UI'yi localhost'ta tutar ve Tailscale Serve ile özel HTTPS yapılandırır."
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "یہ پرامپٹ اپنے Hermes ایجنٹ کو بھیجیں۔ یہ Hermes Web UI انسٹال کرتا ہے، پاس ورڈ کی توثیق فعال کرتا ہے، اور Tailscale رسائی ترتیب دیتا ہے۔"
+            "value" : "یہ پرامپٹ اپنے Hermes ایجنٹ کو بھیجیں۔ یہ موجودہ حالت کا جائزہ لیتا ہے، Hermes Web UI کو localhost پر رکھتا ہے، اور Tailscale Serve کے ساتھ نجی HTTPS ترتیب دیتا ہے۔"
           }
         },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "將此提示傳送給你的 Hermes 代理。它會安裝 Hermes Web UI、啟用密碼驗證並設定 Tailscale 存取權限。"
+            "value" : "將此提示傳送給你的 Hermes 代理。它會檢查現有狀態、讓 Hermes Web UI 保持在 localhost，並使用 Tailscale Serve 設定私人 HTTPS。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "将此提示发送给你的 Hermes 代理。它会安装 Hermes Web UI、启用密码验证并配置 Tailscale 访问。"
+            "value" : "将此提示发送给你的 Hermes 代理。它会检查现有状态、让 Hermes Web UI 保持在 localhost，并使用 Tailscale Serve 配置私有 HTTPS。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "將此提示傳送給你的 Hermes 代理。它會安裝 Hermes Web UI、啟用密碼驗證並設定 Tailscale 存取。"
+            "value" : "將此提示傳送給你的 Hermes 代理。它會檢查現有狀態、讓 Hermes Web UI 保持在 localhost，並使用 Tailscale Serve 設定私人 HTTPS。"
           }
         }
       }

--- a/HermesMobileTests/OnboardingFlowTests.swift
+++ b/HermesMobileTests/OnboardingFlowTests.swift
@@ -101,6 +101,7 @@ final class OnboardingFlowTests: XCTestCase {
             "127.0.0.1:8787",
             "only if HTTPS port 443 at the root path is free",
             "tailscale serve --bg 8787",
+            "Never enable Funnel",
             "HTTPS consent",
             "certificate-transparency disclosure",
             "umask 077",

--- a/HermesMobileTests/OnboardingFlowTests.swift
+++ b/HermesMobileTests/OnboardingFlowTests.swift
@@ -81,15 +81,56 @@ final class OnboardingFlowTests: XCTestCase {
         XCTAssertFalse(OnboardingFlowPolicy.showsServerShortcut(for: OnboardingFlowPolicy.connectPageIndex))
     }
 
-    func testAgentSetupPromptIncludesTailscaleRequirements() {
+    func testAgentSetupPromptDefaultsToSafeStateAwareTailscaleServe() {
         let prompt = OnboardingFlowPolicy.agentSetupPrompt
 
-        XCTAssertTrue(prompt.contains("hermes-webui"))
-        XCTAssertTrue(prompt.contains("HERMES_WEBUI_PASSWORD"))
-        XCTAssertTrue(prompt.contains("tailscale serve --bg 8787"))
-        XCTAssertTrue(prompt.contains("curl http://$(tailscale ip -4):8787/health"))
-        XCTAssertTrue(prompt.contains("Do not use Cloudflare. Optimize for Tailscale + iPhone."))
-        XCTAssertTrue(prompt.contains("Hermex"))
+        let requiredInstructions = [
+            "Python standard library + vanilla JavaScript",
+            "Inventory before changing anything",
+            "command -v tailscale",
+            "tailscale version",
+            "tailscale status",
+            "Only if `command -v tailscale` reports that Tailscale is absent",
+            "correct method for this OS",
+            "rerun `tailscale version`, `tailscale status`, and the authentication check",
+            "tailscale serve status",
+            "tailscale funnel status",
+            "lsof -nP -iTCP:8787 -sTCP:LISTEN",
+            "Do not kill an unknown process",
+            "Do not run tailscale serve reset",
+            "127.0.0.1:8787",
+            "only if HTTPS port 443 at the root path is free",
+            "tailscale serve --bg 8787",
+            "HTTPS consent",
+            "certificate-transparency disclosure",
+            "umask 077",
+            "chmod 600",
+            "Preserve every existing line in `.env`",
+            "only add or update the `HERMES_WEBUI_PASSWORD` entry",
+            "never truncate or replace the file",
+            "Whether `.env` already existed or is new",
+            "Do not print the full .env",
+            "python3 bootstrap.py",
+            "./ctl.sh",
+            "Do not configure auto-start yourself",
+            "Propose the exact OS-appropriate commands and steps",
+            "wait for me to run them",
+            "Do not touch `~/Library/LaunchAgents/` or restart Mac services",
+            "curl --fail http://127.0.0.1:8787/health",
+            "actual ts.net HTTPS URL",
+            "exact HTTPS URL, password, launcher, and both health-check results",
+            "manual fallback",
+            "Do not automate it"
+        ]
+
+        for instruction in requiredInstructions {
+            XCTAssertTrue(prompt.contains(instruction), "Missing safe setup instruction: \(instruction)")
+        }
+
+        XCTAssertFalse(prompt.contains("Node.js"))
+        XCTAssertFalse(prompt.contains("curl http://$(tailscale ip -4):8787/health"))
+        XCTAssertFalse(prompt.contains("fall back: bind the server to 0.0.0.0"))
+        XCTAssertFalse(prompt.contains("Otherwise configure auto-start appropriate for this OS"))
     }
 
     func testTailscaleAppStoreURLUsesITMSDeepLink() {

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -702,19 +702,21 @@ Document it as the recommended path.
 **Pros:** real HTTPS, accessible from anywhere, no VPN client on the phone.
 **Cons:** publicly reachable URL — if the password leaks, anyone can hit your agent. Recommended hardening: add a Cloudflare Access policy in front of the hostname.
 
-### 9.2 Tailscale (alternative — if you don't want a public hostname)
-1. Install Tailscale on the server and the iPhone, sign both into the same account.
-2. On the server, start hermes-webui bound to all interfaces with auth:
-   ```bash
-   HERMES_WEBUI_HOST=0.0.0.0 HERMES_WEBUI_PASSWORD=your-secret ./start.sh
-   ```
-3. Find the server's tailnet IP with `tailscale ip -4`.
-4. In Hermex, enter `http://<tailnet-ip>:8787` and the password.
+### 9.2 Tailscale Serve (private HTTPS alternative)
+1. Before installing or changing anything, locate any existing `hermes-webui` checkout, launcher, service, and process. Identify the owner of port 8787 with `lsof -nP -iTCP:8787 -sTCP:LISTEN` (or the OS equivalent). Never kill an unknown process.
+2. Check `command -v tailscale`, `tailscale version`, and `tailscale status`. Reuse an installed, authenticated Tailscale client; otherwise install or authenticate it with the OS-appropriate flow.
+3. Inspect both `tailscale serve status` and `tailscale funnel status`. Do not reset, remove, or overwrite existing Serve/Funnel routes.
+4. Run Hermes Web UI with its supported Python launcher (`python3 bootstrap.py` or `./ctl.sh`) and keep it bound to `127.0.0.1:8787`.
+5. Preserve every existing line in `.env`; only add or update `HERMES_WEBUI_PASSWORD`, and never truncate or replace the file. Preserve an existing password; otherwise generate one. Use `umask 077` before creating a new `.env`. For both existing and new files, inspect permissions and run `chmod 600 .env`. Never print the full file.
+6. Verify localhost first: `curl --fail http://127.0.0.1:8787/health`.
+7. Only when HTTPS port 443 at the root path is unused, run `tailscale serve --bg 8787`. If Tailscale requires HTTPS consent, complete its consent flow only after reviewing the certificate-transparency disclosure. Never enable Funnel.
+8. Read the actual `https://…ts.net` URL from `tailscale serve status`, then verify `https://<actual-ts.net-hostname>/health`.
+9. Install Tailscale on the iPhone, join the same tailnet, and enter the exact HTTPS URL and password in Hermex.
 
-**Caveat for the iOS app:** Tailscale exposes the server over plain HTTP, which iOS App Transport Security blocks by default. The app supports this in development by adding an ATS exception for tailnet IPs in `Info.plist`. For App Store submission, document that **Cloudflare Tunnel is the recommended setup** because it provides real TLS — App Review will flag a blanket ATS exception.
+**Direct-bind fallback:** binding to `0.0.0.0` and connecting to a Tailscale IP over plain HTTP remains an explicit manual fallback only. Explain the wider listener and ATS implications first; onboarding automation must not choose it.
 
-**Pros:** zero config, encrypted via WireGuard, no public exposure.
-**Cons:** must install Tailscale on both ends; plain HTTP requires ATS exception.
+**Pros:** private tailnet access, real HTTPS, and the WebUI remains loopback-only.
+**Cons:** Tailscale must run on both ends; Serve may require tailnet HTTPS consent and its hostname may appear in public certificate-transparency logs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Self-hosting the server, securing it, and keeping it reachable are your responsi
 ### Making the server reachable
 
 - **HTTPS via a tunnel or reverse proxy (recommended).** Expose the server through Cloudflare Tunnel or any reverse proxy that terminates real TLS at a hostname you own. Real HTTPS keeps iOS App Transport Security happy with no exceptions. On a publicly reachable hostname the password is your only app-level defense — set a strong one.
-- **Tailscale.** Run the server bound to all interfaces with a password, install Tailscale on both the server and the iPhone, and connect to `http://<tailnet-ip>:8787`. The app allows plain HTTP only for Tailscale's `100.64.0.0/10` device range.
+- **Private HTTPS with Tailscale Serve.** Keep the server password-protected and bound to `127.0.0.1:8787`, inspect existing Serve/Funnel routes, then add `tailscale serve --bg 8787` only when HTTPS port 443 at the root path is free. Install Tailscale on the iPhone and connect with the exact `https://…ts.net` URL reported by `tailscale serve status`. Direct binding to `0.0.0.0` over plain HTTP remains a manual fallback, not the default.
 - **Simulator-only local testing** can use `http://localhost:8787` when the server runs on the same Mac.
 
 ### Troubleshooting the connection


### PR DESCRIPTION
## Linked issue

Fixes #178

## What changed

- replace the inaccurate Node.js and reinstall-first setup prompt with a state-aware Hermes Web UI flow
- inventory the existing checkout, launcher, service, process, port 8787 owner, and Tailscale authentication state before making changes
- preserve existing Serve and Funnel routes, services, `.env` contents, and passwords instead of resetting or overwriting them
- keep Hermes Web UI bound to `127.0.0.1:8787` and expose it privately through Tailscale Serve HTTPS; direct binding remains a confirmation-only fallback
- update the onboarding explanation and HTTPS example, all 17 shipped localizations, README guidance, and `PROJECT_SPEC.md` section 9.2

## Reference verification

- verified against the current pinned `hermes-webui` checkout at `ecc47782e3e72a5bf3e848a8f09a2a5a838c71b1`: `bootstrap.py` and `ctl.sh` are supported launchers, loopback is the default host, and `/health` is available
- checked the current official [Tailscale Serve CLI](https://tailscale.com/docs/reference/tailscale-cli/serve) and [HTTPS certificate](https://tailscale.com/docs/how-to/set-up-https-certificates) documentation for background Serve behavior, HTTPS consent, and certificate-transparency disclosure
- no API endpoint or JSON contract was added or changed

## How it was tested

- `xcodebuild build-for-testing -project HermesMobile.xcodeproj -scheme HermesMobile -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test-without-building -project HermesMobile.xcodeproj -scheme HermesMobile -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath DerivedData -resultBundlePath TestResults.xcresult -parallel-testing-enabled YES -parallel-testing-worker-count 1 CODE_SIGNING_ALLOWED=NO`: 1,461 passed, 0 failed, 0 skipped
- `git diff --check origin/master...HEAD`
- signed clean-install walkthrough on iPhone 17 Pro: first-run onboarding, setup-prompt copy feedback, Tailscale step, and the HTTPS `ts.net` connect page
- independent standards and specification/security reviews: passed

## Checklist

- [x] The full test suite passes locally
- [x] No `Codable` model changed in this PR
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes

AI usage: built with OpenAI Codex and reviewed with independent Codex agents.