### PR TITLE
feat: show opt-in response speed metrics

### DIFF
--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -208,6 +208,7 @@ enum ChatTranscriptDisplaySettings {
     static let toolCardsStartExpandedKey = "chatTranscript.toolCardsStartExpanded"
     static let hidesAttachmentPathsKey = "chatTranscript.hidesAttachmentPaths"
     static let showsAssistantTurnTimestampsKey = "chatTranscript.showsAssistantTurnTimestamps"
+    static let showsResponseSpeedKey = "chatTranscript.showsResponseSpeed"
     static let wrapsCodeBlockLinesKey = "chatTranscript.wrapsCodeBlockLines"
 
     /// Backs the Settings → Chat "Right-to-Left Chat Layout" toggle (issue #259).
@@ -290,9 +291,13 @@ enum ChatTranscriptDisplaySettings {
     static func showsAssistantTurnHeader(
         role: String?,
         hasTextContent: Bool,
-        isEnabled: Bool
+        isEnabled: Bool,
+        showsResponseSpeed: Bool = false,
+        hasResponseSpeed: Bool = false
     ) -> Bool {
-        isEnabled && role == "assistant" && hasTextContent
+        (isEnabled || (showsResponseSpeed && hasResponseSpeed)) &&
+            role == "assistant" &&
+            hasTextContent
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -283,7 +283,7 @@ final class ChatPendingActionCoordinator {
             applyApprovalUpdate(update, sessionID: sessionID)
         case .transportError, .error:
             startApprovalFallbackPolling(sessionID: sessionID)
-        case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted, .title, .done, .clarificationPending,
+        case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted, .title, .metering, .done, .clarificationPending,
              .pendingSteerLeftover, .streamEnd, .cancelled, .ignored:
             break
         }
@@ -389,7 +389,7 @@ final class ChatPendingActionCoordinator {
             }
         case .transportError, .error:
             startClarificationFallbackPolling(sessionID: sessionID)
-        case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted, .title, .done,
+        case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted, .title, .metering, .done,
              .pendingSteerLeftover, .streamEnd, .cancelled, .ignored:
             break
         }

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -90,6 +90,7 @@ final class ChatStreamCoordinator {
     private(set) var hasCompletedCurrentResponse = false
     private(set) var lastEventID: String?
     private(set) var lastProgressDate: Date?
+    private(set) var liveTokensPerSecond: Double?
     private var lastRecoveryStatusCheckDate: Date?
     private(set) var isReplayConnection = false
     // Bumped whenever the active run starts or finalizes. Captured before an async
@@ -127,6 +128,7 @@ final class ChatStreamCoordinator {
     func prepareForNewResponse() {
         hasCompletedCurrentResponse = false
         isConnectionSuspended = false
+        liveTokensPerSecond = nil
     }
 
     func start(
@@ -135,6 +137,7 @@ final class ChatStreamCoordinator {
         recoveryState: ActiveStreamRecoveryState = .idle
     ) {
         hasCompletedCurrentResponse = false
+        liveTokensPerSecond = nil
         runGeneration &+= 1
         activeStreamID = streamID
         isConnectionSuspended = false
@@ -182,6 +185,7 @@ final class ChatStreamCoordinator {
     }
 
     func prepareForSessionLoad() -> ChatStreamLoadPreparation {
+        liveTokensPerSecond = nil
         let activeStreamIDBeforeLoad = activeStreamID
         if activeStreamIDBeforeLoad != nil, !hasCompletedCurrentResponse {
             delegate?.streamCoordinatorSaveSnapshotIfNeeded()
@@ -199,6 +203,7 @@ final class ChatStreamCoordinator {
         usedCacheFallback: Bool
     ) {
         hasCompletedCurrentResponse = false
+        liveTokensPerSecond = nil
 
         if usedCacheFallback {
             activeStreamID = nil
@@ -437,6 +442,11 @@ final class ChatStreamCoordinator {
             if delegate?.streamCoordinatorUpdateTitle(payload) == true {
                 markProgress()
             }
+        case .metering(let payload):
+            guard payload.sessionId == nil || payload.sessionId == delegate?.streamCoordinatorSessionID else {
+                break
+            }
+            liveTokensPerSecond = payload.displayableTokensPerSecond
         case .done(let payload):
             let hasCompletedTranscript = delegate?.streamCoordinatorApplyDone(payload) == true
             completeCurrentResponse(needsTranscriptRefresh: !hasCompletedTranscript)
@@ -474,6 +484,7 @@ final class ChatStreamCoordinator {
     }
 
     private func handleTransportError(_ message: String) {
+        liveTokensPerSecond = nil
         guard activeStreamID != nil, !hasCompletedCurrentResponse else {
             if !hasCompletedCurrentResponse {
                 delegate?.streamCoordinatorDidReceiveErrorMessage(message)
@@ -586,6 +597,7 @@ final class ChatStreamCoordinator {
         delegate?.streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: true)
         activeStreamID = nil
         lastEventID = nil
+        liveTokensPerSecond = nil
         delegate?.streamCoordinatorStreamingAssistantMessageID = nil
         hasCompletedCurrentResponse = true
         delegate?.streamCoordinatorDidCompleteCurrentResponse(needsTranscriptRefresh: needsTranscriptRefresh)
@@ -639,6 +651,7 @@ final class ChatStreamCoordinator {
         delegate?.streamCoordinatorRemoveSnapshot(streamID: finishedStreamID)
         activeStreamID = nil
         lastEventID = nil
+        liveTokensPerSecond = nil
         delegate?.streamCoordinatorStreamingAssistantMessageID = nil
         hasCompletedCurrentResponse = false
         delegate?.streamCoordinatorDidFinishStream()

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -17,6 +17,7 @@ struct ChatTranscriptView: View {
     let liveToolCalls: [ToolCall]
     let toolCallAnchorMessageID: String?
     let streamingAssistantMessageID: String?
+    let liveTokensPerSecond: Double?
     let activeStreamRecoveryState: ActiveStreamRecoveryState
     let clarificationPrompt: ClarificationPromptState?
     let isRespondingToClarification: Bool
@@ -232,6 +233,7 @@ struct ChatTranscriptView: View {
                     liveToolCalls: isToolCallAnchor ? liveToolCalls : [],
                     toolCallAnchorMessageID: isToolCallAnchor ? toolCallAnchorMessageID : nil,
                     streamingAssistantMessageID: isStreamingRow ? streamingAssistantMessageID : nil,
+                    liveTokensPerSecond: isStreamingRow ? liveTokensPerSecond : nil,
                     localAttachmentPreviews: localAttachmentPreviews[transcriptMessage.message.id],
                     listeningMessageID: listeningMessageID,
                     isViewingCachedData: isViewingCachedData,
@@ -453,6 +455,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     let liveToolCalls: [ToolCall]
     let toolCallAnchorMessageID: String?
     let streamingAssistantMessageID: String?
+    let liveTokensPerSecond: Double?
     let localAttachmentPreviews: [String: Data]?
     let listeningMessageID: String?
     let isViewingCachedData: Bool
@@ -492,6 +495,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
             lhs.liveToolCalls == rhs.liveToolCalls &&
             lhs.toolCallAnchorMessageID == rhs.toolCallAnchorMessageID &&
             lhs.streamingAssistantMessageID == rhs.streamingAssistantMessageID &&
+            lhs.liveTokensPerSecond == rhs.liveTokensPerSecond &&
             lhs.localAttachmentPreviews == rhs.localAttachmentPreviews &&
             lhs.listeningMessageID == rhs.listeningMessageID &&
             lhs.isViewingCachedData == rhs.isViewingCachedData &&
@@ -524,6 +528,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                         messageID: transcriptMessage.message.messageId,
                         streamingAssistantMessageID: streamingAssistantMessageID
                     ),
+                    liveTokensPerSecond: liveTokensPerSecond,
                     isRegeneratingMessage: isRegeneratingMessage,
                     isEditingMessage: isEditingMessage,
                     isForkingMessage: isForkingMessage,
@@ -606,6 +611,7 @@ private struct ChatTranscriptMessageRow: View {
     let isViewingCachedData: Bool
     let hasActiveStream: Bool
     let isStreaming: Bool
+    let liveTokensPerSecond: Double?
     let isRegeneratingMessage: Bool
     let isEditingMessage: Bool
     let isForkingMessage: Bool
@@ -664,7 +670,8 @@ private struct ChatTranscriptMessageRow: View {
             localAttachmentPreviews: localAttachmentPreviews,
             onPreviewAttachment: onPreviewAttachment,
             onPreviewTranscriptMedia: onPreviewTranscriptMedia,
-            isStreaming: isStreaming
+            isStreaming: isStreaming,
+            liveTokensPerSecond: liveTokensPerSecond
         )
     }
 }

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1077,6 +1077,7 @@ struct ChatView: View {
             liveToolCalls: viewModel.liveToolCalls,
             toolCallAnchorMessageID: viewModel.toolCallAnchorMessageID,
             streamingAssistantMessageID: viewModel.streamingAssistantMessageID,
+            liveTokensPerSecond: viewModel.liveTokensPerSecond,
             activeStreamRecoveryState: viewModel.activeStreamRecoveryState,
             clarificationPrompt: viewModel.clarificationPrompt,
             isRespondingToClarification: viewModel.isRespondingToClarification,
@@ -1906,6 +1907,10 @@ struct ChatView: View {
     }
 
     private func handleResponseCompletionSideEffects() {
+        if !viewModel.responseCompletionNeedsTranscriptRefresh {
+            viewModel.cacheCompletedResponse(modelContext: modelContext)
+        }
+
         guard let completionContext = responseCompletionNotificationTracker.completionContext(
             completionTrigger: viewModel.responseCompletionHapticTrigger,
             sceneIsActive: scenePhase == .active

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -221,6 +221,7 @@ final class ChatViewModel {
     private(set) var isViewingCachedData = false
     var activeStreamID: String? { streamCoordinator.activeStreamID }
     var activeStreamRecoveryState: ActiveStreamRecoveryState { streamCoordinator.recoveryState }
+    var liveTokensPerSecond: Double? { streamCoordinator.liveTokensPerSecond }
     private(set) var errorMessage: String?
     private(set) var sendErrorMessage: String?
     private(set) var messageActionErrorMessage: String?
@@ -1689,7 +1690,8 @@ final class ChatViewModel {
                 toolCalls: loadedAssistant.toolCalls ?? snapshotAssistant.toolCalls,
                 contentParts: loadedAssistant.contentParts ?? snapshotAssistant.contentParts,
                 reasoning: loadedAssistant.reasoning ?? snapshotAssistant.reasoning,
-                attachments: loadedAssistant.attachments ?? snapshotAssistant.attachments
+                attachments: loadedAssistant.attachments ?? snapshotAssistant.attachments,
+                turnTps: loadedAssistant.turnTps ?? snapshotAssistant.turnTps
             )
             return ActiveStreamMessageMerge(
                 messages: mergedMessages,
@@ -2271,6 +2273,11 @@ final class ChatViewModel {
         } catch {
             cacheErrorMessage = error.localizedDescription
         }
+    }
+
+    func cacheCompletedResponse(modelContext: ModelContext) {
+        guard let sessionID else { return }
+        cacheCurrentMessages(sessionID: sessionID, modelContext: modelContext)
     }
 
     func clearTranscript() {
@@ -3221,7 +3228,8 @@ final class ChatViewModel {
             toolCalls: existing.toolCalls,
             contentParts: existing.contentParts,
             reasoning: existing.reasoning,
-            attachments: existing.attachments
+            attachments: existing.attachments,
+            turnTps: existing.turnTps
         )
         scheduleStreamingScrollTrigger()
     }
@@ -3826,7 +3834,7 @@ final class ChatViewModel {
             activeBtwAnswer = "Error: \(message)"
             updateActiveBtwMessage(isLoading: false)
             finishBtwStream()
-        case .ignored, .reasoning, .toolStarted, .toolCompleted, .title, .pendingSteerLeftover:
+        case .ignored, .reasoning, .toolStarted, .toolCompleted, .title, .metering, .pendingSteerLeftover:
             break
         }
     }
@@ -3947,7 +3955,8 @@ final class ChatViewModel {
                 toolCalls: existing.toolCalls,
                 contentParts: existing.contentParts,
                 reasoning: existing.reasoning,
-                attachments: existing.attachments
+                attachments: existing.attachments,
+                turnTps: existing.turnTps
             )
             scheduleStreamingScrollTrigger()
             return true
@@ -4324,7 +4333,8 @@ final class ChatViewModel {
                 toolCalls: existing.toolCalls,
                 contentParts: existing.contentParts,
                 reasoning: existing.reasoning,
-                attachments: existing.attachments
+                attachments: existing.attachments,
+                turnTps: existing.turnTps
             )
             return true
         }
@@ -5002,12 +5012,43 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
     @discardableResult
     func streamCoordinatorApplyDone(_ payload: DoneStreamEvent) -> Bool {
         flushPendingStreamingContent()
+        let currentStreamingAssistantID = streamingAssistantMessageID
         let hasCompletedTranscript = payload.session?.messages?.isEmpty == false
         if let completedSession = payload.session {
             applyCompletedStreamSession(completedSession)
         }
         if let usage = payload.usage {
             contextWindowSnapshot = usage
+        }
+        if let finalTokensPerSecond = payload.usage?.tokensPerSecond,
+           finalTokensPerSecond.isFinite,
+           finalTokensPerSecond > 0,
+           let currentStreamingAssistantID {
+            let currentAssistantID = messages.contains(where: { $0.messageId == currentStreamingAssistantID })
+                ? currentStreamingAssistantID
+                : TranscriptTurnClassifier
+                    .currentTurnAssistantAnchorIDs(in: messages, messageOffset: messagesOffset)
+                    .first
+            guard let currentAssistantID,
+                  let index = messages.firstIndex(where: { $0.messageId == currentAssistantID })
+            else {
+                return hasCompletedTranscript
+            }
+            let message = messages[index]
+            messages[index] = ChatMessage(
+                role: message.role,
+                content: message.content,
+                timestamp: message.timestamp,
+                messageId: message.messageId,
+                name: message.name,
+                toolCallId: message.toolCallId,
+                toolUseId: message.toolUseId,
+                toolCalls: message.toolCalls,
+                contentParts: message.contentParts,
+                reasoning: message.reasoning,
+                attachments: message.attachments,
+                turnTps: finalTokensPerSecond
+            )
         }
         return hasCompletedTranscript
     }

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -5024,14 +5024,20 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
            finalTokensPerSecond.isFinite,
            finalTokensPerSecond > 0,
            let currentStreamingAssistantID {
-            let currentAssistantID = messages.contains(where: { $0.messageId == currentStreamingAssistantID })
-                ? currentStreamingAssistantID
-                : TranscriptTurnClassifier
+            let currentAssistantIndex = messages.firstIndex(where: { $0.messageId == currentStreamingAssistantID })
+                ?? TranscriptTurnClassifier
                     .currentTurnAssistantAnchorIDs(in: messages, messageOffset: messagesOffset)
-                    .first
-            guard let currentAssistantID,
-                  let index = messages.firstIndex(where: { $0.messageId == currentAssistantID })
-            else {
+                    .last
+                    .flatMap { currentAssistantAnchorID in
+                        messages.indices.first { index in
+                            TranscriptTurnClassifier.anchorID(
+                                for: messages[index],
+                                at: index,
+                                messageOffset: messagesOffset
+                            ) == currentAssistantAnchorID
+                        }
+                    }
+            guard let index = currentAssistantIndex else {
                 return hasCompletedTranscript
             }
             let message = messages[index]

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -6,6 +6,7 @@ struct MessageBubbleView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsAssistantTurnTimestamps = false
+    @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
 
     let message: ChatMessage
     let loadAttachmentImage: ((String) async -> Data?)?
@@ -17,6 +18,7 @@ struct MessageBubbleView: View {
     let onPreviewAttachment: ((MessageAttachment, Data?) -> Void)?
     let onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)?
     let isStreaming: Bool
+    let liveTokensPerSecond: Double?
 
     init(
         message: ChatMessage,
@@ -28,7 +30,8 @@ struct MessageBubbleView: View {
         localAttachmentPreviews: [String: Data]? = nil,
         onPreviewAttachment: ((MessageAttachment, Data?) -> Void)? = nil,
         onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)? = nil,
-        isStreaming: Bool = false
+        isStreaming: Bool = false,
+        liveTokensPerSecond: Double? = nil
     ) {
         self.message = message
         self.loadAttachmentImage = loadAttachmentImage
@@ -40,6 +43,7 @@ struct MessageBubbleView: View {
         self.onPreviewAttachment = onPreviewAttachment
         self.onPreviewTranscriptMedia = onPreviewTranscriptMedia
         self.isStreaming = isStreaming
+        self.liveTokensPerSecond = liveTokensPerSecond
     }
 
     var body: some View {
@@ -129,6 +133,11 @@ struct MessageBubbleView: View {
                 Text(time)
                     .foregroundStyle(.secondary)
             }
+
+            if let speed = assistantResponseSpeedText {
+                Text(speed)
+                    .foregroundStyle(.secondary)
+            }
         }
         .font(AppFont.footnote())
         .accessibilityElement(children: .ignore)
@@ -139,7 +148,9 @@ struct MessageBubbleView: View {
         ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
             role: message.role,
             hasTextContent: hasVisibleAssistantText,
-            isEnabled: showsAssistantTurnTimestamps
+            isEnabled: showsAssistantTurnTimestamps,
+            showsResponseSpeed: showsResponseSpeed,
+            hasResponseSpeed: assistantResponseSpeedText != nil
         )
     }
 
@@ -152,12 +163,27 @@ struct MessageBubbleView: View {
     }
 
     private var assistantTurnTimeText: String? {
-        AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: message.timestamp)
+        guard showsAssistantTurnTimestamps else { return nil }
+        return AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: message.timestamp)
+    }
+
+    private var assistantResponseSpeedText: String? {
+        guard showsResponseSpeed else { return nil }
+        return ResponseSpeedFormatter.compactText(isStreaming ? liveTokensPerSecond : message.turnTps)
     }
 
     private var assistantTurnHeaderAccessibilityLabel: String {
-        guard let time = assistantTurnTimeText else { return String(localized: "Assistant") }
-        return String(localized: "Assistant, \(time)")
+        let details = [
+            assistantTurnTimeText,
+            assistantResponseSpeedAccessibilityText
+        ].compactMap { $0 }
+        guard !details.isEmpty else { return String(localized: "Assistant") }
+        return String(localized: "Assistant, \(details.joined(separator: ", "))")
+    }
+
+    private var assistantResponseSpeedAccessibilityText: String? {
+        guard showsResponseSpeed else { return nil }
+        return ResponseSpeedFormatter.accessibilityText(isStreaming ? liveTokensPerSecond : message.turnTps)
     }
 
     private var localNoticeRow: some View {
@@ -715,5 +741,24 @@ enum AssistantTurnTimestampFormatter {
     private static func format(_ timestamp: Double?, with formatter: DateFormatter) -> String? {
         guard let timestamp, timestamp.isFinite else { return nil }
         return formatter.string(from: Date(timeIntervalSince1970: timestamp))
+    }
+}
+
+enum ResponseSpeedFormatter {
+    static func compactText(_ tokensPerSecond: Double?, locale: Locale = .autoupdatingCurrent) -> String? {
+        guard let tokensPerSecond, tokensPerSecond.isFinite, tokensPerSecond > 0 else { return nil }
+        let value = tokensPerSecond.formatted(
+            .number.locale(locale).precision(.fractionLength(1))
+        )
+        return "\(value) t/s"
+    }
+
+    static func accessibilityText(
+        _ tokensPerSecond: Double?,
+        locale: Locale = .autoupdatingCurrent
+    ) -> String? {
+        guard let compact = compactText(tokensPerSecond, locale: locale) else { return nil }
+        let value = compact.dropLast(4)
+        return "\(value) \(String(localized: "tokens per second"))"
     }
 }

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -75,6 +75,7 @@ struct SettingsView: View {
     @AppStorage(ChatTranscriptDisplaySettings.toolCardsStartExpandedKey) private var toolCardsStartExpanded = false
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsAssistantTurnTimestamps = false
+    @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
     @AppStorage(ChatTranscriptDisplaySettings.wrapsCodeBlockLinesKey) private var wrapsCodeBlockLines = false
     @AppStorage(ChatTranscriptDisplaySettings.rtlChatLayoutEnabledKey) private var rtlChatLayoutEnabled = ChatTranscriptDisplaySettings.rtlChatLayoutDefaultEnabled
     @AppStorage(StreamedTextAnimationSettings.isEnabledKey) private var isStreamedTextAnimationEnabled = true
@@ -231,6 +232,14 @@ struct SettingsView: View {
                     )
 
                     SettingsFootnote(String(localized: "Adds a small marker and the time above each response so back-to-back replies are easier to tell apart."))
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        title: String(localized: "Response Speed"),
+                        systemImage: "gauge.with.dots.needle.67percent",
+                        isOn: $showsResponseSpeed
+                    )
 
                     SettingsDivider()
 

--- a/HermesMobile/Models/ChatMessage.swift
+++ b/HermesMobile/Models/ChatMessage.swift
@@ -16,6 +16,7 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
     let contentParts: [JSONValue]?
     let reasoning: String?
     let attachments: [MessageAttachment]?
+    let turnTps: Double?
 
     init(
         role: String?,
@@ -28,7 +29,8 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         toolCalls: [JSONValue]? = nil,
         contentParts: [JSONValue]? = nil,
         reasoning: String? = nil,
-        attachments: [MessageAttachment]? = nil
+        attachments: [MessageAttachment]? = nil,
+        turnTps: Double? = nil
     ) {
         self.role = role
         self.content = content
@@ -41,6 +43,7 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         self.contentParts = contentParts
         self.reasoning = reasoning
         self.attachments = attachments
+        self.turnTps = turnTps
     }
 
     enum CodingKeys: String, CodingKey {
@@ -54,6 +57,7 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         case toolCalls
         case reasoning
         case attachments
+        case turnTps = "_turnTps"
         case underscoredTimestamp = "_ts"
     }
 
@@ -73,6 +77,7 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         reasoning = container.decodeLossyStringIfPresent(forKey: .reasoning)
         let decodedAttachments = Self.decodeAttachmentsTolerantly(from: container)
         attachments = Self.attachments(decodedAttachments, enrichedByMarkerIn: content)
+        turnTps = container.decodeLossyDoubleIfPresent(forKey: .turnTps)
     }
 
     private static func attachments(

--- a/HermesMobile/Models/ContextWindowSnapshot.swift
+++ b/HermesMobile/Models/ContextWindowSnapshot.swift
@@ -7,6 +7,7 @@ struct ContextWindowSnapshot: Decodable, Equatable {
     let inputTokens: Int?
     let outputTokens: Int?
     let estimatedCost: Double?
+    let tokensPerSecond: Double?
 
     enum CodingKeys: String, CodingKey {
         case contextLength = "context_length"
@@ -15,6 +16,36 @@ struct ContextWindowSnapshot: Decodable, Equatable {
         case inputTokens = "input_tokens"
         case outputTokens = "output_tokens"
         case estimatedCost = "estimated_cost"
+        case tokensPerSecond = "tps"
+    }
+
+    init(
+        contextLength: Int?,
+        thresholdTokens: Int?,
+        lastPromptTokens: Int?,
+        inputTokens: Int?,
+        outputTokens: Int?,
+        estimatedCost: Double?,
+        tokensPerSecond: Double? = nil
+    ) {
+        self.contextLength = contextLength
+        self.thresholdTokens = thresholdTokens
+        self.lastPromptTokens = lastPromptTokens
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.estimatedCost = estimatedCost
+        self.tokensPerSecond = tokensPerSecond
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        contextLength = container.decodeLossyIntIfPresent(forKey: .contextLength)
+        thresholdTokens = container.decodeLossyIntIfPresent(forKey: .thresholdTokens)
+        lastPromptTokens = container.decodeLossyIntIfPresent(forKey: .lastPromptTokens)
+        inputTokens = container.decodeLossyIntIfPresent(forKey: .inputTokens)
+        outputTokens = container.decodeLossyIntIfPresent(forKey: .outputTokens)
+        estimatedCost = container.decodeLossyDoubleIfPresent(forKey: .estimatedCost)
+        tokensPerSecond = container.decodeLossyDoubleIfPresent(forKey: .tokensPerSecond)
     }
 
     var tokensUsed: Int? {
@@ -35,7 +66,8 @@ struct ContextWindowSnapshot: Decodable, Equatable {
             lastPromptTokens: tokens,
             inputTokens: inputTokens,
             outputTokens: outputTokens,
-            estimatedCost: estimatedCost
+            estimatedCost: estimatedCost,
+            tokensPerSecond: tokensPerSecond
         )
     }
 }

--- a/HermesMobile/Networking/SSEClient.swift
+++ b/HermesMobile/Networking/SSEClient.swift
@@ -71,6 +71,7 @@ enum SSEEvent: Equatable {
     case toolStarted(ToolStreamEvent)
     case toolCompleted(ToolStreamEvent)
     case title(TitleStreamEvent)
+    case metering(MeteringStreamEvent)
     case done(DoneStreamEvent)
     case approvalPending(ApprovalPendingResponse)
     case clarificationPending(ClarificationPendingResponse)
@@ -172,6 +173,52 @@ struct InterimAssistantStreamEvent: Decodable, Equatable {
     }
 }
 
+struct MeteringStreamEvent: Decodable, Equatable {
+    let tokensPerSecond: Double?
+    let isTokensPerSecondAvailable: Bool?
+    let isEstimated: Bool?
+    let sessionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case tokensPerSecond = "tps"
+        case isTokensPerSecondAvailable = "tps_available"
+        case isEstimated = "estimated"
+        case sessionId = "session_id"
+    }
+
+    init(
+        tokensPerSecond: Double? = nil,
+        isTokensPerSecondAvailable: Bool? = nil,
+        isEstimated: Bool? = nil,
+        sessionId: String? = nil
+    ) {
+        self.tokensPerSecond = tokensPerSecond
+        self.isTokensPerSecondAvailable = isTokensPerSecondAvailable
+        self.isEstimated = isEstimated
+        self.sessionId = sessionId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tokensPerSecond = container.decodeLossyDoubleIfPresent(forKey: .tokensPerSecond)
+        isTokensPerSecondAvailable = container.decodeLossyBoolIfPresent(forKey: .isTokensPerSecondAvailable)
+        isEstimated = container.decodeLossyBoolIfPresent(forKey: .isEstimated)
+        sessionId = container.decodeLossyStringIfPresent(forKey: .sessionId)
+    }
+
+    var displayableTokensPerSecond: Double? {
+        guard isTokensPerSecondAvailable == true,
+              isEstimated != true,
+              let tokensPerSecond,
+              tokensPerSecond.isFinite,
+              tokensPerSecond > 0
+        else {
+            return nil
+        }
+        return tokensPerSecond
+    }
+}
+
 struct SSEEventDecoder {
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile",
@@ -206,6 +253,14 @@ struct SSEEventDecoder {
         case "title":
             let payload = decodePayload(TitleStreamEvent.self, eventType: eventType, from: eventData, decoder: decoder)
             return .title(payload ?? TitleStreamEvent())
+        case "metering":
+            let payload = decodePayload(
+                MeteringStreamEvent.self,
+                eventType: eventType,
+                from: eventData,
+                decoder: decoder
+            )
+            return .metering(payload ?? MeteringStreamEvent())
         case "done":
             guard let payload = decodePayload(DonePayload.self, eventType: eventType, from: eventData, decoder: decoder) else {
                 return .transportError("The stream returned a malformed completion event.")

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -343,7 +343,8 @@ private extension ChatMessage {
             toolCalls: toolCalls,
             contentParts: contentParts,
             reasoning: cachedMessage.reasoning,
-            attachments: attachments
+            attachments: attachments,
+            turnTps: cachedMessage.turnTps
         )
     }
 }

--- a/HermesMobile/Persistence/CachedMessage.swift
+++ b/HermesMobile/Persistence/CachedMessage.swift
@@ -18,6 +18,7 @@ final class CachedMessage {
     var contentPartsData: Data?
     var reasoning: String?
     var attachmentsData: Data?
+    var turnTps: Double?
     var cachedAt: Date
     var expiresAt: Date
 
@@ -72,6 +73,7 @@ final class CachedMessage {
             contentPartsData = nil
         }
         reasoning = message.reasoning
+        turnTps = message.turnTps
         if let attachments = message.attachments, !attachments.isEmpty {
             attachmentsData = try? JSONEncoder().encode(attachments)
         } else {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -5441,6 +5441,112 @@
         }
       }
     },
+    "tokens per second" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رموز في الثانية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Token pro Sekunde"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tokens por segundo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "jetons par seconde"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "אסימונים לשנייה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "token al secondo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1秒あたりのトークン数"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "초당 토큰"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tokens per seconde"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tokenów na sekundę"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tokens por segundo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "токенов в секунду"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "saniye başına token"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ٹوکن فی سیکنڈ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每秒權杖數"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每秒令牌数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每秒權杖數"
+          }
+        }
+      }
+    },
     "%@, %@" : {
       "localizations" : {
         "en" : {
@@ -63550,6 +63656,112 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "回覆完成提醒"
+          }
+        }
+      }
+    },
+    "Response Speed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سرعة الاستجابة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Antwortgeschwindigkeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Velocidad de respuesta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vitesse de réponse"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מהירות תגובה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Velocità di risposta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "応答速度"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "응답 속도"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Antwoordsnelheid"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Szybkość odpowiedzi"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Velocidade de resposta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Скорость ответа"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yanıt Hızı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "جواب کی رفتار"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "回應速度"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "回复速度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "回覆速度"
           }
         }
       }

--- a/HermesMobileTests/CacheStoreTests.swift
+++ b/HermesMobileTests/CacheStoreTests.swift
@@ -386,6 +386,37 @@ final class CacheStoreTests: XCTestCase {
         XCTAssertEqual(cachedMessages.first?.reasoning, "Cached reasoning.")
     }
 
+    func testAssistantTurnTpsDecodesAndRoundTripsThroughCache() throws {
+        let context = try makeContext()
+        let serverURL = URL(string: "https://example.test")!
+        let cachedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let message = try JSONDecoder().decode(
+            ChatMessage.self,
+            from: Data(#"{"role":"assistant","content":"Done","messageId":"m1","_turnTps":48.75}"#.utf8)
+        )
+
+        XCTAssertEqual(message.turnTps, 48.75)
+
+        try CacheStore.cacheMessages(
+            [message],
+            serverURL: serverURL,
+            sessionID: "abc123",
+            in: context,
+            cachedAt: cachedAt
+        )
+
+        XCTAssertEqual(try fetchCachedMessages(in: context).first?.turnTps, 48.75)
+        XCTAssertEqual(
+            try CacheStore.cachedMessages(
+                serverURL: serverURL,
+                sessionID: "abc123",
+                in: context,
+                now: cachedAt.addingTimeInterval(60)
+            ).first?.turnTps,
+            48.75
+        )
+    }
+
     func testCachedMessagesIgnoresExpiredMessages() throws {
         let context = try makeContext()
         let serverURL = URL(string: "https://example.test")!

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -529,16 +529,122 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(liveActivityManager.ends.last?.status, .complete)
 
         coordinator.start(streamID: "stream-error")
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 12.25,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        XCTAssertEqual(coordinator.liveTokensPerSecond, 12.25)
         streamClient.emit(.error("server failed"))
         XCTAssertNil(coordinator.activeStreamID)
+        XCTAssertNil(coordinator.liveTokensPerSecond)
         XCTAssertEqual(delegate.errorMessages, ["server failed"])
         XCTAssertEqual(liveActivityManager.ends.last?.status, .failed)
 
         coordinator.start(streamID: "stream-cancel")
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 24.5,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        XCTAssertEqual(coordinator.liveTokensPerSecond, 24.5)
         let response = try await coordinator.cancelActiveStream()
         XCTAssertEqual(response?.ok, true)
         XCTAssertNil(coordinator.activeStreamID)
+        XCTAssertNil(coordinator.liveTokensPerSecond)
         XCTAssertEqual(liveActivityManager.ends.last?.status, .cancelled)
+    }
+
+    @MainActor
+    func testLiveResponseSpeedAcceptsOnlyCurrentSessionExactReadingsAndClearsOnLifecycleChanges() {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+
+        coordinator.start(streamID: "stream-one")
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 12.25,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        XCTAssertEqual(coordinator.liveTokensPerSecond, 12.25)
+
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 99,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "another-session"
+        )))
+        XCTAssertEqual(coordinator.liveTokensPerSecond, 12.25)
+
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 12.25,
+            isTokensPerSecondAvailable: true,
+            isEstimated: true,
+            sessionId: "session-abc"
+        )))
+        XCTAssertNil(coordinator.liveTokensPerSecond)
+
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 24.5,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        _ = coordinator.prepareForSessionLoad()
+        XCTAssertNil(coordinator.liveTokensPerSecond)
+
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 24.5,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        coordinator.start(streamID: "stream-two")
+        XCTAssertNil(coordinator.liveTokensPerSecond)
+
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 36.75,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        streamClient.emit(.done(DoneStreamEvent(usage: ContextWindowSnapshot(
+            contextLength: nil,
+            thresholdTokens: nil,
+            lastPromptTokens: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            estimatedCost: nil,
+            tokensPerSecond: 40.5
+        ))))
+
+        XCTAssertNil(coordinator.liveTokensPerSecond)
+        XCTAssertEqual(delegate.donePayloads.last?.usage?.tokensPerSecond, 40.5)
+    }
+
+    @MainActor
+    func testLiveResponseSpeedClearsImmediatelyWhenTransportFails() {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+
+        coordinator.start(streamID: "stream-one")
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 12.25,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        XCTAssertEqual(coordinator.liveTokensPerSecond, 12.25)
+
+        streamClient.emit(.transportError("Connection lost"))
+
+        XCTAssertNil(coordinator.liveTokensPerSecond)
+        XCTAssertTrue(coordinator.isConnectionSuspended)
     }
 
     @MainActor
@@ -634,6 +740,7 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
     private(set) var startConnectionReplayValues: [Bool] = []
     private(set) var resetRecoveryCount = 0
     private(set) var tokens: [String] = []
+    private(set) var donePayloads: [DoneStreamEvent] = []
     private(set) var pendingSteerLeftovers: [String] = []
     var latestAssistantMessageID: String? = "assistant-latest"
     var restoredSnapshotEventID: String?
@@ -733,7 +840,8 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
     }
 
     func streamCoordinatorApplyDone(_ payload: DoneStreamEvent) -> Bool {
-        doneHasCompletedTranscript
+        donePayloads.append(payload)
+        return doneHasCompletedTranscript
     }
 
     func streamCoordinatorApplyApprovalUpdate(_ update: ApprovalPendingResponse) {}

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -5838,6 +5838,140 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testDoneUsageReplacesLiveResponseSpeedOnAssistantMessage() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/start")
+            return apiTestJSONResponse("""
+            {
+              "session_id": "session-abc",
+              "stream_id": "stream-123"
+            }
+            """, for: request)
+        }
+
+        let didSend = await viewModel.sendMessage("Measure this")
+        XCTAssertTrue(didSend)
+        streamClient.emit(.token("Measured response."))
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 18.25,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
+        XCTAssertEqual(viewModel.liveTokensPerSecond, 18.25)
+
+        streamClient.emit(.done(DoneStreamEvent(usage: ContextWindowSnapshot(
+            contextLength: nil,
+            thresholdTokens: nil,
+            lastPromptTokens: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            estimatedCost: nil,
+            tokensPerSecond: 20.5
+        ))))
+
+        XCTAssertNil(viewModel.liveTokensPerSecond)
+        XCTAssertEqual(viewModel.messages.last(where: { $0.role == "assistant" })?.turnTps, 20.5)
+    }
+
+    @MainActor
+    func testDoneUsageDoesNotOverwritePreviousAssistantWithoutCurrentStreamingAnchor() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/start")
+            return apiTestJSONResponse("""
+            {
+              "session_id": "session-abc",
+              "stream_id": "stream-123"
+            }
+            """, for: request)
+        }
+
+        let didSend = await viewModel.sendMessage("Run a tool only")
+        XCTAssertTrue(didSend)
+        let completedSession = try makeSessionDetail("""
+        {
+          "session_id": "session-abc",
+          "messages": [
+            {"role":"user","content":"Earlier question","messageId":"user-previous"},
+            {"role":"assistant","content":"Earlier answer","messageId":"assistant-previous"},
+            {"role":"user","content":"Run a tool only","messageId":"user-current"}
+          ]
+        }
+        """)
+
+        streamClient.emit(.done(DoneStreamEvent(
+            usage: ContextWindowSnapshot(
+                contextLength: nil,
+                thresholdTokens: nil,
+                lastPromptTokens: nil,
+                inputTokens: nil,
+                outputTokens: nil,
+                estimatedCost: nil,
+                tokensPerSecond: 20.5
+            ),
+            session: completedSession
+        )))
+
+        XCTAssertNil(viewModel.messages.first(where: { $0.messageId == "assistant-previous" })?.turnTps)
+        XCTAssertFalse(viewModel.messages.contains(where: { $0.turnTps != nil }))
+    }
+
+    @MainActor
+    func testCompletedResponseCachesFinalTurnTpsWithoutTranscriptReload() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let modelContext = try makeContext()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/start")
+            return apiTestJSONResponse("""
+            {
+              "session_id": "session-abc",
+              "stream_id": "stream-123"
+            }
+            """, for: request)
+        }
+
+        let didSend = await viewModel.sendMessage("Measure this", modelContext: modelContext)
+        XCTAssertTrue(didSend)
+        streamClient.emit(.token("Measured response."))
+        let completedSession = try makeSessionDetail("""
+        {
+          "session_id": "session-abc",
+          "messages": [
+            {"role":"user","content":"Measure this","messageId":"user-current"},
+            {"role":"assistant","content":"Measured response.","messageId":"assistant-server"}
+          ]
+        }
+        """)
+        streamClient.emit(.done(DoneStreamEvent(
+            usage: ContextWindowSnapshot(
+                contextLength: nil,
+                thresholdTokens: nil,
+                lastPromptTokens: nil,
+                inputTokens: nil,
+                outputTokens: nil,
+                estimatedCost: nil,
+                tokensPerSecond: 20.5
+            ),
+            session: completedSession
+        )))
+
+        XCTAssertFalse(viewModel.responseCompletionNeedsTranscriptRefresh)
+        viewModel.cacheCompletedResponse(modelContext: modelContext)
+
+        let cachedMessages = try CacheStore.cachedMessages(
+            serverURL: URL(string: "https://example.test")!,
+            sessionID: "session-abc",
+            in: modelContext
+        )
+        XCTAssertEqual(
+            cachedMessages.first(where: { $0.messageId == "assistant-server" })?.turnTps,
+            20.5
+        )
+    }
+
+    @MainActor
     func testTransportErrorChecksStatusAndFinishesWhenStreamIsInactive() async throws {
         let streamClient = SpySSEStreamingClient()
         var didRequestStatus = false

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -5876,6 +5876,54 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testDoneUsageAppliesResponseSpeedToLastAssistantInCompletedToolTurn() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/start")
+            return apiTestJSONResponse("""
+            {
+              "session_id": "session-abc",
+              "stream_id": "stream-123"
+            }
+            """, for: request)
+        }
+
+        let didSend = await viewModel.sendMessage("Run a tool")
+        XCTAssertTrue(didSend)
+        streamClient.emit(.token("I'll inspect that."))
+        let completedSession = try makeSessionDetail("""
+        {
+          "session_id": "session-abc",
+          "messages": [
+            {"role":"user","content":"Run a tool"},
+            {"role":"assistant","content":"I'll inspect that."},
+            {"role":"tool","content":"Tool output"},
+            {"role":"assistant","content":"Finished."}
+          ]
+        }
+        """)
+
+        streamClient.emit(.done(DoneStreamEvent(
+            usage: ContextWindowSnapshot(
+                contextLength: nil,
+                thresholdTokens: nil,
+                lastPromptTokens: nil,
+                inputTokens: nil,
+                outputTokens: nil,
+                estimatedCost: nil,
+                tokensPerSecond: 20.5
+            ),
+            session: completedSession
+        )))
+
+        let assistantMessages = viewModel.messages.filter { $0.role == "assistant" }
+        XCTAssertEqual(assistantMessages.count, 2)
+        XCTAssertNil(assistantMessages.first?.turnTps)
+        XCTAssertEqual(assistantMessages.last?.turnTps, 20.5)
+        XCTAssertFalse(viewModel.responseCompletionNeedsTranscriptRefresh)
+    }
+
+    @MainActor
     func testDoneUsageDoesNotOverwritePreviousAssistantWithoutCurrentStreamingAnchor() async throws {
         let streamClient = SpySSEStreamingClient()
         let viewModel = try makeViewModel(streamClient: streamClient) { request in

--- a/HermesMobileTests/SSEClientTests.swift
+++ b/HermesMobileTests/SSEClientTests.swift
@@ -299,6 +299,168 @@ final class SSEClientTests: XCTestCase {
         ))
     }
 
