### PR TITLE
fix(chat): group agent activity by turn

### DIFF
--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -3232,7 +3232,9 @@ final class ChatViewModel {
             contentParts: existing.contentParts,
             reasoning: existing.reasoning,
             attachments: existing.attachments,
-            turnTps: existing.turnTps
+            turnTps: existing.turnTps,
+            phase: existing.phase,
+            codexMessageItems: existing.codexMessageItems
         )
         scheduleStreamingScrollTrigger()
     }
@@ -3925,47 +3927,49 @@ final class ChatViewModel {
 
     @discardableResult
     private func appendInterimAssistant(_ payload: InterimAssistantStreamEvent) -> Bool {
-        guard payload.alreadyStreamed != true else { return false }
-
         let text = payload.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !text.isEmpty else { return false }
 
         flushPendingStreamingContent()
-
-        if let streamingAssistantMessageID,
-           let index = messages.firstIndex(where: { $0.messageId == streamingAssistantMessageID }) {
-            let existing = messages[index]
-            let currentContent = existing.content ?? ""
-            let textToAppend = deduplicatedReplayText(
-                text,
-                existingContent: currentContent,
-                matchedPrefixLength: &activeStreamReplayMatchedInterimLength
-            )
-            guard !textToAppend.isEmpty else { return false }
-
-            let shouldAppendReplaySuffixDirectly = isActiveStreamReplayConnection && textToAppend != text
-            let shouldUseSeparator = currentContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-                && !shouldAppendReplaySuffixDirectly
-            let separator = shouldUseSeparator ? "\n\n" : ""
-            messages[index] = ChatMessage(
-                role: existing.role,
-                content: currentContent + separator + textToAppend,
-                timestamp: existing.timestamp,
-                messageId: existing.messageId,
-                name: existing.name,
-                toolCallId: existing.toolCallId,
-                toolUseId: existing.toolUseId,
-                toolCalls: existing.toolCalls,
-                contentParts: existing.contentParts,
-                reasoning: existing.reasoning,
-                attachments: existing.attachments,
-                turnTps: existing.turnTps
-            )
-            scheduleStreamingScrollTrigger()
-            return true
+        let messageID = ensureStreamingAssistantMessage()
+        if payload.alreadyStreamed == true {
+            removeAlreadyStreamedInterimText(text, fromMessageID: messageID)
+        }
+        if reasoningAnchorMessageID == nil {
+            reasoningAnchorMessageID = messageID
         }
 
-        return appendAssistantToken(text)
+        let textToAppend = deduplicatedReplayText(
+            text,
+            existingContent: liveReasoningText,
+            matchedPrefixLength: &activeStreamReplayMatchedInterimLength
+        )
+        guard !textToAppend.isEmpty else { return false }
+
+        let separator = liveReasoningText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? ""
+            : "\n\n"
+        liveReasoningText += separator + textToAppend
+        scheduleStreamingScrollTrigger()
+        return true
+    }
+
+    private func removeAlreadyStreamedInterimText(_ text: String, fromMessageID messageID: String) {
+        guard let index = messages.firstIndex(where: { $0.messageId == messageID }) else { return }
+
+        let existing = messages[index]
+        let currentContent = existing.content ?? ""
+        let updatedContent: String
+        if currentContent.trimmingCharacters(in: .whitespacesAndNewlines) == text {
+            updatedContent = ""
+        } else if let range = currentContent.range(of: text, options: [.backwards, .anchored]) {
+            updatedContent = String(currentContent[..<range.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            return
+        }
+
+        messages[index] = existing.replacingContentForTranscript(updatedContent)
     }
 
     private func applyCompletedStreamSession(_ completedSession: SessionDetail) {
@@ -4051,10 +4055,24 @@ final class ChatViewModel {
     }
 
     private func setCompletedToolCallGroups(_ groups: [ToolCallGroup]) {
-        let lookup = ToolCallGroupAnchorLookup(groups: groups)
-        guard completedToolCallGroups != groups else { return }
+        let reanchoredGroups = groups.map { group in
+            guard let anchorMessageID = group.anchorMessageID else { return group }
+            let displayAnchorID = TranscriptTurnClassifier.displayAnchorID(
+                forAssistantAnchorID: anchorMessageID,
+                in: messages,
+                messageOffset: messagesOffset
+            )
+            guard displayAnchorID != anchorMessageID else { return group }
+            return ToolCallGroup(
+                id: group.id,
+                anchorMessageID: displayAnchorID,
+                toolCalls: group.toolCalls
+            )
+        }
+        let lookup = ToolCallGroupAnchorLookup(groups: reanchoredGroups)
+        guard completedToolCallGroups != reanchoredGroups else { return }
 
-        completedToolCallGroups = groups
+        completedToolCallGroups = reanchoredGroups
         completedToolCallGroupLookup = lookup
     }
 
@@ -4337,7 +4355,9 @@ final class ChatViewModel {
                 contentParts: existing.contentParts,
                 reasoning: existing.reasoning,
                 attachments: existing.attachments,
-                turnTps: existing.turnTps
+                turnTps: existing.turnTps,
+                phase: existing.phase,
+                codexMessageItems: existing.codexMessageItems
             )
             return true
         }
@@ -5056,7 +5076,9 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
                 contentParts: message.contentParts,
                 reasoning: message.reasoning,
                 attachments: message.attachments,
-                turnTps: finalTokensPerSecond
+                turnTps: finalTokensPerSecond,
+                phase: message.phase,
+                codexMessageItems: message.codexMessageItems
             )
         }
         return hasCompletedTranscript
@@ -5236,6 +5258,10 @@ extension ChatViewModel {
             messages,
             messageOffset: messageOffset
         )
+        let displayAnchorIDsByAnchorID = TranscriptTurnClassifier.assistantDisplayAnchorIDsByAnchorID(
+            messages,
+            messageOffset: messageOffset
+        )
         let assistantMessagesByID = messages.enumerated().reduce(into: [String: ChatMessage]()) { result, entry in
             let message = entry.element
             guard message.role == "assistant" else { return }
@@ -5263,6 +5289,20 @@ extension ChatViewModel {
                 messageOffset: messageOffset
             )
             let turnKey = turnKeysByMessageID[anchorID] ?? "message:\(anchorID)"
+            for text in TranscriptTurnClassifier.progressTexts(
+                for: message,
+                anchorID: anchorID,
+                displayAnchorIDsByAnchorID: displayAnchorIDsByAnchorID
+            ) {
+                appendReasoningCandidate(
+                    text: text,
+                    anchorMessageID: anchorID,
+                    turnKey: turnKey,
+                    visibleText: nil,
+                    order: &order,
+                    candidates: &candidates
+                )
+            }
             for text in reasoningTexts(from: message) {
                 appendReasoningCandidate(
                     text: text,
@@ -5275,19 +5315,32 @@ extension ChatViewModel {
             }
         }
 
-        var latestCandidateIndexByKey: [String: Int] = [:]
-        for (index, candidate) in candidates.enumerated() {
-            latestCandidateIndexByKey["\(candidate.turnKey)::\(normalizedReasoningKey(candidate.text))"] = index
+        var turnOrder: [String] = []
+        var textsByTurn: [String: [String]] = [:]
+        var anchorByTurn: [String: String?] = [:]
+        var seenKeys: Set<String> = []
+
+        for candidate in candidates {
+            let normalizedKey = normalizedReasoningKey(candidate.text)
+            let candidateKey = "\(candidate.turnKey)::\(normalizedKey)"
+            guard seenKeys.insert(candidateKey).inserted else { continue }
+
+            if textsByTurn[candidate.turnKey] == nil {
+                turnOrder.append(candidate.turnKey)
+            }
+            textsByTurn[candidate.turnKey, default: []].append(candidate.text)
+            anchorByTurn[candidate.turnKey] = candidate.anchorMessageID.map {
+                displayAnchorIDsByAnchorID[$0] ?? $0
+            }
         }
 
-        return candidates.enumerated().compactMap { index, candidate in
-            let key = "\(candidate.turnKey)::\(normalizedReasoningKey(candidate.text))"
-            guard latestCandidateIndexByKey[key] == index else { return nil }
-
+        return turnOrder.compactMap { turnKey in
+            guard let texts = textsByTurn[turnKey], !texts.isEmpty else { return nil }
+            let anchor = anchorByTurn[turnKey] ?? nil
             return ReasoningGroup(
-                id: "reasoning-\(candidate.anchorMessageID ?? "unanchored")-\(candidate.order)",
-                anchorMessageID: candidate.anchorMessageID,
-                text: candidate.text
+                id: "reasoning-turn-\(anchor ?? turnKey)",
+                anchorMessageID: anchor,
+                text: texts.joined(separator: "\n\n")
             )
         }
     }
@@ -5302,6 +5355,10 @@ extension ChatViewModel {
         hidingStreamingAssistantID streamingAssistantID: String?
     ) -> [TranscriptMessage] {
         let offset = max(0, messageOffset ?? 0)
+        let displayAnchorIDsByAnchorID = TranscriptTurnClassifier.assistantDisplayAnchorIDsByAnchorID(
+            messages,
+            messageOffset: messageOffset
+        )
         var transcriptMessages: [TranscriptMessage] = []
         transcriptMessages.reserveCapacity(messages.count)
 
@@ -5317,14 +5374,25 @@ extension ChatViewModel {
                 at: loadedIndex,
                 messageOffset: messageOffset
             )
+            if message.role == "assistant",
+               ChatMarkerMessageClassifier.classify(message) == nil,
+               displayAnchorIDsByAnchorID[anchorID] != anchorID {
+                continue
+            }
             let absoluteIndex = offset + loadedIndex
             let renderID = "transcript:\(absoluteIndex)"
+            let displayMessage: ChatMessage
+            if message.role == "assistant", let finalText = message.codexFinalAnswerText {
+                displayMessage = message.replacingContentForTranscript(finalText)
+            } else {
+                displayMessage = message
+            }
 
             transcriptMessages.append(TranscriptMessage(
                 loadedIndex: loadedIndex,
                 renderID: renderID,
                 anchorID: anchorID,
-                message: message
+                message: displayMessage
             ))
         }
 

--- a/HermesMobile/Models/ChatMessage.swift
+++ b/HermesMobile/Models/ChatMessage.swift
@@ -17,6 +17,8 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
     let reasoning: String?
     let attachments: [MessageAttachment]?
     let turnTps: Double?
+    let phase: String?
+    let codexMessageItems: [CodexMessageItem]?
 
     init(
         role: String?,
@@ -30,7 +32,9 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         contentParts: [JSONValue]? = nil,
         reasoning: String? = nil,
         attachments: [MessageAttachment]? = nil,
-        turnTps: Double? = nil
+        turnTps: Double? = nil,
+        phase: String? = nil,
+        codexMessageItems: [CodexMessageItem]? = nil
     ) {
         self.role = role
         self.content = content
@@ -44,6 +48,8 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         self.reasoning = reasoning
         self.attachments = attachments
         self.turnTps = turnTps
+        self.phase = phase
+        self.codexMessageItems = codexMessageItems
     }
 
     enum CodingKeys: String, CodingKey {
@@ -58,6 +64,8 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         case reasoning
         case attachments
         case turnTps = "_turnTps"
+        case phase
+        case codexMessageItems
         case underscoredTimestamp = "_ts"
     }
 
@@ -78,6 +86,51 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         let decodedAttachments = Self.decodeAttachmentsTolerantly(from: container)
         attachments = Self.attachments(decodedAttachments, enrichedByMarkerIn: content)
         turnTps = container.decodeLossyDoubleIfPresent(forKey: .turnTps)
+        phase = container.decodeLossyStringIfPresent(forKey: .phase)
+        codexMessageItems = try? container.decodeIfPresent([CodexMessageItem].self, forKey: .codexMessageItems)
+    }
+
+    var codexCommentaryTexts: [String] {
+        codexMessageItems?.compactMap { item in
+            guard item.phase == "commentary" else { return nil }
+            return item.visibleText
+        } ?? []
+    }
+
+    var codexFinalAnswerText: String? {
+        if phase == "final_answer" {
+            return Self.nonEmptyString(content)
+        }
+
+        return codexMessageItems?.reversed().compactMap { item in
+            guard item.phase == "final_answer" else { return nil }
+            return item.visibleText
+        }.first
+    }
+
+    var isCodexCommentaryOnly: Bool {
+        phase == "commentary" || (
+            codexCommentaryTexts.isEmpty == false && codexFinalAnswerText == nil
+        )
+    }
+
+    func replacingContentForTranscript(_ replacement: String) -> ChatMessage {
+        ChatMessage(
+            role: role,
+            content: replacement,
+            timestamp: timestamp,
+            messageId: messageId,
+            name: name,
+            toolCallId: toolCallId,
+            toolUseId: toolUseId,
+            toolCalls: toolCalls,
+            contentParts: contentParts,
+            reasoning: reasoning,
+            attachments: attachments,
+            turnTps: turnTps,
+            phase: phase,
+            codexMessageItems: codexMessageItems
+        )
     }
 
     private static func attachments(
@@ -200,6 +253,75 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
     }
 }
 
+struct CodexMessageItem: Codable, Equatable {
+    let type: String?
+    let role: String?
+    let phase: String?
+    let text: String?
+    let content: [JSONValue]?
+
+    init(
+        type: String? = nil,
+        role: String? = nil,
+        phase: String? = nil,
+        text: String? = nil,
+        content: [JSONValue]? = nil
+    ) {
+        self.type = type
+        self.role = role
+        self.phase = phase
+        self.text = text
+        self.content = content
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case role
+        case phase
+        case text
+        case content
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = container.decodeLossyStringIfPresent(forKey: .type)
+        role = container.decodeLossyStringIfPresent(forKey: .role)
+        phase = container.decodeLossyStringIfPresent(forKey: .phase)
+        text = container.decodeLossyStringIfPresent(forKey: .text)
+        if let parts = try? container.decodeIfPresent([JSONValue].self, forKey: .content) {
+            content = parts
+        } else if let value = try? container.decodeIfPresent(JSONValue.self, forKey: .content) {
+            content = [value]
+        } else {
+            content = nil
+        }
+    }
+
+    var visibleText: String? {
+        if let text = nonEmpty(text) {
+            return text
+        }
+
+        let joined = (content ?? []).compactMap { part -> String? in
+            guard case .object(let object) = part else {
+                if case .string(let value) = part { return value }
+                return nil
+            }
+
+            guard case .string(let value)? = object["text"] else { return nil }
+            return value
+        }
+        .joined()
+
+        return nonEmpty(joined)
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}
+
 enum TranscriptTurnClassifier {
     static func anchorID(for message: ChatMessage, at index: Int, messageOffset: Int? = nil) -> String {
         if let messageID = nonEmpty(message.messageId) {
@@ -237,6 +359,74 @@ enum TranscriptTurnClassifier {
 
     static func assistantTurnKeysByMessageID(_ messages: [ChatMessage]) -> [String: String] {
         assistantTurnKeysByAnchorID(messages)
+    }
+
+    /// Maps every assistant row in a user turn to the single row that should
+    /// own that turn's activity and final answer. Codex explicitly marks the
+    /// final message; other providers fall back to the last visible assistant.
+    static func assistantDisplayAnchorIDsByAnchorID(
+        _ messages: [ChatMessage],
+        messageOffset: Int? = nil
+    ) -> [String: String] {
+        var result: [String: String] = [:]
+        var turnAssistantIndexes: [Int] = []
+
+        func flushTurn() {
+            defer { turnAssistantIndexes = [] }
+            guard !turnAssistantIndexes.isEmpty else { return }
+
+            let displayIndex = turnAssistantIndexes.last(where: { index in
+                messages[index].codexFinalAnswerText != nil || messages[index].phase == "final_answer"
+            }) ?? turnAssistantIndexes.last(where: { index in
+                let message = messages[index]
+                return message.isCodexCommentaryOnly == false && nonEmpty(message.content) != nil
+            }) ?? turnAssistantIndexes[turnAssistantIndexes.count - 1]
+            let displayAnchor = anchorID(
+                for: messages[displayIndex],
+                at: displayIndex,
+                messageOffset: messageOffset
+            )
+
+            for index in turnAssistantIndexes {
+                result[anchorID(for: messages[index], at: index, messageOffset: messageOffset)] = displayAnchor
+            }
+        }
+
+        for (index, message) in messages.enumerated() {
+            if isUserTurnBoundary(message) {
+                flushTurn()
+            }
+
+            guard message.role == "assistant",
+                  ChatMarkerMessageClassifier.classify(message) == nil
+            else { continue }
+            turnAssistantIndexes.append(index)
+        }
+        flushTurn()
+        return result
+    }
+
+    static func displayAnchorID(
+        forAssistantAnchorID anchorID: String,
+        in messages: [ChatMessage],
+        messageOffset: Int? = nil
+    ) -> String {
+        assistantDisplayAnchorIDsByAnchorID(messages, messageOffset: messageOffset)[anchorID] ?? anchorID
+    }
+
+    static func progressTexts(
+        for message: ChatMessage,
+        anchorID: String,
+        displayAnchorIDsByAnchorID: [String: String]
+    ) -> [String] {
+        if !message.codexCommentaryTexts.isEmpty {
+            return message.codexCommentaryTexts
+        }
+
+        guard displayAnchorIDsByAnchorID[anchorID] != anchorID,
+              let content = nonEmpty(message.content)
+        else { return [] }
+        return [content]
     }
 
     static func assistantAnchorID(

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -348,6 +348,12 @@ private extension ChatMessage {
         } else {
             contentParts = nil
         }
+        let codexMessageItems: [CodexMessageItem]?
+        if let data = cachedMessage.codexMessageItemsData {
+            codexMessageItems = try? JSONDecoder().decode([CodexMessageItem].self, from: data)
+        } else {
+            codexMessageItems = nil
+        }
         self.init(
             role: cachedMessage.role,
             content: cachedMessage.content,
@@ -360,7 +366,9 @@ private extension ChatMessage {
             contentParts: contentParts,
             reasoning: cachedMessage.reasoning,
             attachments: attachments,
-            turnTps: cachedMessage.turnTps
+            turnTps: cachedMessage.turnTps,
+            phase: cachedMessage.phase,
+            codexMessageItems: codexMessageItems
         )
     }
 }

--- a/HermesMobile/Persistence/CachedMessage.swift
+++ b/HermesMobile/Persistence/CachedMessage.swift
@@ -19,6 +19,8 @@ final class CachedMessage {
     var reasoning: String?
     var attachmentsData: Data?
     var turnTps: Double?
+    var phase: String?
+    var codexMessageItemsData: Data?
     var cachedAt: Date
     var expiresAt: Date
 
@@ -74,6 +76,12 @@ final class CachedMessage {
         }
         reasoning = message.reasoning
         turnTps = message.turnTps
+        phase = message.phase
+        if let codexMessageItems = message.codexMessageItems, !codexMessageItems.isEmpty {
+            codexMessageItemsData = try? JSONEncoder().encode(codexMessageItems)
+        } else {
+            codexMessageItemsData = nil
+        }
         if let attachments = message.attachments, !attachments.isEmpty {
             attachmentsData = try? JSONEncoder().encode(attachments)
         } else {

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -88,15 +88,12 @@ final class APIClientConfigurationTests: APIClientTestCase {
         let reasoningGroups = ChatViewModel.reasoningDisplayGroups(messages: messages, archivedGroups: [])
         let transcriptMessages = ChatViewModel.transcriptMessages(from: messages)
 
-        XCTAssertEqual(reasoningGroups.map(\.anchorMessageID), [
-            "assistant-tools",
-            "assistant-post-tools",
-            "assistant-final"
-        ])
-        XCTAssertEqual(reasoningGroups[0].text, "The user wants me to use terminal and search_files. I should run a quick command.")
-        XCTAssertEqual(reasoningGroups[1].text, "Terminal works. Now run search_files to show that works too.")
-        XCTAssertTrue(reasoningGroups[2].text.contains("Both tools worked. I should give a concise summary."))
-        XCTAssertFalse(reasoningGroups[2].text.contains("**Terminal:**"))
+        XCTAssertEqual(reasoningGroups.map(\.anchorMessageID), ["assistant-final"])
+        XCTAssertTrue(reasoningGroups[0].text.contains("The user wants me to use terminal and search_files."))
+        XCTAssertTrue(reasoningGroups[0].text.contains("Terminal works. Now run search_files"))
+        XCTAssertTrue(reasoningGroups[0].text.contains("Both tools worked. I should give a concise summary."))
+        XCTAssertFalse(reasoningGroups[0].text.contains("**Terminal:**"))
+        XCTAssertEqual(transcriptMessages.map(\.message.id), ["user-tools", "assistant-final"])
         XCTAssertFalse(transcriptMessages.contains { $0.message.id == "tool-results" })
     }
 

--- a/HermesMobileTests/APIClientSessionDetailTests.swift
+++ b/HermesMobileTests/APIClientSessionDetailTests.swift
@@ -1443,17 +1443,17 @@ final class APIClientSessionDetailTests: APIClientTestCase {
         )
         let transcriptMessages = ChatViewModel.transcriptMessages(from: messages, messageOffset: 4)
 
-        XCTAssertEqual(transcriptMessages.map(\.anchorID), ["raw:4", "raw:5", "raw:7", "raw:9"])
+        XCTAssertEqual(transcriptMessages.map(\.anchorID), ["raw:4", "raw:9"])
         XCTAssertEqual(groups.count, 1)
         XCTAssertEqual(groups.first?.anchorMessageID, "raw:5")
         XCTAssertEqual(groups.first?.activityTitle, "Activity: 2 tools")
         XCTAssertEqual(groups.first?.toolCalls.map(\.id), ["functions.terminal:1", "functions.search_files:2"])
         XCTAssertEqual(groups.first?.toolCalls.map(\.name), ["terminal", "search_files"])
-        XCTAssertEqual(reasoningGroups.map(\.anchorMessageID), ["raw:5", "raw:7", "raw:9"])
-        XCTAssertEqual(reasoningGroups[0].text, "The user wants me to use terminal and search_files. I should run a quick command to show both work.")
-        XCTAssertEqual(reasoningGroups[1].text, "Terminal works. Now run search_files to show that works too.")
-        XCTAssertTrue(reasoningGroups[2].text.contains("Both tools worked. I should give a concise summary."))
-        XCTAssertFalse(reasoningGroups[2].text.contains(finalAnswer))
+        XCTAssertEqual(reasoningGroups.map(\.anchorMessageID), ["raw:9"])
+        XCTAssertTrue(reasoningGroups[0].text.contains("The user wants me to use terminal and search_files."))
+        XCTAssertTrue(reasoningGroups[0].text.contains("Terminal works. Now run search_files"))
+        XCTAssertTrue(reasoningGroups[0].text.contains("Both tools worked. I should give a concise summary."))
+        XCTAssertFalse(reasoningGroups[0].text.contains(finalAnswer))
     }
 
     func testPartialPersistedToolCallsMergeMissingMessageToolCalls() {

--- a/HermesMobileTests/CacheStoreTests.swift
+++ b/HermesMobileTests/CacheStoreTests.swift
@@ -417,6 +417,45 @@ final class CacheStoreTests: XCTestCase {
         )
     }
 
+    func testCodexMessagePhasesRoundTripThroughCache() throws {
+        let context = try makeContext()
+        let serverURL = URL(string: "https://example.test")!
+        let cachedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let message = try decoder.decode(
+            ChatMessage.self,
+            from: Data(#"""
+            {
+              "role":"assistant",
+              "content":"Working. Done.",
+              "message_id":"m1",
+              "codex_message_items":[
+                {"type":"message","phase":"commentary","content":[{"type":"output_text","text":"Working."}]},
+                {"type":"message","phase":"final_answer","content":[{"type":"output_text","text":"Done."}]}
+              ]
+            }
+            """#.utf8)
+        )
+
+        try CacheStore.cacheMessages(
+            [message],
+            serverURL: serverURL,
+            sessionID: "abc123",
+            in: context,
+            cachedAt: cachedAt
+        )
+
+        let restored = try XCTUnwrap(CacheStore.cachedMessages(
+            serverURL: serverURL,
+            sessionID: "abc123",
+            in: context,
+            now: cachedAt.addingTimeInterval(60)
+        ).first)
+        XCTAssertEqual(restored.codexCommentaryTexts, ["Working."])
+        XCTAssertEqual(restored.codexFinalAnswerText, "Done.")
+    }
+
     func testCachedMessagesIgnoresExpiredMessages() throws {
         let context = try makeContext()
         let serverURL = URL(string: "https://example.test")!

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -1940,7 +1940,8 @@ final class ChatViewModelSendTests: XCTestCase {
         )))
 
         XCTAssertEqual(viewModel.messages.compactMap(\.role), ["user", "assistant"])
-        XCTAssertEqual(viewModel.messages.last?.content, "Inspecting repo structure.")
+        XCTAssertEqual(viewModel.messages.last?.content, "")
+        XCTAssertEqual(viewModel.liveReasoningText, "Inspecting repo structure.")
         XCTAssertNotNil(viewModel.streamingAssistantMessageID)
         XCTAssertFalse(viewModel.responseCompletionHapticTrigger > 0)
     }
@@ -2438,7 +2439,13 @@ final class ChatViewModelSendTests: XCTestCase {
             alreadyStreamed: true
         )))
 
-        XCTAssertEqual(viewModel.messages.last?.content, "Inspecting repo structure.")
+        XCTAssertEqual(viewModel.messages.last?.content, "")
+        XCTAssertEqual(viewModel.liveReasoningText, "Inspecting repo structure.")
+
+        streamClient.emit(.token("Final answer."))
+        viewModel.flushPendingStreamingContent()
+
+        XCTAssertEqual(viewModel.messages.last?.content, "Final answer.")
     }
 
     @MainActor
@@ -2635,13 +2642,13 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertNil(viewModel.activeStreamID)
         XCTAssertTrue(viewModel.liveToolCalls.isEmpty)
         XCTAssertEqual(viewModel.completedToolCallGroups.count, 1)
-        XCTAssertEqual(viewModel.completedToolCallGroups.first?.anchorMessageID, "assistant-tool")
+        XCTAssertEqual(viewModel.completedToolCallGroups.first?.anchorMessageID, "assistant-final")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.activityTitle, "Activity: 1 tool")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.first?.name, "terminal")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.first?.preview, "/Users/uzair/project")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.first?.args?["command"], .string("pwd"))
         XCTAssertEqual(
-            viewModel.completedToolCallGroupsForAnchor("assistant-tool"),
+            viewModel.completedToolCallGroupsForAnchor("assistant-final"),
             viewModel.completedToolCallGroups
         )
         XCTAssertTrue(viewModel.completedToolCallGroupsForAnchor(nil).isEmpty)
@@ -2731,14 +2738,14 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertNil(viewModel.activeStreamID)
         XCTAssertTrue(viewModel.liveToolCalls.isEmpty)
         XCTAssertEqual(viewModel.completedToolCallGroups.count, 1)
-        XCTAssertEqual(viewModel.completedToolCallGroups.first?.anchorMessageID, "assistant-skills")
+        XCTAssertEqual(viewModel.completedToolCallGroups.first?.anchorMessageID, "assistant-final")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.activityTitle, "Activity: 2 tools")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.map(\.name), ["skill_view", "terminal"])
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.first?.id, "toolu-skill-xurl")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.first?.preview, "X/Twitter via xurl CLI")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.last?.preview, "xurl not installed")
         XCTAssertEqual(
-            viewModel.completedToolCallGroupsForAnchor("assistant-skills"),
+            viewModel.completedToolCallGroupsForAnchor("assistant-final"),
             viewModel.completedToolCallGroups
         )
     }
@@ -2850,7 +2857,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertNil(viewModel.activeStreamID)
         XCTAssertTrue(viewModel.liveToolCalls.isEmpty)
         XCTAssertEqual(viewModel.completedToolCallGroups.count, 1)
-        XCTAssertEqual(viewModel.completedToolCallGroups.first?.anchorMessageID, "assistant-tools")
+        XCTAssertEqual(viewModel.completedToolCallGroups.first?.anchorMessageID, "assistant-final")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.activityTitle, "Activity: 2 tools")
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.map(\.name), ["terminal", "search_files"])
         XCTAssertEqual(viewModel.completedToolCallGroups.first?.toolCalls.map(\.id), ["call-terminal", "call-search"])
@@ -4554,7 +4561,8 @@ final class ChatViewModelSendTests: XCTestCase {
         streamClient.emit(.interimAssistant(InterimAssistantStreamEvent(text: "Draft answer.")))
 
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .reconnecting)
-        XCTAssertEqual(viewModel.messages.compactMap(\.content), ["Keep working", "Draft answer."])
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), ["Keep working", ""])
+        XCTAssertEqual(viewModel.liveReasoningText, "Draft answer.")
     }
 
     @MainActor

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -23,8 +23,8 @@ final class TranscriptMessageTests: XCTestCase {
 
         let transcriptMessages = ChatViewModel.transcriptMessages(from: messages)
 
-        XCTAssertEqual(transcriptMessages.map(\.loadedIndex), [0, 1, 3])
-        XCTAssertEqual(transcriptMessages.map(\.message.id), ["u1", "a1", "a2"])
+        XCTAssertEqual(transcriptMessages.map(\.loadedIndex), [0, 3])
+        XCTAssertEqual(transcriptMessages.map(\.message.id), ["u1", "a2"])
     }
 
     func testTranscriptMessagesCanHideActiveStreamingAssistantTurn() {
@@ -171,6 +171,53 @@ final class TranscriptMessageTests: XCTestCase {
 
         XCTAssertEqual(transcriptMessages.map(\.loadedIndex), [0, 1])
         XCTAssertEqual(transcriptMessages.map(\.message.role), ["user", "assistant"])
+    }
+
+    func testCodexItemsProjectCommentaryOntoOneThinkingCardAndFinalAnswerRow() throws {
+        let data = Data(#"""
+        [
+          {"role":"user","content":"Fix it","message_id":"u1"},
+          {
+            "role":"assistant",
+            "content":"Inspecting. Final answer.",
+            "message_id":"a1",
+            "codex_message_items":[
+              {"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"Inspecting the transcript."}]},
+              {"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Final answer."}]}
+            ]
+          }
+        ]
+        """#.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let messages = try decoder.decode([ChatMessage].self, from: data)
+
+        let transcript = ChatViewModel.transcriptMessages(from: messages)
+        let reasoning = ChatViewModel.reasoningDisplayGroups(messages: messages, archivedGroups: [])
+
+        XCTAssertEqual(transcript.map(\.message.content), ["Fix it", "Final answer."])
+        XCTAssertEqual(reasoning.count, 1)
+        XCTAssertEqual(reasoning.first?.anchorMessageID, "a1")
+        XCTAssertEqual(reasoning.first?.text, "Inspecting the transcript.")
+    }
+
+    func testMultipleAssistantToolRoundsCollapseOntoFinalTurnAnchor() {
+        let messages = [
+            ChatMessage(role: "user", content: "Fix it", timestamp: 1, messageId: "u1"),
+            ChatMessage(role: "assistant", content: "Inspecting files.", timestamp: 2, messageId: "a1"),
+            ChatMessage(role: "tool", content: "result", timestamp: 3, messageId: "t1", toolCallId: "call-1"),
+            ChatMessage(role: "assistant", content: "Running tests.", timestamp: 4, messageId: "a2"),
+            ChatMessage(role: "tool", content: "passed", timestamp: 5, messageId: "t2", toolCallId: "call-2"),
+            ChatMessage(role: "assistant", content: "Fixed and verified.", timestamp: 6, messageId: "a3")
+        ]
+
+        let transcript = ChatViewModel.transcriptMessages(from: messages)
+        let reasoning = ChatViewModel.reasoningDisplayGroups(messages: messages, archivedGroups: [])
+
+        XCTAssertEqual(transcript.map(\.message.id), ["u1", "a3"])
+        XCTAssertEqual(reasoning.count, 1)
+        XCTAssertEqual(reasoning.first?.anchorMessageID, "a3")
+        XCTAssertEqual(reasoning.first?.text, "Inspecting files.\n\nRunning tests.")
     }
 }
 

--- a/docs/images/hermex-codex-timeline-comparison.svg
+++ b/docs/images/hermex-codex-timeline-comparison.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="bg"><stop stop-color="#05070b"/><stop offset="1" stop-color="#111722"/></linearGradient>
+    <linearGradient id="accent"><stop stop-color="#ff8a20"/><stop offset="1" stop-color="#ffbd45"/></linearGradient>
+    <style>
+      .title{font:700 42px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;fill:#f6f7f9}.sub{font:400 22px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;fill:#9aa5b5}.cap{font:700 18px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;letter-spacing:2px}.label{font:650 23px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;fill:#f1f4f8}.body{font:400 19px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;fill:#bdc6d2}.tiny{font:500 17px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;fill:#97a2b2}
+    </style>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <text x="800" y="66" text-anchor="middle" class="title">Hermex conversation timeline</text>
+  <text x="800" y="102" text-anchor="middle" class="sub">How one tool-heavy assistant turn reads now vs. the Codex-style update</text>
+  <g transform="translate(70 145)">
+    <rect width="700" height="680" rx="28" fill="#0b0f16" stroke="#26303e"/>
+    <text x="36" y="55" class="cap" fill="#f06d67">CURRENT HERMEX</text>
+    <text x="36" y="88" class="sub">Every stream fragment becomes another row</text>
+    <g fill="#171c25" stroke="#333d4c">
+      <rect x="36" y="118" width="628" height="58" rx="16"/><rect x="36" y="188" width="628" height="58" rx="16"/>
+      <rect x="36" y="258" width="628" height="58" rx="16"/><rect x="36" y="328" width="628" height="58" rx="16"/>
+      <rect x="36" y="398" width="628" height="58" rx="16"/>
+    </g>
+    <text x="58" y="154" class="label">Thinking</text><text x="620" y="154" text-anchor="end" class="tiny">Planning... v</text>
+    <text x="58" y="224" class="label">Thinking</text><text x="620" y="224" text-anchor="end" class="tiny">Checking files... v</text>
+    <text x="58" y="294" class="label">Thinking</text><text x="620" y="294" text-anchor="end" class="tiny">Running tests... v</text>
+    <text x="58" y="364" class="label">Thinking</text><text x="620" y="364" text-anchor="end" class="tiny">Fixing issue... v</text>
+    <text x="58" y="434" class="label">Activity: 8 tools</text><text x="620" y="434" text-anchor="end" class="tiny">v</text>
+    <text x="36" y="500" class="tiny">Intermediate assistant message</text><text x="36" y="530" class="body">I found the rendering path and I am checking...</text>
+    <text x="36" y="575" class="tiny">Final assistant message</text><text x="36" y="608" class="body">The timeline is updated and tests pass.</text>
+    <rect x="36" y="635" width="242" height="5" rx="2.5" fill="#f06d67"/><text x="295" y="646" class="tiny">noisy / fragmented / tall</text>
+  </g>
+  <g transform="translate(830 145)">
+    <rect width="700" height="680" rx="28" fill="#0b0f16" stroke="#784b21"/>
+    <text x="36" y="55" class="cap" fill="#ff9f2e">CODEX-STYLE UPDATE</text>
+    <text x="36" y="88" class="sub">One turn becomes one compact activity cluster</text>
+    <g fill="#171c25" stroke="#665039"><rect x="36" y="118" width="628" height="58" rx="16"/><rect x="36" y="188" width="628" height="58" rx="16"/></g>
+    <text x="58" y="154" class="label">Thinking</text><text x="620" y="154" text-anchor="end" class="tiny">Planning to tests to fix  v</text>
+    <text x="58" y="224" class="label">Activity: 8 tools</text><text x="620" y="224" text-anchor="end" class="tiny">v</text>
+    <path d="M350 276v48m-12-11 12 12 12-12" fill="none" stroke="#ff9f2e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <rect x="36" y="350" width="628" height="165" rx="18" fill="#111720" stroke="#2f3947"/>
+    <text x="58" y="392" class="tiny">Final assistant message</text>
+    <text x="58" y="438" class="label">The timeline is updated and tests pass.</text>
+    <text x="58" y="475" class="body">Thinking and tools stay available above,</text><text x="58" y="503" class="body">but only the final answer remains in the flow.</text>
+    <rect x="36" y="555" width="238" height="5" rx="2.5" fill="url(#accent)"/><text x="291" y="566" class="tiny">compact / ordered / scannable</text>
+  </g>
+  <rect x="600" y="840" width="400" height="42" rx="21" fill="url(#accent)"/>
+  <text x="800" y="868" text-anchor="middle" style="font:700 20px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;fill:#0a0d12">Same events, clearer hierarchy</text>
+</svg>


### PR DESCRIPTION
## Summary
- decode and cache Codex `commentary` / `final_answer` message items exposed by Hermes WebUI
- collapse multi-message agent loops onto one turn anchor so Thinking and Activity render once above the final answer
- route live `interim_assistant` boundaries into the progress card, including `already_streamed` replay handling
- re-anchor completed tool groups to the final assistant row and preserve the final answer as its own bubble

## Verification
- full simulator XCTest suite: 1,558 passed, 0 failed
- signed Debug build installed and launched on iPhone 17 simulator
- visual simulator fixture confirmed user message -> one Thinking card -> one Activity card -> final answer