### PR TITLE
docs: add 1.5.0 changelog section and refresh TestFlight snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,25 @@ Security sections per release.
 
 ## [Unreleased]
 
+## [1.5.0] - TBA
+
 ### Added
+- Kanban boards: browse cards by status column, view card detail with comments
+  and operational history, create and edit cards, move cards through their
+  workflow, act on many cards at once with accessible bulk actions, manage
+  boards with shared active-board controls, preview and run the dispatcher from
+  a toolbar sheet, and stay current through live updates with offline
+  reconciliation.
+- Settings toggles to hide unused parts of the app: session-list entries
+  (Tasks, Kanban, Skills, Memory, Insights, Active Profile, Projects) and chat
+  controls (Files button, Git actions). Everything stays visible by default.
+- Opt-in response speed metrics.
 - Public open-source release of the Hermex codebase.
+
+### Fixed
+- Interrupted backend streams now recover instead of stalling the response.
+- Opening a transcript no longer jitters.
+- Reopening a chat bounds the cached transcript instead of loading it all.
+- Deep-linked sessions no longer lose the race to last-session restore.
+- The file browser keeps the latest directory navigation.
+- The session list refreshes after returning from a new chat.

--- a/TESTFLIGHT.md
+++ b/TESTFLIGHT.md
@@ -8,16 +8,14 @@ Goal: invite external testers only after a clean release-candidate build has bee
 
 ## Current Readiness Snapshot
 
-As of 2026-05-30:
+As of 2026-08-04:
 
 - This file remains the external TestFlight mechanics runbook (the separate full App Store release checklist doc was retired during open-source prep).
-- The GitHub Actions `External TestFlight` workflow is available and has uploaded an external-capable production build.
-- Current external-capable upload: version `1.0.1`, build `1`.
-- Verified workflow evidence: run `26833031469` / `External TestFlight from master` completed successfully from `master` at `9e8078215586643eb11c519bf9c73dfa103070ea`.
-- Run `26833031469` selected build number `1`, used `ci/ExternalTestFlightExportOptions.plist`, archived successfully, and uploaded to App Store Connect successfully.
-- Owner still needs to wait for App Store Connect processing, confirm build `1.0.1 (1)` appears and is not internal-only, and resolve any compliance prompts before using it for external testing or App Review replacement.
-- Earlier external-capable build `1.0 (32)` remains the repo-recorded App Review submission unless the owner manually replaces it in App Store Connect.
-- The local release branch cleanup is complete; the feature-gap and crash-investigation notes were committed, and the whitespace-only `AGENTS.md` change was removed.
+- Version `1.4` is the approved App Store release; App Store Connect has closed the `1.4` pre-release train, so external-capable uploads now require a higher marketing version (this forced the bump to `1.5` in #223).
+- Current external-capable upload: version `1.5`, build `1`.
+- Verified workflow evidence: run `30888612331` / `External TestFlight from master` completed successfully from `master` at `a4adf347b00a925b168245287e80a0f2b889cc55`.
+- Run `30888612331` selected build number `1`, used `ci/ExternalTestFlightExportOptions.plist`, archived successfully, and uploaded to App Store Connect successfully.
+- Owner still needs to wait for App Store Connect processing, confirm build `1.5 (1)` appears and is not internal-only, and resolve any compliance prompts before using it for external testing or App Review replacement.
 - The share extension's automatic app-launch workaround remains the highest Beta/App Store Review code risk until removed or explicitly accepted.
 - Full local XCTest passed on iPhone 17 Simulator for the latest code validation recorded in `CURRENT.md`, but every RC should be validated again before submission.
 


### PR DESCRIPTION
## What changed

Docs only — no code.

- **CHANGELOG.md**: moves the Unreleased items under a new `## [1.5.0] - TBA` heading covering the 23 commits since `v1.4.0`: Kanban boards, the section-visibility toggles (#190), opt-in response speed metrics (#182), the open-source release, and six fixes (#131, #137, #164, #188, #193, #215). The TBA becomes the release date when 1.5 goes live on the App Store, matching the file's convention that version headings correspond to App Store releases.
- **TESTFLIGHT.md**: refreshes the Current Readiness Snapshot (was dated 2026-05-30 and recorded 1.0.1 build 1) to record the 1.5 (1) external-capable upload from run 30888612331 at a4adf34, and the closed-1.4-train constraint that forced the version bump (#223).

## How it was tested

Docs-only change; proofread against `git log v1.4.0..master` and the run 30888612331 log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)