### PR TITLE
fix(files): keep latest directory navigation

### DIFF
--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -82,6 +82,36 @@ struct FileBrowserView: View {
                 await reloadCurrentPath()
             }
             .listStyle(.plain)
+            .safeAreaInset(edge: .top, spacing: 0) {
+                if viewModel.isLoading {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                        Text("Loading files...")
+                    }
+                    .font(.footnote)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    .padding(.vertical, 10)
+                    .background(Color(.secondarySystemBackground))
+                } else if let errorMessage = viewModel.errorMessage {
+                    HStack(spacing: 12) {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+
+                        Spacer(minLength: 0)
+
+                        Button("Try Again") {
+                            Task { await retryLastLoad() }
+                        }
+                        .font(.footnote.weight(.semibold))
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 10)
+                    .background(Color(.secondarySystemBackground))
+                }
+            }
         }
     }
 
@@ -208,6 +238,11 @@ struct FileBrowserView: View {
 
     private func reloadCurrentPath() async {
         await viewModel.reloadCurrentPath()
+        handleLastError()
+    }
+
+    private func retryLastLoad() async {
+        await viewModel.retryLastLoad()
         handleLastError()
     }
 

--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -42,7 +42,7 @@ struct FileBrowserView: View {
                 Text(errorMessage)
             } actions: {
                 Button("Try Again") {
-                    Task { await loadRoot() }
+                    Task { await retryLastLoad() }
                 }
             }
         } else if visibleEntries.isEmpty {

--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -297,6 +297,7 @@ private struct FileBrowserRow: View {
             }
         }
         .padding(.vertical, 2)
+        .contentShape(Rectangle())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
     }

