### PR TITLE
feat(kanban): activate normal navigation

### DIFF
--- a/HermesMobile/Features/Kanban/KanbanCardDetailState.swift
+++ b/HermesMobile/Features/Kanban/KanbanCardDetailState.swift
@@ -47,6 +47,7 @@ final class KanbanCardDetailState {
     private let client: any KanbanDataClient
     private let onAPIError: (Error) -> Void
     private let onDetailLoaded: (KanbanCardDetailEnvelope) -> Void
+    private let onCapabilityUnavailable: (KanbanWriteCapability) -> Void
     private var activeDetailLoadID: UUID?
     private var activeMutationID: UUID?
     private var lastReconciledRevision = -1
@@ -57,13 +58,15 @@ final class KanbanCardDetailState {
         board: String,
         client: any KanbanDataClient,
         onAPIError: @escaping (Error) -> Void = { _ in },
-        onDetailLoaded: @escaping (KanbanCardDetailEnvelope) -> Void = { _ in }
+        onDetailLoaded: @escaping (KanbanCardDetailEnvelope) -> Void = { _ in },
+        onCapabilityUnavailable: @escaping (KanbanWriteCapability) -> Void = { _ in }
     ) {
         self.cardID = cardID
         self.board = board
         self.client = client
         self.onAPIError = onAPIError
         self.onDetailLoaded = onDetailLoaded
+        self.onCapabilityUnavailable = onCapabilityUnavailable
     }
 
     var canSubmitDraft: Bool {
@@ -125,7 +128,12 @@ final class KanbanCardDetailState {
             guard activeMutationID == mutationID else { return }
             guard !isCancellation(error) else { return }
             forwardAuthentication(error)
-            if isNotFound(error) {
+            if KanbanEndpointCompatibility.isMissingCapability(error) {
+                onCapabilityUnavailable(.comments)
+                commentSubmission = .failed
+                pendingAttempt = nil
+                activeMutationID = nil
+            } else if isNotFound(error) {
                 pendingAttempt = nil
                 activeMutationID = nil
                 await reconcileMissingEntity(loadID: nil)

--- a/HermesMobile/Features/Kanban/KanbanCardDetailView.swift
+++ b/HermesMobile/Features/Kanban/KanbanCardDetailView.swift
@@ -74,7 +74,7 @@ private struct KanbanCardDetailContent: View {
                     guard let detail = state.detail else { return }
                     cardEditor = featureModel.makeEditCardEditorState(detail: detail)
                 }
-                .disabled(!featureModel.canMutateCards || state.loadState != .loaded)
+                .disabled(!featureModel.canEditCards || state.loadState != .loaded)
                 if let card = state.detail?.card {
                     cardActionsMenu(card)
                 }
@@ -83,7 +83,7 @@ private struct KanbanCardDetailContent: View {
         .sheet(item: $cardEditor) { editor in
             KanbanCardEditorView(
                 state: editor,
-                allowsMutation: featureModel.canMutateCards,
+                allowsMutation: featureModel.canEditCards,
                 onSaved: {
                     await featureModel.reconcileAfterCardMutation()
                     await state.refresh()
@@ -228,6 +228,8 @@ private struct KanbanCardDetailContent: View {
         } footer: {
             if !featureModel.canAddComments, featureModel.isOffline {
                 Text("Offline Data")
+            } else if featureModel.unavailableWriteCapabilities.contains(.comments) {
+                Text("Unavailable")
             } else if !featureModel.canAddComments {
                 Text("Read-only")
             }

--- a/HermesMobile/Features/Kanban/KanbanCardEditorState.swift
+++ b/HermesMobile/Features/Kanban/KanbanCardEditorState.swift
@@ -61,6 +61,7 @@ final class KanbanCardEditorState: Identifiable {
     private(set) var remoteCard: KanbanCard?
 
     private let client: any KanbanDataClient
+    private let onCapabilityUnavailable: (KanbanWriteCapability) -> Void
     private var baselineCard: KanbanCard?
     private let baselineMatchingCardIDs: Set<String>
     private var activeAttemptID: UUID?
@@ -82,7 +83,8 @@ final class KanbanCardEditorState: Identifiable {
         tenantOptions: [String] = [],
         prerequisiteOptions: [KanbanCard] = [],
         baselineCards: [KanbanCard] = [],
-        idempotencyKey: String = UUID().uuidString
+        idempotencyKey: String = UUID().uuidString,
+        onCapabilityUnavailable: @escaping (KanbanWriteCapability) -> Void = { _ in }
     ) {
         self.mode = mode
         self.board = board
@@ -91,6 +93,7 @@ final class KanbanCardEditorState: Identifiable {
         self.tenantOptions = tenantOptions
         self.prerequisiteOptions = prerequisiteOptions
         self.idempotencyKey = idempotencyKey
+        self.onCapabilityUnavailable = onCapabilityUnavailable
         baselineCard = card
         baselineMatchingCardIDs = Set(baselineCards.compactMap(\.cardID))
         if let card {
@@ -210,6 +213,9 @@ final class KanbanCardEditorState: Identifiable {
             complete(with: card, attemptID: attemptID)
         } catch {
             guard isCurrent(attemptID) else { return }
+            if KanbanEndpointCompatibility.isMissingCapability(error) {
+                onCapabilityUnavailable(isEditing ? .editCard : .createCard)
+            }
             if isDefinitiveWriteFailure(error) {
                 submission = .failed
                 activeAttemptID = nil

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -17,6 +17,39 @@ enum KanbanReadCapabilityWarning: Hashable, Sendable {
     case profileHistoryUnavailable
 }
 
+enum KanbanWriteCapability: String, CaseIterable, Hashable, Sendable {
+    case createCard
+    case editCard
+    case comments
+    case cardWorkflow
+    case bulkActions
+    case boardManagement
+
+    var title: String {
+        switch self {
+        case .createCard: String(localized: "New Card")
+        case .editCard: String(localized: "Edit Card")
+        case .comments: String(localized: "Comment")
+        case .cardWorkflow: String(localized: "Card Actions")
+        case .bulkActions: String(localized: "Bulk Actions")
+        case .boardManagement: String(localized: "Board")
+        }
+    }
+}
+
+enum KanbanEndpointCompatibility {
+    static func isMissingCapability(_ error: Error) -> Bool {
+        guard let apiError = error as? APIError,
+              case let .http(statusCode, _) = apiError else { return false }
+        if statusCode == 405 { return true }
+        guard statusCode == 404,
+              let message = apiError.serverMessage?.lowercased() else { return false }
+        return message.contains("unknown kanban endpoint")
+            || message.contains("kanban endpoint not found")
+            || message.contains("unsupported kanban endpoint")
+    }
+}
+
 enum KanbanDispatchMode: Equatable, Sendable {
     case preview
     case run
@@ -285,6 +318,7 @@ final class KanbanFeatureState {
     private(set) var stats: KanbanStats?
     private(set) var assigneeHistory: KanbanAssigneeHistory?
     private(set) var capabilityWarnings: Set<KanbanReadCapabilityWarning> = []
+    private(set) var unavailableWriteCapabilities: Set<KanbanWriteCapability> = []
     private(set) var isLoading = false
     private(set) var isRefreshing = false
     private(set) var refreshFailed = false
@@ -371,7 +405,7 @@ final class KanbanFeatureState {
         snapshot != nil && !isOffline && !isRefreshing && !refreshFailed
     }
 
-    var canAddComments: Bool {
+    private var canUseWrites: Bool {
         canUseServerAuthoritativeActions
             && configuration?.readOnly == false
             && boardsResponse?.readOnly == false
@@ -380,17 +414,38 @@ final class KanbanFeatureState {
             && !boardMutationBlocksWrites
     }
 
+    var canAddComments: Bool {
+        canUseWrites && !unavailableWriteCapabilities.contains(.comments)
+    }
+
     var canMutateCards: Bool {
-        canAddComments
+        canUseWrites
             && bulkActionPhase == nil
             && Set(KanbanCardEditorState.createStatuses).isSubset(of: Set(configuration?.columns ?? []))
     }
 
+    var canCreateCards: Bool {
+        canMutateCards && !unavailableWriteCapabilities.contains(.createCard)
+    }
+
+    var canEditCards: Bool {
+        canMutateCards && !unavailableWriteCapabilities.contains(.editCard)
+    }
+
+    var canUseCardWorkflow: Bool {
+        canMutateCards && !unavailableWriteCapabilities.contains(.cardWorkflow)
+    }
+
+    var canUseBulkActions: Bool {
+        canMutateCards && !unavailableWriteCapabilities.contains(.bulkActions)
+    }
+
     var canManageBoards: Bool {
-        canAddComments
+        canUseWrites
             && bulkActionPhase == nil
             && activeCardMutationIDs.isEmpty
             && dispatchState?.phase.isInFlight != true
+            && !unavailableWriteCapabilities.contains(.boardManagement)
     }
 
     var dispatcherAvailability: KanbanDispatcherAvailability {
@@ -463,7 +518,8 @@ final class KanbanFeatureState {
         if isRefreshing { return .refreshing }
         guard state == .compatible || state == .partial,
               snapshot != nil,
-              Set(KanbanCardEditorState.createStatuses).isSubset(of: Set(configuration?.columns ?? []))
+              Set(KanbanCardEditorState.createStatuses).isSubset(of: Set(configuration?.columns ?? [])),
+              !unavailableWriteCapabilities.contains(.bulkActions)
         else { return .incompatible }
         guard configuration?.readOnly == false,
               boardsResponse?.readOnly == false,
@@ -554,7 +610,7 @@ final class KanbanFeatureState {
     }
 
     func canMutateCard(_ card: KanbanCard) -> Bool {
-        guard canMutateCards,
+        guard canUseCardWorkflow,
               normalizedOptional(card.cardID) != nil,
               let status = card.status?.rawValue else { return false }
         return Self.liveStatuses.contains(status) || status == "archived"
@@ -804,6 +860,7 @@ final class KanbanFeatureState {
         invalidateBoardMutation()
         invalidateDispatch()
         dispatcherCapabilityIsIncompatible = false
+        unavailableWriteCapabilities = []
         archiveUndoTask?.cancel()
         archiveUndo = nil
         clearSettledMutationPresentation()
@@ -1174,6 +1231,7 @@ final class KanbanFeatureState {
             markOfflineIfNeeded(error)
             if isDispatcherIncompatible(error) {
                 dispatcherCapabilityIsIncompatible = true
+                updatePartialState()
             }
             let completedAt = now()
             if isDefinitiveWriteFailure(error) {
@@ -1409,12 +1467,15 @@ final class KanbanFeatureState {
             onAPIError: onAPIError,
             onDetailLoaded: { [weak self] detail in
                 self?.acknowledgeLoadedCardDetail(detail)
+            },
+            onCapabilityUnavailable: { [weak self] capability in
+                self?.markCapabilityUnavailable(capability)
             }
         )
     }
 
     func makeCreateCardEditorState() -> KanbanCardEditorState? {
-        guard let board = selectedBoardSlug else { return nil }
+        guard canCreateCards, let board = selectedBoardSlug else { return nil }
         return KanbanCardEditorState(
             mode: .create,
             board: board,
@@ -1422,12 +1483,16 @@ final class KanbanFeatureState {
             profileOptions: profileOptions,
             tenantOptions: tenantOptions,
             prerequisiteOptions: allCards.filter { $0.cardID != nil },
-            baselineCards: allCards
+            baselineCards: allCards,
+            onCapabilityUnavailable: { [weak self] capability in
+                self?.markCapabilityUnavailable(capability)
+            }
         )
     }
 
     func makeEditCardEditorState(detail: KanbanCardDetailEnvelope) -> KanbanCardEditorState? {
-        guard let board = selectedBoardSlug,
+        guard canEditCards,
+              let board = selectedBoardSlug,
               let card = detail.card,
               let cardID = normalized(card.cardID) else { return nil }
         return KanbanCardEditorState(
@@ -1439,7 +1504,10 @@ final class KanbanFeatureState {
             profileOptions: profileOptions,
             tenantOptions: tenantOptions,
             prerequisiteOptions: allCards.filter { $0.cardID != nil && $0.cardID != cardID },
-            baselineCards: allCards
+            baselineCards: allCards,
+            onCapabilityUnavailable: { [weak self] capability in
+                self?.markCapabilityUnavailable(capability)
+            }
         )
     }
 
@@ -1472,6 +1540,7 @@ final class KanbanFeatureState {
             ))
         } catch {
             forwardAuthentication(error)
+            markCapabilityUnavailableIfNeeded(.bulkActions, error: error)
         }
 
         guard selectedBoardSlug == board else {
@@ -1668,6 +1737,7 @@ final class KanbanFeatureState {
                 return
             }
             forwardAuthentication(error)
+            markCapabilityUnavailableIfNeeded(.cardWorkflow, error: error)
             if isDefinitiveWriteFailure(error) {
                 restoreFailedOptimisticMutation(cardID: cardID, baseline: baseline, kind: kind, phase: .failed)
             } else {
@@ -1791,6 +1861,7 @@ final class KanbanFeatureState {
         } catch {
             guard activeCardMutationIDs[cardID] == mutationID else { return }
             forwardAuthentication(error)
+            markCapabilityUnavailableIfNeeded(.cardWorkflow, error: error)
             if isDefinitiveWriteFailure(error) {
                 pendingDependencyChanges[cardID] = nil
                 finishMutation(cardID: cardID, kind: kind, phase: .failed)
@@ -2025,6 +2096,7 @@ final class KanbanFeatureState {
             }
             guard continueBoardMutation(mutationGeneration, kind: kind) else { return }
             forwardAuthentication(error)
+            markCapabilityUnavailableIfNeeded(.boardManagement, error: error)
             definitiveFailure = isDefinitiveWriteFailure(error)
         }
         guard continueBoardMutation(mutationGeneration, kind: kind) else {
@@ -2545,7 +2617,25 @@ final class KanbanFeatureState {
 
     private func updatePartialState() {
         guard snapshot != nil else { return }
-        state = report?.isPartial == true || !capabilityWarnings.isEmpty ? .partial : .compatible
+        state = report?.isPartial == true
+            || !capabilityWarnings.isEmpty
+            || !unavailableWriteCapabilities.isEmpty
+            || dispatcherCapabilityIsIncompatible
+            ? .partial
+            : .compatible
+    }
+
+    private func markCapabilityUnavailableIfNeeded(
+        _ capability: KanbanWriteCapability,
+        error: Error
+    ) {
+        guard KanbanEndpointCompatibility.isMissingCapability(error) else { return }
+        markCapabilityUnavailable(capability)
+    }
+
+    private func markCapabilityUnavailable(_ capability: KanbanWriteCapability) {
+        unavailableWriteCapabilities.insert(capability)
+        updatePartialState()
     }
 
     private func isCurrent(_ loadID: UUID) -> Bool {

--- a/HermesMobile/Features/Kanban/KanbanLabView.swift
+++ b/HermesMobile/Features/Kanban/KanbanLabView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 enum KanbanCardAction: Equatable {
     case move(String)
@@ -176,7 +177,7 @@ struct KanbanStatusFocusView: View {
         .sheet(item: $cardEditor) { editor in
             KanbanCardEditorView(
                 state: editor,
-                allowsMutation: model.canMutateCards,
+                allowsMutation: editor.isEditing ? model.canEditCards : model.canCreateCards,
                 onSaved: { await model.reconcileAfterCardMutation() }
             )
         }
@@ -770,8 +771,15 @@ struct KanbanStatusFocusView: View {
 
     private var compatibilityBanner: some View {
         Label {
-            Text("Kanban is available with limited capabilities.")
-                .font(.footnote)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Kanban is available with limited capabilities.")
+                if !model.unavailableWriteCapabilities.isEmpty {
+                    Text("Unavailable")
+                        + Text(verbatim: ": ")
+                        + Text(verbatim: unavailableWriteCapabilityNames)
+                }
+            }
+            .font(.footnote)
         } icon: {
             Image(systemName: "exclamationmark.triangle.fill")
         }
@@ -780,6 +788,13 @@ struct KanbanStatusFocusView: View {
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.orange.opacity(0.12))
+    }
+
+    private var unavailableWriteCapabilityNames: String {
+        KanbanWriteCapability.allCases
+            .filter(model.unavailableWriteCapabilities.contains)
+            .map(\.title)
+            .joined(separator: ", ")
     }
 
     private var refreshErrorBanner: some View {
@@ -796,45 +811,234 @@ struct KanbanStatusFocusView: View {
     }
 
     private var statusSelector: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: 8) {
-                ForEach(model.availableStatuses, id: \.self) { status in
+        KanbanStatusSelector(model: model)
+    }
+
+    private struct KanbanStatusSelector: UIViewRepresentable {
+        @Bindable var model: KanbanFeatureState
+        @ScaledMetric(relativeTo: .subheadline) private var height: CGFloat = 56
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(parent: self)
+        }
+
+        func makeUIView(context: Context) -> UIScrollView {
+            let scrollView = KanbanStatusScrollView()
+            scrollView.alwaysBounceHorizontal = false
+            scrollView.alwaysBounceVertical = false
+            scrollView.delaysContentTouches = false
+            scrollView.isDirectionalLockEnabled = true
+            scrollView.showsHorizontalScrollIndicator = false
+            scrollView.showsVerticalScrollIndicator = false
+            scrollView.refreshControl = nil
+            scrollView.accessibilityIdentifier = "KanbanStatusSelector"
+            context.coordinator.install(in: scrollView)
+            return scrollView
+        }
+
+        func updateUIView(_ scrollView: UIScrollView, context: Context) {
+            context.coordinator.parent = self
+            context.coordinator.update(height: height)
+        }
+
+        @MainActor
+        final class KanbanStatusScrollView: UIScrollView {
+            override func touchesShouldCancel(in view: UIView) -> Bool {
+                true
+            }
+        }
+
+        func sizeThatFits(
+            _ proposal: ProposedViewSize,
+            uiView: UIScrollView,
+            context: Context
+        ) -> CGSize? {
+            CGSize(width: proposal.width ?? uiView.intrinsicContentSize.width, height: height)
+        }
+
+        @MainActor
+        final class Coordinator: NSObject {
+            var parent: KanbanStatusSelector
+            private let stackView = UIStackView()
+            private var controls: [String: KanbanStatusControl] = [:]
+            private var orderedStatuses: [String] = []
+
+            init(parent: KanbanStatusSelector) {
+                self.parent = parent
+            }
+
+            func install(in scrollView: UIScrollView) {
+                stackView.axis = .horizontal
+                stackView.alignment = .center
+                stackView.spacing = 8
+                stackView.translatesAutoresizingMaskIntoConstraints = false
+                scrollView.addSubview(stackView)
+                let tapRecognizer = UITapGestureRecognizer(
+                    target: self,
+                    action: #selector(selectStatus(at:))
+                )
+                tapRecognizer.cancelsTouchesInView = false
+                scrollView.addGestureRecognizer(tapRecognizer)
+
+                NSLayoutConstraint.activate([
+                    stackView.leadingAnchor.constraint(
+                        equalTo: scrollView.contentLayoutGuide.leadingAnchor,
+                        constant: 16
+                    ),
+                    stackView.trailingAnchor.constraint(
+                        equalTo: scrollView.contentLayoutGuide.trailingAnchor,
+                        constant: -16
+                    ),
+                    stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+                    stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+                    stackView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor)
+                ])
+            }
+
+            func update(height: CGFloat) {
+                let statuses = parent.model.availableStatuses
+                if statuses != orderedStatuses {
+                    rebuild(statuses)
+                }
+
+                let controlHeight = max(44, height - 12)
+                for status in statuses {
                     let presentation = KanbanStatusPresentation(status)
-                    Button {
-                        model.selectedStatus = status
-                    } label: {
-                        HStack(spacing: 6) {
-                            Circle()
-                                .fill(presentation.color)
-                                .frame(width: 8, height: 8)
-                            Text(presentation.title)
-                            Text(verbatim: "\(model.statusCount(status))")
-                                .font(.caption.monospacedDigit())
-                                .foregroundStyle(.secondary)
-                        }
-                        .font(.subheadline.weight(model.selectedStatus == status ? .semibold : .regular))
-                        .padding(.horizontal, 12)
-                        .frame(minHeight: 44)
-                        .background(
-                            model.selectedStatus == status ? Color.secondary.opacity(0.16) : Color.clear,
-                            in: Capsule()
-                        )
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(
-                        String.localizedStringWithFormat(
-                            String(localized: "%@, %@"),
-                            presentation.title,
-                            KanbanCountFormatter.cards(model.statusCount(status))
-                        )
+                    controls[status]?.update(
+                        title: presentation.title,
+                        count: parent.model.statusCount(status),
+                        color: UIColor(presentation.color),
+                        isSelected: parent.model.selectedStatus == status,
+                        height: controlHeight
                     )
-                    .accessibilityAddTraits(model.selectedStatus == status ? .isSelected : [])
                 }
             }
-            .padding(.horizontal)
-            .padding(.vertical, 6)
+
+            private func rebuild(_ statuses: [String]) {
+                orderedStatuses = statuses
+                for view in stackView.arrangedSubviews {
+                    stackView.removeArrangedSubview(view)
+                    view.removeFromSuperview()
+                }
+                controls.removeAll()
+
+                for status in statuses {
+                    let control = KanbanStatusControl()
+                    control.status = status
+                    control.addTarget(
+                        self,
+                        action: #selector(selectStatus(_:)),
+                        for: [.touchUpInside, .primaryActionTriggered]
+                    )
+                    stackView.addArrangedSubview(control)
+                    controls[status] = control
+                }
+            }
+
+            @objc
+            private func selectStatus(_ sender: KanbanStatusControl) {
+                parent.model.selectedStatus = sender.status
+            }
+
+            @objc
+            private func selectStatus(at recognizer: UITapGestureRecognizer) {
+                guard recognizer.state == .ended else { return }
+                let location = recognizer.location(in: stackView)
+                guard let control = stackView.arrangedSubviews
+                    .compactMap({ $0 as? KanbanStatusControl })
+                    .first(where: { $0.frame.contains(location) })
+                else { return }
+                parent.model.selectedStatus = control.status
+            }
         }
-        .scrollIndicators(.hidden)
+
+        @MainActor
+        final class KanbanStatusControl: UIControl {
+            var status = ""
+            private let dotView = UIView()
+            private let titleLabel = UILabel()
+            private let countLabel = UILabel()
+            private let stackView = UIStackView()
+            private var heightConstraint: NSLayoutConstraint?
+
+            override init(frame: CGRect) {
+                super.init(frame: frame)
+                isAccessibilityElement = true
+                layer.cornerCurve = .continuous
+
+                dotView.translatesAutoresizingMaskIntoConstraints = false
+                dotView.layer.cornerRadius = 4
+                NSLayoutConstraint.activate([
+                    dotView.widthAnchor.constraint(equalToConstant: 8),
+                    dotView.heightAnchor.constraint(equalToConstant: 8)
+                ])
+
+                titleLabel.adjustsFontForContentSizeCategory = true
+                titleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+                countLabel.adjustsFontForContentSizeCategory = true
+                countLabel.font = .monospacedDigitSystemFont(
+                    ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize,
+                    weight: .regular
+                )
+                countLabel.textColor = .secondaryLabel
+
+                stackView.axis = .horizontal
+                stackView.alignment = .center
+                stackView.spacing = 6
+                stackView.translatesAutoresizingMaskIntoConstraints = false
+                stackView.addArrangedSubview(dotView)
+                stackView.addArrangedSubview(titleLabel)
+                stackView.addArrangedSubview(countLabel)
+                addSubview(stackView)
+
+                NSLayoutConstraint.activate([
+                    stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+                    stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+                    stackView.centerYAnchor.constraint(equalTo: centerYAnchor)
+                ])
+            }
+
+            @available(*, unavailable)
+            required init?(coder: NSCoder) {
+                fatalError("init(coder:) has not been implemented")
+            }
+
+            func update(
+                title: String,
+                count: Int,
+                color: UIColor,
+                isSelected: Bool,
+                height: CGFloat
+            ) {
+                titleLabel.text = title
+                let preferredTitleFont = UIFont.preferredFont(forTextStyle: .subheadline)
+                titleLabel.font = .systemFont(
+                    ofSize: preferredTitleFont.pointSize,
+                    weight: isSelected ? .semibold : .regular
+                )
+                countLabel.font = .monospacedDigitSystemFont(
+                    ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize,
+                    weight: .regular
+                )
+                countLabel.text = "\(count)"
+                dotView.backgroundColor = color
+                self.isSelected = isSelected
+                backgroundColor = isSelected ? .secondarySystemFill : .clear
+                layer.cornerRadius = height / 2
+                accessibilityLabel = String.localizedStringWithFormat(
+                    String(localized: "%@, %@"),
+                    title,
+                    KanbanCountFormatter.cards(count)
+                )
+                accessibilityTraits = isSelected ? [.button, .selected] : .button
+
+                if heightConstraint?.constant != height {
+                    heightConstraint?.isActive = false
+                    heightConstraint = heightAnchor.constraint(equalToConstant: height)
+                    heightConstraint?.isActive = true
+                }
+            }
+        }
     }
 
     private var cardList: some View {
@@ -1132,7 +1336,7 @@ struct KanbanStatusFocusView: View {
             } label: {
                 Image(systemName: model.isSelectingCards ? "xmark" : "checkmark.circle")
             }
-            .disabled(model.bulkActionPhase != nil)
+            .disabled(model.bulkActionPhase != nil || !model.canUseBulkActions)
             .frame(minWidth: 44, minHeight: 44)
             .accessibilityLabel(model.isSelectingCards ? Text("Cancel") : Text("Select Cards"))
 
@@ -1141,7 +1345,7 @@ struct KanbanStatusFocusView: View {
             } label: {
                 Image(systemName: "plus")
             }
-            .disabled(!model.canMutateCards)
+            .disabled(!model.canCreateCards)
             .frame(minWidth: 44, minHeight: 44)
             .accessibilityLabel(Text("New Card"))
 
@@ -2050,6 +2254,26 @@ struct KanbanStatusPresentation {
     }
 }
 
+struct KanbanView: View {
+    @State private var model: KanbanFeatureState
+
+    init(server: URL, onAPIError: @escaping (Error) -> Void) {
+        _model = State(
+            initialValue: KanbanFeatureState(
+                server: server,
+                onAPIError: onAPIError
+            )
+        )
+    }
+
+    var body: some View {
+        KanbanStatusFocusView(model: model)
+            .task {
+                await model.load()
+            }
+    }
+}
+
 enum KanbanAgeFormatter {
     static func abbreviated(_ seconds: Double) -> String { format(seconds, style: .abbreviated) }
     static func full(_ seconds: Double) -> String { format(seconds, style: .full) }
@@ -2182,7 +2406,7 @@ enum KanbanLabScenario: String, CaseIterable, Identifiable {
 
 actor KanbanLabClient: KanbanDataClient {
     let scenario: KanbanLabScenario
-    private var submittedComments: [String] = []
+    private var submittedComments: [String: [String: [String]]] = [:]
     private var storedCards: [String: [String: StoredCard]] = [:]
     private var cardIDsByIntent: [String: String] = [:]
     private var nextCardSequence = 100
@@ -2333,56 +2557,60 @@ actor KanbanLabClient: KanbanDataClient {
 
     func kanbanCardDetail(_ request: KanbanCardDetailRequest) async throws -> KanbanCardDetailEnvelope {
         if scenario == .detailError { throw APIError.http(statusCode: 503, body: nil) }
-        if let stored = storedCards[request.board]?[request.cardID] {
-            return decode([
-                "task": stored.object,
-                "comments": [],
-                "events": [],
-                "links": [
-                    "parents": stored.prerequisiteID.map { [$0] } ?? [],
-                    "children": []
-                ],
-                "runs": [],
-                "read_only": false
-            ])
-        }
+        let stored = storedCards[request.board]?[request.cardID]
+        let isFixture = fixtureCard(cardID: request.cardID) != nil
         let isEmpty = scenario == .detailEmpty
-        var comments: [[String: Any]] = isEmpty ? [] : [
+        var comments: [[String: Any]] = isEmpty || !isFixture ? [] : [
             ["id": 1, "task_id": request.cardID, "author": "reviewer", "body": "Looks good from the review side.", "created_at": 1_700_000_000]
         ]
-        comments += submittedComments.enumerated().map { offset, body in
+        let cardComments = submittedComments[request.board]?[request.cardID] ?? []
+        comments += cardComments.enumerated().map { offset, body in
             ["id": offset + 2, "task_id": request.cardID, "author": "webui", "body": body, "created_at": 1_700_000_100 + offset]
         }
+        let task: [String: Any] = stored?.object ?? [
+            "id": request.cardID,
+            "title": isEmpty ? "Empty history fixture" : "Implement Status Focus",
+            "body": isEmpty ? "" : "This **Markdown** description stays selectable.",
+            "status": "ready",
+            "assignee": "builder",
+            "tenant": "app",
+            "priority": 1,
+            "created_at": 1_699_999_000,
+            "updated_at": 1_700_000_000,
+            "workspace_kind": "worktree",
+            "workspace_path": "/private/fixture/explicit-history-only",
+            "skills": ["swiftui-patterns"],
+            "max_runtime_seconds": 3600,
+            "current_run_id": "run-fixture",
+            "claim_lock": "claim-fixture",
+            "worker_pid": 4242
+        ]
+        let links: [String: [String]]
+        if let stored {
+            links = [
+                "parents": stored.prerequisiteID.map { [$0] } ?? [],
+                "children": []
+            ]
+        } else {
+            links = isEmpty ? ["parents": [], "children": []] : [
+                "parents": ["CARD-1"],
+                "children": ["CARD-7"]
+            ]
+        }
+        let hasFixtureHistory = !isEmpty && isFixture
         let payload: [String: Any] = [
-            "task": [
-                "id": request.cardID,
-                "title": isEmpty ? "Empty history fixture" : "Implement Status Focus",
-                "body": isEmpty ? "" : "This **Markdown** description stays selectable.",
-                "status": "ready",
-                "assignee": "builder",
-                "tenant": "app",
-                "priority": 1,
-                "created_at": 1_699_999_000,
-                "updated_at": 1_700_000_000,
-                "workspace_kind": "worktree",
-                "workspace_path": "/private/fixture/explicit-history-only",
-                "skills": ["swiftui-patterns"],
-                "max_runtime_seconds": 3600,
-                "current_run_id": "run-fixture",
-                "claim_lock": "claim-fixture",
-                "worker_pid": 4242
-            ],
+            "task": task,
             "comments": comments,
-            "events": isEmpty ? [] : [[
+            "events": hasFixtureHistory ? [[
                 "id": 9, "task_id": request.cardID, "kind": "status",
                 "payload": ["status": "ready", "secret": "discarded"], "created_at": 1_700_000_000
-            ]],
-            "links": isEmpty ? ["parents": [], "children": []] : ["parents": ["CARD-1"], "children": ["CARD-7"]],
-            "runs": isEmpty ? [] : [[
+            ]] : [],
+            "links": links,
+            "runs": hasFixtureHistory ? [[
                 "id": "run-fixture", "status": "finished", "outcome": "success",
                 "summary": "Validated the focused suite.", "worker": "worker-fixture",
                 "started_at": 1_699_999_500, "finished_at": 1_700_000_000
-            ]],
+            ]] : [],
             "read_only": false
         ]
         return decode(payload)
@@ -2404,8 +2632,9 @@ actor KanbanLabClient: KanbanDataClient {
     }
 
     func addKanbanComment(_ request: KanbanAddCommentRequest) async throws -> KanbanAddCommentResponse {
-        submittedComments.append(request.body)
-        return decode(["ok": true, "comment_id": submittedComments.count + 1, "read_only": false])
+        submittedComments[request.board, default: [:]][request.cardID, default: []].append(request.body)
+        let count = submittedComments[request.board]?[request.cardID]?.count ?? 0
+        return decode(["ok": true, "comment_id": count + 1, "read_only": false])
     }
 
     func createKanbanCard(_ request: KanbanCreateCardRequest) async throws -> KanbanCardMutationEnvelope {

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -135,6 +135,10 @@ struct SessionSidebarUtilityRows: View {
                 openDestination(.tasks)
             }
 
+            SidebarNavButton(title: String(localized: "Kanban"), assetImage: "LucideColumns3") {
+                openDestination(.kanban)
+            }
+
             SidebarNavButton(title: String(localized: "Skills"), assetImage: "LucideHammer") {
                 openDestination(.skills)
             }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -331,6 +331,8 @@ struct SessionListView: View {
                 SettingsView(authManager: authManager, server: server, initialScrollTarget: scrollTo)
             case .tasks:
                 TasksView(server: server, onAPIError: authManager.handleAPIError)
+            case .kanban:
+                KanbanView(server: server, onAPIError: authManager.handleAPIError)
             case .skills:
                 SkillsView(server: server, onAPIError: authManager.handleAPIError)
             case .memory:
@@ -1264,6 +1266,7 @@ enum SessionListUtilityDestination: Hashable, Identifiable {
     /// passes `.servers`, a plain avatar tap passes `nil` (#283).
     case settings(SettingsScrollAnchor?)
     case tasks
+    case kanban
     case skills
     case memory
     case insights

--- a/HermesMobile/HermesMobileApp.swift
+++ b/HermesMobile/HermesMobileApp.swift
@@ -55,10 +55,6 @@ struct HermesMobileApp: App {
                 NavigationStack {
                     StreamingLabView()
                 }
-            } else if ProcessInfo.processInfo.arguments.contains("--kanban-lab") {
-                NavigationStack {
-                    KanbanLabView()
-                }
             } else {
                 ContentView(authManager: authManager)
                     .preferredColorScheme(AppTheme.storedValue(appThemeRawValue).colorScheme)

--- a/HermesMobile/Models/Kanban.swift
+++ b/HermesMobile/Models/Kanban.swift
@@ -384,12 +384,32 @@ struct KanbanConfiguration: Decodable, Equatable, Sendable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         columns = try? container.decodeIfPresent([String].self, forKey: .columns)
-        assignees = try? container.decodeIfPresent([String].self, forKey: .assignees)
+        assignees = (try? container.decodeIfPresent(
+            [KanbanAssigneeValue].self,
+            forKey: .assignees
+        ))?.compactMap(\.name)
         defaultTenant = container.decodeLossyStringIfPresent(forKey: .defaultTenant)
         laneByProfile = container.decodeLossyBoolIfPresent(forKey: .laneByProfile)
         includeArchivedByDefault = container.decodeLossyBoolIfPresent(forKey: .includeArchivedByDefault)
         renderMarkdown = container.decodeLossyBoolIfPresent(forKey: .renderMarkdown)
         readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+    }
+}
+
+private struct KanbanAssigneeValue: Decodable {
+    let name: String?
+
+    enum CodingKeys: CodingKey { case name }
+
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer(),
+           let value = try? container.decode(String.self) {
+            name = value
+            return
+        }
+
+        let container = try? decoder.container(keyedBy: CodingKeys.self)
+        name = container?.decodeLossyStringIfPresent(forKey: .name)
     }
 }
 
@@ -868,8 +888,9 @@ struct KanbanDispatchRun: Decodable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case runID = "id"
         case alternateRunID = "runId"
-        case status, outcome, summary, error, startedAt, finishedAt
+        case status, outcome, summary, error, startedAt, finishedAt, endedAt
         case workerID = "worker"
+        case workerPID = "workerPid"
         case logTail
     }
 
@@ -882,8 +903,10 @@ struct KanbanDispatchRun: Decodable, Equatable, Sendable {
         summary = container.decodeLossyStringIfPresent(forKey: .summary)
         error = container.decodeLossyStringIfPresent(forKey: .error)
         startedAt = container.decodeLossyStringIfPresent(forKey: .startedAt)
-        finishedAt = container.decodeLossyStringIfPresent(forKey: .finishedAt)
-        workerID = container.decodeLossyStringIfPresent(forKey: .workerID)
+        finishedAt = container.decodeLossyStringIfPresent(forKey: .endedAt)
+            ?? container.decodeLossyStringIfPresent(forKey: .finishedAt)
+        workerID = container.decodeLossyStringIfPresent(forKey: .workerPID)
+            ?? container.decodeLossyStringIfPresent(forKey: .workerID)
         logTail = container.decodeLossyStringIfPresent(forKey: .logTail)
     }
 
@@ -1004,7 +1027,10 @@ struct KanbanAssigneeHistory: Decodable, Equatable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        assignees = try? container.decodeIfPresent([String].self, forKey: .assignees)
+        assignees = (try? container.decodeIfPresent(
+            [KanbanAssigneeValue].self,
+            forKey: .assignees
+        ))?.compactMap(\.name)
     }
 }
 

--- a/HermesMobile/Resources/Assets.xcassets/LucideColumns3.imageset/Contents.json
+++ b/HermesMobile/Resources/Assets.xcassets/LucideColumns3.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "lucide-columns-3.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/HermesMobile/Resources/Assets.xcassets/LucideColumns3.imageset/lucide-columns-3.svg
+++ b/HermesMobile/Resources/Assets.xcassets/LucideColumns3.imageset/lucide-columns-3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M9 3v18" />
+  <path d="M15 3v18" />
+</svg>

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -27,7 +27,10 @@ final class APIClientKanbanTests: APIClientTestCase {
                 return apiTestJSONResponse(Self.statsJSON, for: request)
             case "/api/kanban/assignees":
                 XCTAssertEqual(request.url?.query, "board=main%20board")
-                return apiTestJSONResponse(#"{"assignees":["work","review"]}"#, for: request)
+                return apiTestJSONResponse(
+                    #"{"assignees":[{"name":"work","on_disk":true,"counts":{"ready":2}},"review",{"future":true}]}"#,
+                    for: request
+                )
             default:
                 throw URLError(.badURL)
             }
@@ -635,6 +638,8 @@ final class APIClientKanbanTests: APIClientTestCase {
         XCTAssertEqual(detail.links?.prerequisites, ["CARD-0"])
         XCTAssertEqual(detail.links?.dependents, ["CARD-2"])
         XCTAssertEqual(detail.runs?.first?.runID, "run-1")
+        XCTAssertEqual(detail.runs?.first?.finishedAt, "1700000002")
+        XCTAssertEqual(detail.runs?.first?.workerID, "31415")
         XCTAssertNil(detail.card?.workerID) // malformed metadata is ignored
 
         let minimal = try decoder.decode(KanbanCardDetailEnvelope.self, from: Data(
@@ -753,6 +758,20 @@ final class APIClientKanbanTests: APIClientTestCase {
     func testCardSummaryFieldsStatsEnvelopesAndStalenessDecodeTolerantly() throws {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let configuration = try decoder.decode(
+            KanbanConfiguration.self,
+            from: Data("""
+            {
+              "columns":["triage","todo","ready"],
+              "assignees":[
+                {"name":"builder","on_disk":true,"counts":{"ready":2}},
+                "reviewer",
+                {"future":true}
+              ],
+              "read_only":false
+            }
+            """.utf8)
+        )
         let snapshot = try decoder.decode(KanbanBoardSnapshot.self, from: Data("""
         {
           "changed": true,
@@ -773,6 +792,7 @@ final class APIClientKanbanTests: APIClientTestCase {
         XCTAssertEqual(card.linkCounts?.children, 2)
         XCTAssertEqual(card.staleness, .critical)
         XCTAssertEqual(snapshot.filters?.includeArchived, true)
+        XCTAssertEqual(configuration.assignees, ["builder", "reviewer"])
 
         let current = try decoder.decode(KanbanStats.self, from: Data(Self.statsJSON.utf8))
         XCTAssertEqual(current.total, 3)
@@ -868,7 +888,10 @@ final class APIClientKanbanTests: APIClientTestCase {
       "comments":[{"id":7,"task_id":"CARD-1","author":"review","body":"Ship it","created_at":1700000000}],
       "events":[{"id":8,"task_id":"CARD-1","kind":"status","payload":{"status":"ready","secret":"discarded"},"created_at":1700000001}],
       "links":{"parents":["CARD-0"],"children":["CARD-2"]},
-      "runs":[{"run_id":"run-1","status":"finished","worker":"worker-private","future":true}],
+      "runs":[{
+        "id":"run-1","status":"finished","worker_pid":31415,
+        "started_at":1700000001,"ended_at":1700000002,"future":true
+      }],
       "read_only":false,
       "future_envelope_field":{"nested":true}
     }

--- a/HermesMobileTests/KanbanCardDetailStateTests.swift
+++ b/HermesMobileTests/KanbanCardDetailStateTests.swift
@@ -42,6 +42,33 @@ final class KanbanCardDetailStateTests: XCTestCase {
         XCTAssertEqual(calls, 1)
     }
 
+    func testMissingCommentEndpointDisablesCommentsWithoutTreatingCardAsMissing() async {
+        let client = CardDetailClient(
+            details: [.success(.baseline)],
+            commentResult: .failure(APIError.http(
+                statusCode: 404,
+                body: #"{"error":"Unknown Kanban endpoint; refresh the client"}"#
+            ))
+        )
+        var unavailable: [KanbanWriteCapability] = []
+        let state = KanbanCardDetailState(
+            cardID: "CARD-1",
+            board: "main",
+            client: client,
+            onCapabilityUnavailable: { unavailable.append($0) }
+        )
+
+        await state.load()
+        state.commentDraft = "Hello"
+        await state.submitComment(allowsMutation: true)
+
+        XCTAssertEqual(state.loadState, .loaded)
+        XCTAssertEqual(state.commentSubmission, .failed)
+        XCTAssertEqual(unavailable, [.comments])
+        let boardCalls = await client.boardCallCount
+        XCTAssertEqual(boardCalls, 0)
+    }
+
     func testAmbiguousCommentOutcomeReconcilesPresentAbsentAndUncertain() async {
         let network = APIError.network(underlying: URLError(.networkConnectionLost))
 

--- a/HermesMobileTests/KanbanCardEditorStateTests.swift
+++ b/HermesMobileTests/KanbanCardEditorStateTests.swift
@@ -74,6 +74,54 @@ final class KanbanCardEditorStateTests: XCTestCase {
         XCTAssertEqual(keys, ["fixed-intent", "fixed-intent"])
     }
 
+    func testMissingCreateEndpointReportsOnlyCreateCapabilityUnavailable() async {
+        let client = CardEditorClient(createResults: [
+            .failure(APIError.http(
+                statusCode: 404,
+                body: #"{"error":"Unknown Kanban endpoint; refresh the client"}"#
+            ))
+        ])
+        var unavailable: [KanbanWriteCapability] = []
+        let state = KanbanCardEditorState(
+            mode: .create,
+            board: "main",
+            client: client,
+            onCapabilityUnavailable: { unavailable.append($0) }
+        )
+        state.title = "Release evidence"
+
+        await state.save(allowsMutation: true)
+
+        XCTAssertEqual(state.submission, .failed)
+        XCTAssertEqual(unavailable, [.createCard])
+    }
+
+    func testMissingEditEndpointReportsOnlyEditCapabilityUnavailable() async {
+        let client = CardEditorClient(
+            editResults: [
+                .failure(APIError.http(
+                    statusCode: 404,
+                    body: #"{"error":"Unknown Kanban endpoint; refresh the client"}"#
+                ))
+            ],
+            detailResults: [.success(.baseline)]
+        )
+        var unavailable: [KanbanWriteCapability] = []
+        let state = KanbanCardEditorState(
+            mode: .edit(cardID: "CARD-1"),
+            board: "main",
+            client: client,
+            card: .baseline,
+            onCapabilityUnavailable: { unavailable.append($0) }
+        )
+        state.title = "Release evidence"
+
+        await state.save(allowsMutation: true)
+
+        XCTAssertEqual(state.submission, .failed)
+        XCTAssertEqual(unavailable, [.editCard])
+    }
+
     func testAmbiguousCreateReconcilesPresentAbsentAndUncertainWithoutBlindRetry() async {
         let lost = APIError.network(underlying: URLError(.networkConnectionLost))
 
@@ -422,6 +470,42 @@ final class KanbanLabClientMutationTests: XCTestCase {
         XCTAssertEqual(detail.card?.skills, ["swiftui-patterns"])
         XCTAssertEqual(detail.card?.maxRuntimeSeconds, 900)
         XCTAssertEqual(detail.links?.prerequisites, ["CARD-1"])
+    }
+
+    func testEditingFixtureCardPreservesHistoryAndCommentsStayScopedToCard() async throws {
+        let client = KanbanLabClient(scenario: .dense)
+
+        _ = try await client.editKanbanCard(KanbanEditCardRequest(
+            cardID: "CARD-3",
+            board: "default",
+            title: "Edited fixture",
+            body: "Edited body",
+            tenant: "app",
+            priority: 1,
+            assignee: "builder",
+            status: "ready"
+        ))
+        _ = try await client.addKanbanComment(KanbanAddCommentRequest(
+            cardID: "CARD-3",
+            board: "default",
+            body: "Scoped comment"
+        ))
+
+        let edited = try await client.kanbanCardDetail(
+            KanbanCardDetailRequest(cardID: "CARD-3", board: "default")
+        )
+        let other = try await client.kanbanCardDetail(
+            KanbanCardDetailRequest(cardID: "CARD-4", board: "default")
+        )
+
+        XCTAssertEqual(edited.card?.title, "Edited fixture")
+        XCTAssertEqual(edited.comments?.map(\.body), [
+            "Looks good from the review side.",
+            "Scoped comment"
+        ])
+        XCTAssertEqual(edited.events?.count, 1)
+        XCTAssertEqual(edited.runs?.count, 1)
+        XCTAssertEqual(other.comments?.map(\.body), ["Looks good from the review side."])
     }
 }
 

--- a/HermesMobileTests/KanbanFeatureStateTests.swift
+++ b/HermesMobileTests/KanbanFeatureStateTests.swift
@@ -897,6 +897,30 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(state.mutationState(for: "CARD-2")?.phase, .succeeded)
     }
 
+    func testMissingWorkflowEndpointDisablesOnlyCardWorkflow() async throws {
+        let client = ImmediateMutationClient(statusResults: [
+            .failure(APIError.http(
+                statusCode: 404,
+                body: #"{"error":"Unknown Kanban endpoint; refresh the client"}"#
+            ))
+        ])
+        let state = KanbanFeatureState(
+            server: URL(string: "https://workflow-capability.example.test")!,
+            client: client
+        )
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+
+        await state.completeCard(card)
+
+        XCTAssertEqual(state.state, .partial)
+        XCTAssertEqual(state.unavailableWriteCapabilities, [.cardWorkflow])
+        XCTAssertFalse(state.canUseCardWorkflow)
+        XCTAssertTrue(state.canUseBulkActions)
+        XCTAssertTrue(state.canCreateCards)
+        XCTAssertTrue(state.canManageBoards)
+    }
+
     func testAmbiguousMutationRequiresReconciliationBeforeTryAgain() async throws {
         let network = APIError.network(underlying: URLError(.networkConnectionLost))
         let client = ImmediateMutationClient(
@@ -1354,6 +1378,41 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(state.bulkActionSummary?.succeededCount, 2)
         let detailRequests = await client.detailRequests()
         XCTAssertEqual(Set(detailRequests), ["CARD-1", "CARD-2"])
+    }
+
+    func testMissingBulkEndpointDisablesOnlyBulkActionsAfterReconciliation() async throws {
+        let client = BulkActionClient(
+            boardSnapshots: [
+                bulkSnapshot(firstStatus: "todo", secondStatus: "todo"),
+                bulkSnapshot(firstStatus: "todo", secondStatus: "todo")
+            ],
+            bulkResponses: [],
+            detailResults: [
+                "CARD-1": [
+                    .success(mutationDecode(#"{"task":{"id":"CARD-1","status":"todo"}}"#))
+                ]
+            ],
+            bulkError: APIError.http(
+                statusCode: 404,
+                body: #"{"error":"Unknown Kanban endpoint; refresh the client"}"#
+            )
+        )
+        let state = KanbanFeatureState(
+            server: URL(string: "https://bulk-capability.example.test")!,
+            client: client
+        )
+        await state.load()
+        let card = try XCTUnwrap(state.allCards.first { $0.cardID == "CARD-1" })
+        state.beginSelectingCards()
+        state.toggleCardSelection(card)
+
+        await state.performBulkAction(.changeStatus("done"))
+
+        XCTAssertEqual(state.state, .partial)
+        XCTAssertEqual(state.unavailableWriteCapabilities, [.bulkActions])
+        XCTAssertFalse(state.canUseBulkActions)
+        XCTAssertTrue(state.canUseCardWorkflow)
+        XCTAssertTrue(state.canCreateCards)
     }
 
     func testBulkReconciliationFetchesCardDetailsConcurrently() async throws {
@@ -1822,6 +1881,64 @@ final class KanbanFeatureStateTests: XCTestCase {
         XCTAssertEqual(editRequest?.slug, "release")
         XCTAssertEqual(activeRequest?.slug, "release")
         XCTAssertEqual(archiveRequest?.slug, "release")
+    }
+
+    func testMissingBoardManagementEndpointDisablesOnlyThatCapabilityUntilReload() async {
+        let missingEndpoint = APIError.http(
+            statusCode: 404,
+            body: #"{"error":"Unknown Kanban endpoint; refresh the client"}"#
+        )
+        let client = BoardManagementClient(
+            boardsResponses: [
+                .success(KanbanFixtures.boards),
+                .success(KanbanFixtures.boards)
+            ],
+            createResult: .failure(missingEndpoint),
+            boardSnapshot: KanbanFixtures.snapshot
+        )
+        let state = KanbanFeatureState(
+            server: URL(string: "https://capability.example.test")!,
+            client: client
+        )
+
+        await state.load()
+        await state.createBoard(KanbanCreateBoardRequest(
+            slug: "release",
+            name: "Release",
+            description: "",
+            icon: "",
+            color: ""
+        ))
+
+        XCTAssertEqual(state.state, .partial)
+        XCTAssertEqual(state.unavailableWriteCapabilities, [.boardManagement])
+        XCTAssertFalse(state.canManageBoards)
+        XCTAssertTrue(state.canCreateCards)
+        XCTAssertTrue(state.canUseCardWorkflow)
+
+        await state.load()
+
+        XCTAssertEqual(state.state, .compatible)
+        XCTAssertTrue(state.unavailableWriteCapabilities.isEmpty)
+        XCTAssertTrue(state.canManageBoards)
+    }
+
+    func testCapabilityDetectionDoesNotConfuseMissingEntitiesWithMissingEndpoints() {
+        XCTAssertTrue(KanbanEndpointCompatibility.isMissingCapability(
+            APIError.http(statusCode: 405, body: nil)
+        ))
+        XCTAssertTrue(KanbanEndpointCompatibility.isMissingCapability(
+            APIError.http(
+                statusCode: 404,
+                body: #"{"error":"Unknown Kanban endpoint; refresh the client"}"#
+            )
+        ))
+        XCTAssertFalse(KanbanEndpointCompatibility.isMissingCapability(
+            APIError.http(statusCode: 404, body: #"{"error":"task not found"}"#)
+        ))
+        XCTAssertFalse(KanbanEndpointCompatibility.isMissingCapability(
+            APIError.http(statusCode: 404, body: nil)
+        ))
     }
 
     private func waitUntil(

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -125,6 +125,15 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertNil(reevaluatedState.selectedSessionID)
     }
 
+    func testKanbanIsSelectableAsAUtilityDestination() {
+        var state = SessionNavigationState()
+
+        state.select(SessionListUtilityDestination.kanban)
+
+        XCTAssertEqual(state.destination, .utility(.kanban))
+        XCTAssertNil(state.selectedSessionID)
+    }
+
     func testReselectingRootDestinationAdvancesNavigationRevision() {
         var state = SessionNavigationState()
         state.select(SessionListUtilityDestination.skills)

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -97,7 +97,6 @@ sub-paths of a group. Do not reorder casually.
 | `/api/workspace/` | roadmap | P3 | write | Workspace Management |
 | `/api/file/` | roadmap | P4 | write | File Editing / Management — owner-deferred |
 | `/api/folder/` | roadmap | P4 | write | File Editing / Management — owner-deferred |
-| `/api/kanban` | roadmap | P4 | write | Kanban Board — owner-deferred |
 | `/api/terminal/` | roadmap | P4 | exec | Terminal — owner-deferred; App Store/safety-sensitive |
 | `/api/commands/exec` | roadmap | P4 | exec | Plugin command exec — owner-deferred |
 | `/api/gateway/` | roadmap | P5 | read | Gateway / Messaging Bridge |
@@ -118,9 +117,10 @@ sub-paths of a group. Do not reorder casually.
 list is a human convenience only and is intentionally **not** machine-read.
 Shipping parity features include: Clarification System, Goal Submission, Session
 Search, Memory Editing, Cron mutations, Project Rename, Server-Side Insights,
-Transcript `MEDIA:` inline image rendering, and the core session/chat/streaming
-surface. For each feature's regression-check notes and last-validated shapes, see
-the archived catalog in `git log` history (removed during open-source prep, #347).
+Transcript `MEDIA:` inline image rendering, Kanban Board, and the core
+session/chat/streaming surface. For each feature's regression-check notes and
+last-validated shapes, see the archived catalog in `git log` history (removed
+during open-source prep, #347).
 
 ### Not in this index → `new`
 

--- a/scripts/verify_kanban_reference_server.py
+++ b/scripts/verify_kanban_reference_server.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Exercise the pinned Hermes Kanban HTTP bridge against an isolated real DB.
+
+This verifier intentionally:
+
+- binds only to loopback on an ephemeral port;
+- stores all Hermes/Kanban state in a temporary directory;
+- imports the pinned reference WebUI and Hermes Agent source trees;
+- hard-disables the worker spawn function; and
+- calls Dispatcher only with ``dry_run=true``.
+
+It prints aggregate evidence only. Task IDs, payload contents, local paths, and
+configuration values are never emitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
+
+
+EXPECTED_AGENT_REVISION = "2ccfdb2db4eedf385f6c5b3fe722e183cee1b6de"
+EXPECTED_WEBUI_REVISION = "2f3e42dc649e6d2bae572a0655681d9bb212c78d"
+
+
+class VerificationError(RuntimeError):
+    """A redaction-safe verification failure."""
+
+
+def git_revision(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def require(condition: bool, label: str) -> None:
+    if not condition:
+        raise VerificationError(label)
+
+
+def configure_imports(agent_root: Path, webui_root: Path, state_root: Path):
+    require(git_revision(agent_root) == EXPECTED_AGENT_REVISION, "agent-revision")
+    require(git_revision(webui_root) == EXPECTED_WEBUI_REVISION, "webui-revision")
+
+    os.environ["HERMES_HOME"] = str(state_root / "hermes")
+    os.environ["HERMES_KANBAN_HOME"] = str(state_root / "kanban-home")
+    os.environ["HERMES_KANBAN_DB"] = str(state_root / "kanban-home" / "kanban.db")
+    os.environ["HERMES_KANBAN_WORKSPACES_ROOT"] = str(state_root / "workspaces")
+    os.environ["HERMES_KANBAN_ATTACHMENTS_ROOT"] = str(state_root / "attachments")
+
+    sys.path.insert(0, str(webui_root))
+    sys.path.insert(0, str(agent_root))
+
+    from api import kanban_bridge
+    from hermes_cli import kanban_db
+
+    return kanban_bridge, kanban_db
+
+
+def make_handler(bridge):
+    class BridgeHandler(BaseHTTPRequestHandler):
+        server_version = "KanbanReferenceVerifier/1"
+
+        def log_message(self, _format: str, *_args: Any) -> None:
+            return
+
+        def _body(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length", "0") or 0)
+            if length == 0:
+                return {}
+            try:
+                value = json.loads(self.rfile.read(length))
+            except (TypeError, ValueError, json.JSONDecodeError):
+                return {}
+            return value if isinstance(value, dict) else {}
+
+        def _unknown(self) -> None:
+            payload = b'{"error":"unknown kanban endpoint"}'
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self) -> None:
+            result = bridge.handle_kanban_get(self, urlsplit(self.path))
+            if result is False:
+                self._unknown()
+
+        def do_POST(self) -> None:
+            result = bridge.handle_kanban_post(
+                self,
+                urlsplit(self.path),
+                self._body(),
+            )
+            if result is False:
+                self._unknown()
+
+        def do_PATCH(self) -> None:
+            result = bridge.handle_kanban_patch(
+                self,
+                urlsplit(self.path),
+                self._body(),
+            )
+            if result is False:
+                self._unknown()
+
+        def do_DELETE(self) -> None:
+            result = bridge.handle_kanban_delete(
+                self,
+                urlsplit(self.path),
+                self._body(),
+            )
+            if result is False:
+                self._unknown()
+
+    return BridgeHandler
+
+
+class ReferenceClient:
+    def __init__(self, port: int):
+        self.base_url = f"http://127.0.0.1:{port}"
+        self.request_count = 0
+        self.mutation_request_count = 0
+
+    def request(
+        self,
+        label: str,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.request_count += 1
+        if method != "GET" and not path.startswith("/api/kanban/dispatch"):
+            self.mutation_request_count += 1
+        encoded = None if body is None else json.dumps(body).encode("utf-8")
+        request = Request(
+            self.base_url + path,
+            data=encoded,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urlopen(request, timeout=10) as response:
+                status = response.status
+                raw = response.read()
+        except HTTPError as error:
+            status = error.code
+            raw = error.read()
+        require(status == 200, f"{label}-http-{status}")
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError) as error:
+            raise VerificationError(f"{label}-json") from error
+        require(isinstance(payload, dict), f"{label}-envelope")
+        return payload
+
+
+def verify(client: ReferenceClient, kanban_db) -> dict[str, int]:
+    spawn_attempts = 0
+
+    def forbidden_spawn(*_args: Any, **_kwargs: Any):
+        nonlocal spawn_attempts
+        spawn_attempts += 1
+        raise VerificationError("worker-spawn-attempted")
+
+    kanban_db._default_spawn = forbidden_spawn
+
+    initial_boards = client.request("initial-boards", "GET", "/api/kanban/boards")
+    require(isinstance(initial_boards.get("boards"), list), "initial-boards-shape")
+
+    created_board = client.request(
+        "create-board",
+        "POST",
+        "/api/kanban/boards",
+        {"slug": "verification", "name": "Verification"},
+    )
+    require(created_board.get("board", {}).get("slug") == "verification", "create-board-shape")
+
+    updated_board = client.request(
+        "update-board",
+        "PATCH",
+        "/api/kanban/boards/verification",
+        {"name": "Reference Verification", "color": "blue"},
+    )
+    require(updated_board.get("board", {}).get("name") == "Reference Verification", "update-board-shape")
+
+    switched = client.request(
+        "switch-board",
+        "POST",
+        "/api/kanban/boards/verification/switch",
+        {},
+    )
+    require(switched.get("current") == "verification", "switch-board-shape")
+
+    configuration = client.request(
+        "configuration",
+        "GET",
+        "/api/kanban/config?board=verification",
+    )
+    require(isinstance(configuration.get("columns"), list), "configuration-shape")
+
+    first = client.request(
+        "create-first-task",
+        "POST",
+        "/api/kanban/tasks?board=verification",
+        {
+            "title": "Reference parent",
+            "status": "todo",
+            "tenant": "verification",
+            "workspace_kind": "scratch",
+        },
+    )
+    second = client.request(
+        "create-second-task",
+        "POST",
+        "/api/kanban/tasks?board=verification",
+        {
+            "title": "Reference child",
+            "status": "triage",
+            "tenant": "verification",
+            "workspace_kind": "scratch",
+        },
+    )
+    first_id = first.get("task", {}).get("id")
+    second_id = second.get("task", {}).get("id")
+    require(isinstance(first_id, str) and bool(first_id), "first-task-shape")
+    require(isinstance(second_id, str) and bool(second_id), "second-task-shape")
+
+    patched = client.request(
+        "patch-task",
+        "PATCH",
+        f"/api/kanban/tasks/{first_id}?board=verification",
+        {
+            "title": "Reference parent updated",
+            "assignee": "reference-profile",
+            "priority": 7,
+            "status": "ready",
+        },
+    )
+    require(patched.get("task", {}).get("status") == "ready", "patch-task-shape")
+
+    comment = client.request(
+        "comment-task",
+        "POST",
+        f"/api/kanban/tasks/{first_id}/comments?board=verification",
+        {"author": "verifier", "body": "Isolated reference comment"},
+    )
+    require(comment.get("ok") is True, "comment-shape")
+
+    linked = client.request(
+        "link-tasks",
+        "POST",
+        "/api/kanban/links?board=verification",
+        {"parent_id": first_id, "child_id": second_id},
+    )
+    require(linked.get("ok") is True, "link-shape")
+
+    detail = client.request(
+        "task-detail",
+        "GET",
+        f"/api/kanban/tasks/{second_id}?board=verification",
+    )
+    require(first_id in detail.get("links", {}).get("parents", []), "detail-links")
+
+    board = client.request(
+        "board-snapshot",
+        "GET",
+        "/api/kanban/board?board=verification",
+    )
+    task_count = sum(
+        len(column.get("tasks", []))
+        for column in board.get("columns", [])
+        if isinstance(column, dict)
+    )
+    require(task_count == 2, "board-task-count")
+
+    stats = client.request(
+        "board-stats",
+        "GET",
+        "/api/kanban/stats?board=verification",
+    )
+    require(isinstance(stats.get("by_status"), dict), "stats-shape")
+
+    assignees = client.request(
+        "board-assignees",
+        "GET",
+        "/api/kanban/assignees?board=verification",
+    )
+    assignee_names = [
+        item.get("name") if isinstance(item, dict) else item
+        for item in assignees.get("assignees", [])
+    ]
+    require("reference-profile" in assignee_names, "assignees-shape")
+
+    events = client.request(
+        "board-events",
+        "GET",
+        "/api/kanban/events?board=verification&since=0&limit=200",
+    )
+    require(len(events.get("events", [])) > 0, "events-shape")
+
+    log = client.request(
+        "task-log",
+        "GET",
+        f"/api/kanban/tasks/{first_id}/log?board=verification&tail=1024",
+    )
+    require(log.get("exists") is False, "log-shape")
+
+    blocked = client.request(
+        "block-task",
+        "POST",
+        f"/api/kanban/tasks/{first_id}/block?board=verification",
+        {"reason": "Reference verification"},
+    )
+    require(blocked.get("task", {}).get("status") == "blocked", "block-task-shape")
+
+    unblocked = client.request(
+        "unblock-task",
+        "POST",
+        f"/api/kanban/tasks/{first_id}/unblock?board=verification",
+        {},
+    )
+    require(unblocked.get("task", {}).get("status") in {"todo", "ready"}, "unblock-task-shape")
+
+    bulk = client.request(
+        "bulk-update",
+        "POST",
+        "/api/kanban/tasks/bulk?board=verification",
+        {"ids": [first_id, second_id], "priority": 3},
+    )
+    results = bulk.get("results", [])
+    require(len(results) == 2 and all(item.get("ok") for item in results), "bulk-update-shape")
+
+    before_dispatch = client.request(
+        "pre-dispatch-detail",
+        "GET",
+        f"/api/kanban/tasks/{first_id}?board=verification",
+    )
+    dispatch = client.request(
+        "dispatch-dry-run",
+        "POST",
+        "/api/kanban/dispatch?board=verification&dry_run=true&max=8",
+        {},
+    )
+    require(
+        any(
+            key in dispatch
+            for key in (
+                "spawned",
+                "promoted",
+                "reclaimed",
+                "skipped_unassigned",
+                "skipped_nonspawnable",
+            )
+        ),
+        "dispatch-shape",
+    )
+    after_dispatch = client.request(
+        "post-dispatch-detail",
+        "GET",
+        f"/api/kanban/tasks/{first_id}?board=verification",
+    )
+    require(
+        before_dispatch.get("task", {}).get("status")
+        == after_dispatch.get("task", {}).get("status"),
+        "dispatch-mutated-status",
+    )
+    require(spawn_attempts == 0, "worker-spawn-attempted")
+
+    unlinked = client.request(
+        "unlink-tasks",
+        "DELETE",
+        "/api/kanban/links?board=verification",
+        {"parent_id": first_id, "child_id": second_id},
+    )
+    require(unlinked.get("ok") is True, "unlink-shape")
+
+    archived_task = client.request(
+        "archive-task",
+        "POST",
+        "/api/kanban/tasks/bulk?board=verification",
+        {"ids": [second_id], "archive": True},
+    )
+    require(archived_task.get("results", [{}])[0].get("ok") is True, "archive-task-shape")
+
+    archived_board = client.request(
+        "archive-board",
+        "DELETE",
+        "/api/kanban/boards/verification",
+        {},
+    )
+    require(archived_board.get("current") == "default", "archive-board-shape")
+    require(
+        archived_board.get("result", {}).get("action") == "archived",
+        "archive-board-result",
+    )
+
+    final_boards = client.request(
+        "final-boards",
+        "GET",
+        "/api/kanban/boards?include_archived=true",
+    )
+    require(
+        all(item.get("slug") != "verification" for item in final_boards.get("boards", [])),
+        "archived-board-removal",
+    )
+
+    return {
+        "requests": client.request_count,
+        "mutations": client.mutation_request_count,
+        "worker_spawns": spawn_attempts,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-root", type=Path, required=True)
+    parser.add_argument("--webui-root", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermex-kanban-reference-") as temporary:
+            state_root = Path(temporary)
+            bridge, kanban_db = configure_imports(
+                args.agent_root.resolve(),
+                args.webui_root.resolve(),
+                state_root,
+            )
+            server = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(bridge))
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                evidence = verify(ReferenceClient(server.server_port), kanban_db)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+    except (OSError, subprocess.SubprocessError, VerificationError) as error:
+        label = str(error) if isinstance(error, VerificationError) else type(error).__name__
+        print(f"result=failed check={label}")
+        return 1
+
+    print(
+        "result=passed "
+        f"requests={evidence['requests']} "
+        f"mutations={evidence['mutations']} "
+        "dispatcher_mode=dry_run "
+        f"worker_spawns={evidence['worker_spawns']} "
+        "temporary_state=removed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #158

## Summary

- expose Kanban as a normal main-screen utility destination and remove the temporary `--kanban-lab` route
- complete capability-scoped Card, Board, Bulk Actions, Dispatcher, live-update, reconciliation, and safety behavior needed for activation
- make the Status strip persistent across Card navigation, horizontally scrollable only, and reliably selectable
- add contract/state/navigation coverage plus an isolated reference-server verifier that hard-disables worker spawning
- mark Kanban as shipped in the feature-gap index

## Validation

- `git diff --check`
- focused Kanban/navigation XCTest suite: 140 passed, 0 failed
- full XCTest suite: 1,517 passed, 0 failed
- signed Debug build/install/launch on the configured iPhone 17 simulator
- runtime UI checks: every Status selects; horizontal drag reveals Blocked/Done; vertical drag is inert; Card detail → Back and Bulk Actions transitions preserve the Status strip
- isolated reference server: 26 requests, 14 mutations, Dispatcher dry-run, 0 worker spawns, temporary state removed
- authenticated live-server JSON handshake and read-only SSE hello passed without storing credentials or response values

## Owner manual checks

- owner confirmed normal Kanban navigation and the SSE path work
- owner confirmed the corrected Status selection and strip behavior work well in the signed simulator build
- owner explicitly waived another physical-iPhone/TestFlight pass for the final interaction fix

## Safety

- no test mutates the maintainer's live Boards
- Dispatcher integration evidence uses `dry_run=true` and rejects any worker spawn attempt
- no live credentials, Card identifiers, or response payloads are committed
