### PR TITLE
Fix CJK IME composition clobbered by SwiftUI re-render

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		C13000000000000000000001 /* ChatVerticalScrollAxisGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13000000000000000000002 /* ChatVerticalScrollAxisGuardTests.swift */; };
 		C04100000000000000000001 /* ChatComposerConfigLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04100000000000000000002 /* ChatComposerConfigLoader.swift */; };
 		C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */; };
+		C04900000000000000000005 /* ComposerTextSynchronizationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04900000000000000000006 /* ComposerTextSynchronizationPolicyTests.swift */; };
 		C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */; };
 		C042A000000000000000001 /* ChatComposerSelectorControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000002 /* ChatComposerSelectorControls.swift */; };
 		C042A000000000000000003 /* ChatComposerSelectorSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000004 /* ChatComposerSelectorSheets.swift */; };
@@ -437,6 +438,7 @@
 		C13000000000000000000002 /* ChatVerticalScrollAxisGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVerticalScrollAxisGuardTests.swift; sourceTree = "<group>"; };
 		C04100000000000000000002 /* ChatComposerConfigLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerConfigLoader.swift; sourceTree = "<group>"; };
 		C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerConfigLoaderTests.swift; sourceTree = "<group>"; };
+		C04900000000000000000006 /* ComposerTextSynchronizationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTextSynchronizationPolicyTests.swift; sourceTree = "<group>"; };
 		C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerAttachmentStripView.swift; sourceTree = "<group>"; };
 		C042A000000000000000002 /* ChatComposerSelectorControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorControls.swift; sourceTree = "<group>"; };
 		C042A000000000000000004 /* ChatComposerSelectorSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorSheets.swift; sourceTree = "<group>"; };
@@ -780,6 +782,7 @@
 				C03270000000000000F102 /* APIClientSessionExportTests.swift */,
 				C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */,
 					C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */,
+					C04900000000000000000006 /* ComposerTextSynchronizationPolicyTests.swift */,
 					C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */,
 					C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */,
 					C0390000000000000000000E /* ChatViewModelSendTests.swift */,
@@ -1645,6 +1648,7 @@
 				C03270000000000000B102 /* APIClientSessionExportTests.swift in Sources */,
 				C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */,
 					C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */,