--- a/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
@@ -11,6 +11,8 @@ final class FileBrowserViewModel {
     private(set) var errorMessage: String?
     private(set) var lastError: Error?
     private var hasLoadedInitialPath = false
+    private var lastRequestedPath = "."
+    private var loadRevision = 0
 
     var isAtRoot: Bool {
         currentPath == "."
@@ -46,9 +48,9 @@ final class FileBrowserViewModel {
         return breadcrumbs
     }
 
-    init(session: SessionSummary, server: URL) {
+    init(session: SessionSummary, server: URL, apiClient: APIClient? = nil) {
         self.session = session
-        apiClient = APIClient(baseURL: server)
+        self.apiClient = apiClient ?? APIClient(baseURL: server)
     }
 
     @MainActor
@@ -69,21 +71,31 @@ final class FileBrowserViewModel {
     }
 
     @MainActor
+    func retryLastLoad() async {
+        await load(path: lastRequestedPath)
+    }
+
+    @MainActor
     func load(path: String) async {
         guard let sessionID = session.sessionId else {
             errorMessage = String(localized: "Session ID is missing.")
             return
         }
 
+        lastRequestedPath = path
+        loadRevision += 1
+        let revision = loadRevision
         isLoading = true
         errorMessage = nil
         lastError = nil
 
         do {
             let response = try await apiClient.directoryList(sessionID: sessionID, path: path)
+            guard revision == loadRevision else { return }
             currentPath = response.path ?? path
             entries = response.entries ?? []
         } catch {
+            guard revision == loadRevision else { return }
             lastError = error
             errorMessage = error.localizedDescription
         }

--- a/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
@@ -96,11 +96,29 @@ final class FileBrowserViewModel {
             entries = response.entries ?? []
         } catch {
             guard revision == loadRevision else { return }
-            lastError = error
-            errorMessage = error.localizedDescription
+            if !Self.isCancellationError(error) {
+                lastError = error
+                errorMessage = error.localizedDescription
+            }
         }
 
         isLoading = false
+    }
+
+    private static func isCancellationError(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+
+        let underlying: Error
+        if case APIError.network(let wrapped) = error {
+            underlying = wrapped
+        } else {
+            underlying = error
+        }
+
+        guard let urlError = underlying as? URLError else { return false }
+        return urlError.code == .cancelled
     }
 }
 

--- a/HermesMobileTests/APIClientWorkspaceFileTests.swift
+++ b/HermesMobileTests/APIClientWorkspaceFileTests.swift
@@ -525,6 +525,24 @@ final class APIClientWorkspaceFileTests: APIClientTestCase {
         XCTAssertEqual(catAttempts, 2)
     }
 
+    @MainActor
+    func testFileBrowserCancellationDoesNotSurfaceError() async throws {
+        let client = makeClient { _ in
+            throw URLError(.cancelled)
+        }
+        let viewModel = try FileBrowserViewModel(
+            session: makeFilePreviewSession(),
+            server: XCTUnwrap(URL(string: "https://example.test")),
+            apiClient: client
+        )
+
+        await viewModel.loadRoot()
+
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNil(viewModel.lastError)
+    }
+
     func testFileReadBuildsExpectedQueryAndDecodesTextResponse() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/file")

--- a/HermesMobileTests/APIClientWorkspaceFileTests.swift
+++ b/HermesMobileTests/APIClientWorkspaceFileTests.swift
@@ -443,6 +443,88 @@ final class APIClientWorkspaceFileTests: APIClientTestCase {
         XCTAssertEqual(response.path, "Sources/App")
     }
 
+    @MainActor
+    func testFileBrowserLatestDirectoryRequestWins() async throws {
+        let firstRequestStarted = expectation(description: "First directory request started")
+        let client = makeClient { request in
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let path = components?.queryItems?.first(where: { $0.name == "path" })?.value
+
+            if path == "cat" {
+                firstRequestStarted.fulfill()
+                Thread.sleep(forTimeInterval: 0.3)
+            }
+
+            return apiTestJSONResponse("""
+            {
+              "entries": [],
+              "path": "\(path ?? ".")"
+            }
+            """, for: request)
+        }
+        let viewModel = try FileBrowserViewModel(
+            session: makeFilePreviewSession(),
+            server: XCTUnwrap(URL(string: "https://example.test")),
+            apiClient: client
+        )
+
+        let firstLoad = Task { await viewModel.load(path: "cat") }
+        await fulfillment(of: [firstRequestStarted], timeout: 1)
+        let latestLoad = Task { await viewModel.load(path: "leetcode-editor") }
+
+        await latestLoad.value
+        await firstLoad.value
+
+        XCTAssertEqual(viewModel.currentPath, "leetcode-editor")
+    }
+
+    @MainActor
+    func testFileBrowserRetriesFailedDirectoryWithoutDiscardingCurrentEntries() async throws {
+        var catAttempts = 0
+        let client = makeClient { request in
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let path = components?.queryItems?.first(where: { $0.name == "path" })?.value
+
+            if path == "cat" {
+                catAttempts += 1
+                if catAttempts == 1 {
+                    let response = HTTPURLResponse(
+                        url: try XCTUnwrap(request.url),
+                        statusCode: 503,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "application/json"]
+                    )
+                    return (try XCTUnwrap(response), Data(#"{"error":"temporarily unavailable"}"#.utf8))
+                }
+            }
+
+            return apiTestJSONResponse("""
+            {
+              "entries": [{"name": "cat", "path": "cat", "type": "dir"}],
+              "path": "\(path ?? ".")"
+            }
+            """, for: request)
+        }
+        let viewModel = try FileBrowserViewModel(
+            session: makeFilePreviewSession(),
+            server: XCTUnwrap(URL(string: "https://example.test")),
+            apiClient: client
+        )
+
+        await viewModel.loadRoot()
+        await viewModel.load(path: "cat")
+
+        XCTAssertEqual(viewModel.currentPath, ".")
+        XCTAssertEqual(viewModel.entries.first?.name, "cat")
+        XCTAssertNotNil(viewModel.errorMessage)
+
+        await viewModel.retryLastLoad()
+
+        XCTAssertEqual(viewModel.currentPath, "cat")
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertEqual(catAttempts, 2)
+    }
+
     func testFileReadBuildsExpectedQueryAndDecodesTextResponse() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/file")


### PR DESCRIPTION
## Linked issue

Fixes #187

## What changed

- Show an inline loading status while keeping the current directory list visible and usable.
- Ignore out-of-order directory responses so the latest navigation request wins.
- Keep load errors visible above an existing list and retry the failed directory path.
- Add regression coverage for out-of-order responses and failed-directory retry.

The race is resolved in `FileBrowserViewModel`, where every file-browser navigation request already converges, instead of adding guards to individual buttons.

## How it was tested

- Targeted regression tests:
  - `testFileBrowserLatestDirectoryRequestWins`
  - `testFileBrowserRetriesFailedDirectoryWithoutDiscardingCurrentEntries`
  - `testFileBrowserCancellationDoesNotSurfaceError`
- Full XCTest suite:
  - `xcodebuild -quiet -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test`
  - Result: 1,464 passed, 0 failed, 0 skipped.
- Signed Simulator validation:
  - Built the Debug `HermesMobile` scheme without disabling signing.
  - Installed and launched `com.uzairansar.hermesmobile` on iPhone 17 / iOS 26.5.

The signed app launch was verified, but the configured Simulator server was offline, so the delayed-response UI was validated deterministically at the request/view-model boundary rather than against a live server.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no `Codable` models changed)
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [x] No invented API endpoints or JSON shapes (no API contract changes)

## AI assistance

OpenAI Codex was used to diagnose the bug, implement the fix, and run the validation described above.