+    func testDecodesDisplayableLiveMeteringPayload() {
+        let event = SSEEventDecoder.decode(
+            eventType: "metering",
+            data: """
+            {
+              "session_id": "abc123",
+              "tps": 42.25,
+              "tps_available": true,
+              "estimated": false,
+              "unknown_future_field": "ignored"
+            }
+            """
+        )
+
+        guard case .metering(let payload) = event else {
+            XCTFail("Expected metering event.")
+            return
+        }
+
+        XCTAssertEqual(payload.sessionId, "abc123")
+        XCTAssertEqual(payload.displayableTokensPerSecond, 42.25)
+    }
+
+    func testDecodesMissingLiveMeteringFieldsAsNil() {
+        let event = SSEEventDecoder.decode(eventType: "metering", data: "{}")
+
+        guard case .metering(let payload) = event else {
+            XCTFail("Expected metering event.")
+            return
+        }
+
+        XCTAssertNil(payload.tokensPerSecond)
+        XCTAssertNil(payload.isTokensPerSecondAvailable)
+        XCTAssertNil(payload.isEstimated)
+        XCTAssertNil(payload.sessionId)
+    }
+
+    func testMalformedLiveMeteringFieldsDoNotDiscardValidFields() {
+        let event = SSEEventDecoder.decode(
+            eventType: "metering",
+            data: """
+            {
+              "tps": {"unexpected": true},
+              "tps_available": ["unexpected"],
+              "estimated": {"unexpected": true},
+              "session_id": "abc123"
+            }
+            """
+        )
+
+        guard case .metering(let payload) = event else {
+            XCTFail("Expected metering event.")
+            return
+        }
+
+        XCTAssertNil(payload.tokensPerSecond)
+        XCTAssertNil(payload.isTokensPerSecondAvailable)
+        XCTAssertNil(payload.isEstimated)
+        XCTAssertEqual(payload.sessionId, "abc123")
+
+        let malformedSessionEvent = SSEEventDecoder.decode(
+            eventType: "metering",
+            data: """
+            {
+              "tps": 42.5,
+              "tps_available": true,
+              "estimated": false,
+              "session_id": {"unexpected": true}
+            }
+            """
+        )
+
+        guard case .metering(let malformedSessionPayload) = malformedSessionEvent else {
+            XCTFail("Expected metering event.")
+            return
+        }
+
+        XCTAssertEqual(malformedSessionPayload.displayableTokensPerSecond, 42.5)
+        XCTAssertNil(malformedSessionPayload.sessionId)
+    }
+
+    func testLiveMeteringUsesLossyDecodingForOptionalFields() {
+        let event = SSEEventDecoder.decode(
+            eventType: "metering",
+            data: """
+            {
+              "tps": "42.5",
+              "tps_available": "true",
+              "estimated": 0,
+              "session_id": 123
+            }
+            """
+        )
+
+        guard case .metering(let payload) = event else {
+            XCTFail("Expected metering event.")
+            return
+        }
+
+        XCTAssertEqual(payload.tokensPerSecond, 42.5)
+        XCTAssertEqual(payload.isTokensPerSecondAvailable, true)
+        XCTAssertEqual(payload.isEstimated, false)
+        XCTAssertEqual(payload.sessionId, "123")
+    }
+
+    func testLiveMeteringRequiresAvailableExactPositiveFiniteTps() {
+        XCTAssertNil(MeteringStreamEvent(
+            tokensPerSecond: 10,
+            isTokensPerSecondAvailable: false,
+            isEstimated: false,
+            sessionId: nil
+        ).displayableTokensPerSecond)
+        XCTAssertNil(MeteringStreamEvent(
+            tokensPerSecond: 10,
+            isTokensPerSecondAvailable: true,
+            isEstimated: true,
+            sessionId: nil
+        ).displayableTokensPerSecond)
+        XCTAssertNil(MeteringStreamEvent(
+            tokensPerSecond: 0,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: nil
+        ).displayableTokensPerSecond)
+        XCTAssertNil(MeteringStreamEvent(
+            tokensPerSecond: .infinity,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: nil
+        ).displayableTokensPerSecond)
+    }
+
+    func testDoneUsageDecodesFinalTokensPerSecond() {
+        let event = SSEEventDecoder.decode(
+            eventType: "done",
+            data: #"{"usage":{"tps":51.75}}"#
+        )
+
+        guard case .done(let payload) = event else {
+            XCTFail("Expected done event.")
+            return
+        }
+
+        XCTAssertEqual(payload.usage?.tokensPerSecond, 51.75)
+    }
+
+    func testMalformedDoneUsageTpsDoesNotDiscardOtherUsageFields() {
+        let event = SSEEventDecoder.decode(
+            eventType: "done",
+            data: #"{"usage":{"context_length":"32768","input_tokens":1200,"tps":{"unexpected":true}}}"#
+        )
+
+        guard case .done(let payload) = event else {
+            XCTFail("Expected done event.")
+            return
+        }
+
+        XCTAssertEqual(payload.usage?.contextLength, 32_768)
+        XCTAssertEqual(payload.usage?.inputTokens, 1_200)
+        XCTAssertNil(payload.usage?.tokensPerSecond)
+    }
+
     func testDecodesDoneEventSessionMessages() {
         let event = SSEEventDecoder.decode(
             eventType: "done",

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -306,6 +306,58 @@ final class ChatTranscriptDisplaySettingsTests: XCTestCase {
         )
     }
 
+    func testResponseSpeedKeyIsStableAndDistinct() {
+        XCTAssertEqual(
+            ChatTranscriptDisplaySettings.showsResponseSpeedKey,
+            "chatTranscript.showsResponseSpeed"
+        )
+        XCTAssertNotEqual(
+            ChatTranscriptDisplaySettings.showsResponseSpeedKey,
+            ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey
+        )
+    }
+
+    func testTimestampAndResponseSpeedTogglesAreIndependent() {
+        XCTAssertFalse(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
+            role: "assistant",
+            hasTextContent: true,
+            isEnabled: false,
+            showsResponseSpeed: false,
+            hasResponseSpeed: true
+        ))
+        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
+            role: "assistant",
+            hasTextContent: true,
+            isEnabled: true,
+            showsResponseSpeed: false,
+            hasResponseSpeed: true
+        ))
+        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
+            role: "assistant",
+            hasTextContent: true,
+            isEnabled: false,
+            showsResponseSpeed: true,
+            hasResponseSpeed: true
+        ))
+        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
+            role: "assistant",
+            hasTextContent: true,
+            isEnabled: true,
+            showsResponseSpeed: true,
+            hasResponseSpeed: true
+        ))
+    }
+
+    func testInvalidResponseSpeedAloneDoesNotCreateHeaderRow() {
+        XCTAssertFalse(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
+            role: "assistant",
+            hasTextContent: true,
+            isEnabled: false,
+            showsResponseSpeed: true,
+            hasResponseSpeed: false
+        ))
+    }
+
     func testAssistantTurnHeaderShowsForAssistantTextTurnWhenEnabled() {
         XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
             role: "assistant",
@@ -502,5 +554,25 @@ final class AssistantTurnTimestampFormatterTests: XCTestCase {
 
     func testCurrentLocaleOverloadFormatsFiniteTimestamp() {
         XCTAssertNotNil(AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: fixedTimestamp))
+    }
+}
+
+final class ResponseSpeedFormatterTests: XCTestCase {
+    func testFormatsOneDecimalWithCompactAndAccessibleUnits() {
+        let locale = Locale(identifier: "en_US")
+
+        XCTAssertEqual(ResponseSpeedFormatter.compactText(12.34, locale: locale), "12.3 t/s")
+        XCTAssertEqual(
+            ResponseSpeedFormatter.accessibilityText(12.34, locale: locale),
+            "12.3 tokens per second"
+        )
+    }
+
+    func testReturnsNilForMissingNonPositiveOrNonFiniteValues() {
+        XCTAssertNil(ResponseSpeedFormatter.compactText(nil))
+        XCTAssertNil(ResponseSpeedFormatter.compactText(0))
+        XCTAssertNil(ResponseSpeedFormatter.compactText(-1))
+        XCTAssertNil(ResponseSpeedFormatter.compactText(.infinity))
+        XCTAssertNil(ResponseSpeedFormatter.compactText(.nan))
     }
 }