+					C04900000000000000000005 /* ComposerTextSynchronizationPolicyTests.swift in Sources */,
 					C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */,
 					C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */,
 					C0391000000000000000000E /* ChatViewModelSendTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -102,7 +102,7 @@ private struct ComposerTextView: UIViewRepresentable {
 
     func updateUIView(_ textView: PastingTextView, context: Context) {
         context.coordinator.onHeightChange = onHeightChange
-        if textView.text != text {
+        if textView.text != text, textView.markedTextRange == nil {
             textView.text = text
         }
         // Mirror the chat RTL toggle onto the text view itself (#259): SwiftUI's

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -102,7 +102,17 @@ private struct ComposerTextView: UIViewRepresentable {
 
     func updateUIView(_ textView: PastingTextView, context: Context) {
         context.coordinator.onHeightChange = onHeightChange
-        if textView.text != text, textView.markedTextRange == nil {
+        var shouldUpdateText = textView.text != text
+        if let markedRange = textView.markedTextRange, !text.isEmpty {
+            let start = textView.offset(from: textView.beginningOfDocument, to: markedRange.start)
+            let end = textView.offset(from: textView.beginningOfDocument, to: markedRange.end)
+            let nsText = textView.text as NSString
+            if start >= 0, end <= nsText.length, start <= end {
+                let committedText = nsText.replacingCharacters(in: NSRange(location: start, length: end - start), with: "")
+                shouldUpdateText = committedText != text
+            }
+        }
+        if shouldUpdateText {
             textView.text = text
         }
         // Mirror the chat RTL toggle onto the text view itself (#259): SwiftUI's

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -102,17 +102,19 @@ private struct ComposerTextView: UIViewRepresentable {
 
     func updateUIView(_ textView: PastingTextView, context: Context) {
         context.coordinator.onHeightChange = onHeightChange
-        var shouldUpdateText = textView.text != text
-        if let markedRange = textView.markedTextRange, !text.isEmpty {
+        var markedNSRange: NSRange?
+        if let markedRange = textView.markedTextRange {
             let start = textView.offset(from: textView.beginningOfDocument, to: markedRange.start)
             let end = textView.offset(from: textView.beginningOfDocument, to: markedRange.end)
-            let nsText = textView.text as NSString
-            if start >= 0, end <= nsText.length, start <= end {
-                let committedText = nsText.replacingCharacters(in: NSRange(location: start, length: end - start), with: "")
-                shouldUpdateText = committedText != text
+            if start >= 0, start <= end {
+                markedNSRange = NSRange(location: start, length: end - start)
             }
         }
-        if shouldUpdateText {
+        if ComposerTextSynchronizationPolicy.shouldApplyBoundText(
+            viewText: textView.text,
+            boundText: text,
+            markedRange: markedNSRange
+        ) {
             textView.text = text
         }
         // Mirror the chat RTL toggle onto the text view itself (#259): SwiftUI's
@@ -330,6 +332,30 @@ private struct ComposerTextView: UIViewRepresentable {
                 $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
             }
         }
+    }
+}
+
+/// Keeps external draft updates flowing without committing an active IME marked range.
+enum ComposerTextSynchronizationPolicy {
+    static func shouldApplyBoundText(
+        viewText: String,
+        boundText: String,
+        markedRange: NSRange?
+    ) -> Bool {
+        var shouldApply = viewText != boundText
+        guard let markedRange, !boundText.isEmpty else { return shouldApply }
+
+        let nsViewText = viewText as NSString
+        guard markedRange.location <= nsViewText.length,
+              markedRange.length <= nsViewText.length - markedRange.location else {
+            return shouldApply
+        }
+
+        let committedText = nsViewText.replacingCharacters(in: markedRange, with: "")
+        if committedText == boundText {
+            shouldApply = false
+        }
+        return shouldApply
     }
 }
 

--- a/HermesMobileTests/ComposerTextSynchronizationPolicyTests.swift
+++ b/HermesMobileTests/ComposerTextSynchronizationPolicyTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import HermesMobile
+
+final class ComposerTextSynchronizationPolicyTests: XCTestCase {
+    func testMatchingBoundTextDoesNotClobberActiveComposition() {
+        XCTAssertFalse(
+            ComposerTextSynchronizationPolicy.shouldApplyBoundText(
+                viewText: "자",
+                boundText: "자",
+                markedRange: NSRange(location: 0, length: 1)
+            )
+        )
+    }
+
+    func testCommittedBindingDoesNotClobberActiveComposition() {
+        XCTAssertFalse(
+            ComposerTextSynchronizationPolicy.shouldApplyBoundText(
+                viewText: "draft자",
+                boundText: "draft",
+                markedRange: NSRange(location: 5, length: 1)
+            )
+        )
+    }
+
+    func testExternalReplacementAppliesDuringActiveComposition() {
+        XCTAssertTrue(
+            ComposerTextSynchronizationPolicy.shouldApplyBoundText(
+                viewText: "draft자",
+                boundText: "replacement",
+                markedRange: NSRange(location: 5, length: 1)
+            )
+        )
+    }
+
+    func testExternalClearAppliesDuringActiveComposition() {
+        XCTAssertTrue(
+            ComposerTextSynchronizationPolicy.shouldApplyBoundText(
+                viewText: "draft자",
+                boundText: "",
+                markedRange: NSRange(location: 5, length: 1)
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- `ComposerTextView.updateUIView` unconditionally sets `textView.text = text` whenever the bound `text` differs from `textView.text`. SwiftUI calls `updateUIView` on any parent re-render (e.g. a streaming assistant response updating other state), not just when the user's own typing changed `text`.
- If this fires while the user is mid-composition (Korean/Chinese/Japanese IME marked text), it forces UIKit to commit the in-progress syllable early, splitting it into separate jamo/characters. Observed on iOS as: typing "자모음" renders as "ㅈㅏ모음" — only the character being composed at the moment of the re-render is affected, which matches the first character being the most common collision point (composition starts right as focus/streaming kicks off a re-render).
- Fix: skip the assignment while `textView.markedTextRange != nil` (an active IME composition), so an external re-render never clobbers in-flight marked text.

## Test plan
- [ ] Type Korean (or other CJK) text into the chat composer while a streaming response or other composer state change is happening in the background, confirm the composed syllable is no longer split
- [ ] Confirm normal external updates to `text` (e.g. clearing composer after send, programmatic edits) still apply correctly outside of active composition

Fixes #312