### PR TITLE
fix(chat): make stream liveness recovery transport-aware

### DIFF
--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -284,7 +284,7 @@ final class ChatPendingActionCoordinator {
         case .transportError, .error:
             startApprovalFallbackPolling(sessionID: sessionID)
         case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted, .title, .metering, .done, .clarificationPending,
-             .pendingSteerLeftover, .streamEnd, .cancelled, .ignored:
+             .pendingSteerLeftover, .streamEnd, .cancelled, .heartbeat, .ignored:
             break
         }
     }
@@ -390,7 +390,7 @@ final class ChatPendingActionCoordinator {
         case .transportError, .error:
             startClarificationFallbackPolling(sessionID: sessionID)
         case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted, .title, .metering, .done,
-             .pendingSteerLeftover, .streamEnd, .cancelled, .ignored:
+             .pendingSteerLeftover, .streamEnd, .cancelled, .heartbeat, .ignored:
             break
         }
     }

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -347,8 +347,24 @@ final class ChatStreamCoordinator {
             return
         }
 
+        let reconnectInterval = delegate?.streamCoordinatorHasRunningLiveToolCall == true
+            ? timing.runningToolReconnectInterval
+            : timing.reconnectInterval
         guard let lastProgressDate else {
-            recoveryState = .idle
+            guard let lastTransportActivityDate,
+                  now.timeIntervalSince(lastTransportActivityDate) >= reconnectInterval
+            else {
+                recoveryState = .idle
+                return
+            }
+
+            recoveryState = .checking
+            lastRecoveryStatusCheckDate = now
+            await recoverStaleStream(
+                streamID: activeStreamID,
+                forceReconnect: true,
+                modelContext: modelContext
+            )
             return
         }
 
@@ -359,9 +375,6 @@ final class ChatStreamCoordinator {
         }
 
         recoveryState = .checking
-        let reconnectInterval = delegate?.streamCoordinatorHasRunningLiveToolCall == true
-            ? timing.runningToolReconnectInterval
-            : timing.reconnectInterval
         let transportElapsed = now.timeIntervalSince(lastTransportActivityDate ?? lastProgressDate)
         let shouldForceReconnect = transportElapsed >= reconnectInterval
         guard shouldForceReconnect || shouldPollStatus(now: now) else { return }
