### PR TITLE
fix: deep-linked session loses race to last-session restore

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -1119,14 +1119,19 @@ struct SessionListView: View {
     /// `restoreLastSelectedSessionIfNeeded()` — otherwise the restore races the deep
     /// link's network load and wins with the previous session.
     private func openPendingDeepLinkedSessionIfNeeded() async {
-        guard !Task.isCancelled,
-              let sessionID = pendingDeepLinkedSessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !sessionID.isEmpty
-        else {
-            return
-        }
+        guard !Task.isCancelled else { return }
 
-        pendingDeepLinkedSessionID = nil
+        while let sessionID = navigationState.beginDeepLinkedSessionLoad(
+            id: pendingDeepLinkedSessionID
+        ) {
+            pendingDeepLinkedSessionID = nil
+            await openDeepLinkedSession(id: sessionID)
+            navigationState.finishDeepLinkedSessionLoad(id: sessionID)
+            guard !Task.isCancelled else { return }
+        }
+    }
+
+    private func openDeepLinkedSession(id sessionID: String) async {
         if let loadedSession = viewModel.sessions.first(where: { $0.sessionId == sessionID }) {
             selectSession(loadedSession)
             return

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -191,13 +191,18 @@ struct SessionListView: View {
                 AddServerView(authManager: authManager)
             }
             .task {
-                // Resolved first, not merely before the restore: the link needs only
-                // the cache or a single session fetch, so gating it behind the
-                // session/project/profile chain would delay the very navigation the
-                // notification asked for.
-                await openPendingDeepLinkedSessionIfNeeded()
-                guard !Task.isCancelled else { return }
-                await refreshSessionsAndActiveProfile()
+                // Start the normal refresh immediately so a slow direct session
+                // request cannot leave the sidebar empty. Deep-link resolution still
+                // owns navigation precedence and is awaited before stored selection
+                // restoration.
+                await SessionListInitialLoad.run(
+                    resolvePendingDeepLink: {
+                        await openPendingDeepLinkedSessionIfNeeded()
+                    },
+                    refreshSessionsAndActiveProfile: {
+                        await refreshSessionsAndActiveProfile()
+                    }
+                )
                 guard !Task.isCancelled else { return }
                 didCompleteInitialLoad = true
                 // Ordered after the deep link so restoreIfNeeded() sees the explicit
@@ -1196,6 +1201,18 @@ struct SessionListView: View {
         SessionNavigationPersistence.save(navigationState.lastSelectedSessionID, for: server)
     }
 
+}
+
+enum SessionListInitialLoad {
+    @MainActor
+    static func run(
+        resolvePendingDeepLink: @escaping @MainActor () async -> Void,
+        refreshSessionsAndActiveProfile: @escaping @MainActor () async -> Void
+    ) async {
+        async let initialRefresh: Void = refreshSessionsAndActiveProfile()
+        await resolvePendingDeepLink()
+        await initialRefresh
+    }
 }
 
 struct HermesHeaderLogo: View {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -191,8 +191,17 @@ struct SessionListView: View {
                 AddServerView(authManager: authManager)
             }
             .task {
+                // Resolved first, not merely before the restore: the link needs only
+                // the cache or a single session fetch, so gating it behind the
+                // session/project/profile chain would delay the very navigation the
+                // notification asked for.
+                await openPendingDeepLinkedSessionIfNeeded()
+                guard !Task.isCancelled else { return }
                 await refreshSessionsAndActiveProfile()
+                guard !Task.isCancelled else { return }
                 didCompleteInitialLoad = true
+                // Ordered after the deep link so restoreIfNeeded() sees the explicit
+                // destination and leaves the stored selection alone.
                 restoreLastSelectedSessionIfNeeded()
             }
             .task(id: remoteSearchTaskID) {
@@ -203,7 +212,6 @@ struct SessionListView: View {
             }
             .onAppear {
                 openPendingSharedImportIfNeeded()
-                openPendingDeepLinkedSessionIfNeeded()
                 openRequestedNewChatIfNeeded()
                 refreshAfterReturningIfNeeded()
             }
@@ -211,7 +219,7 @@ struct SessionListView: View {
                 openPendingSharedImportIfNeeded()
             }
             .onChange(of: pendingDeepLinkedSessionID) {
-                openPendingDeepLinkedSessionIfNeeded()
+                Task { await openPendingDeepLinkedSessionIfNeeded() }
             }
             .onChange(of: requestedNewChat) {
                 openRequestedNewChatIfNeeded()
@@ -1107,8 +1115,12 @@ struct SessionListView: View {
         )
     }
 
-    private func openPendingDeepLinkedSessionIfNeeded() {
-        guard let sessionID = pendingDeepLinkedSessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+    /// Awaited (not fire-and-forget) so the cold-start `.task` can resolve it before
+    /// `restoreLastSelectedSessionIfNeeded()` — otherwise the restore races the deep
+    /// link's network load and wins with the previous session.
+    private func openPendingDeepLinkedSessionIfNeeded() async {
+        guard !Task.isCancelled,
+              let sessionID = pendingDeepLinkedSessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
               !sessionID.isEmpty
         else {
             return
@@ -1120,12 +1132,16 @@ struct SessionListView: View {
             return
         }
 
-        Task {
-            if let session = await viewModel.loadSessionForDeepLink(id: sessionID, modelContext: modelContext) {
-                selectSession(session)
-            }
-            handleLastError()
+        let session = await viewModel.loadSessionForDeepLink(id: sessionID, modelContext: modelContext)
+        // Re-checked post-await: the view (and this task) may have been torn down —
+        // e.g. dismissed, or the active server changed under `.id(server)` — while
+        // the network load was in flight. Selecting or persisting for a session
+        // whose owning view no longer exists is stale work, not a real navigation.
+        guard !Task.isCancelled else { return }
+        if let session {
+            selectSession(session)
         }
+        handleLastError()
     }
 
     /// Opens the New Chat composer in response to the "New Chat" App Intents (#337/#338),
@@ -1165,7 +1181,8 @@ struct SessionListView: View {
     private func restoreLastSelectedSessionIfNeeded() {
         navigationState.restoreIfNeeded(
             from: viewModel.sessions,
-            clearsMissingSelection: viewModel.sessionLoadError == nil
+            clearsMissingSelection: viewModel.sessionLoadError == nil,
+            pendingDeepLinkedSessionID: pendingDeepLinkedSessionID
         )
         persistLastSelectedSession()
     }

--- a/HermesMobile/Features/SessionList/SessionNavigationState.swift
+++ b/HermesMobile/Features/SessionList/SessionNavigationState.swift
@@ -66,11 +66,18 @@ struct SessionNavigationState: Equatable {
 
     /// Restores only when no explicit route already won. Deep links, shared drafts,
     /// and App Intent requests therefore take precedence over the stored selection.
+    /// A still-pending deep link (not yet resolved into a destination) also blocks
+    /// the restore, so an in-flight deep-link load is never pre-empted by the
+    /// stored selection; the stored ID is kept for a later restore.
     mutating func restoreIfNeeded(
         from sessions: [SessionSummary],
-        clearsMissingSelection: Bool = true
+        clearsMissingSelection: Bool = true,
+        pendingDeepLinkedSessionID: String? = nil
     ) {
-        guard destination == nil, let lastSelectedSessionID else { return }
+        guard destination == nil,
+              Self.normalized(pendingDeepLinkedSessionID) == nil,
+              let lastSelectedSessionID
+        else { return }
 
         guard let session = sessions.first(where: {
             Self.normalized($0.sessionId) == lastSelectedSessionID

--- a/HermesMobile/Features/SessionList/SessionNavigationState.swift
+++ b/HermesMobile/Features/SessionList/SessionNavigationState.swift
@@ -18,6 +18,7 @@ struct SessionNavigationState: Equatable {
     private(set) var lastSelectedSessionID: String?
     private(set) var rootRevision = 0
     private var newChatSessionID: String?
+    private var deepLinkedSessionLoadID: String?
 
     init(lastSelectedSessionID: String? = nil) {
         self.lastSelectedSessionID = Self.normalized(lastSelectedSessionID)
@@ -64,17 +65,32 @@ struct SessionNavigationState: Equatable {
         newChatSessionID = nil
     }
 
+    mutating func beginDeepLinkedSessionLoad(id: String?) -> String? {
+        guard deepLinkedSessionLoadID == nil,
+              let sessionID = Self.normalized(id)
+        else { return nil }
+
+        deepLinkedSessionLoadID = sessionID
+        return sessionID
+    }
+
+    mutating func finishDeepLinkedSessionLoad(id: String?) {
+        guard Self.normalized(id) == deepLinkedSessionLoadID else { return }
+        deepLinkedSessionLoadID = nil
+    }
+
     /// Restores only when no explicit route already won. Deep links, shared drafts,
     /// and App Intent requests therefore take precedence over the stored selection.
-    /// A still-pending deep link (not yet resolved into a destination) also blocks
-    /// the restore, so an in-flight deep-link load is never pre-empted by the
-    /// stored selection; the stored ID is kept for a later restore.
+    /// A pending or in-flight deep link (not yet resolved into a destination) also
+    /// blocks the restore, so its network load is never pre-empted by the stored
+    /// selection; the stored ID is kept for a later restore.
     mutating func restoreIfNeeded(
         from sessions: [SessionSummary],
         clearsMissingSelection: Bool = true,
         pendingDeepLinkedSessionID: String? = nil
     ) {
         guard destination == nil,
+              deepLinkedSessionLoadID == nil,
               Self.normalized(pendingDeepLinkedSessionID) == nil,
               let lastSelectedSessionID
         else { return }

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -78,6 +78,30 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertEqual(state.destination, .session(stored))
     }
 
+    func testInitialRefreshStartsBeforeDelayedDeepLinkFinishes() async {
+        let recorder = SessionInitialLoadEventRecorder()
+
+        await SessionListInitialLoad.run(
+            resolvePendingDeepLink: {
+                await recorder.record(.deepLinkStarted)
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                await recorder.record(.deepLinkFinished)
+            },
+            refreshSessionsAndActiveProfile: {
+                await recorder.record(.refreshStarted)
+            }
+        )
+
+        let events = await recorder.snapshot()
+        guard let refreshIndex = events.firstIndex(of: .refreshStarted),
+              let deepLinkFinishIndex = events.firstIndex(of: .deepLinkFinished)
+        else {
+            return XCTFail("Expected both refresh and deep-link completion events")
+        }
+
+        XCTAssertLessThan(refreshIndex, deepLinkFinishIndex)
+    }
+
     func testExplicitNewChatRouteOverridesStoredSelection() {
         let route = PendingNewChatRoute(initialDraft: "Shared draft")
         var state = SessionNavigationState(lastSelectedSessionID: "session-1")
@@ -199,5 +223,23 @@ final class SessionNavigationStateTests: XCTestCase {
             SessionNavigationPersistence.load(for: secondServer, defaults: defaults),
             "second-session"
         )
+    }
+}
+
+private actor SessionInitialLoadEventRecorder {
+    enum Event: Equatable {
+        case deepLinkStarted
+        case refreshStarted
+        case deepLinkFinished
+    }
+
+    private var events: [Event] = []
+
+    func record(_ event: Event) {
+        events.append(event)
+    }
+
+    func snapshot() -> [Event] {
+        events
     }
 }

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -52,6 +52,23 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertEqual(state.lastSelectedSessionID, "stored")
     }
 
+    func testRestoreSkipsAfterPendingDeepLinkIsConsumedWhileLoadIsInFlight() {
+        let stored = SessionSummary(sessionId: "stored")
+        var state = SessionNavigationState(lastSelectedSessionID: "stored")
+
+        let deepLinkedSessionID = state.beginDeepLinkedSessionLoad(id: "deep-linked")
+        state.restoreIfNeeded(from: [stored], pendingDeepLinkedSessionID: nil)
+
+        XCTAssertEqual(deepLinkedSessionID, "deep-linked")
+        XCTAssertNil(state.destination)
+        XCTAssertEqual(state.lastSelectedSessionID, "stored")
+
+        state.finishDeepLinkedSessionLoad(id: deepLinkedSessionID)
+        state.restoreIfNeeded(from: [stored], pendingDeepLinkedSessionID: nil)
+
+        XCTAssertEqual(state.destination, .session(stored))
+    }
+
     func testRestoreProceedsWhenPendingDeepLinkIDIsBlank() {
         let stored = SessionSummary(sessionId: "stored")
         var state = SessionNavigationState(lastSelectedSessionID: "stored")

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -42,6 +42,25 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertEqual(state.lastSelectedSessionID, "session-1")
     }
 
+    func testRestoreSkipsWhileDeepLinkIsPendingAndKeepsStoredSelection() {
+        let stored = SessionSummary(sessionId: "stored")
+        var state = SessionNavigationState(lastSelectedSessionID: "stored")
+
+        state.restoreIfNeeded(from: [stored], pendingDeepLinkedSessionID: "deep-linked")
+
+        XCTAssertNil(state.destination)
+        XCTAssertEqual(state.lastSelectedSessionID, "stored")
+    }
+
+    func testRestoreProceedsWhenPendingDeepLinkIDIsBlank() {
+        let stored = SessionSummary(sessionId: "stored")
+        var state = SessionNavigationState(lastSelectedSessionID: "stored")
+
+        state.restoreIfNeeded(from: [stored], pendingDeepLinkedSessionID: "   ")
+
+        XCTAssertEqual(state.destination, .session(stored))
+    }
+
     func testExplicitNewChatRouteOverridesStoredSelection() {
         let route = PendingNewChatRoute(initialDraft: "Shared draft")
         var state = SessionNavigationState(lastSelectedSessionID: "session-1")


### PR DESCRIPTION
Fixes #192

## Summary

- Resolve a pending deep-link session inside the cold-start `.task`, awaited
  ahead of `restoreLastSelectedSessionIfNeeded()`, instead of firing it from
  `.onAppear` as an unstructured `Task { }`. The deep link's network round-trip
  no longer races the stored-session restore.
- `SessionNavigationState.restoreIfNeeded()` now also skips (keeping the
  stored ID for a later restore) while a pending deep-link session ID exists,
  closing the secondary window where a link arrives mid-refresh via
  `onChange(of: pendingDeepLinkedSessionID)`.
- Added `SessionNavigationStateTests` coverage for the new pending-deep-link
  guard, including the blank/whitespace-ID edge case.

## Test plan

- [x] Full `HermesMobileTests` suite on iPhone 17 simulator — 1475 passed, 0 failed.
- [x] Signed Debug build installed on a physical iPhone; cold-started via a
      real ntfy push notification deep link (`hermes-agent://session?id=...`)
      while a different session was last-selected — opens directly on the
      deep-linked session with no flash of the previous one.