### PR TITLE
Refresh sessions after returning from new chat

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -35,6 +35,7 @@ struct SessionListView: View {
     @State private var selectedProjectID: String?
     @State private var sidebarScrollPosition: String?
     @State private var didCompleteInitialLoad = false
+    @State private var returnRefreshID: UUID?
     @FocusState private var searchFieldIsFocused: Bool
     @AppStorage(SessionSidebarDisclosureSettings.profilesAreExpandedKey)
     private var profilesAreExpanded = SessionSidebarDisclosureSettings.defaultProfilesAreExpanded
@@ -214,6 +215,10 @@ struct SessionListView: View {
             }
             .task(id: activeSessionMonitorTaskID) {
                 await monitorActiveSessionRows()
+            }
+            .task(id: returnRefreshID) {
+                guard returnRefreshID != nil else { return }
+                await refreshSessionsAndActiveProfile()
             }
             .onAppear {
                 openPendingSharedImportIfNeeded()
@@ -884,6 +889,7 @@ struct SessionListView: View {
 
     private func refreshSessionsAndActiveProfile() async {
         await loadSessions()
+        guard !Task.isCancelled else { return }
         await viewModel.loadActiveProfile()
     }
 
@@ -949,10 +955,7 @@ struct SessionListView: View {
 
     private func refreshAfterReturningIfNeeded() {
         guard didCompleteInitialLoad else { return }
-
-        Task {
-            await refreshSessionsAndActiveProfile()
-        }
+        returnRefreshID = UUID()
     }
 
     private func monitorActiveSessionRows() async {
@@ -994,10 +997,12 @@ struct SessionListView: View {
 
     private func loadSessions() async {
         await viewModel.load(modelContext: modelContext)
+        guard !Task.isCancelled else { return }
         handleLastError()
 
         if !viewModel.isViewingCachedData {
             await viewModel.loadProjects()
+            guard !Task.isCancelled else { return }
             handleLastError()
         }
     }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -230,14 +230,12 @@ struct SessionListView: View {
                 openRequestedNewChatIfNeeded()
             }
             .onChange(of: navigationState.destination) { oldValue, newValue in
-                if case .newChat = oldValue,
-                   case .newChat = newValue {
-                    return
-                }
-
-                if case .newChat = oldValue {
-                    viewModel.removeEmptySidebarPlaceholders()
-                }
+                SessionListNewChatReturn.run(
+                    from: oldValue,
+                    to: newValue,
+                    suppressEmptyPlaceholders: viewModel.removeEmptySidebarPlaceholders,
+                    refreshSessions: refreshAfterReturningIfNeeded
+                )
             }
             .refreshable {
                 await refreshSessionsAndActiveProfile()
@@ -1214,6 +1212,24 @@ enum SessionListInitialLoad {
         async let initialRefresh: Void = refreshSessionsAndActiveProfile()
         await resolvePendingDeepLink()
         await initialRefresh
+    }
+}
+
+enum SessionListNewChatReturn {
+    static func run(
+        from oldValue: SessionNavigationDestination?,
+        to newValue: SessionNavigationDestination?,
+        suppressEmptyPlaceholders: () -> Void,
+        refreshSessions: () -> Void
+    ) {
+        guard case .newChat = oldValue else { return }
+        if case .newChat = newValue { return }
+
+        // Keep this synchronous so an empty Untitled placeholder cannot flash
+        // during the navigation transition. The refresh then adopts the server's
+        // latest metadata for a new chat that has become contentful.
+        suppressEmptyPlaceholders()
+        refreshSessions()
     }
 }
 

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -154,6 +154,58 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertTrue(state.isCreatingNewChat)
     }
 
+    func testReturningFromContentfulNewChatSuppressesPlaceholdersThenRefreshesSessions() {
+        let route = PendingNewChatRoute()
+        var state = SessionNavigationState()
+        state.select(route)
+        state.remember(SessionSummary(sessionId: "created-session"))
+        let oldDestination = state.destination
+        state.clearDestination()
+        var events: [NewChatReturnEvent] = []
+
+        SessionListNewChatReturn.run(
+            from: oldDestination,
+            to: state.destination,
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertEqual(events, [.suppressedPlaceholders, .refreshedSessions])
+    }
+
+    func testReturningFromEmptyNewChatSuppressesPlaceholderThenRefreshesSessions() {
+        let route = PendingNewChatRoute()
+        var state = SessionNavigationState()
+        state.select(route)
+        let oldDestination = state.destination
+        state.clearDestination()
+        var events: [NewChatReturnEvent] = []
+
+        SessionListNewChatReturn.run(
+            from: oldDestination,
+            to: state.destination,
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertEqual(events, [.suppressedPlaceholders, .refreshedSessions])
+    }
+
+    func testReplacingNewChatRouteDoesNotRefreshSessions() {
+        let firstRoute = PendingNewChatRoute()
+        let secondRoute = PendingNewChatRoute()
+        var events: [NewChatReturnEvent] = []
+
+        SessionListNewChatReturn.run(
+            from: .newChat(firstRoute),
+            to: .newChat(secondRoute),
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertTrue(events.isEmpty)
+    }
+
     func testRemovingSelectedSessionClearsDestinationAndRestorationID() {
         let session = SessionSummary(sessionId: "session-1")
         var state = SessionNavigationState()
@@ -233,6 +285,11 @@ final class SessionNavigationStateTests: XCTestCase {
             "second-session"
         )
     }
+}
+
+private enum NewChatReturnEvent: Equatable {
+    case suppressedPlaceholders
+    case refreshedSessions
 }
 
 private actor SessionInitialLoadEventRecorder {


### PR DESCRIPTION
## Summary

- Refresh the sessions list when navigation leaves the new-chat destination.
- Keep empty Untitled placeholders suppressed synchronously during the return transition.
- Add focused regression coverage for contentful, empty, and replacement new-chat routes.

## Root cause

The existing return handler only removed empty placeholders from the in-memory list. It never requested current session metadata from the server, so a new session that had gained messages stayed absent until pull-to-refresh.

## User impact

A contentful new chat now appears in its server-determined list position immediately after navigating back. Returning from an unused new chat continues to hide the empty Untitled placeholder without a transition flash.

## Validation

- `git diff --check`
- Focused `SessionNavigationStateTests`: 22 passed, 0 failed
- Full XCTest suite: 1,547 passed, 0 failed, 0 skipped
- Signed Debug build/install/launch on iPhone 17

## Owner manual checks

- [x] A new chat appears immediately after one completed exchange.
- [x] The return behavior works after multiple exchanges.
- [x] Returning from an unused new chat does not show an empty Untitled row, including transiently.
- [x] Existing contentful untitled sessions remain visible.

Fixes #214