@@ -673,8 +686,9 @@ final class ChatStreamCoordinator {
         isReplay: Bool,
         recoveryState: ActiveStreamRecoveryState
     ) {
-        lastProgressDate = Date()
-        lastTransportActivityDate = lastProgressDate
+        let startedAt = Date()
+        lastProgressDate = isReplay ? startedAt : nil
+        lastTransportActivityDate = startedAt
         lastRecoveryStatusCheckDate = nil
         self.recoveryState = recoveryState
         isReplayConnection = isReplay

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -90,6 +90,7 @@ final class ChatStreamCoordinator {
     private(set) var hasCompletedCurrentResponse = false
     private(set) var lastEventID: String?
     private(set) var lastProgressDate: Date?
+    private(set) var lastTransportActivityDate: Date?
     private(set) var liveTokensPerSecond: Double?
     private var lastRecoveryStatusCheckDate: Date?
     private(set) var isReplayConnection = false
@@ -361,7 +362,8 @@ final class ChatStreamCoordinator {
         let reconnectInterval = delegate?.streamCoordinatorHasRunningLiveToolCall == true
             ? timing.runningToolReconnectInterval
             : timing.reconnectInterval
-        let shouldForceReconnect = elapsed >= reconnectInterval
+        let transportElapsed = now.timeIntervalSince(lastTransportActivityDate ?? lastProgressDate)
+        let shouldForceReconnect = transportElapsed >= reconnectInterval
         guard shouldForceReconnect || shouldPollStatus(now: now) else { return }
 
         lastRecoveryStatusCheckDate = now
@@ -374,6 +376,7 @@ final class ChatStreamCoordinator {
 
     func markProgress(now: Date = Date()) {
         lastProgressDate = now
+        lastTransportActivityDate = now
         lastRecoveryStatusCheckDate = nil
         recoveryState = .idle
     }
@@ -405,6 +408,7 @@ final class ChatStreamCoordinator {
 
     private func handle(_ event: SSEEvent) {
         lastEventID = streamClient.lastEventID ?? lastEventID
+        lastTransportActivityDate = Date()
 
         switch event {
         case .token(let text):
@@ -478,6 +482,8 @@ final class ChatStreamCoordinator {
             finishStream()
         case .transportError(let message):
             handleTransportError(message)
+        case .heartbeat:
+            break
         case .ignored:
             break
         }
@@ -668,6 +674,7 @@ final class ChatStreamCoordinator {
         recoveryState: ActiveStreamRecoveryState
     ) {
         lastProgressDate = isReplay ? Date() : nil
+        lastTransportActivityDate = lastProgressDate
         lastRecoveryStatusCheckDate = nil
         self.recoveryState = recoveryState
         isReplayConnection = isReplay
@@ -677,6 +684,7 @@ final class ChatStreamCoordinator {
     private func resetRecoveryState() {
         recoveryState = .idle
         lastProgressDate = nil
+        lastTransportActivityDate = nil
         lastRecoveryStatusCheckDate = nil
         isReplayConnection = false
         delegate?.streamCoordinatorDidResetRecoveryState()

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -673,7 +673,7 @@ final class ChatStreamCoordinator {
         isReplay: Bool,
         recoveryState: ActiveStreamRecoveryState
     ) {
-        lastProgressDate = isReplay ? Date() : nil
+        lastProgressDate = Date()
         lastTransportActivityDate = lastProgressDate
         lastRecoveryStatusCheckDate = nil
         self.recoveryState = recoveryState

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -3837,7 +3837,7 @@ final class ChatViewModel {
             activeBtwAnswer = "Error: \(message)"
             updateActiveBtwMessage(isLoading: false)
             finishBtwStream()
-        case .ignored, .reasoning, .toolStarted, .toolCompleted, .title, .metering, .pendingSteerLeftover:
+        case .heartbeat, .ignored, .reasoning, .toolStarted, .toolCompleted, .title, .metering, .pendingSteerLeftover:
             break
         }
     }

--- a/HermesMobile/Networking/SSEClient.swift
+++ b/HermesMobile/Networking/SSEClient.swift
@@ -80,6 +80,7 @@ enum SSEEvent: Equatable {
     case cancelled
     case error(String)
     case transportError(String)
+    case heartbeat
     case ignored
 }
 
@@ -393,7 +394,11 @@ private final class SSEEventHandler: EventHandler {
         }
     }
 
-    func onComment(comment: String) {}
+    func onComment(comment _: String) {
+        Task { @MainActor in
+            onEvent(.heartbeat)
+        }
+    }
 
     func onError(error: Error) {
         Task { @MainActor in

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -376,6 +376,28 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testSilentInitialConnectionReconnectsWhenStale() async throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient) { request in
+            apiTestJSONResponse(
+                #"{"active": true, "stream_id": "stream-123", "replay_available": true}"#,
+                for: request
+            )
+        }
+
+        coordinator.start(streamID: "stream-123")
+        let connectionStartedAt = try XCTUnwrap(coordinator.lastProgressDate)
+
+        await coordinator.recoverStaleStreamIfNeeded(
+            now: connectionStartedAt.addingTimeInterval(18.1)
+        )
+
+        XCTAssertEqual(streamClient.startedURLs.count, 2)
+        XCTAssertEqual(streamClient.stopCount, 1)
+        XCTAssertEqual(coordinator.recoveryState, .reconnecting)
+    }
+
+    @MainActor
     func testStaleRecoveryDoesNotFinishReplacementStreamAfterTranscriptLoad() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let liveActivityManager = CoordinatorSpyLiveActivityManager()

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -386,7 +386,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         }
 
         coordinator.start(streamID: "stream-123")
-        let connectionStartedAt = try XCTUnwrap(coordinator.lastProgressDate)
+        XCTAssertNil(coordinator.lastProgressDate)
+        let connectionStartedAt = try XCTUnwrap(coordinator.lastTransportActivityDate)
 
         await coordinator.recoverStaleStreamIfNeeded(
             now: connectionStartedAt.addingTimeInterval(18.1)

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -331,6 +331,51 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testHeartbeatKeepsSemanticallyQuietStreamOnOriginalConnection() async throws {
+        var statusRequests = 0
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient) { request in
+            statusRequests += 1
+            return apiTestJSONResponse(
+                #"{"active": true, "stream_id": "stream-123", "replay_available": true}"#,
+                for: request
+            )
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.markProgress(now: Date().addingTimeInterval(-60))
+        streamClient.emit(.heartbeat)
+
+        await coordinator.recoverStaleStreamIfNeeded(now: Date().addingTimeInterval(1))
+
+        XCTAssertEqual(statusRequests, 1)
+        XCTAssertEqual(streamClient.startedURLs.count, 1)
+        XCTAssertEqual(streamClient.stopCount, 0)
+        XCTAssertEqual(coordinator.recoveryState, .checking)
+    }
+
+    @MainActor
+    func testMissingTransportActivityReconnectsStaleActiveStream() async throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient) { request in
+            apiTestJSONResponse(
+                #"{"active": true, "stream_id": "stream-123", "replay_available": true}"#,
+                for: request
+            )
+        }
+        let start = Date(timeIntervalSince1970: 1_770_000_000)
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.markProgress(now: start)
+
+        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(18.1))
+
+        XCTAssertEqual(streamClient.startedURLs.count, 2)
+        XCTAssertEqual(streamClient.stopCount, 1)
+        XCTAssertEqual(coordinator.recoveryState, .reconnecting)
+    }
+
+    @MainActor
     func testStaleRecoveryDoesNotFinishReplacementStreamAfterTranscriptLoad() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let liveActivityManager = CoordinatorSpyLiveActivityManager()

--- a/HermesMobileTests/SSEClientTests.swift
+++ b/HermesMobileTests/SSEClientTests.swift
@@ -94,6 +94,25 @@ final class SSEClientTests: XCTestCase {
         )
     }
 
+    func testSSEClientForwardsHeartbeatComments() async {
+        DelayedSSEURLProtocol.configure(chunks: [
+            DelayedSSEChunk(text: ": heartbeat\n\n", delayNanoseconds: 0)
+        ])
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DelayedSSEURLProtocol.self]
+        let client = SSEClient(urlSessionConfiguration: configuration)
+        let heartbeat = expectation(description: "received heartbeat comment")
+
+        client.start(url: URL(string: "https://example.test/api/chat/stream?stream_id=stream-123")!) { event in
+            if case .heartbeat = event {
+                heartbeat.fulfill()
+            }
+        }
+
+        await fulfillment(of: [heartbeat], timeout: 5)
+        client.stop()
+    }
+
     func testDecodesToolStartedEventFromUpstreamPayload() {
         let event = SSEEventDecoder.decode(
             eventType: "tool",


### PR DESCRIPTION
## Summary
- Track transport activity separately from semantic response progress.
- Treat SSE comment heartbeats as active transport, preventing false stale-stream recovery.
- Detect a silent initial connection after the reconnect timeout, while keeping recovery state hidden during the normal initial wait.
- Add regression coverage for heartbeat-only, missing-transport-activity, and silent-initial-stream paths.

## Root cause
Stale recovery measured only semantic progress: a healthy heartbeat-only stream could reconnect unnecessarily, while a connection with no initial event never became stale. Marking semantic progress at connection start fixes the latter but shows recovery state too early. The coordinator now distinguishes transport liveness from visible response progress.

Fixes #186

## Validation
- `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17' -parallel-testing-enabled NO` — 1,548 passed, 0 failed, 0 skipped.
- Normally signed Debug app installed and launched on iPhone 17, iOS 26.5.
- `git diff --check origin/master..HEAD`

## Need to verify
- Live-server heartbeat-only stream and a temporarily silent initial stream on the target deployment.
- A deployment that emits no SSE comments at all — an older server, or a proxy that strips them. Nothing then refreshes transport activity before the first event, so the new silent-initial branch force-reconnects once every `reconnectInterval` (18s, or 25s while a live tool call is running) until the first event arrives. Recovery re-checks `chatStreamStatus` and reconnects with replay, so the user turn is never resent, but the forced reconnect currently has no backoff or cap. Whether the target deployment actually sends comment heartbeats is unverified here: the read-only upstream checkout emits them, but it is neither the compatibility pin nor the live server.

## AI assistance
Prepared with Codex; changes and validation were reviewed before updating this draft.
