### PR TITLE
Implement Board management and shared active-Board controls

### DIFF
--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -623,6 +623,7 @@ final class KanbanFeatureState {
 
     func load() async {
         let previouslySelectedBoard = normalizedOptional(selectedBoardSlug)
+        let previouslySelectedBoardName = selectedBoard?.name
         archiveUndoTask?.cancel()
         archiveUndo = nil
         clearSettledMutationPresentation()
@@ -657,11 +658,23 @@ final class KanbanFeatureState {
             let availableBoards = boardsResponse.boards ?? []
             if let previouslySelectedBoard,
                !availableBoards.contains(where: { normalized($0.slug) == previouslySelectedBoard }) {
+                let validationSnapshot = try await client.kanbanBoard(
+                    KanbanBoardRequest(board: currentBoard)
+                )
+                guard isCurrent(loadID) else { return }
+                let report = try KanbanCompatibilityValidator.validate(
+                    configuration: configuration,
+                    boardsResponse: boardsResponse,
+                    boardSlug: currentBoard,
+                    snapshot: validationSnapshot
+                )
+                guard isCurrent(loadID) else { return }
                 self.configuration = configuration
                 self.boardsResponse = boardsResponse
                 boards = availableBoards
-                handleRemovedBoard(previouslySelectedBoard)
-                state = .compatible
+                handleRemovedBoard(previouslySelectedBoardName ?? previouslySelectedBoard)
+                self.report = report
+                state = report.isPartial ? .partial : .compatible
                 return
             }
             let boardToLoad = previouslySelectedBoard ?? currentBoard
@@ -1625,7 +1638,7 @@ final class KanbanFeatureState {
         }
     }
 
-    private func handleRemovedBoard(_ boardName: String) {
+    private func handleRemovedBoard(_ boardDisplayName: String) {
         activeBoardLoadID = nil
         resetLiveUpdates(clearCursor: true)
         resetCardSelection()
@@ -1645,7 +1658,7 @@ final class KanbanFeatureState {
         report = nil
         capabilityWarnings = []
         refreshFailed = false
-        boardSelectionNotice = KanbanBoardSelectionNotice(boardName: boardName)
+        boardSelectionNotice = KanbanBoardSelectionNotice(boardName: boardDisplayName)
     }
 
     private func normalizedOptional(_ value: String?) -> String? {

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -55,6 +55,29 @@ enum KanbanBulkActionPhase: Equatable, Sendable {
     case reconciling
 }
 
+enum KanbanBoardMutationKind: Equatable, Sendable {
+    case create(slug: String)
+    case edit(slug: String)
+    case archive(slug: String)
+    case makeActive(slug: String)
+
+    var slug: String {
+        switch self {
+        case let .create(slug), let .edit(slug), let .archive(slug), let .makeActive(slug):
+            slug
+        }
+    }
+}
+
+struct KanbanBoardMutationState: Equatable, Sendable {
+    let kind: KanbanBoardMutationKind
+    let phase: KanbanCardMutationPhase
+}
+
+struct KanbanBoardSelectionNotice: Equatable, Sendable {
+    let boardName: String
+}
+
 enum KanbanBulkMemberOutcome: Equatable, Sendable {
     case succeeded
     case failed
@@ -147,6 +170,8 @@ final class KanbanFeatureState {
     private(set) var selectedCardIDs: Set<String> = []
     private(set) var bulkActionPhase: KanbanBulkActionPhase?
     private(set) var bulkActionSummary: KanbanBulkActionSummary?
+    private(set) var boardMutationState: KanbanBoardMutationState?
+    private(set) var boardSelectionNotice: KanbanBoardSelectionNotice?
 
     private(set) var selectedBoardSlug: String?
     var selectedStatus = "triage"
@@ -181,6 +206,7 @@ final class KanbanFeatureState {
     private var pendingDependencyChanges: [String: KanbanPendingDependencyChange] = [:]
     private var archiveUndoTask: Task<Void, Never>?
     private var selectedCardsByID: [String: KanbanCard] = [:]
+    private var boardMutationIntendedResult: ((KanbanBoardsResponse) -> Bool)?
 
     init(
         server: URL,
@@ -219,7 +245,28 @@ final class KanbanFeatureState {
     var canMutateCards: Bool {
         canAddComments
             && bulkActionPhase == nil
+            && boardMutationState?.phase.isInFlight != true
             && Set(KanbanCardEditorState.createStatuses).isSubset(of: Set(configuration?.columns ?? []))
+    }
+
+    var canManageBoards: Bool {
+        canAddComments
+            && bulkActionPhase == nil
+            && activeCardMutationIDs.isEmpty
+            && boardMutationState?.phase.isInFlight != true
+            && boardMutationState?.phase != .outcomeUncertain
+    }
+
+    var sharedActiveBoardSlug: String? {
+        normalizedOptional(boardsResponse?.current)
+    }
+
+    var requiresBoardSelection: Bool {
+        selectedBoardSlug == nil && !boards.isEmpty
+    }
+
+    func canArchiveBoard(_ board: KanbanBoard) -> Bool {
+        canManageBoards && normalizedOptional(board.slug) != "default"
     }
 
     var selectedCardCount: Int { selectedCardIDs.count }
@@ -230,7 +277,11 @@ final class KanbanFeatureState {
 
     private func bulkActionsAvailability(for cardIDs: Set<String>) -> KanbanBulkActionsAvailability {
         if cardIDs.isEmpty { return .noSelection }
-        if bulkActionPhase != nil || !activeCardMutationIDs.isEmpty { return .boardBusy }
+        if bulkActionPhase != nil
+            || !activeCardMutationIDs.isEmpty
+            || boardMutationState?.phase.isInFlight == true {
+            return .boardBusy
+        }
         if isOffline { return .offline }
         if isRefreshing { return .refreshing }
         guard state == .compatible || state == .partial,
@@ -571,6 +622,7 @@ final class KanbanFeatureState {
     }
 
     func load() async {
+        let previouslySelectedBoard = normalizedOptional(selectedBoardSlug)
         archiveUndoTask?.cancel()
         archiveUndo = nil
         clearSettledMutationPresentation()
@@ -602,7 +654,18 @@ final class KanbanFeatureState {
             guard let currentBoard = normalized(boardsResponse.current) else {
                 throw KanbanContractViolation.missingCurrentBoard
             }
-            let snapshot = try await client.kanbanBoard(KanbanBoardRequest(board: currentBoard))
+            let availableBoards = boardsResponse.boards ?? []
+            if let previouslySelectedBoard,
+               !availableBoards.contains(where: { normalized($0.slug) == previouslySelectedBoard }) {
+                self.configuration = configuration
+                self.boardsResponse = boardsResponse
+                boards = availableBoards
+                handleRemovedBoard(previouslySelectedBoard)
+                state = .compatible
+                return
+            }
+            let boardToLoad = previouslySelectedBoard ?? currentBoard
+            let snapshot = try await client.kanbanBoard(KanbanBoardRequest(board: boardToLoad))
             guard isCurrent(loadID) else { return }
 
             let report = try KanbanCompatibilityValidator.validate(
@@ -611,20 +674,21 @@ final class KanbanFeatureState {
                 snapshot: snapshot
             )
             guard isCurrent(loadID) else { return }
-            if selectedBoardSlug != nil, selectedBoardSlug != currentBoard {
+            if selectedBoardSlug != nil, selectedBoardSlug != boardToLoad {
                 resetCardSelection()
             }
             self.configuration = configuration
             self.boardsResponse = boardsResponse
-            boards = boardsResponse.boards ?? []
-            selectedBoardSlug = currentBoard
+            boards = availableBoards
+            selectedBoardSlug = boardToLoad
+            boardSelectionNotice = nil
             self.snapshot = snapshot
             detailRefreshRevision &+= 1
             liveCursor = max(0, snapshot.latestEventID ?? 0)
             self.report = report
             state = report.isPartial ? .partial : .compatible
 
-            await loadSupplementaryReads(board: currentBoard, loadID: loadID)
+            await loadSupplementaryReads(board: boardToLoad, loadID: loadID)
             startLiveUpdatesIfReady()
         } catch is CancellationError {
             guard activeLoadID == loadID else { return }
@@ -647,7 +711,7 @@ final class KanbanFeatureState {
     }
 
     func refresh() async {
-        guard let board = selectedBoardSlug else { return }
+        guard await reconcileBoardCollection(), let board = selectedBoardSlug else { return }
         let generation = liveGeneration
         let succeeded = await refreshBoard(usingCursor: false, refreshSupplementary: true)
         guard isSameLiveGeneration(board: board, generation: generation) else { return }
@@ -663,6 +727,7 @@ final class KanbanFeatureState {
     func selectBoard(_ slug: String) async {
         guard activeCardMutationIDs.isEmpty,
               bulkActionPhase == nil,
+              boardMutationState?.phase.isInFlight != true,
               boards.contains(where: { normalized($0.slug) == slug }),
               slug != selectedBoardSlug else { return }
         clearCardSelection()
@@ -671,6 +736,7 @@ final class KanbanFeatureState {
         clearSettledMutationPresentation()
         resetLiveUpdates(clearCursor: true)
         selectedBoardSlug = slug
+        boardSelectionNotice = nil
         snapshot = nil
         stats = nil
         assigneeHistory = nil
@@ -679,6 +745,99 @@ final class KanbanFeatureState {
         state = .compatible
         let succeeded = await refreshBoard(usingCursor: false, refreshSupplementary: true)
         if succeeded { startLiveUpdatesIfReady() }
+    }
+
+    func dismissBoardMutationResult() {
+        guard boardMutationState?.phase.isInFlight != true,
+              boardMutationState?.phase != .outcomeUncertain else { return }
+        boardMutationState = nil
+        boardMutationIntendedResult = nil
+    }
+
+    func checkBoardMutationResult() async {
+        guard let mutation = boardMutationState,
+              mutation.phase == .outcomeUncertain,
+              let intendedResult = boardMutationIntendedResult else { return }
+        boardMutationState = KanbanBoardMutationState(kind: mutation.kind, phase: .checkingResult)
+        let response = await fetchBoardCollection()
+        guard boardMutationState?.kind == mutation.kind else { return }
+        if let response {
+            boardMutationState = KanbanBoardMutationState(
+                kind: mutation.kind,
+                phase: intendedResult(response) ? .succeeded : .failed
+            )
+        } else {
+            boardMutationState = KanbanBoardMutationState(
+                kind: mutation.kind,
+                phase: .outcomeUncertain
+            )
+        }
+    }
+
+    func createBoard(_ request: KanbanCreateBoardRequest) async {
+        guard let slug = normalizedOptional(request.slug),
+              let name = normalizedOptional(request.name),
+              canManageBoards else { return }
+        let normalizedRequest = KanbanCreateBoardRequest(
+            slug: slug,
+            name: name,
+            description: request.description.trimmingCharacters(in: .whitespacesAndNewlines),
+            icon: request.icon.trimmingCharacters(in: .whitespacesAndNewlines),
+            color: request.color.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        await performBoardMutation(kind: .create(slug: slug)) {
+            try await self.client.createKanbanBoard(normalizedRequest)
+        } intendedResult: { response in
+            response.boards?.contains(where: { self.normalized($0.slug) == slug }) == true
+        }
+    }
+
+    func editBoard(_ request: KanbanEditBoardRequest) async {
+        guard let slug = normalizedOptional(request.slug),
+              let name = normalizedOptional(request.name),
+              boards.contains(where: { normalized($0.slug) == slug }),
+              canManageBoards else { return }
+        let normalizedRequest = KanbanEditBoardRequest(
+            slug: slug,
+            name: name,
+            description: request.description.trimmingCharacters(in: .whitespacesAndNewlines),
+            icon: request.icon.trimmingCharacters(in: .whitespacesAndNewlines),
+            color: request.color.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        await performBoardMutation(kind: .edit(slug: slug)) {
+            try await self.client.editKanbanBoard(normalizedRequest)
+        } intendedResult: { response in
+            guard let board = response.boards?.first(where: { self.normalized($0.slug) == slug }) else {
+                return false
+            }
+            return self.normalizedOptional(board.name) == normalizedRequest.name
+                && self.normalizedOptional(board.description) == self.normalizedOptional(normalizedRequest.description)
+                && self.normalizedOptional(board.icon) == self.normalizedOptional(normalizedRequest.icon)
+                && self.normalizedOptional(board.color) == self.normalizedOptional(normalizedRequest.color)
+        }
+    }
+
+    func archiveBoard(slug: String) async {
+        guard let slug = normalizedOptional(slug),
+              slug != "default",
+              boards.contains(where: { normalized($0.slug) == slug }),
+              canManageBoards else { return }
+        await performBoardMutation(kind: .archive(slug: slug)) {
+            try await self.client.archiveKanbanBoard(KanbanBoardMutationRequest(slug: slug))
+        } intendedResult: { response in
+            response.boards?.contains(where: { self.normalized($0.slug) == slug }) != true
+        }
+    }
+
+    func makeBoardActive(slug: String) async {
+        guard let slug = normalizedOptional(slug),
+              boards.contains(where: { normalized($0.slug) == slug }),
+              canManageBoards else { return }
+        await performBoardMutation(kind: .makeActive(slug: slug)) {
+            try await self.client.makeKanbanBoardActive(KanbanBoardMutationRequest(slug: slug))
+        } intendedResult: { response in
+            self.normalized(response.current) == slug
+        }
     }
 
     func setVisible(_ visible: Bool) {
@@ -698,7 +857,9 @@ final class KanbanFeatureState {
             suspendLiveUpdates()
             return
         }
-        guard isVisible, snapshot != nil, let board = selectedBoardSlug else { return }
+        guard isVisible, snapshot != nil,
+              await reconcileBoardCollection(),
+              let board = selectedBoardSlug else { return }
         let generation = liveGeneration
         let succeeded = await refreshBoard(usingCursor: false, refreshSupplementary: true)
         guard isCurrentLiveWork(board: board, generation: generation) else { return }
@@ -1400,6 +1561,93 @@ final class KanbanFeatureState {
         return false
     }
 
+    private func performBoardMutation(
+        kind: KanbanBoardMutationKind,
+        write: () async throws -> KanbanBoardMutationEnvelope,
+        intendedResult: @escaping (KanbanBoardsResponse) -> Bool
+    ) async {
+        guard canManageBoards else { return }
+        boardMutationIntendedResult = intendedResult
+        boardMutationState = KanbanBoardMutationState(kind: kind, phase: .updating)
+        var definitiveFailure = false
+        do {
+            _ = try await write()
+        } catch {
+            forwardAuthentication(error)
+            definitiveFailure = isDefinitiveWriteFailure(error)
+        }
+
+        if !definitiveFailure {
+            boardMutationState = KanbanBoardMutationState(kind: kind, phase: .checkingResult)
+        }
+        let response = await fetchBoardCollection()
+        guard boardMutationState?.kind == kind else { return }
+        if definitiveFailure {
+            boardMutationState = KanbanBoardMutationState(kind: kind, phase: .failed)
+        } else if let response {
+            boardMutationState = KanbanBoardMutationState(
+                kind: kind,
+                phase: intendedResult(response) ? .succeeded : .failed
+            )
+        } else {
+            boardMutationState = KanbanBoardMutationState(kind: kind, phase: .outcomeUncertain)
+        }
+    }
+
+    @discardableResult
+    private func reconcileBoardCollection() async -> Bool {
+        await fetchBoardCollection() != nil
+    }
+
+    private func fetchBoardCollection() async -> KanbanBoardsResponse? {
+        do {
+            let response = try await client.kanbanBoards()
+            guard let availableBoards = response.boards,
+                  normalizedOptional(response.current) != nil else {
+                return nil
+            }
+            let previousBoards = boards
+            boardsResponse = response
+            boards = availableBoards
+            if let selectedBoardSlug,
+               !availableBoards.contains(where: { normalized($0.slug) == selectedBoardSlug }) {
+                let previousName = previousBoards
+                    .first(where: { normalized($0.slug) == selectedBoardSlug })?
+                    .name
+                handleRemovedBoard(previousName ?? selectedBoardSlug)
+            }
+            isOffline = false
+            return response
+        } catch {
+            markOfflineIfNeeded(error)
+            forwardAuthentication(error)
+            return nil
+        }
+    }
+
+    private func handleRemovedBoard(_ boardName: String) {
+        activeBoardLoadID = nil
+        resetLiveUpdates(clearCursor: true)
+        resetCardSelection()
+        archiveUndoTask?.cancel()
+        archiveUndo = nil
+        clearSettledMutationPresentation()
+        activeCardMutationIDs.removeAll()
+        pendingOptimisticStatuses.removeAll()
+        pendingDependencyChanges.removeAll()
+        uncertainProtectedCards.removeAll()
+        bulkActionPhase = nil
+        bulkActionSummary = nil
+        selectedBoardSlug = nil
+        snapshot = nil
+        stats = nil
+        assigneeHistory = nil
+        report = nil
+        capabilityWarnings = []
+        refreshFailed = false
+        boardSelectionNotice = KanbanBoardSelectionNotice(boardName: boardName)
+    }
+
     private func normalizedOptional(_ value: String?) -> String? {
         let value = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         return value?.isEmpty == false ? value : nil
@@ -1456,6 +1704,10 @@ final class KanbanFeatureState {
             return false
         } catch {
             guard isCurrentBoardLoad(boardLoadID, board: board) else { return false }
+            if isNotFound(error) {
+                _ = await reconcileBoardCollection()
+                if selectedBoardSlug == nil { return false }
+            }
             refreshFailed = true
             markOfflineIfNeeded(error)
             forwardAuthentication(error)

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -207,6 +207,7 @@ final class KanbanFeatureState {
     private var archiveUndoTask: Task<Void, Never>?
     private var selectedCardsByID: [String: KanbanCard] = [:]
     private var boardMutationIntendedResult: ((KanbanBoardsResponse) -> Bool)?
+    private var boardMutationGeneration = 0
 
     init(
         server: URL,
@@ -231,7 +232,7 @@ final class KanbanFeatureState {
     /// Future write slices must use this single seam before exposing any
     /// mutation, Dispatcher, or shared-state action.
     var canUseServerAuthoritativeActions: Bool {
-        snapshot != nil && !isOffline && !isRefreshing
+        snapshot != nil && !isOffline && !isRefreshing && !refreshFailed
     }
 
     var canAddComments: Bool {
@@ -240,12 +241,12 @@ final class KanbanFeatureState {
             && boardsResponse?.readOnly == false
             && snapshot?.readOnly == false
             && selectedBoard?.readOnly != true
+            && !boardMutationBlocksWrites
     }
 
     var canMutateCards: Bool {
         canAddComments
             && bulkActionPhase == nil
-            && boardMutationState?.phase.isInFlight != true
             && Set(KanbanCardEditorState.createStatuses).isSubset(of: Set(configuration?.columns ?? []))
     }
 
@@ -253,8 +254,6 @@ final class KanbanFeatureState {
         canAddComments
             && bulkActionPhase == nil
             && activeCardMutationIDs.isEmpty
-            && boardMutationState?.phase.isInFlight != true
-            && boardMutationState?.phase != .outcomeUncertain
     }
 
     var sharedActiveBoardSlug: String? {
@@ -279,7 +278,7 @@ final class KanbanFeatureState {
         if cardIDs.isEmpty { return .noSelection }
         if bulkActionPhase != nil
             || !activeCardMutationIDs.isEmpty
-            || boardMutationState?.phase.isInFlight == true {
+            || boardMutationBlocksWrites {
             return .boardBusy
         }
         if isOffline { return .offline }
@@ -624,6 +623,7 @@ final class KanbanFeatureState {
     func load() async {
         let previouslySelectedBoard = normalizedOptional(selectedBoardSlug)
         let previouslySelectedBoardName = selectedBoard?.name
+        invalidateBoardMutation()
         archiveUndoTask?.cancel()
         archiveUndo = nil
         clearSettledMutationPresentation()
@@ -724,7 +724,12 @@ final class KanbanFeatureState {
     }
 
     func refresh() async {
-        guard await reconcileBoardCollection(), let board = selectedBoardSlug else { return }
+        refreshFailed = false
+        guard await reconcileBoardCollection() else {
+            reportBoardCollectionRefreshFailure()
+            return
+        }
+        guard let board = selectedBoardSlug else { return }
         let generation = liveGeneration
         let succeeded = await refreshBoard(usingCursor: false, refreshSupplementary: true)
         guard isSameLiveGeneration(board: board, generation: generation) else { return }
@@ -740,7 +745,7 @@ final class KanbanFeatureState {
     func selectBoard(_ slug: String) async {
         guard activeCardMutationIDs.isEmpty,
               bulkActionPhase == nil,
-              boardMutationState?.phase.isInFlight != true,
+              !boardMutationBlocksWrites,
               boards.contains(where: { normalized($0.slug) == slug }),
               slug != selectedBoardSlug else { return }
         clearCardSelection()
@@ -771,9 +776,16 @@ final class KanbanFeatureState {
         guard let mutation = boardMutationState,
               mutation.phase == .outcomeUncertain,
               let intendedResult = boardMutationIntendedResult else { return }
+        boardMutationGeneration &+= 1
+        let mutationGeneration = boardMutationGeneration
         boardMutationState = KanbanBoardMutationState(kind: mutation.kind, phase: .checkingResult)
-        let response = await fetchBoardCollection()
-        guard boardMutationState?.kind == mutation.kind else { return }
+        let response = await fetchBoardCollection(
+            expectedBoardMutationGeneration: mutationGeneration
+        )
+        guard continueBoardMutation(mutationGeneration, kind: mutation.kind) else {
+            clearBoardMutationIfCurrent(mutationGeneration)
+            return
+        }
         if let response {
             boardMutationState = KanbanBoardMutationState(
                 kind: mutation.kind,
@@ -870,9 +882,12 @@ final class KanbanFeatureState {
             suspendLiveUpdates()
             return
         }
-        guard isVisible, snapshot != nil,
-              await reconcileBoardCollection(),
-              let board = selectedBoardSlug else { return }
+        guard isVisible, snapshot != nil else { return }
+        guard await reconcileBoardCollection() else {
+            reportBoardCollectionRefreshFailure()
+            return
+        }
+        guard let board = selectedBoardSlug else { return }
         let generation = liveGeneration
         let succeeded = await refreshBoard(usingCursor: false, refreshSupplementary: true)
         guard isCurrentLiveWork(board: board, generation: generation) else { return }
@@ -1580,21 +1595,37 @@ final class KanbanFeatureState {
         intendedResult: @escaping (KanbanBoardsResponse) -> Bool
     ) async {
         guard canManageBoards else { return }
+        boardMutationGeneration &+= 1
+        let mutationGeneration = boardMutationGeneration
         boardMutationIntendedResult = intendedResult
         boardMutationState = KanbanBoardMutationState(kind: kind, phase: .updating)
         var definitiveFailure = false
         do {
             _ = try await write()
         } catch {
+            if isCancellation(error) {
+                clearBoardMutationIfCurrent(mutationGeneration)
+                return
+            }
+            guard continueBoardMutation(mutationGeneration, kind: kind) else { return }
             forwardAuthentication(error)
             definitiveFailure = isDefinitiveWriteFailure(error)
+        }
+        guard continueBoardMutation(mutationGeneration, kind: kind) else {
+            clearBoardMutationIfCurrent(mutationGeneration)
+            return
         }
 
         if !definitiveFailure {
             boardMutationState = KanbanBoardMutationState(kind: kind, phase: .checkingResult)
         }
-        let response = await fetchBoardCollection()
-        guard boardMutationState?.kind == kind else { return }
+        let response = await fetchBoardCollection(
+            expectedBoardMutationGeneration: mutationGeneration
+        )
+        guard continueBoardMutation(mutationGeneration, kind: kind) else {
+            clearBoardMutationIfCurrent(mutationGeneration)
+            return
+        }
         if definitiveFailure {
             boardMutationState = KanbanBoardMutationState(kind: kind, phase: .failed)
         } else if let response {
@@ -1612,9 +1643,16 @@ final class KanbanFeatureState {
         await fetchBoardCollection() != nil
     }
 
-    private func fetchBoardCollection() async -> KanbanBoardsResponse? {
+    private func fetchBoardCollection(
+        expectedBoardMutationGeneration: Int? = nil
+    ) async -> KanbanBoardsResponse? {
         do {
             let response = try await client.kanbanBoards()
+            guard expectedBoardMutationGeneration == nil
+                    || expectedBoardMutationGeneration == boardMutationGeneration,
+                  !Task.isCancelled else {
+                return nil
+            }
             guard let availableBoards = response.boards,
                   normalizedOptional(response.current) != nil else {
                 return nil
@@ -1632,10 +1670,45 @@ final class KanbanFeatureState {
             isOffline = false
             return response
         } catch {
+            guard expectedBoardMutationGeneration == nil
+                    || expectedBoardMutationGeneration == boardMutationGeneration,
+                  !Task.isCancelled else {
+                return nil
+            }
             markOfflineIfNeeded(error)
             forwardAuthentication(error)
             return nil
         }
+    }
+
+    private var boardMutationBlocksWrites: Bool {
+        guard let phase = boardMutationState?.phase else { return false }
+        return phase.isInFlight || phase == .outcomeUncertain
+    }
+
+    private func continueBoardMutation(
+        _ generation: Int,
+        kind: KanbanBoardMutationKind
+    ) -> Bool {
+        generation == boardMutationGeneration
+            && boardMutationState?.kind == kind
+            && !Task.isCancelled
+    }
+
+    private func clearBoardMutationIfCurrent(_ generation: Int) {
+        guard generation == boardMutationGeneration else { return }
+        boardMutationState = nil
+        boardMutationIntendedResult = nil
+    }
+
+    private func invalidateBoardMutation() {
+        boardMutationGeneration &+= 1
+        boardMutationState = nil
+        boardMutationIntendedResult = nil
+    }
+
+    private func reportBoardCollectionRefreshFailure() {
+        if !isOffline { refreshFailed = true }
     }
 
     private func handleRemovedBoard(_ boardDisplayName: String) {

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -725,13 +725,17 @@ final class KanbanFeatureState {
 
     func refresh() async {
         refreshFailed = false
-        guard await reconcileBoardCollection() else {
+        let boardCollectionSucceeded = await reconcileBoardCollection()
+        if !boardCollectionSucceeded {
             reportBoardCollectionRefreshFailure()
-            return
         }
         guard let board = selectedBoardSlug else { return }
         let generation = liveGeneration
-        let succeeded = await refreshBoard(usingCursor: false, refreshSupplementary: true)
+        let succeeded = await refreshBoard(
+            usingCursor: false,
+            refreshSupplementary: true,
+            preserveRefreshFailure: !boardCollectionSucceeded
+        )
         guard isSameLiveGeneration(board: board, generation: generation) else { return }
         if succeeded {
             isOffline = false
@@ -739,6 +743,9 @@ final class KanbanFeatureState {
             retryLiveStream()
         } else if isOffline {
             startPollingIfNeeded()
+        }
+        if !boardCollectionSucceeded {
+            reportBoardCollectionRefreshFailure()
         }
     }
 
@@ -883,13 +890,17 @@ final class KanbanFeatureState {
             return
         }
         guard isVisible, snapshot != nil else { return }
-        guard await reconcileBoardCollection() else {
+        let boardCollectionSucceeded = await reconcileBoardCollection()
+        if !boardCollectionSucceeded {
             reportBoardCollectionRefreshFailure()
-            return
         }
         guard let board = selectedBoardSlug else { return }
         let generation = liveGeneration
-        let succeeded = await refreshBoard(usingCursor: false, refreshSupplementary: true)
+        let succeeded = await refreshBoard(
+            usingCursor: false,
+            refreshSupplementary: true,
+            preserveRefreshFailure: !boardCollectionSucceeded
+        )
         guard isCurrentLiveWork(board: board, generation: generation) else { return }
         if succeeded {
             isOffline = false
@@ -897,6 +908,9 @@ final class KanbanFeatureState {
             retryLiveStream()
         } else {
             startPollingIfNeeded()
+        }
+        if !boardCollectionSucceeded {
+            reportBoardCollectionRefreshFailure()
         }
     }
 
@@ -1708,7 +1722,7 @@ final class KanbanFeatureState {
     }
 
     private func reportBoardCollectionRefreshFailure() {
-        if !isOffline { refreshFailed = true }
+        refreshFailed = !isOffline
     }
 
     private func handleRemovedBoard(_ boardDisplayName: String) {
@@ -1750,12 +1764,18 @@ final class KanbanFeatureState {
     }
 
     @discardableResult
-    private func refreshBoard(usingCursor: Bool, refreshSupplementary: Bool = false) async -> Bool {
+    private func refreshBoard(
+        usingCursor: Bool,
+        refreshSupplementary: Bool = false,
+        preserveRefreshFailure: Bool = false
+    ) async -> Bool {
         guard let board = selectedBoardSlug else { return false }
         let boardLoadID = UUID()
         activeBoardLoadID = boardLoadID
         isRefreshing = true
-        refreshFailed = false
+        if !preserveRefreshFailure {
+            refreshFailed = false
+        }
         defer {
             if activeBoardLoadID == boardLoadID { isRefreshing = false }
         }
@@ -1782,6 +1802,9 @@ final class KanbanFeatureState {
             }
             liveCursor = max(liveCursor, response.latestEventID ?? 0)
             isOffline = false
+            if preserveRefreshFailure {
+                refreshFailed = true
+            }
             if refreshSupplementary {
                 await loadSupplementaryReads(board: board, boardLoadID: boardLoadID)
             }

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -724,8 +724,13 @@ final class KanbanFeatureState {
     }
 
     func refresh() async {
+        let previousRefreshFailed = refreshFailed
         refreshFailed = false
         let boardCollectionSucceeded = await reconcileBoardCollection()
+        guard !Task.isCancelled else {
+            refreshFailed = previousRefreshFailed
+            return
+        }
         if !boardCollectionSucceeded {
             reportBoardCollectionRefreshFailure()
         }
@@ -736,6 +741,14 @@ final class KanbanFeatureState {
             refreshSupplementary: true,
             preserveRefreshFailure: !boardCollectionSucceeded
         )
+        guard !Task.isCancelled else {
+            if boardCollectionSucceeded {
+                refreshFailed = previousRefreshFailed
+            } else {
+                reportBoardCollectionRefreshFailure()
+            }
+            return
+        }
         guard isSameLiveGeneration(board: board, generation: generation) else { return }
         if succeeded {
             isOffline = false
@@ -890,7 +903,12 @@ final class KanbanFeatureState {
             return
         }
         guard isVisible, snapshot != nil else { return }
+        let previousRefreshFailed = refreshFailed
         let boardCollectionSucceeded = await reconcileBoardCollection()
+        guard !Task.isCancelled else {
+            refreshFailed = previousRefreshFailed
+            return
+        }
         if !boardCollectionSucceeded {
             reportBoardCollectionRefreshFailure()
         }
@@ -901,6 +919,14 @@ final class KanbanFeatureState {
             refreshSupplementary: true,
             preserveRefreshFailure: !boardCollectionSucceeded
         )
+        guard !Task.isCancelled else {
+            if boardCollectionSucceeded {
+                refreshFailed = previousRefreshFailed
+            } else {
+                reportBoardCollectionRefreshFailure()
+            }
+            return
+        }
         guard isCurrentLiveWork(board: board, generation: generation) else { return }
         if succeeded {
             isOffline = false

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -22,6 +22,7 @@ struct KanbanStatusFocusView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Bindable var model: KanbanFeatureState
     @State private var showsFilters = false
+    @State private var showsBoardManagement = false
     @State private var visibleModel: KanbanFeatureState?
     @State private var cardEditor: KanbanCardEditorState?
     @State private var pendingRunningAction: KanbanPendingCardAction?
@@ -71,6 +72,11 @@ struct KanbanStatusFocusView: View {
         .toolbar { toolbarContent }
         .sheet(isPresented: $showsFilters) {
             KanbanFiltersView(model: model)
+        }
+        .sheet(isPresented: $showsBoardManagement) {
+            NavigationStack {
+                KanbanBoardManagementView(model: model)
+            }
         }
         .sheet(item: $cardEditor) { editor in
             KanbanCardEditorView(
@@ -170,6 +176,12 @@ struct KanbanStatusFocusView: View {
 
     private var boardContent: some View {
         VStack(spacing: 0) {
+            if let notice = model.boardSelectionNotice {
+                boardSelectionNotice(notice)
+            }
+            if model.requiresBoardSelection {
+                boardSelectionContent
+            } else {
             if model.state == .partial {
                 compatibilityBanner
             }
@@ -195,6 +207,40 @@ struct KanbanStatusFocusView: View {
             statusSelector
             Divider()
             cardList
+            }
+        }
+    }
+
+    private func boardSelectionNotice(_ notice: KanbanBoardSelectionNotice) -> some View {
+        Label {
+            Text("This Board no longer exists. Return to Kanban to choose another Board.")
+        } icon: {
+            Image(systemName: "rectangle.stack.badge.minus")
+        }
+        .font(.footnote)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.orange.opacity(0.12))
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(Text(notice.boardName))
+    }
+
+    private var boardSelectionContent: some View {
+        ContentUnavailableView {
+            Label("Board", systemImage: "rectangle.stack")
+        } description: {
+            Text("This Board no longer exists. Return to Kanban to choose another Board.")
+        } actions: {
+            Menu("Board") {
+                ForEach(model.boards, id: \.slug) { board in
+                    if let slug = board.slug {
+                        Button(board.name ?? slug) {
+                            Task { await model.selectBoard(slug) }
+                        }
+                    }
+                }
+            }
+            .frame(minHeight: 44)
         }
     }
 
@@ -713,6 +759,12 @@ struct KanbanStatusFocusView: View {
                         }
                     }
                 }
+                Divider()
+                Button {
+                    showsBoardManagement = true
+                } label: {
+                    Label("Manage", systemImage: "slider.horizontal.3")
+                }
             } label: {
                 HStack(spacing: 4) {
                     Text(model.selectedBoard?.name ?? model.selectedBoardSlug ?? String(localized: "Board"))
@@ -775,6 +827,327 @@ struct KanbanStatusFocusView: View {
         } actions: {
             Button("Try Again") { Task { await model.retry() } }
                 .frame(minHeight: 44)
+        }
+    }
+}
+
+private enum KanbanBoardEditorMode: Identifiable {
+    case create
+    case edit(KanbanBoard)
+
+    var id: String {
+        switch self {
+        case .create: "create"
+        case let .edit(board): "edit-\(board.slug ?? "")"
+        }
+    }
+}
+
+private struct KanbanBoardManagementView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var model: KanbanFeatureState
+    @State private var editorMode: KanbanBoardEditorMode?
+    @State private var pendingArchive: KanbanBoard?
+    @State private var pendingActivation: KanbanBoard?
+
+    var body: some View {
+        List {
+            if let mutation = model.boardMutationState {
+                Section {
+                    boardMutationStatus(mutation)
+                }
+            }
+
+            Section {
+                ForEach(model.boards, id: \.slug) { board in
+                    boardRow(board)
+                }
+            } footer: {
+                Text("Browsing a Board stays local to Hermex. Making a Board active changes shared server state.")
+            }
+        }
+        .navigationTitle("Manage")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    model.dismissBoardMutationResult()
+                    editorMode = .create
+                } label: {
+                    Label("Create", systemImage: "plus")
+                }
+                .disabled(!model.canManageBoards)
+                .accessibilityHint(Text("Creating a Board does not make it active."))
+            }
+        }
+        .sheet(item: $editorMode) { mode in
+            NavigationStack {
+                KanbanBoardEditorView(model: model, mode: mode)
+            }
+        }
+        .alert(
+            "Archive",
+            isPresented: Binding(
+                get: { pendingArchive != nil },
+                set: { if !$0 { pendingArchive = nil } }
+            ),
+            presenting: pendingArchive
+        ) { board in
+            Button("Cancel", role: .cancel) { pendingArchive = nil }
+            Button("Archive", role: .destructive) {
+                pendingArchive = nil
+                Task { await model.archiveBoard(slug: board.slug ?? "") }
+            }
+        } message: { _ in
+            Text("Hermex cannot restore an archived Board in-app.")
+        }
+        .alert(
+            "Make Active Board",
+            isPresented: Binding(
+                get: { pendingActivation != nil },
+                set: { if !$0 { pendingActivation = nil } }
+            ),
+            presenting: pendingActivation
+        ) { board in
+            Button("Cancel", role: .cancel) { pendingActivation = nil }
+            Button("Make Active Board") {
+                pendingActivation = nil
+                Task { await model.makeBoardActive(slug: board.slug ?? "") }
+            }
+        } message: { _ in
+            Text("Making this Board active changes shared server state for other Hermes clients.")
+        }
+    }
+
+    private func boardRow(_ board: KanbanBoard) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(board.icon ?? "▣")
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(board.name ?? board.slug ?? String(localized: "Board"))
+                        .font(.headline)
+                    if let slug = board.slug {
+                        Text(slug)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                if board.slug == model.selectedBoardSlug {
+                    Text("Browsing")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if board.slug == model.sharedActiveBoardSlug {
+                    Text("Active")
+                        .font(.caption.bold())
+                }
+            }
+
+            if let description = board.description, !description.isEmpty {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Text(KanbanCountFormatter.cards(board.total ?? 0))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                if board.slug != model.selectedBoardSlug {
+                    Button("Board") {
+                        guard let slug = board.slug else { return }
+                        Task { await model.selectBoard(slug) }
+                    }
+                    .accessibilityLabel(Text("Board"))
+                }
+                Button("Edit") {
+                    model.dismissBoardMutationResult()
+                    editorMode = .edit(board)
+                }
+                .disabled(!model.canManageBoards)
+                Button("Make Active Board") {
+                    pendingActivation = board
+                }
+                .disabled(board.slug == model.sharedActiveBoardSlug || !model.canManageBoards)
+                Button("Archive", role: .destructive) {
+                    pendingArchive = board
+                }
+                .disabled(!model.canArchiveBoard(board))
+            }
+            .buttonStyle(.borderless)
+            .frame(minHeight: 44)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func boardMutationStatus(_ mutation: KanbanBoardMutationState) -> some View {
+        HStack(spacing: 10) {
+            if mutation.phase.isInFlight {
+                ProgressView()
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(boardMutationAction(mutation.kind))
+                    .font(.headline)
+                Text(boardMutationPhase(mutation.phase))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if mutation.phase == .outcomeUncertain {
+                Button("Checking Result") {
+                    Task { await model.checkBoardMutationResult() }
+                }
+            } else if !mutation.phase.isInFlight {
+                Button {
+                    model.dismissBoardMutationResult()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .accessibilityLabel(Text("Dismiss"))
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func boardMutationAction(_ kind: KanbanBoardMutationKind) -> LocalizedStringKey {
+        switch kind {
+        case .create: "Create"
+        case .edit: "Edit"
+        case .archive: "Archive"
+        case .makeActive: "Make Active Board"
+        }
+    }
+
+    private func boardMutationPhase(_ phase: KanbanCardMutationPhase) -> LocalizedStringKey {
+        switch phase {
+        case .updating: "Updating Board..."
+        case .checkingResult: "Checking Result"
+        case .succeeded: "Done"
+        case .failed: "Failed"
+        case .outcomeUncertain: "Outcome Uncertain"
+        }
+    }
+}
+
+private struct KanbanBoardEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var model: KanbanFeatureState
+    let mode: KanbanBoardEditorMode
+    @State private var slug: String
+    @State private var name: String
+    @State private var description: String
+    @State private var icon: String
+    @State private var color: String
+    @State private var showsSlugError = false
+    @State private var showsNameError = false
+
+    init(model: KanbanFeatureState, mode: KanbanBoardEditorMode) {
+        self.model = model
+        self.mode = mode
+        switch mode {
+        case .create:
+            _slug = State(initialValue: "")
+            _name = State(initialValue: "")
+            _description = State(initialValue: "")
+            _icon = State(initialValue: "")
+            _color = State(initialValue: "")
+        case let .edit(board):
+            _slug = State(initialValue: board.slug ?? "")
+            _name = State(initialValue: board.name ?? "")
+            _description = State(initialValue: board.description ?? "")
+            _icon = State(initialValue: board.icon ?? "")
+            _color = State(initialValue: board.color ?? "")
+        }
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Slug", text: $slug)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .disabled(isEditing)
+                    .accessibilityHint(Text("The slug cannot be changed after the Board is created."))
+                if showsSlugError {
+                    Text("Required")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+                TextField("Name", text: $name)
+                if showsNameError {
+                    Text("Required")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+                TextField("Description", text: $description, axis: .vertical)
+                    .lineLimit(2...5)
+                TextField("Icon", text: $icon)
+                TextField("Color", text: $color)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+            } footer: {
+                Text("Creating a Board does not make it active.")
+            }
+
+            if let mutation = model.boardMutationState,
+               mutation.kind.slug == slug,
+               mutation.phase == .failed || mutation.phase == .outcomeUncertain {
+                Section {
+                    Text(mutation.phase == .failed ? "Failed" : "Outcome Uncertain")
+                        .foregroundStyle(.red)
+                    Text("Refresh the Board before trying again.")
+                        .font(.footnote)
+                }
+            }
+        }
+        .navigationTitle(isEditing ? "Edit" : "Create")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { submit() }
+                    .disabled(model.boardMutationState?.phase.isInFlight == true)
+            }
+        }
+    }
+
+    private var isEditing: Bool {
+        if case .edit = mode { true } else { false }
+    }
+
+    private func submit() {
+        let trimmedSlug = slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        showsSlugError = trimmedSlug.isEmpty
+        showsNameError = trimmedName.isEmpty
+        guard !showsSlugError, !showsNameError else { return }
+        Task {
+            if isEditing {
+                await model.editBoard(KanbanEditBoardRequest(
+                    slug: trimmedSlug,
+                    name: trimmedName,
+                    description: description,
+                    icon: icon,
+                    color: color
+                ))
+            } else {
+                await model.createBoard(KanbanCreateBoardRequest(
+                    slug: trimmedSlug,
+                    name: trimmedName,
+                    description: description,
+                    icon: icon,
+                    color: color
+                ))
+            }
+            if model.boardMutationState?.phase == .succeeded {
+                dismiss()
+            }
         }
     }
 }
@@ -1159,7 +1532,7 @@ struct KanbanLabView: View {
     var body: some View {
         KanbanStatusFocusView(model: model)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .bottomBar) {
                     Menu {
                         Picker("Scenario", selection: $scenario) {
                             ForEach(KanbanLabScenario.allCases) { scenario in
@@ -1241,6 +1614,17 @@ actor KanbanLabClient: KanbanDataClient {
     private var storedCards: [String: [String: StoredCard]] = [:]
     private var cardIDsByIntent: [String: String] = [:]
     private var nextCardSequence = 100
+    private var activeBoardSlug = "default"
+    private var storedBoards: [String: StoredBoard] = [
+        "default": StoredBoard(
+            slug: "default", name: "Default Board", description: "Primary fixture Board",
+            icon: "📋", color: "#5B8DEF", total: 8
+        ),
+        "release": StoredBoard(
+            slug: "release", name: "Release Board", description: "Shipping fixture",
+            icon: "🚀", color: "#34C759", total: 2
+        )
+    ]
 
     init(scenario: KanbanLabScenario) { self.scenario = scenario }
 
@@ -1256,7 +1640,66 @@ actor KanbanLabClient: KanbanDataClient {
     }
 
     func kanbanBoards() throws -> KanbanBoardsResponse {
-        decode(#"{"boards":[{"slug":"main","name":"Main Board","total":8},{"slug":"release","name":"Release Board","total":2}],"current":"main","read_only":false}"#)
+        decode([
+            "boards": storedBoards.values.sorted { $0.slug < $1.slug }.map(\.object),
+            "current": activeBoardSlug,
+            "read_only": false
+        ])
+    }
+
+    func createKanbanBoard(
+        _ request: KanbanCreateBoardRequest
+    ) throws -> KanbanBoardMutationEnvelope {
+        let board = storedBoards[request.slug] ?? StoredBoard(
+            slug: request.slug,
+            name: request.name,
+            description: request.description,
+            icon: request.icon,
+            color: request.color,
+            total: 0
+        )
+        storedBoards[request.slug] = board
+        return decode([
+            "board": board.object,
+            "current": activeBoardSlug,
+            "read_only": false
+        ])
+    }
+
+    func editKanbanBoard(
+        _ request: KanbanEditBoardRequest
+    ) throws -> KanbanBoardMutationEnvelope {
+        guard var board = storedBoards[request.slug] else {
+            throw APIError.http(statusCode: 404, body: nil)
+        }
+        board.name = request.name
+        board.description = request.description
+        board.icon = request.icon
+        board.color = request.color
+        storedBoards[request.slug] = board
+        return decode(["board": board.object, "read_only": false])
+    }
+
+    func archiveKanbanBoard(
+        _ request: KanbanBoardMutationRequest
+    ) throws -> KanbanBoardMutationEnvelope {
+        guard request.slug != "default", storedBoards.removeValue(forKey: request.slug) != nil else {
+            throw APIError.http(statusCode: 400, body: nil)
+        }
+        if activeBoardSlug == request.slug {
+            activeBoardSlug = storedBoards["default"] != nil ? "default" : storedBoards.keys.sorted().first ?? "default"
+        }
+        return decode(["current": activeBoardSlug, "read_only": false])
+    }
+
+    func makeKanbanBoardActive(
+        _ request: KanbanBoardMutationRequest
+    ) throws -> KanbanBoardMutationEnvelope {
+        guard storedBoards[request.slug] != nil else {
+            throw APIError.http(statusCode: 404, body: nil)
+        }
+        activeBoardSlug = request.slug
+        return decode(["current": activeBoardSlug, "read_only": false])
     }
 
     func kanbanBoard(_ request: KanbanBoardRequest) throws -> KanbanBoardSnapshot {
@@ -1600,6 +2043,29 @@ actor KanbanLabClient: KanbanDataClient {
             if let workspacePath { result["workspace_path"] = workspacePath }
             if let skills { result["skills"] = skills }
             if let maxRuntimeSeconds { result["max_runtime_seconds"] = maxRuntimeSeconds }
+            return result
+        }
+    }
+
+    private struct StoredBoard: Sendable {
+        let slug: String
+        var name: String?
+        var description: String?
+        var icon: String?
+        var color: String?
+        let total: Int
+
+        var object: [String: Any] {
+            var result: [String: Any] = [
+                "slug": slug,
+                "total": total,
+                "counts": total == 0 ? [:] : ["ready": total],
+                "read_only": false
+            ]
+            result["name"] = name
+            result["description"] = description
+            result["icon"] = icon
+            result["color"] = color
             return result
         }
     }

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -176,9 +176,6 @@ struct KanbanStatusFocusView: View {
 
     private var boardContent: some View {
         VStack(spacing: 0) {
-            if let notice = model.boardSelectionNotice {
-                boardSelectionNotice(notice)
-            }
             if model.requiresBoardSelection {
                 boardSelectionContent
             } else {
@@ -211,27 +208,16 @@ struct KanbanStatusFocusView: View {
         }
     }
 
-    private func boardSelectionNotice(_ notice: KanbanBoardSelectionNotice) -> some View {
-        Label {
-            Text("This Board no longer exists. Return to Kanban to choose another Board.")
-        } icon: {
-            Image(systemName: "rectangle.stack.badge.minus")
-        }
-        .font(.footnote)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding()
-        .background(.orange.opacity(0.12))
-        .accessibilityElement(children: .combine)
-        .accessibilityHint(Text(notice.boardName))
-    }
-
     private var boardSelectionContent: some View {
         ContentUnavailableView {
-            Label("Board", systemImage: "rectangle.stack")
+            Label(
+                model.boardSelectionNotice?.boardName ?? String(localized: "Board"),
+                systemImage: "rectangle.stack.badge.minus"
+            )
         } description: {
-            Text("This Board no longer exists. Return to Kanban to choose another Board.")
+            Text("This Board no longer exists. Choose another Board.")
         } actions: {
-            Menu("Board") {
+            Menu("Choose Board") {
                 ForEach(model.boards, id: \.slug) { board in
                     if let slug = board.slug {
                         Button(board.name ?? slug) {
@@ -959,11 +945,11 @@ private struct KanbanBoardManagementView: View {
 
             HStack {
                 if board.slug != model.selectedBoardSlug {
-                    Button("Board") {
+                    Button("Browse Board") {
                         guard let slug = board.slug else { return }
                         Task { await model.selectBoard(slug) }
                     }
-                    .accessibilityLabel(Text("Board"))
+                    .accessibilityLabel(Text(KanbanBoardAccessibility.browseLabel(board)))
                 }
                 Button("Edit") {
                     model.dismissBoardMutationResult()
@@ -998,7 +984,7 @@ private struct KanbanBoardManagementView: View {
             }
             Spacer()
             if mutation.phase == .outcomeUncertain {
-                Button("Checking Result") {
+                Button("Check Result") {
                     Task { await model.checkBoardMutationResult() }
                 }
             } else if !mutation.phase.isInFlight {
@@ -1112,7 +1098,7 @@ private struct KanbanBoardEditorView: View {
             }
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") { submit() }
-                    .disabled(model.boardMutationState?.phase.isInFlight == true)
+                    .disabled(!model.canManageBoards)
             }
         }
     }
@@ -1426,6 +1412,13 @@ enum KanbanCardAccessibility {
         if dependents > 0 { parts.append(KanbanCountFormatter.dependents(dependents)) }
         if let age = card.ageSeconds { parts.append(String(localized: "Age \(KanbanAgeFormatter.full(age))")) }
         return parts.joined(separator: ", ")
+    }
+}
+
+enum KanbanBoardAccessibility {
+    static func browseLabel(_ board: KanbanBoard) -> String {
+        let boardName = board.name ?? board.slug ?? String(localized: "Board")
+        return String.localizedStringWithFormat(String(localized: "Browse Board: %@"), boardName)
     }
 }
 

--- a/HermesMobile/Models/Kanban.swift
+++ b/HermesMobile/Models/Kanban.swift
@@ -268,6 +268,26 @@ struct KanbanBoardRequest: Equatable, Sendable {
     }
 }
 
+struct KanbanCreateBoardRequest: Equatable, Sendable {
+    let slug: String
+    let name: String
+    let description: String
+    let icon: String
+    let color: String
+}
+
+struct KanbanEditBoardRequest: Equatable, Sendable {
+    let slug: String
+    let name: String
+    let description: String
+    let icon: String
+    let color: String
+}
+
+struct KanbanBoardMutationRequest: Equatable, Sendable {
+    let slug: String
+}
+
 /// Tolerant read-only boundary for the independently-versioned Kanban bridge.
 /// Every upstream field stays optional so an added or renamed server field never
 /// prevents the rest of the shell from decoding.
@@ -338,6 +358,23 @@ struct KanbanBoard: Decodable, Equatable, Sendable {
         isCurrent = container.decodeLossyBoolIfPresent(forKey: .isCurrent)
         total = container.decodeLossyIntIfPresent(forKey: .total)
         counts = try? container.decodeIfPresent([String: Int].self, forKey: .counts)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+struct KanbanBoardMutationEnvelope: Decodable, Equatable, Sendable {
+    let board: KanbanBoard?
+    let current: String?
+    let readOnly: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case board, current, readOnly
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        board = try? container.decodeIfPresent(KanbanBoard.self, forKey: .board)
+        current = container.decodeLossyStringIfPresent(forKey: .current)
         readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
     }
 }

--- a/HermesMobile/Networking/APIClient+Kanban.swift
+++ b/HermesMobile/Networking/APIClient+Kanban.swift
@@ -3,6 +3,10 @@ import Foundation
 protocol KanbanDataClient: Sendable {
     func kanbanConfiguration() async throws -> KanbanConfiguration
     func kanbanBoards() async throws -> KanbanBoardsResponse
+    func createKanbanBoard(_ request: KanbanCreateBoardRequest) async throws -> KanbanBoardMutationEnvelope
+    func editKanbanBoard(_ request: KanbanEditBoardRequest) async throws -> KanbanBoardMutationEnvelope
+    func archiveKanbanBoard(_ request: KanbanBoardMutationRequest) async throws -> KanbanBoardMutationEnvelope
+    func makeKanbanBoardActive(_ request: KanbanBoardMutationRequest) async throws -> KanbanBoardMutationEnvelope
     func kanbanBoard(_ request: KanbanBoardRequest) async throws -> KanbanBoardSnapshot
     func kanbanStats(board: String) async throws -> KanbanStats
     func kanbanAssignees(board: String) async throws -> KanbanAssigneeHistory
@@ -21,6 +25,22 @@ protocol KanbanDataClient: Sendable {
 }
 
 extension KanbanDataClient {
+    func createKanbanBoard(_ request: KanbanCreateBoardRequest) async throws -> KanbanBoardMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.createBoard
+    }
+
+    func editKanbanBoard(_ request: KanbanEditBoardRequest) async throws -> KanbanBoardMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.editBoard
+    }
+
+    func archiveKanbanBoard(_ request: KanbanBoardMutationRequest) async throws -> KanbanBoardMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.archiveBoard
+    }
+
+    func makeKanbanBoardActive(_ request: KanbanBoardMutationRequest) async throws -> KanbanBoardMutationEnvelope {
+        throw KanbanUnsupportedClientMethod.makeBoardActive
+    }
+
     func kanbanCardDetail(_ request: KanbanCardDetailRequest) async throws -> KanbanCardDetailEnvelope {
         throw KanbanUnsupportedClientMethod.cardDetail
     }
@@ -67,6 +87,10 @@ extension KanbanDataClient {
 }
 
 private enum KanbanUnsupportedClientMethod: Error {
+    case createBoard
+    case editBoard
+    case archiveBoard
+    case makeBoardActive
     case cardDetail
     case workerLog
     case addComment
@@ -87,6 +111,36 @@ extension APIClient: KanbanDataClient {
 
     func kanbanBoards() async throws -> KanbanBoardsResponse {
         try await kanbanJSON(endpoint: .kanbanBoards)
+    }
+
+    func createKanbanBoard(_ request: KanbanCreateBoardRequest) async throws -> KanbanBoardMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanCreateBoard,
+            method: "POST",
+            body: KanbanCreateBoardBody(request: request)
+        )
+    }
+
+    func editKanbanBoard(_ request: KanbanEditBoardRequest) async throws -> KanbanBoardMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanEditBoard(request),
+            method: "PATCH",
+            body: KanbanEditBoardBody(request: request)
+        )
+    }
+
+    func archiveKanbanBoard(_ request: KanbanBoardMutationRequest) async throws -> KanbanBoardMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanArchiveBoard(request),
+            method: "DELETE"
+        )
+    }
+
+    func makeKanbanBoardActive(_ request: KanbanBoardMutationRequest) async throws -> KanbanBoardMutationEnvelope {
+        try await kanbanJSON(
+            endpoint: .kanbanMakeBoardActive(request),
+            method: "POST"
+        )
     }
 
     func kanbanBoard(_ request: KanbanBoardRequest) async throws -> KanbanBoardSnapshot {
@@ -193,9 +247,16 @@ extension APIClient: KanbanDataClient {
     }
 
     private func kanbanJSON<Response: Decodable>(endpoint: Endpoint) async throws -> Response {
+        try await kanbanJSON(endpoint: endpoint, method: "GET")
+    }
+
+    private func kanbanJSON<Response: Decodable>(
+        endpoint: Endpoint,
+        method: String
+    ) async throws -> Response {
         let (data, response) = try await sendDataReturningResponse(
             endpoint: endpoint,
-            method: "GET",
+            method: method,
             encodedBody: nil
         )
         let contentType = response.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
@@ -223,6 +284,38 @@ extension APIClient: KanbanDataClient {
             throw KanbanResponseError.nonJSONContentType
         }
         return try decode(Response.self, from: data)
+    }
+}
+
+private struct KanbanCreateBoardBody: Encodable {
+    let slug: String
+    let name: String
+    let description: String
+    let icon: String
+    let color: String
+
+    init(request: KanbanCreateBoardRequest) {
+        slug = request.slug
+        name = request.name
+        description = request.description
+        icon = request.icon
+        color = request.color
+    }
+}
+
+private struct KanbanEditBoardBody: Encodable {
+    let request: KanbanEditBoardRequest
+
+    enum CodingKeys: CodingKey {
+        case name, description, icon, color
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(request.name, forKey: .name)
+        try container.encode(request.description, forKey: .description)
+        try container.encode(request.icon, forKey: .icon)
+        try container.encode(request.color, forKey: .color)
     }
 }
 

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -95,6 +95,10 @@ enum Endpoint {
     case cronDeliveryOptions
     case kanbanConfig
     case kanbanBoards
+    case kanbanCreateBoard
+    case kanbanEditBoard(KanbanEditBoardRequest)
+    case kanbanArchiveBoard(KanbanBoardMutationRequest)
+    case kanbanMakeBoardActive(KanbanBoardMutationRequest)
     case kanbanBoard(KanbanBoardRequest)
     case kanbanStats(board: String)
     case kanbanAssignees(board: String)
@@ -308,8 +312,14 @@ enum Endpoint {
             return "/api/crons/delivery-options"
         case .kanbanConfig:
             return "/api/kanban/config"
-        case .kanbanBoards:
+        case .kanbanBoards, .kanbanCreateBoard:
             return "/api/kanban/boards"
+        case let .kanbanEditBoard(request):
+            return "/api/kanban/boards/\(request.slug)"
+        case let .kanbanArchiveBoard(request):
+            return "/api/kanban/boards/\(request.slug)"
+        case let .kanbanMakeBoardActive(request):
+            return "/api/kanban/boards/\(request.slug)/switch"
         case .kanbanBoard:
             return "/api/kanban/board"
         case .kanbanStats:
@@ -515,6 +525,12 @@ enum Endpoint {
         switch self {
         case let .kanbanCardDetail(request):
             url = kanbanTaskURL(relativeTo: baseURL, cardID: request.cardID)
+        case let .kanbanEditBoard(request):
+            url = kanbanBoardURL(relativeTo: baseURL, slug: request.slug)
+        case let .kanbanArchiveBoard(request):
+            url = kanbanBoardURL(relativeTo: baseURL, slug: request.slug)
+        case let .kanbanMakeBoardActive(request):
+            url = kanbanBoardURL(relativeTo: baseURL, slug: request.slug, suffix: "/switch")
         case let .kanbanWorkerLog(request):
             url = kanbanTaskURL(relativeTo: baseURL, cardID: request.cardID, suffix: "/log")
         case let .kanbanAddComment(request):
@@ -547,6 +563,17 @@ enum Endpoint {
             return root
         }
         components.percentEncodedPath += "/\(encodedCardID)\(suffix)"
+        return components.url ?? root
+    }
+
+    private func kanbanBoardURL(relativeTo baseURL: URL, slug: String, suffix: String = "") -> URL {
+        let root = baseURL.appending(path: "/api/kanban/boards")
+        guard var components = URLComponents(url: root, resolvingAgainstBaseURL: false),
+              let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: Self.pathSegmentAllowed)
+        else {
+            return root
+        }
+        components.percentEncodedPath += "/\(encodedSlug)\(suffix)"
         return components.url ?? root
     }
 

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -109944,6 +109944,27 @@
         "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "Checking Result" } }
       }
     },
+    "Check Result" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تحقق من النتيجة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Ergebnis prüfen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Comprobar resultado" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Vérifier le résultat" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "בדיקת התוצאה" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Verifica risultato" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "結果を確認" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "결과 확인" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Resultaat controleren" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Sprawdź wynik" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Verificar resultado" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Проверить результат" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Sonucu Kontrol Et" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "نتیجہ چیک کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "檢查結果" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "检查结果" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "檢查結果" } }
+      }
+    },
     "Claim Expires" : {
       "localizations" : {
         "ar" : { "stringUnit" : { "state" : "translated", "value" : "Claim Expires" } },
@@ -110446,6 +110467,90 @@
         "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "This Board no longer exists. Return to Kanban to choose another Board." } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "This Board no longer exists. Return to Kanban to choose another Board." } },
         "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "This Board no longer exists. Return to Kanban to choose another Board." } }
+      }
+    },
+    "Browse Board" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تصفح اللوحة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Board anzeigen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Explorar tablero" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Parcourir le tableau" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "עיון בלוח" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Sfoglia bacheca" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボードを表示" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드 탐색" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Bord bekijken" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Przeglądaj tablicę" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Explorar quadro" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Открыть доску" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Panoya Göz At" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ دیکھیں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "瀏覽看板" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "浏览看板" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "瀏覽看板" } }
+      }
+    },
+    "Browse Board: %@" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "تصفح اللوحة: %@" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Board anzeigen: %@" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Explorar tablero: %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Parcourir le tableau : %@" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "עיון בלוח: %@" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Sfoglia bacheca: %@" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボードを表示：%@" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드 탐색: %@" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Bord bekijken: %@" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Przeglądaj tablicę: %@" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Explorar quadro: %@" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Открыть доску: %@" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Panoya Göz At: %@" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ دیکھیں: %@" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "瀏覽看板：%@" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "浏览看板：%@" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "瀏覽看板：%@" } }
+      }
+    },
+    "Choose Board" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "اختر لوحة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Board auswählen" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Elegir tablero" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Choisir un tableau" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "בחירת לוח" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Scegli bacheca" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボードを選択" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드 선택" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Bord kiezen" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Wybierz tablicę" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Escolher quadro" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Выбрать доску" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Pano Seç" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ منتخب کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "選擇看板" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "选择看板" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "選擇看板" } }
+      }
+    },
+    "This Board no longer exists. Choose another Board." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "لم تعد هذه اللوحة موجودة. اختر لوحة أخرى." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Dieses Board existiert nicht mehr. Wähle ein anderes Board." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Este tablero ya no existe. Elige otro tablero." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ce tableau n’existe plus. Choisissez-en un autre." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הלוח הזה כבר לא קיים. יש לבחור לוח אחר." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Questa bacheca non esiste più. Scegli un’altra bacheca." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "このボードは存在しません。別のボードを選択してください。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이 보드는 더 이상 존재하지 않습니다. 다른 보드를 선택하세요." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Dit bord bestaat niet meer. Kies een ander bord." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Ta tablica już nie istnieje. Wybierz inną tablicę." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Este quadro não existe mais. Escolha outro quadro." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Эта доска больше не существует. Выберите другую доску." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Bu pano artık mevcut değil. Başka bir pano seçin." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "یہ بورڈ اب موجود نہیں ہے۔ دوسرا بورڈ منتخب کریں۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "此看板已不存在。請選擇另一個看板。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "此看板已不存在。请选择另一个看板。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "此看板已不存在。請選擇另一個看板。" } }
       }
     },
     "This Card no longer exists on this Board. The Board has been refreshed." : {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -111519,6 +111519,216 @@
         "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "還原封存" } }
       }
     },
+    "Browsing" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "قيد التصفح" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Geöffnet" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Explorando" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Parcouru" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "בגלישה" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "In consultazione" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "閲覧中" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "탐색 중" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Bekeken" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Przeglądana" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Em navegação" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Открыта" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Görüntüleniyor" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "زیرِ مطالعہ" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "正在瀏覽" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在浏览" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "正在瀏覽" } }
+      }
+    },
+    "Browsing a Board stays local to Hermex. Making a Board active changes shared server state." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "يبقى تصفح اللوحة محليًا في Hermex. جعل اللوحة نشطة يغيّر حالة الخادم المشتركة." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Das Öffnen eines Boards bleibt lokal in Hermex. Das Aktivieren eines Boards ändert den gemeinsamen Serverstatus." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Explorar un tablero es local en Hermex. Activarlo cambia el estado compartido del servidor." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Parcourir un tableau reste local à Hermex. L’activer modifie l’état partagé du serveur." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "גלישה בלוח נשארת מקומית ב-Hermex. הפיכת לוח לפעיל משנה את מצב השרת המשותף." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Consultare una bacheca resta locale in Hermex. Attivarla cambia lo stato condiviso del server." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボードの閲覧はHermex内だけの操作です。ボードをアクティブにすると共有サーバーの状態が変わります。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드 탐색은 Hermex에만 적용됩니다. 보드를 활성화하면 공유 서버 상태가 변경됩니다." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Een bord bekijken blijft lokaal in Hermex. Een bord actief maken wijzigt de gedeelde serverstatus." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Przeglądanie tablicy pozostaje lokalne w Hermex. Ustawienie jej jako aktywnej zmienia współdzielony stan serwera." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Navegar por um quadro permanece local no Hermex. Ativá-lo altera o estado compartilhado do servidor." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Просмотр доски остаётся локальным в Hermex. Активация доски меняет общее состояние сервера." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Bir panoya göz atmak Hermex’te yerel kalır. Panoyu etkinleştirmek paylaşılan sunucu durumunu değiştirir." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ دیکھنا Hermex تک مقامی رہتا ہے۔ بورڈ فعال کرنے سے مشترکہ سرور کی حالت بدلتی ہے۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "瀏覽看板只會影響 Hermex。將看板設為作用中會更改共享伺服器狀態。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "浏览看板只会影响 Hermex。将看板设为当前会更改共享服务器状态。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "瀏覽看板只會影響 Hermex。將看板設為作用中會更改共享伺服器狀態。" } }
+      }
+    },
+    "Creating a Board does not make it active." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "إنشاء لوحة لا يجعلها نشطة." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Beim Erstellen wird das Board nicht aktiviert." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Crear un tablero no lo activa." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Créer un tableau ne l’active pas." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "יצירת לוח אינה הופכת אותו לפעיל." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "La creazione di una bacheca non la rende attiva." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボードを作成してもアクティブにはなりません。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드를 만들어도 활성 보드로 변경되지 않습니다." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Een bord maken maakt het niet actief." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Utworzenie tablicy nie ustawia jej jako aktywnej." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Criar um quadro não o torna ativo." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Создание доски не делает её активной." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Pano oluşturmak onu etkinleştirmez." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ بنانے سے وہ فعال نہیں ہوتا۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "建立看板不會將它設為作用中。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "创建看板不会将其设为当前看板。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "建立看板不會將它設為作用中。" } }
+      }
+    },
+    "Hermex cannot restore an archived Board in-app." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "لا يستطيع Hermex استعادة لوحة مؤرشفة من داخل التطبيق." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Hermex kann ein archiviertes Board nicht in der App wiederherstellen." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Hermex no puede restaurar un tablero archivado desde la app." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Hermex ne peut pas restaurer un tableau archivé dans l’app." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "Hermex לא יכול לשחזר לוח שהועבר לארכיון מתוך היישום." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Hermex non può ripristinare nell’app una bacheca archiviata." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Hermexアプリ内ではアーカイブ済みボードを復元できません。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "Hermex 앱에서는 보관된 보드를 복원할 수 없습니다." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Hermex kan een gearchiveerd bord niet in de app herstellen." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Hermex nie może przywrócić zarchiwizowanej tablicy w aplikacji." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "O Hermex não pode restaurar um quadro arquivado pelo app." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Hermex не может восстановить архивную доску в приложении." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Hermex arşivlenmiş bir panoyu uygulama içinden geri yükleyemez." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "Hermex ایپ میں محفوظ شدہ بورڈ بحال نہیں کر سکتا۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "Hermex 無法在 App 內還原已封存的看板。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Hermex 无法在 App 内恢复已归档的看板。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "Hermex 無法在 App 內還原已封存的看板。" } }
+      }
+    },
+    "Icon" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "الأيقونة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Symbol" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Icono" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Icône" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "סמל" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Icona" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アイコン" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "아이콘" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Pictogram" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Ikona" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Ícone" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Значок" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Simge" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "آئیکن" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "圖示" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "图标" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "圖示" } }
+      }
+    },
+    "Make Active Board" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "جعل اللوحة نشطة" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Board aktivieren" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Activar tablero" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Activer le tableau" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הפיכת הלוח לפעיל" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Attiva bacheca" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボードをアクティブにする" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드를 활성화" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Bord actief maken" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Ustaw tablicę jako aktywną" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Ativar quadro" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Сделать доску активной" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Panoyu etkinleştir" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ فعال کریں" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "將看板設為作用中" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "将看板设为当前" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "將看板設為作用中" } }
+      }
+    },
+    "Making this Board active changes shared server state for other Hermes clients." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "جعل هذه اللوحة نشطة يغيّر حالة الخادم المشتركة لعملاء Hermes الآخرين." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Das Aktivieren dieses Boards ändert den gemeinsamen Serverstatus für andere Hermes-Clients." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Activar este tablero cambia el estado compartido del servidor para otros clientes de Hermes." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Activer ce tableau modifie l’état partagé du serveur pour les autres clients Hermes." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הפיכת לוח זה לפעיל משנה את מצב השרת המשותף עבור לקוחות Hermes אחרים." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Attivare questa bacheca cambia lo stato condiviso del server per gli altri client Hermes." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "このボードをアクティブにすると、他のHermesクライアントにも見える共有サーバー状態が変わります。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이 보드를 활성화하면 다른 Hermes 클라이언트가 공유하는 서버 상태가 변경됩니다." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Dit bord actief maken wijzigt de gedeelde serverstatus voor andere Hermes-clients." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Ustawienie tej tablicy jako aktywnej zmienia współdzielony stan serwera dla innych klientów Hermes." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Ativar este quadro altera o estado compartilhado do servidor para outros clientes Hermes." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Активация этой доски меняет общее состояние сервера для других клиентов Hermes." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Bu panoyu etkinleştirmek diğer Hermes istemcileri için paylaşılan sunucu durumunu değiştirir." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "اس بورڈ کو فعال کرنے سے دیگر Hermes کلائنٹس کے لیے مشترکہ سرور کی حالت بدلتی ہے۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "將此看板設為作用中會更改其他 Hermes 用戶端共用的伺服器狀態。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "将此看板设为当前会更改其他 Hermes 客户端共享的服务器状态。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "將此看板設為作用中會更改其他 Hermes 用戶端共用的伺服器狀態。" } }
+      }
+    },
+    "Slug" : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "المعرّف" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Kurzname" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Identificador" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Identifiant" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "מזהה" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Identificatore" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スラッグ" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "슬러그" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Korte naam" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Identyfikator" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Identificador" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Идентификатор" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Kısa ad" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "شناختی نام" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "識別碼" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "标识符" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "識別碼" } }
+      }
+    },
+    "The slug cannot be changed after the Board is created." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "لا يمكن تغيير المعرّف بعد إنشاء اللوحة." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Der Kurzname kann nach dem Erstellen des Boards nicht geändert werden." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "El identificador no se puede cambiar después de crear el tablero." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "L’identifiant ne peut plus être modifié après la création du tableau." } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "לא ניתן לשנות את המזהה לאחר יצירת הלוח." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "L’identificatore non può essere modificato dopo la creazione della bacheca." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボード作成後はスラッグを変更できません。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드를 만든 후에는 슬러그를 변경할 수 없습니다." } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "De korte naam kan na het maken van het bord niet worden gewijzigd." } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Identyfikatora nie można zmienić po utworzeniu tablicy." } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "O identificador não pode ser alterado após a criação do quadro." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Идентификатор нельзя изменить после создания доски." } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Pano oluşturulduktan sonra kısa ad değiştirilemez." } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ بننے کے بعد شناختی نام تبدیل نہیں کیا جا سکتا۔" } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "建立看板後便無法更改識別碼。" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "创建看板后无法更改标识符。" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "建立看板後便無法更改識別碼。" } }
+      }
+    },
+    "Updating Board..." : {
+      "localizations" : {
+        "ar" : { "stringUnit" : { "state" : "translated", "value" : "جارٍ تحديث اللوحة..." } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Board wird aktualisiert …" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Actualizando tablero…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mise à jour du tableau…" } },
+        "he" : { "stringUnit" : { "state" : "translated", "value" : "הלוח מתעדכן..." } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Aggiornamento bacheca…" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ボードを更新中…" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보드 업데이트 중…" } },
+        "nl" : { "stringUnit" : { "state" : "translated", "value" : "Bord bijwerken…" } },
+        "pl" : { "stringUnit" : { "state" : "translated", "value" : "Aktualizowanie tablicy…" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Atualizando quadro…" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Обновление доски…" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "Pano güncelleniyor…" } },
+        "ur" : { "stringUnit" : { "state" : "translated", "value" : "بورڈ اپ ڈیٹ ہو رہا ہے..." } },
+        "zh-HK" : { "stringUnit" : { "state" : "translated", "value" : "正在更新看板⋯" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在更新看板…" } },
+        "zh-Hant" : { "stringUnit" : { "state" : "translated", "value" : "正在更新看板⋯" } }
+      }
+    },
     "Update failed" : {
       "localizations" : {
         "ar" : { "stringUnit" : { "state" : "translated", "value" : "فشل التحديث" } },

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -75,6 +75,106 @@ final class APIClientKanbanTests: APIClientTestCase {
         XCTAssertEqual(snapshot.latestEventID, 42)
     }
 
+    func testBoardManagementUsesExactVerifiedRequestsWithoutImplicitSwitchOrHardDelete() async throws {
+        var requestIndex = 0
+        let client = makeClient { request in
+            defer { requestIndex += 1 }
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            XCTAssertNil(components?.query)
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "Origin"))
+            XCTAssertNil(request.value(forHTTPHeaderField: "Referer"))
+
+            switch requestIndex {
+            case 0:
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(components?.path, "/api/kanban/boards")
+                let data = try XCTUnwrap(apiTestBodyData(from: request))
+                let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                XCTAssertEqual(Set(body.keys), ["slug", "name", "description", "icon", "color"])
+                XCTAssertEqual(body["slug"] as? String, "release board")
+                XCTAssertNil(body["switch"], "Creation must never implicitly change shared active-Board state.")
+                return apiTestJSONResponse(
+                    #"{"board":{"slug":"release board","name":"Release"},"current":"main","read_only":false}"#,
+                    for: request
+                )
+            case 1:
+                XCTAssertEqual(request.httpMethod, "PATCH")
+                XCTAssertEqual(components?.path, "/api/kanban/boards/release board")
+                let data = try XCTUnwrap(apiTestBodyData(from: request))
+                let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                XCTAssertEqual(Set(body.keys), ["name", "description", "icon", "color"])
+                XCTAssertNil(body["slug"])
+                XCTAssertEqual(body["description"] as? String, "")
+                return apiTestJSONResponse(
+                    #"{"board":{"slug":"release board","name":"Release 2"},"read_only":false}"#,
+                    for: request
+                )
+            case 2:
+                XCTAssertEqual(request.httpMethod, "DELETE")
+                XCTAssertEqual(components?.path, "/api/kanban/boards/release board")
+                XCTAssertNil(request.httpBody)
+                XCTAssertFalse(request.url?.absoluteString.contains("delete=") == true)
+                return apiTestJSONResponse(
+                    #"{"result":{"action":"archived"},"current":"main","read_only":false}"#,
+                    for: request
+                )
+            default:
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(components?.path, "/api/kanban/boards/release board/switch")
+                XCTAssertNil(request.httpBody)
+                return apiTestJSONResponse(
+                    #"{"current":"release board","read_only":false,"future":true}"#,
+                    for: request
+                )
+            }
+        }
+
+        let created = try await client.createKanbanBoard(KanbanCreateBoardRequest(
+            slug: "release board",
+            name: "Release",
+            description: "Ship work",
+            icon: "🚀",
+            color: "#7AA2FF"
+        ))
+        let edited = try await client.editKanbanBoard(KanbanEditBoardRequest(
+            slug: "release board",
+            name: "Release 2",
+            description: "",
+            icon: "📦",
+            color: "#00AAFF"
+        ))
+        let archived = try await client.archiveKanbanBoard(
+            KanbanBoardMutationRequest(slug: "release board")
+        )
+        let activated = try await client.makeKanbanBoardActive(
+            KanbanBoardMutationRequest(slug: "release board")
+        )
+
+        XCTAssertEqual(created.current, "main")
+        XCTAssertEqual(edited.board?.name, "Release 2")
+        XCTAssertEqual(archived.current, "main")
+        XCTAssertEqual(activated.current, "release board")
+    }
+
+    func testBoardManagementPathKeepsSlugInOneEncodedSegmentAndResponsesDecodeTolerantly() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/kanban/boards/../release/switch")
+            XCTAssertTrue(request.url?.absoluteString.contains("%2E%2E%2Frelease") == true)
+            return apiTestJSONResponse(
+                #"{"current":42,"read_only":"false","unknown":{"db_path":"/secret"}}"#,
+                for: request
+            )
+        }
+
+        let result = try await client.makeKanbanBoardActive(
+            KanbanBoardMutationRequest(slug: "../release")
+        )
+
+        XCTAssertEqual(result.current, "42")
+        XCTAssertEqual(result.readOnly, false)
+    }
+
     func testEventPollingUsesVerifiedCursorEnvelopeAndBounds() async throws {
         let client = makeClient { request in
             let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -1041,6 +1041,23 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertFalse(state.canManageBoards)
     }
 
+    func testCancelledBoardCollectionRefreshDoesNotReportFailureOrBlockWrites() async {
+        let client = DeferredBoardCollectionClient()
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        let refresh = Task { await state.refresh() }
+        await client.waitForDeferredCollection()
+        refresh.cancel()
+        await client.resumeDeferredCollection()
+        await refresh.value
+
+        XCTAssertFalse(state.refreshFailed)
+        XCTAssertTrue(state.canUseServerAuthoritativeActions)
+        let boardRequestCount = await client.boardRequestCount
+        XCTAssertEqual(boardRequestCount, 1)
+    }
+
     func testBoardManagementStateRemainsIsolatedPerServer() async {
         let firstClient = BoardManagementClient(boardsResponses: [
             .success(mutationDecode(
@@ -1412,6 +1429,39 @@ private actor BoardManagementClient: KanbanDataClient {
     func resumeDeferredCreate() {
         createContinuation?.resume()
         createContinuation = nil
+    }
+}
+
+private actor DeferredBoardCollectionClient: KanbanDataClient {
+    private var collectionRequestCount = 0
+    private var collectionContinuation: CheckedContinuation<KanbanBoardsResponse, Never>?
+    private(set) var boardRequestCount = 0
+
+    func kanbanConfiguration() -> KanbanConfiguration { KanbanFixtures.configuration }
+
+    func kanbanBoards() async -> KanbanBoardsResponse {
+        collectionRequestCount += 1
+        if collectionRequestCount == 1 {
+            return KanbanFixtures.boards
+        }
+        return await withCheckedContinuation { collectionContinuation = $0 }
+    }
+
+    func kanbanBoard(_ request: KanbanBoardRequest) -> KanbanBoardSnapshot {
+        boardRequestCount += 1
+        return KanbanFixtures.richSnapshot
+    }
+
+    func kanbanStats(board: String) -> KanbanStats { KanbanFixtures.stats }
+    func kanbanAssignees(board: String) -> KanbanAssigneeHistory { KanbanFixtures.history }
+
+    func waitForDeferredCollection() async {
+        while collectionContinuation == nil { await Task.yield() }
+    }
+
+    func resumeDeferredCollection() {
+        collectionContinuation?.resume(returning: KanbanFixtures.boards)
+        collectionContinuation = nil
     }
 }
 

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -1018,6 +1018,27 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertFalse(state.refreshFailed)
     }
 
+    func testIncompleteBoardCollectionRefreshReportsFailureAndPreservesSnapshot() async {
+        let client = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
+            )),
+            .success(mutationDecode(
+                #"{"current":"main","read_only":false}"#
+            ))
+        ])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let loadedCards = state.allCards
+
+        await state.refresh()
+
+        XCTAssertFalse(state.isOffline)
+        XCTAssertTrue(state.refreshFailed)
+        XCTAssertEqual(state.allCards, loadedCards)
+        XCTAssertFalse(state.canManageBoards)
+    }
+
     func testBoardManagementStateRemainsIsolatedPerServer() async {
         let firstClient = BoardManagementClient(boardsResponses: [
             .success(mutationDecode(
@@ -1093,21 +1114,23 @@ final class KanbanFeatureStateTests: XCTestCase {
         let client = BoardManagementClient(
             boardsResponses: [
                 .success(mutationDecode(
-                    #"{"boards":[{"slug":"main"}],"current":"main","read_only":false}"#
+                    #"{"boards":[{"slug":"main"},{"slug":"release"}],"current":"main","read_only":false}"#
                 )),
                 .failure(APIError.network(underlying: URLError(.networkConnectionLost))),
                 .success(mutationDecode(
-                    #"{"boards":[{"slug":"main"},{"slug":"release"}],"current":"main","read_only":false}"#
+                    #"{"boards":[{"slug":"main"},{"slug":"release"},{"slug":"planned"}],"current":"main","read_only":false}"#
                 ))
             ],
             createResult: .failure(APIError.network(underlying: URLError(.timedOut)))
         )
         let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
         await state.load()
+        state.beginSelectingCards()
+        if let card = state.allCards.first { state.toggleCardSelection(card) }
 
         await state.createBoard(KanbanCreateBoardRequest(
-            slug: "release",
-            name: "Release",
+            slug: "planned",
+            name: "Planned",
             description: "",
             icon: "",
             color: ""
@@ -1115,9 +1138,55 @@ final class KanbanFeatureStateTests: XCTestCase {
 
         XCTAssertEqual(state.boardMutationState?.phase, .outcomeUncertain)
         XCTAssertFalse(state.canManageBoards)
+        XCTAssertFalse(state.canAddComments)
+        XCTAssertFalse(state.canMutateCards)
+        XCTAssertEqual(state.bulkActionsAvailability, .boardBusy)
+        await state.selectBoard("release")
+        XCTAssertEqual(state.selectedBoardSlug, "main")
         await state.checkBoardMutationResult()
         XCTAssertEqual(state.boardMutationState?.phase, .succeeded)
         XCTAssertTrue(state.canManageBoards)
+        XCTAssertTrue(state.canMutateCards)
+    }
+
+    func testReloadInvalidatesInFlightBoardMutationBeforeItCanApplyStaleState() async {
+        let client = BoardManagementClient(
+            boardsResponses: [
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"main","name":"Original"}],"current":"main","read_only":false}"#
+                )),
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"main","name":"Reloaded"}],"current":"main","read_only":false}"#
+                ))
+            ],
+            defersCreate: true
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        let creation = Task {
+            await state.createBoard(KanbanCreateBoardRequest(
+                slug: "release",
+                name: "Release",
+                description: "",
+                icon: "",
+                color: ""
+            ))
+        }
+        await client.waitForDeferredCreate()
+        XCTAssertEqual(state.boardMutationState?.phase, .updating)
+
+        await state.load()
+        XCTAssertEqual(state.boards.first?.name, "Reloaded")
+        XCTAssertNil(state.boardMutationState)
+
+        await client.resumeDeferredCreate()
+        await creation.value
+
+        XCTAssertEqual(state.boards.first?.name, "Reloaded")
+        XCTAssertNil(state.boardMutationState)
+        let boardsRequestCount = await client.boardsRequestCount
+        XCTAssertEqual(boardsRequestCount, 2)
     }
 
     func testEditActivateAndArchiveReconcileTheBoardCollection() async {
@@ -1252,6 +1321,7 @@ private actor BoardManagementClient: KanbanDataClient {
     private(set) var createRequestCount = 0
     private(set) var archiveRequestCount = 0
     private(set) var makeActiveRequestCount = 0
+    private(set) var boardsRequestCount = 0
 
     init(
         boardsResponses: [Result<KanbanBoardsResponse, Error>],
@@ -1273,6 +1343,7 @@ private actor BoardManagementClient: KanbanDataClient {
     func kanbanConfiguration() -> KanbanConfiguration { configuration }
 
     func kanbanBoards() throws -> KanbanBoardsResponse {
+        boardsRequestCount += 1
         if boardsResponses.count > 1 {
             return try boardsResponses.removeFirst().get()
         }

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -812,7 +812,7 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(state.bulkActionSummary?.succeededCount, 2)
     }
 
-    func testReloadToAnotherBoardClearsSelectionDuringBulkSubmission() async throws {
+    func testReloadAfterBrowsedBoardRemovalClearsSelectionDuringBulkSubmission() async throws {
         let client = BulkActionClient(
             boardSnapshots: [
                 bulkSnapshot(firstStatus: "todo", secondStatus: "todo"),
@@ -838,7 +838,8 @@ final class KanbanFeatureStateTests: XCTestCase {
         await client.waitForDeferredBulkResponse()
         await state.load()
 
-        XCTAssertEqual(state.selectedBoardSlug, "release")
+        XCTAssertNil(state.selectedBoardSlug)
+        XCTAssertEqual(state.boardSelectionNotice?.boardName, "main")
         XCTAssertFalse(state.isSelectingCards)
         XCTAssertTrue(state.selectedCardIDs.isEmpty)
 
@@ -862,6 +863,197 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(state.bulkActionSummary?.failedCount, 1)
         XCTAssertEqual(state.selectedCardIDs, ["CARD-4"])
         XCTAssertTrue(state.canRetryFailedBulkAction)
+    }
+
+    func testBoardWritesSerializeAndCreationNeverChangesLocalOrSharedSelection() async throws {
+        let client = BoardManagementClient(
+            boardsResponses: [
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
+                )),
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"main","name":"Main"},{"slug":"release","name":"Release"}],"current":"main","read_only":false}"#
+                ))
+            ],
+            defersCreate: true
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        let creation = Task {
+            await state.createBoard(KanbanCreateBoardRequest(
+                slug: "release",
+                name: "Release",
+                description: "",
+                icon: "",
+                color: ""
+            ))
+        }
+        await client.waitForDeferredCreate()
+        XCTAssertEqual(state.boardMutationState?.phase, .updating)
+
+        await state.makeBoardActive(slug: "main")
+        let makeActiveRequestCount = await client.makeActiveRequestCount
+        XCTAssertEqual(makeActiveRequestCount, 0)
+
+        await client.resumeDeferredCreate()
+        await creation.value
+
+        let createRequestCount = await client.createRequestCount
+        XCTAssertEqual(createRequestCount, 1)
+        XCTAssertEqual(state.boardMutationState?.phase, .succeeded)
+        XCTAssertEqual(state.selectedBoardSlug, "main")
+        XCTAssertEqual(state.sharedActiveBoardSlug, "main")
+        XCTAssertTrue(state.boards.contains { $0.slug == "release" })
+    }
+
+    func testRemoteSharedActiveChangeNeverNavigatesLocallyBrowsedBoard() async {
+        let client = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main"},{"slug":"release"}],"current":"main","read_only":false}"#
+            )),
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main"},{"slug":"release"}],"current":"release","read_only":false}"#
+            ))
+        ])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        await state.refresh()
+
+        XCTAssertEqual(state.sharedActiveBoardSlug, "release")
+        XCTAssertEqual(state.selectedBoardSlug, "main")
+        let lastBoardRequest = await client.boardRequests().last
+        XCTAssertEqual(lastBoardRequest?.board, "main")
+    }
+
+    func testRemoteArchiveReturnsToBoardSelectionAndTearsDownBoardState() async throws {
+        let client = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"},{"slug":"release","name":"Release"}],"current":"main","read_only":false}"#
+            )),
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
+            ))
+        ])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        await state.selectBoard("release")
+        state.beginSelectingCards()
+        if let card = state.allCards.first { state.toggleCardSelection(card) }
+
+        await state.refresh()
+
+        XCTAssertNil(state.selectedBoardSlug)
+        XCTAssertNil(state.snapshot)
+        XCTAssertTrue(state.selectedCardIDs.isEmpty)
+        XCTAssertEqual(state.boardSelectionNotice?.boardName, "Release")
+        XCTAssertTrue(state.requiresBoardSelection)
+    }
+
+    func testAmbiguousBoardWriteChecksAuthoritativeListAndDefaultArchiveIsBlocked() async {
+        let client = BoardManagementClient(
+            boardsResponses: [
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"default"}],"current":"default","read_only":false}"#
+                )),
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"default"},{"slug":"release"}],"current":"default","read_only":false}"#
+                ))
+            ],
+            createResult: .failure(APIError.network(underlying: URLError(.timedOut)))
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        await state.archiveBoard(slug: "default")
+        let archiveRequestCount = await client.archiveRequestCount
+        XCTAssertEqual(archiveRequestCount, 0)
+
+        await state.createBoard(KanbanCreateBoardRequest(
+            slug: "release",
+            name: "Release",
+            description: "",
+            icon: "",
+            color: ""
+        ))
+
+        XCTAssertEqual(state.boardMutationState?.phase, .succeeded)
+        XCTAssertEqual(state.selectedBoardSlug, "default")
+    }
+
+    func testUncertainBoardWriteBlocksRetryUntilAnotherAuthoritativeCheck() async {
+        let client = BoardManagementClient(
+            boardsResponses: [
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"main"}],"current":"main","read_only":false}"#
+                )),
+                .failure(APIError.network(underlying: URLError(.networkConnectionLost))),
+                .success(mutationDecode(
+                    #"{"boards":[{"slug":"main"},{"slug":"release"}],"current":"main","read_only":false}"#
+                ))
+            ],
+            createResult: .failure(APIError.network(underlying: URLError(.timedOut)))
+        )
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        await state.createBoard(KanbanCreateBoardRequest(
+            slug: "release",
+            name: "Release",
+            description: "",
+            icon: "",
+            color: ""
+        ))
+
+        XCTAssertEqual(state.boardMutationState?.phase, .outcomeUncertain)
+        XCTAssertFalse(state.canManageBoards)
+        await state.checkBoardMutationResult()
+        XCTAssertEqual(state.boardMutationState?.phase, .succeeded)
+        XCTAssertTrue(state.canManageBoards)
+    }
+
+    func testEditActivateAndArchiveReconcileTheBoardCollection() async {
+        let client = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"default","name":"Default"},{"slug":"release","name":"Old"}],"current":"default","read_only":false}"#
+            )),
+            .success(mutationDecode(
+                ##"{"boards":[{"slug":"default","name":"Default"},{"slug":"release","name":"Release","description":"","icon":"🚀","color":"#00AAFF"}],"current":"default","read_only":false}"##
+            )),
+            .success(mutationDecode(
+                ##"{"boards":[{"slug":"default","name":"Default"},{"slug":"release","name":"Release","description":"","icon":"🚀","color":"#00AAFF"}],"current":"release","read_only":false}"##
+            )),
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"default","name":"Default"}],"current":"default","read_only":false}"#
+            ))
+        ])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        await state.editBoard(KanbanEditBoardRequest(
+            slug: "release",
+            name: "Release",
+            description: "",
+            icon: "🚀",
+            color: "#00AAFF"
+        ))
+        XCTAssertEqual(state.boardMutationState?.phase, .succeeded)
+
+        await state.makeBoardActive(slug: "release")
+        XCTAssertEqual(state.boardMutationState?.phase, .succeeded)
+        XCTAssertEqual(state.sharedActiveBoardSlug, "release")
+        XCTAssertEqual(state.selectedBoardSlug, "default")
+
+        await state.archiveBoard(slug: "release")
+        XCTAssertEqual(state.boardMutationState?.phase, .succeeded)
+        XCTAssertFalse(state.boards.contains { $0.slug == "release" })
+        let editRequest = await client.editRequests().first
+        let activeRequest = await client.activeRequests().first
+        let archiveRequest = await client.archiveRequests().first
+        XCTAssertEqual(editRequest?.slug, "release")
+        XCTAssertEqual(activeRequest?.slug, "release")
+        XCTAssertEqual(archiveRequest?.slug, "release")
     }
 
     private func waitUntil(
@@ -936,6 +1128,98 @@ private actor KanbanClientStub: KanbanDataClient {
     }
 
     func calls() -> [Call] { recordedCalls }
+}
+
+private actor BoardManagementClient: KanbanDataClient {
+    private var boardsResponses: [Result<KanbanBoardsResponse, Error>]
+    private let createResult: Result<KanbanBoardMutationEnvelope, Error>
+    private var createContinuation: CheckedContinuation<Void, Never>?
+    private let defersCreate: Bool
+    private var shouldDeferCreate: Bool
+    private var recordedBoardRequests: [KanbanBoardRequest] = []
+    private var recordedEditRequests: [KanbanEditBoardRequest] = []
+    private var recordedArchiveRequests: [KanbanBoardMutationRequest] = []
+    private var recordedActiveRequests: [KanbanBoardMutationRequest] = []
+    private(set) var createRequestCount = 0
+    private(set) var archiveRequestCount = 0
+    private(set) var makeActiveRequestCount = 0
+
+    init(
+        boardsResponses: [Result<KanbanBoardsResponse, Error>],
+        createResult: Result<KanbanBoardMutationEnvelope, Error> = .success(
+            mutationDecode(#"{"board":{"slug":"release"},"current":"main","read_only":false}"#)
+        ),
+        defersCreate: Bool = false
+    ) {
+        self.boardsResponses = boardsResponses
+        self.createResult = createResult
+        self.defersCreate = defersCreate
+        shouldDeferCreate = defersCreate
+    }
+
+    func kanbanConfiguration() -> KanbanConfiguration { KanbanFixtures.configuration }
+
+    func kanbanBoards() throws -> KanbanBoardsResponse {
+        if boardsResponses.count > 1 {
+            return try boardsResponses.removeFirst().get()
+        }
+        return try boardsResponses[0].get()
+    }
+
+    func kanbanBoard(_ request: KanbanBoardRequest) -> KanbanBoardSnapshot {
+        recordedBoardRequests.append(request)
+        return KanbanFixtures.richSnapshot
+    }
+
+    func kanbanStats(board: String) -> KanbanStats { KanbanFixtures.stats }
+    func kanbanAssignees(board: String) -> KanbanAssigneeHistory { KanbanFixtures.history }
+
+    func createKanbanBoard(_ request: KanbanCreateBoardRequest) async throws -> KanbanBoardMutationEnvelope {
+        createRequestCount += 1
+        if shouldDeferCreate {
+            shouldDeferCreate = false
+            await withCheckedContinuation { createContinuation = $0 }
+        }
+        return try createResult.get()
+    }
+
+    func archiveKanbanBoard(
+        _ request: KanbanBoardMutationRequest
+    ) -> KanbanBoardMutationEnvelope {
+        archiveRequestCount += 1
+        recordedArchiveRequests.append(request)
+        return mutationDecode(#"{"current":"main","read_only":false}"#)
+    }
+
+    func editKanbanBoard(
+        _ request: KanbanEditBoardRequest
+    ) -> KanbanBoardMutationEnvelope {
+        recordedEditRequests.append(request)
+        return mutationDecode(#"{"board":{"slug":"\#(request.slug)"},"read_only":false}"#)
+    }
+
+    func makeKanbanBoardActive(
+        _ request: KanbanBoardMutationRequest
+    ) -> KanbanBoardMutationEnvelope {
+        makeActiveRequestCount += 1
+        recordedActiveRequests.append(request)
+        return mutationDecode(#"{"current":"\#(request.slug)","read_only":false}"#)
+    }
+
+    func boardRequests() -> [KanbanBoardRequest] { recordedBoardRequests }
+    func editRequests() -> [KanbanEditBoardRequest] { recordedEditRequests }
+    func archiveRequests() -> [KanbanBoardMutationRequest] { recordedArchiveRequests }
+    func activeRequests() -> [KanbanBoardMutationRequest] { recordedActiveRequests }
+
+    func waitForDeferredCreate() async {
+        guard defersCreate else { return }
+        while createContinuation == nil { await Task.yield() }
+    }
+
+    func resumeDeferredCreate() {
+        createContinuation?.resume()
+        createContinuation = nil
+    }
 }
 
 private actor DeferredFirstConfigurationClient: KanbanDataClient {

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -274,6 +274,10 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertTrue(bulkLabel.contains("1 \(String(localized: "Outcome Uncertain"))"))
         XCTAssertEqual(KanbanCountFormatter.cards(1), "1 Card")
         XCTAssertEqual(KanbanCountFormatter.cards(2), "2 Cards")
+        let board: KanbanBoard = mutationDecode(
+            #"{"slug":"release","name":"Release"}"#
+        )
+        XCTAssertEqual(KanbanBoardAccessibility.browseLabel(board), "Browse Board: Release")
     }
 
     func testStatusSpecificStalenessThresholds() {
@@ -951,6 +955,109 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertTrue(state.requiresBoardSelection)
     }
 
+    func testRemovedBoardReloadPreservesPartialCompatibilityAndDisplayName() async {
+        let client = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"},{"slug":"release","name":"Release"}],"current":"main","read_only":false}"#
+            )),
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
+            ))
+        ])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        await state.selectBoard("release")
+
+        await state.load()
+
+        XCTAssertEqual(state.state, .partial)
+        XCTAssertEqual(state.report?.warnings, [.unsupportedStatus("future")])
+        XCTAssertNil(state.selectedBoardSlug)
+        XCTAssertEqual(state.boardSelectionNotice?.boardName, "Release")
+    }
+
+    func testPartialBoardContractDisablesBoardManagement() async {
+        let client = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"}],"current":"main"}"#
+            ))
+        ])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+
+        XCTAssertEqual(state.state, .partial)
+        XCTAssertFalse(state.canManageBoards)
+        await state.createBoard(KanbanCreateBoardRequest(
+            slug: "release",
+            name: "Release",
+            description: "",
+            icon: "",
+            color: ""
+        ))
+        let createRequestCount = await client.createRequestCount
+        XCTAssertEqual(createRequestCount, 0)
+    }
+
+    func testOfflineBoardCollectionRefreshDisablesBoardManagementAndPreservesSnapshot() async {
+        let client = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
+            )),
+            .failure(APIError.network(underlying: URLError(.notConnectedToInternet)))
+        ])
+        let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
+        await state.load()
+        let loadedCards = state.allCards
+
+        await state.refresh()
+
+        XCTAssertTrue(state.isOffline)
+        XCTAssertTrue(state.loadedDetailIsStale)
+        XCTAssertEqual(state.allCards, loadedCards)
+        XCTAssertFalse(state.canManageBoards)
+        XCTAssertFalse(state.refreshFailed)
+    }
+
+    func testBoardManagementStateRemainsIsolatedPerServer() async {
+        let firstClient = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
+            )),
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"main","name":"Main"},{"slug":"release","name":"Release"}],"current":"main","read_only":false}"#
+            ))
+        ])
+        let secondClient = BoardManagementClient(boardsResponses: [
+            .success(mutationDecode(
+                #"{"boards":[{"slug":"personal","name":"Personal"}],"current":"personal","read_only":false}"#
+            ))
+        ])
+        let first = KanbanFeatureState(
+            server: URL(string: "https://first.example.test")!,
+            client: firstClient
+        )
+        let second = KanbanFeatureState(
+            server: URL(string: "https://second.example.test")!,
+            client: secondClient
+        )
+        await first.load()
+        await second.load()
+
+        await first.createBoard(KanbanCreateBoardRequest(
+            slug: "release",
+            name: "Release",
+            description: "",
+            icon: "",
+            color: ""
+        ))
+
+        XCTAssertTrue(first.boards.contains { $0.slug == "release" })
+        XCTAssertEqual(second.boards.map(\.slug), ["personal"])
+        XCTAssertEqual(second.selectedBoardSlug, "personal")
+        let secondCreateRequestCount = await secondClient.createRequestCount
+        XCTAssertEqual(secondCreateRequestCount, 0)
+    }
+
     func testAmbiguousBoardWriteChecksAuthoritativeListAndDefaultArchiveIsBlocked() async {
         let client = BoardManagementClient(
             boardsResponses: [
@@ -1133,6 +1240,8 @@ private actor KanbanClientStub: KanbanDataClient {
 private actor BoardManagementClient: KanbanDataClient {
     private var boardsResponses: [Result<KanbanBoardsResponse, Error>]
     private let createResult: Result<KanbanBoardMutationEnvelope, Error>
+    private let configuration: KanbanConfiguration
+    private let boardSnapshot: KanbanBoardSnapshot
     private var createContinuation: CheckedContinuation<Void, Never>?
     private let defersCreate: Bool
     private var shouldDeferCreate: Bool
@@ -1149,15 +1258,19 @@ private actor BoardManagementClient: KanbanDataClient {
         createResult: Result<KanbanBoardMutationEnvelope, Error> = .success(
             mutationDecode(#"{"board":{"slug":"release"},"current":"main","read_only":false}"#)
         ),
+        configuration: KanbanConfiguration = KanbanFixtures.configuration,
+        boardSnapshot: KanbanBoardSnapshot = KanbanFixtures.richSnapshot,
         defersCreate: Bool = false
     ) {
         self.boardsResponses = boardsResponses
         self.createResult = createResult
+        self.configuration = configuration
+        self.boardSnapshot = boardSnapshot
         self.defersCreate = defersCreate
         shouldDeferCreate = defersCreate
     }
 
-    func kanbanConfiguration() -> KanbanConfiguration { KanbanFixtures.configuration }
+    func kanbanConfiguration() -> KanbanConfiguration { configuration }
 
     func kanbanBoards() throws -> KanbanBoardsResponse {
         if boardsResponses.count > 1 {
@@ -1168,7 +1281,7 @@ private actor BoardManagementClient: KanbanDataClient {
 
     func kanbanBoard(_ request: KanbanBoardRequest) -> KanbanBoardSnapshot {
         recordedBoardRequests.append(request)
-        return KanbanFixtures.richSnapshot
+        return boardSnapshot
     }
 
     func kanbanStats(board: String) -> KanbanStats { KanbanFixtures.stats }

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -998,7 +998,7 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(createRequestCount, 0)
     }
 
-    func testOfflineBoardCollectionRefreshDisablesBoardManagementAndPreservesSnapshot() async {
+    func testNetworkBoardCollectionFailureRefreshesSelectedBoardAndKeepsWritesDisabled() async {
         let client = BoardManagementClient(boardsResponses: [
             .success(mutationDecode(
                 #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
@@ -1011,14 +1011,14 @@ final class KanbanFeatureStateTests: XCTestCase {
 
         await state.refresh()
 
-        XCTAssertTrue(state.isOffline)
-        XCTAssertTrue(state.loadedDetailIsStale)
+        XCTAssertFalse(state.isOffline)
+        XCTAssertFalse(state.loadedDetailIsStale)
         XCTAssertEqual(state.allCards, loadedCards)
         XCTAssertFalse(state.canManageBoards)
-        XCTAssertFalse(state.refreshFailed)
+        XCTAssertTrue(state.refreshFailed)
     }
 
-    func testIncompleteBoardCollectionRefreshReportsFailureAndPreservesSnapshot() async {
+    func testIncompleteBoardCollectionRefreshesSelectedBoardButKeepsWritesDisabled() async {
         let client = BoardManagementClient(boardsResponses: [
             .success(mutationDecode(
                 #"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#
@@ -1026,16 +1026,18 @@ final class KanbanFeatureStateTests: XCTestCase {
             .success(mutationDecode(
                 #"{"current":"main","read_only":false}"#
             ))
-        ])
+        ], refreshBoardSnapshot: mutationDecode(
+            #"{"changed":true,"latest_event_id":12,"read_only":false,"columns":[{"name":"ready","tasks":[{"id":"REFRESHED","status":"ready"}]}]}"#
+        ))
         let state = KanbanFeatureState(server: URL(string: "https://example.test")!, client: client)
         await state.load()
-        let loadedCards = state.allCards
 
         await state.refresh()
 
         XCTAssertFalse(state.isOffline)
         XCTAssertTrue(state.refreshFailed)
-        XCTAssertEqual(state.allCards, loadedCards)
+        XCTAssertEqual(state.allCards.map(\.cardID), ["REFRESHED"])
+        XCTAssertFalse(state.canUseServerAuthoritativeActions)
         XCTAssertFalse(state.canManageBoards)
     }
 
@@ -1310,7 +1312,7 @@ private actor BoardManagementClient: KanbanDataClient {
     private var boardsResponses: [Result<KanbanBoardsResponse, Error>]
     private let createResult: Result<KanbanBoardMutationEnvelope, Error>
     private let configuration: KanbanConfiguration
-    private let boardSnapshot: KanbanBoardSnapshot
+    private var boardSnapshots: [KanbanBoardSnapshot]
     private var createContinuation: CheckedContinuation<Void, Never>?
     private let defersCreate: Bool
     private var shouldDeferCreate: Bool
@@ -1330,12 +1332,16 @@ private actor BoardManagementClient: KanbanDataClient {
         ),
         configuration: KanbanConfiguration = KanbanFixtures.configuration,
         boardSnapshot: KanbanBoardSnapshot = KanbanFixtures.richSnapshot,
+        refreshBoardSnapshot: KanbanBoardSnapshot? = nil,
         defersCreate: Bool = false
     ) {
         self.boardsResponses = boardsResponses
         self.createResult = createResult
         self.configuration = configuration
-        self.boardSnapshot = boardSnapshot
+        boardSnapshots = [boardSnapshot]
+        if let refreshBoardSnapshot {
+            boardSnapshots.append(refreshBoardSnapshot)
+        }
         self.defersCreate = defersCreate
         shouldDeferCreate = defersCreate
     }
@@ -1352,7 +1358,10 @@ private actor BoardManagementClient: KanbanDataClient {
 
     func kanbanBoard(_ request: KanbanBoardRequest) -> KanbanBoardSnapshot {
         recordedBoardRequests.append(request)
-        return boardSnapshot
+        if boardSnapshots.count > 1 {
+            return boardSnapshots.removeFirst()
+        }
+        return boardSnapshots[0]
     }
 
     func kanbanStats(board: String) -> KanbanStats { KanbanFixtures.stats }

--- a/HermesMobileTests/KanbanLiveUpdateTests.swift
+++ b/HermesMobileTests/KanbanLiveUpdateTests.swift
@@ -117,6 +117,29 @@ final class KanbanLiveUpdateTests: XCTestCase {
         state.setVisible(false)
     }
 
+    func testForegroundBoardCollectionFailureStillRefreshesAndRestartsStream() async {
+        let client = LiveKanbanClient(
+            boardResults: [.success(.rich), .success(.newer)],
+            boardsResults: [.success(.single), .success(.incomplete)]
+        )
+        let stream = KanbanStreamSpy()
+        let state = makeState(client: client, stream: stream)
+
+        await state.load()
+        state.setVisible(true)
+        await state.setSceneActive(false)
+
+        await state.setSceneActive(true)
+
+        let boardCallCount = await client.boardCallCount
+        XCTAssertEqual(boardCallCount, 2)
+        XCTAssertEqual(state.snapshot?.latestEventID, 13)
+        XCTAssertEqual(stream.startURLs.count, 2)
+        XCTAssertTrue(state.refreshFailed)
+        XCTAssertFalse(state.canUseServerAuthoritativeActions)
+        state.setVisible(false)
+    }
+
     func testForegroundRefreshCannotStopNewBoardStreamAfterBoardSwitch() async throws {
         let client = ForegroundBoardSwitchClient()
         let stream = KanbanStreamSpy()
@@ -339,7 +362,7 @@ private final class KanbanStreamSpy: KanbanEventStreamingClient {
 }
 
 private actor LiveKanbanClient: KanbanDataClient {
-    private let boards: KanbanBoardsResponse
+    private var boardsResults: [Result<KanbanBoardsResponse, Error>]
     private var boardResults: [Result<KanbanBoardSnapshot, Error>]
     private let eventsResult: Result<KanbanEventsEnvelope, Error>
     private(set) var boardRequests: [KanbanBoardRequest] = []
@@ -350,9 +373,10 @@ private actor LiveKanbanClient: KanbanDataClient {
     init(
         boards: KanbanBoardsResponse = .single,
         boardResults: [Result<KanbanBoardSnapshot, Error>],
-        eventsResult: Result<KanbanEventsEnvelope, Error> = .success(.events(cursor: 11))
+        eventsResult: Result<KanbanEventsEnvelope, Error> = .success(.events(cursor: 11)),
+        boardsResults: [Result<KanbanBoardsResponse, Error>]? = nil
     ) {
-        self.boards = boards
+        self.boardsResults = boardsResults ?? [.success(boards)]
         self.boardResults = boardResults
         self.eventsResult = eventsResult
     }
@@ -360,7 +384,13 @@ private actor LiveKanbanClient: KanbanDataClient {
     var boardCallCount: Int { boardRequests.count }
 
     func kanbanConfiguration() -> KanbanConfiguration { .liveConfiguration }
-    func kanbanBoards() -> KanbanBoardsResponse { boards }
+    func kanbanBoards() throws -> KanbanBoardsResponse {
+        guard !boardsResults.isEmpty else { return .single }
+        if boardsResults.count > 1 {
+            return try boardsResults.removeFirst().get()
+        }
+        return try boardsResults[0].get()
+    }
 
     func kanbanBoard(_ request: KanbanBoardRequest) throws -> KanbanBoardSnapshot {
         boardRequests.append(request)
@@ -430,6 +460,7 @@ private extension KanbanConfiguration {
 private extension KanbanBoardsResponse {
     static let single: Self = decode(#"{"boards":[{"slug":"main","name":"Main"}],"current":"main","read_only":false}"#)
     static let multiple: Self = decode(#"{"boards":[{"slug":"main","name":"Main"},{"slug":"release","name":"Release"}],"current":"main","read_only":false}"#)
+    static let incomplete: Self = decode(#"{"current":"main","read_only":false}"#)
 }
 
 private extension KanbanBoardSnapshot {

--- a/HermesMobileTests/LocalizationCatalogTests.swift
+++ b/HermesMobileTests/LocalizationCatalogTests.swift
@@ -186,4 +186,36 @@ final class LocalizationCatalogTests: XCTestCase {
             }
         }
     }
+
+    func testKanbanBoardManagementCopyIsLocalizedInEveryShippedLanguage() throws {
+        let data = try Data(contentsOf: catalogURL())
+        let root = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let strings = try XCTUnwrap(root["strings"] as? [String: Any])
+        let boardKeys = [
+            "Browsing",
+            "Browsing a Board stays local to Hermex. Making a Board active changes shared server state.",
+            "Creating a Board does not make it active.",
+            "Hermex cannot restore an archived Board in-app.",
+            "Icon",
+            "Make Active Board",
+            "Making this Board active changes shared server state for other Hermes clients.",
+            "Slug",
+            "The slug cannot be changed after the Board is created.",
+            "Updating Board..."
+        ]
+
+        for key in boardKeys {
+            let entry = try XCTUnwrap(strings[key] as? [String: Any], key)
+            let localizations = try XCTUnwrap(entry["localizations"] as? [String: Any], key)
+            for language in Self.shippedLanguages {
+                let localization = try XCTUnwrap(
+                    localizations[language] as? [String: Any],
+                    "[\(language)] \(key)"
+                )
+                XCTAssertTrue(hasNonEmptyValue(localization), "[\(language)] \(key) is empty")
+                let translatedValue = (localization["stringUnit"] as? [String: Any])?["value"] as? String
+                XCTAssertNotEqual(translatedValue, key, "[\(language)] \(key) still uses English")
+            }
+        }
+    }
 }

--- a/HermesMobileTests/LocalizationCatalogTests.swift
+++ b/HermesMobileTests/LocalizationCatalogTests.swift
@@ -192,8 +192,12 @@ final class LocalizationCatalogTests: XCTestCase {
         let root = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
         let strings = try XCTUnwrap(root["strings"] as? [String: Any])
         let boardKeys = [
+            "Browse Board",
+            "Browse Board: %@",
             "Browsing",
             "Browsing a Board stays local to Hermex. Making a Board active changes shared server state.",
+            "Check Result",
+            "Choose Board",
             "Creating a Board does not make it active.",
             "Hermex cannot restore an archived Board in-app.",
             "Icon",
@@ -201,6 +205,7 @@ final class LocalizationCatalogTests: XCTestCase {
             "Making this Board active changes shared server state for other Hermes clients.",
             "Slug",
             "The slug cannot be changed after the Board is created.",
+            "This Board no longer exists. Choose another Board.",
             "Updating Board..."
         ]
 


### PR DESCRIPTION
Closes #156

## What changed

- add verified Create, Edit, Archive, and Make Active Board requests
- keep local Board browsing independent from the server-global active Board
- serialize Board-wide writes and reconcile the authoritative Board list/current pointer after every result or ambiguity
- recover safely when the browsed Board is removed, including a validated compatibility handshake before reporting readiness
- add localized Board management forms, confirmations, progress/result states, recovery copy, and distinct VoiceOver labels for local browsing versus shared activation
- prevent editor submission while a Board write outcome is still uncertain

## Why

Hermex needs native Board administration without changing other clients’ shared active Board as a side effect of local navigation. The review follow-up also corrected a recovery path that previously marked the server compatible without validating an available Board snapshot, removed duplicated recovery messaging, and made uncertain-write behavior explicit.

## User impact

Users can create and edit Board metadata, archive non-default Boards, explicitly change the shared active Board, and browse a different Board locally. Timeout and disconnect outcomes reconcile against server state instead of blindly retrying. If a Board disappears remotely, Hermex presents one named recovery state and asks the user to choose another Board.

## Validation

- focused Kanban feature-state and localization suites: 51 passed, 0 failed
- full XCTest suite: 1,486 passed, 0 failed, 0 skipped (`-parallel-testing-enabled NO`)
- `git diff --check`
- signed Debug build and launch on iPhone 17 simulator with `--kanban-lab`
- owner manually validated the original Board-management flow before the review-fix commit