### PR TITLE
Refine Kanban card row affordances

### DIFF
--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -8,6 +8,16 @@ enum KanbanCardAction: Equatable {
     case archive
 }
 
+enum KanbanCardRowPrimaryAction: Equatable {
+    case openDetail(String)
+    case toggleSelection(String)
+
+    static func resolve(for card: KanbanCard, isSelecting: Bool) -> Self? {
+        guard let cardID = card.cardID else { return nil }
+        return isSelecting ? .toggleSelection(cardID) : .openDetail(cardID)
+    }
+}
+
 struct KanbanPendingCardAction: Identifiable, Equatable {
     let id = UUID()
     let card: KanbanCard
@@ -29,6 +39,7 @@ struct KanbanStatusFocusView: View {
     @State private var showsBulkActions = false
     @State private var confirmsBulkArchive = false
     @State private var confirmsRunDispatcher = false
+    @State private var presentedCardID: String?
     @AccessibilityFocusState private var focusedCardID: String?
     @AccessibilityFocusState private var archiveUndoIsFocused: Bool
     @AccessibilityFocusState private var selectionControlsAreFocused: Bool
@@ -67,6 +78,9 @@ struct KanbanStatusFocusView: View {
                     systemImage: "exclamationmark.triangle"
                 )
             }
+        }
+        .navigationDestination(item: $presentedCardID) { cardID in
+            KanbanCardDetailView(featureModel: model, cardID: cardID)
         }
         .navigationTitle(String(localized: "Kanban"))
         .navigationBarTitleDisplayMode(.inline)