### PR DESCRIPTION
## Linked issue

Fixes #174

## What changed

- tolerantly decode valid live `metering` TPS, final `done.usage.tps`, and persisted `_turnTps` metadata without changing unknown-event compatibility
- add an opt-in Settings → Chat preference named Response Speed that defaults off and remains independent from Response Timestamps
- show live TPS only when it is available, non-estimated, finite, and positive, then replace it with the turn-specific final value
- persist completed TPS for reopened and offline transcripts while clearing live state on new streams, completion, cancellation, errors, and session changes
- add localized compact `t/s` display and a full tokens-per-second accessibility label

## Contract verification

- verified against `hermes-webui` commit `2f3e42dc649e6d2bae572a0655681d9bb212c78d`
- live source: `metering.tps`, `metering.tps_available`, and `metering.estimated`
- final source: `done.usage.tps` and `done.usage.duration_seconds`
- persisted source: assistant-message `_turnTps` and `_turnDuration`
- cross-checked the official [chat streaming documentation](https://get-hermes.ai/api-docs/reference/chat-streaming/); no endpoint was added or changed

## How it was tested

- `xcodebuild build-for-testing -project HermesMobile.xcodeproj -scheme HermesMobile -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test-without-building -project HermesMobile.xcodeproj -scheme HermesMobile -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath DerivedData -resultBundlePath TestResults.xcresult -parallel-testing-enabled YES -parallel-testing-worker-count 1 CODE_SIGNING_ALLOWED=NO`: 1,479 passed, 0 failed, 0 skipped
- `git diff --check origin/master...HEAD`
- signed iPhone 17 simulator walkthrough: default-off state, live-to-final replacement, cancellation clearing, reopened and offline persistence, speed/timestamp combinations, dark appearance, large Dynamic Type, and accessibility label
- missing-TPS and terminal-error paths covered with upstream-compatible HTTP/SSE scenarios and XCTest
- independent standards and specification reviews: passed

## Checklist

- [x] The full test suite passes locally
- [x] New and changed `Codable` models decode optional upstream fields tolerantly
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes

AI usage: built with OpenAI Codex and reviewed with independent Codex agents.