### PR TITLE
fix: refresh sessions when app becomes active

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -2,6 +2,20 @@ import SwiftUI
 import SwiftData
 import UIKit
 
+enum SessionListForegroundRefreshPolicy {
+    static func shouldRefresh(
+        previousPhase: ScenePhase,
+        currentPhase: ScenePhase,
+        didCompleteInitialLoad: Bool,
+        isLoading: Bool
+    ) -> Bool {
+        previousPhase != .active
+            && currentPhase == .active
+            && didCompleteInitialLoad
+            && !isLoading
+    }
+}
+
 @MainActor
 struct SessionListView: View {
     private static let searchChromeIconVisualSize: CGFloat = 36
@@ -18,6 +32,7 @@ struct SessionListView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel: SessionListViewModel
     @State private var navigationState: SessionNavigationState
     @State private var sessionPendingRename: SessionSummary?
@@ -219,6 +234,16 @@ struct SessionListView: View {
                 openPendingSharedImportIfNeeded()
                 openRequestedNewChatIfNeeded()
                 refreshAfterReturningIfNeeded()
+            }
+            .onChange(of: scenePhase) { previousPhase, currentPhase in
+                guard SessionListForegroundRefreshPolicy.shouldRefresh(
+                    previousPhase: previousPhase,
+                    currentPhase: currentPhase,
+                    didCompleteInitialLoad: didCompleteInitialLoad,
+                    isLoading: viewModel.isLoading
+                ) else { return }
+
+                Task { await refreshSessionsAndActiveProfile() }
             }
             .onChange(of: pendingSharedImport) {
                 openPendingSharedImportIfNeeded()

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 @testable import HermesMobile
 
@@ -231,6 +232,39 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertEqual(
             SessionNavigationPersistence.load(for: secondServer, defaults: defaults),
             "second-session"
+        )
+    }
+
+    func testCompletedSessionListRefreshesWhenTheAppReturnsToForeground() {
+        XCTAssertTrue(
+            SessionListForegroundRefreshPolicy.shouldRefresh(
+                previousPhase: .background,
+                currentPhase: .active,
+                didCompleteInitialLoad: true,
+                isLoading: false
+            )
+        )
+    }
+
+    func testInitialSceneActivationDoesNotDuplicateTheInitialLoad() {
+        XCTAssertFalse(
+            SessionListForegroundRefreshPolicy.shouldRefresh(
+                previousPhase: .inactive,
+                currentPhase: .active,
+                didCompleteInitialLoad: false,
+                isLoading: false
+            )
+        )
+    }
+
+    func testForegroundActivationDoesNotOverlapAnExistingRefresh() {
+        XCTAssertFalse(
+            SessionListForegroundRefreshPolicy.shouldRefresh(
+                previousPhase: .background,
+                currentPhase: .active,
+                didCompleteInitialLoad: true,
+                isLoading: true
+            )
         )
     }
 }


### PR DESCRIPTION
## Linked issue

Fixes #205

## What changed

- Observe `scenePhase` in `SessionListView` and refresh sessions/profile when a previously loaded list returns to the foreground.
- Skip the lifecycle refresh during initial loading or while another list refresh is already running.
- Add focused regression tests for foreground refresh, initial-load suppression, and overlapping-load suppression.

This keeps the existing initial-load, navigation-return, and pull-to-refresh paths unchanged. It does not change server APIs, caching, authentication, or persistence.

## How it was tested

- Confirmed the regression tests fail before the policy exists (`Cannot find 'SessionListForegroundRefreshPolicy' in scope`).
- Confirmed the app and XCTest target compile and link with the implementation.
- `git diff --check` passes.
- The local simulator test run could not finish because the available Mac host was heavily contended; this draft PR intentionally relies on contributor CI for the full XCTest execution before it is marked ready.

AI disclosure: built with Hermes Agent (GPT-5.6).

## Checklist

- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (not applicable; no model changes)
- [x] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [x] No invented API endpoints or JSON shapes (no API changes)