@@ -122,6 +136,13 @@ struct KanbanStatusFocusView: View {
         .onChange(of: model.dispatchState?.phase) { oldPhase, newPhase in
             if oldPhase?.isInFlight == true, newPhase?.isInFlight == false {
                 dispatchSummaryIsFocused = true
+            }
+        }
+        .onChange(of: presentedCardID) { previousCardID, currentCardID in
+            guard currentCardID == nil, let previousCardID else { return }
+            Task { @MainActor in
+                await Task.yield()
+                focusedCardID = previousCardID
             }
         }
         .alert(
@@ -762,8 +783,7 @@ struct KanbanStatusFocusView: View {
     private func cardNavigationLink(_ card: KanbanCard) -> some View {
         if model.isSelectingCards {
             Button {
-                model.toggleCardSelection(card)
-                selectionControlsAreFocused = true
+                activateCard(card)
             } label: {
                 HStack(spacing: 12) {
                     Image(systemName: model.selectedCardIDs.contains(card.cardID ?? "")
@@ -788,20 +808,38 @@ struct KanbanStatusFocusView: View {
                     : AccessibilityTraits()
             )
         } else {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
-                NavigationLink {
-                    if let cardID = card.cardID {
-                        KanbanCardDetailView(featureModel: model, cardID: cardID)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .top, spacing: 4) {
+                    Button {
+                        activateCard(card)
+                    } label: {
+                        KanbanCardSummaryView(card: card)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
                     }
-                } label: {
-                    KanbanCardSummaryView(card: card)
+                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                    .disabled(card.cardID == nil)
+                    .accessibilityLabel(KanbanCardAccessibility.summary(card))
+                    .accessibilityFocused($focusedCardID, equals: card.cardID)
+
+                    cardActionsMenu(card)
                 }
-                cardActionsMenu(card)
+                mutationStatus(for: card)
             }
-            mutationStatus(for: card)
         }
-        .accessibilityFocused($focusedCardID, equals: card.cardID)
+    }
+
+    private func activateCard(_ card: KanbanCard) {
+        switch KanbanCardRowPrimaryAction.resolve(for: card, isSelecting: model.isSelectingCards) {
+        case let .openDetail(cardID):
+            focusedCardID = cardID
+            presentedCardID = cardID
+        case .toggleSelection:
+            model.toggleCardSelection(card)
+            selectionControlsAreFocused = true
+        case nil:
+            break
         }
     }
 
@@ -1535,6 +1573,7 @@ private struct KanbanFiltersView: View {
 
 struct KanbanCardSummaryView: View {
     let card: KanbanCard
+    @ScaledMetric(relativeTo: .caption) private var stalenessIconSlot = 16
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -1551,9 +1590,15 @@ struct KanbanCardSummaryView: View {
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 4)
                 if let age = card.ageSeconds {
-                    Label(KanbanAgeFormatter.abbreviated(age), systemImage: stalenessImage)
+                    HStack(spacing: 3) {
+                        Image(systemName: stalenessImage)
+                            .frame(width: stalenessIconSlot)
+                        Text(KanbanAgeFormatter.abbreviated(age))
+                            .monospaced()
+                    }
                         .font(.caption)
                         .foregroundStyle(stalenessColor)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
             }
 
@@ -1569,8 +1614,13 @@ struct KanbanCardSummaryView: View {
             }
 
             ViewThatFits(in: .horizontal) {
-                HStack(spacing: 12) { metadataLabels }
-                VStack(alignment: .leading, spacing: 5) { metadataLabels }
+                HStack(spacing: 12) {
+                    metadataLabels(locksHorizontalSize: true)
+                }
+                VStack(alignment: .leading, spacing: 5) {
+                    metadataLabels(locksHorizontalSize: false)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .font(.caption)
             .foregroundStyle(.secondary)
@@ -1581,18 +1631,46 @@ struct KanbanCardSummaryView: View {
     }
 
     @ViewBuilder
-    private var metadataLabels: some View {
-        Label(card.assignee ?? String(localized: "Unassigned"), systemImage: "person")
+    private func metadataLabels(locksHorizontalSize: Bool) -> some View {
+        metadataLabel(
+            card.assignee ?? String(localized: "Unassigned"),
+            systemImage: "person",
+            locksHorizontalSize: locksHorizontalSize
+        )
         if let tenant = card.tenant, !tenant.isEmpty {
-            Label(tenant, systemImage: "building.2")
+            metadataLabel(
+                tenant,
+                systemImage: "building.2",
+                locksHorizontalSize: locksHorizontalSize
+            )
         }
         if let comments = card.commentCount, comments > 0 {
-            Label("\(comments)", systemImage: "bubble.left")
+            metadataLabel(
+                "\(comments)",
+                systemImage: "bubble.left",
+                locksHorizontalSize: locksHorizontalSize
+            )
         }
         let dependencies = (card.linkCounts?.parents ?? 0) + (card.linkCounts?.children ?? 0)
         if dependencies > 0 {
-            Label("\(dependencies)", systemImage: "link")
+            metadataLabel(
+                "\(dependencies)",
+                systemImage: "link",
+                locksHorizontalSize: locksHorizontalSize
+            )
         }
+    }
+
+    private func metadataLabel(
+        _ title: String,
+        systemImage: String,
+        locksHorizontalSize: Bool
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 3) {
+            Image(systemName: systemImage)
+            Text(title)
+        }
+        .fixedSize(horizontal: locksHorizontalSize, vertical: false)
     }
 
     private var stalenessImage: String {

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -815,12 +815,12 @@ struct KanbanStatusFocusView: View {
                     : AccessibilityTraits()
             )
         } else {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(alignment: .top, spacing: 4) {
+            ZStack(alignment: .trailing) {
+                VStack(alignment: .leading, spacing: 6) {
                     Button {
                         activateCard(card)
                     } label: {
-                        KanbanCardSummaryView(card: card)
+                        KanbanCardSummaryView(card: card, reservesTrailingActionSpace: true)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                     }
@@ -830,9 +830,10 @@ struct KanbanStatusFocusView: View {
                     .accessibilityLabel(KanbanCardAccessibility.summary(card))
                     .accessibilityFocused($focusedCardID, equals: card.cardID)
 
-                    cardActionsMenu(card)
+                    mutationStatus(for: card)
                 }
-                mutationStatus(for: card)
+
+                cardActionsMenu(card)
             }
         }
     }
@@ -875,8 +876,10 @@ struct KanbanStatusFocusView: View {
             }
         } label: {
             Image(systemName: "ellipsis.circle")
+                .foregroundStyle(.primary)
                 .frame(minWidth: 44, minHeight: 44)
         }
+        .tint(.primary)
         .disabled(!model.canMutateCard(card) || model.isMutatingCard(card.cardID))
         .accessibilityLabel(Text("Card Actions"))
     }
@@ -1580,6 +1583,7 @@ private struct KanbanFiltersView: View {
 
 struct KanbanCardSummaryView: View {
     let card: KanbanCard
+    var reservesTrailingActionSpace = false
     @ScaledMetric(relativeTo: .caption) private var stalenessIconSlot = 16
 
     var body: some View {
@@ -1612,12 +1616,14 @@ struct KanbanCardSummaryView: View {
             Text(card.title ?? String(localized: "Untitled Card"))
                 .font(.headline)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing, trailingActionInset)
 
             if let body = card.body, !body.isEmpty {
                 Text(markdownPreview(body))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .lineLimit(3)
+                    .padding(.trailing, trailingActionInset)
             }
 
             ViewThatFits(in: .horizontal) {
@@ -1631,10 +1637,15 @@ struct KanbanCardSummaryView: View {
             }
             .font(.caption)
             .foregroundStyle(.secondary)
+            .padding(.trailing, trailingActionInset)
         }
         .padding(.vertical, 6)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(KanbanCardAccessibility.summary(card))
+    }
+
+    private var trailingActionInset: CGFloat {
+        reservesTrailingActionSpace ? 44 : 0
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -16,6 +16,10 @@ enum KanbanCardRowPrimaryAction: Equatable {
         guard let cardID = card.cardID else { return nil }
         return isSelecting ? .toggleSelection(cardID) : .openDetail(cardID)
     }
+
+    static func focusTarget(afterDismissing cardID: String, visibleCards: [KanbanCard]) -> String? {
+        visibleCards.contains { $0.cardID == cardID } ? cardID : nil
+    }
 }
 
 struct KanbanPendingCardAction: Identifiable, Equatable {
@@ -142,7 +146,10 @@ struct KanbanStatusFocusView: View {
             guard currentCardID == nil, let previousCardID else { return }
             Task { @MainActor in
                 await Task.yield()
-                focusedCardID = previousCardID
+                focusedCardID = KanbanCardRowPrimaryAction.focusTarget(
+                    afterDismissing: previousCardID,
+                    visibleCards: model.visibleCards
+                )
             }
         }
         .alert(

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -329,6 +329,19 @@ final class KanbanFeatureStateTests: XCTestCase {
             KanbanCardRowPrimaryAction.resolve(for: card, isSelecting: true),
             .toggleSelection(cardID)
         )
+        XCTAssertEqual(
+            KanbanCardRowPrimaryAction.focusTarget(
+                afterDismissing: cardID,
+                visibleCards: [card]
+            ),
+            cardID
+        )
+        XCTAssertNil(
+            KanbanCardRowPrimaryAction.focusTarget(
+                afterDismissing: cardID,
+                visibleCards: []
+            )
+        )
 
         let missingIdentity: KanbanCard = mutationDecode(#"{"title":"Missing identity"}"#)
         XCTAssertNil(

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -317,6 +317,28 @@ final class KanbanFeatureStateTests: XCTestCase {
         )
     }
 
+    func testCardRowPrimaryActionKeepsNavigationAndSelectionDistinct() throws {
+        let card = try XCTUnwrap(KanbanFixtures.richSnapshot.columns?[1].cards?.first)
+        let cardID = try XCTUnwrap(card.cardID)
+
+        XCTAssertEqual(
+            KanbanCardRowPrimaryAction.resolve(for: card, isSelecting: false),
+            .openDetail(cardID)
+        )
+        XCTAssertEqual(
+            KanbanCardRowPrimaryAction.resolve(for: card, isSelecting: true),
+            .toggleSelection(cardID)
+        )
+
+        let missingIdentity: KanbanCard = mutationDecode(#"{"title":"Missing identity"}"#)
+        XCTAssertNil(
+            KanbanCardRowPrimaryAction.resolve(for: missingIdentity, isSelecting: false)
+        )
+        XCTAssertNil(
+            KanbanCardRowPrimaryAction.resolve(for: missingIdentity, isSelecting: true)
+        )
+    }
+
     func testStatusSpecificStalenessThresholds() {
         let cards = KanbanFixtures.stalenessSnapshot.columns?.flatMap { $0.cards ?? [] } ?? []
         XCTAssertEqual(cards.map(\.staleness), [


### PR DESCRIPTION
## Summary

- make the Card content region the primary detail-navigation target while keeping the 44pt ellipsis menu independent
- remove the chevron and preserve selection-mode behavior plus accessibility focus restoration after returning from detail
- align the nontruncating age indicator at the trailing edge and make metadata spacing / `ViewThatFits` fallback deliberate across mixed widths
- add narrow coverage proving browse navigation and selection toggling remain distinct

## Impact / root cause

The previous row embedded the summary in a `NavigationLink`, so its generated chevron competed with age/action affordances and constrained the primary hit region. Stock `Label` spacing and compressible horizontal metadata also produced uneven icon/value grouping and delayed the intended vertical fallback.

## Validation

- `git diff --check`
- focused Kanban XCTest: 57 passed, 0 failed
- localization catalog XCTest: 7 passed, 0 failed
- full XCTest rerun: 1,504 passed, 0 failed, 0 skipped
- signed Debug build and launch on dedicated iPhone 17 simulator
- agent visual spot checks: standard light, accessibility XXXL, Arabic RTL dark

## Owner checks before merge

Signed-simulator manual validation remains mandatory and is intentionally deferred until the owner returns. Please exercise every staleness state, mixed age widths, narrow/wide `ViewThatFits` behavior, Dynamic Type, RTL, VoiceOver semantics/focus, selection mode, per-card actions, and mutation status before merging.

No real Board, Dispatcher, production, or TestFlight state was touched. This PR does not implement #195 or #196.

Fixes #184
