### PR TITLE
ci: fail external TestFlight fast when the release train is closed

### DIFF
--- a/.github/workflows/external-testflight.yml
+++ b/.github/workflows/external-testflight.yml
@@ -120,10 +120,15 @@ jobs:
           chmod 600 "${key_path}"
           echo "APP_STORE_CONNECT_KEY_PATH=${key_path}" >> "${GITHUB_ENV}"
 
-      - name: Select build number
+      # ENFORCE_OPEN_TRAIN fails this step in seconds — instead of the upload
+      # step after a ~15-minute archive — when the marketing version's
+      # pre-release train is already closed by an approved App Store version
+      # (bitten 2026-06-02 with 1.0 and 2026-08-04 with 1.4).
+      - name: Check release train and select build number
         env:
           BUNDLE_ID: com.uzairansar.hermesmobile
           REQUESTED_BUILD_NUMBER: ${{ inputs.build_number }}
+          ENFORCE_OPEN_TRAIN: "1"
         run: |
           set -euo pipefail
 

--- a/TESTFLIGHT.md
+++ b/TESTFLIGHT.md
@@ -517,6 +517,11 @@ Purpose: create the build that can be submitted to Beta App Review.
 
 Use the new external-capable workflow or manual Xcode upload. The build must not be marked internal-only.
 
+Version-train rule (bitten 2026-06-02 with `1.0` → `1.0.1` and 2026-08-04 with `1.4` → `1.5`): once a version is approved for the App Store, Apple closes its pre-release train and rejects any upload with that `CFBundleShortVersionString` (ASC errors 90186/90062). Two defenses:
+
+- Bump `MARKETING_VERSION` (in `HermesMobile.xcodeproj/project.pbxproj`, all entries) on `master` right after each App Store release goes live, so the next upload always targets an open train.
+- The workflow preflights the train against App Store Connect before archiving (`ENFORCE_OPEN_TRAIN` in `ci/select_testflight_build_number.rb`) and fails in seconds with a bump instruction if the train is closed.
+
 Workflow path, if implemented:
 
 1. Run `External TestFlight` from GitHub Actions.

--- a/ci/select_testflight_build_number.rb
+++ b/ci/select_testflight_build_number.rb
@@ -12,6 +12,18 @@ class TestFlightBuildNumberSelector
   API_BASE = "https://api.appstoreconnect.apple.com"
   BUILD_NUMBER_PATTERN = /\A\d+(?:\.\d+)*\z/
 
+  # App Store version states in which Apple has approved the version and closed
+  # its pre-release train: any later upload must carry a higher
+  # CFBundleShortVersionString (ASC upload errors 90186/90062, hit on
+  # 2026-06-02 with 1.0 and again on 2026-08-04 with 1.4).
+  APPROVED_APP_STORE_STATES = %w[
+    READY_FOR_SALE
+    READY_FOR_DISTRIBUTION
+    PENDING_DEVELOPER_RELEASE
+    PENDING_APPLE_RELEASE
+    PROCESSING_FOR_APP_STORE
+  ].freeze
+
   class SelectionError < StandardError; end
 
   def self.valid_build_number?(value)
@@ -61,6 +73,17 @@ class TestFlightBuildNumberSelector
     latest_build_number ? increment_build_number(latest_build_number) : "1"
   end
 
+  # Returns the approved App Store version that closes the train for
+  # marketing_version, or nil when the train is open. Approved version strings
+  # that are not plain dotted numerics cannot be compared and are ignored.
+  def self.closed_train_version(marketing_version:, approved_versions:)
+    validate_build_number!(marketing_version, "marketing version")
+
+    approved_versions
+      .select { |value| valid_build_number?(value) }
+      .find { |value| compare_build_numbers(marketing_version, value) <= 0 }
+  end
+
   def self.validate_build_number!(value, label)
     return if valid_build_number?(value)
 
@@ -77,6 +100,8 @@ class TestFlightBuildNumberSelector
     bundle_id = required_env("BUNDLE_ID")
     marketing_version = required_env("MARKETING_VERSION")
     requested_build_number = @env.fetch("REQUESTED_BUILD_NUMBER", "")
+
+    enforce_open_train!(bundle_id: bundle_id, marketing_version: marketing_version) if @env["ENFORCE_OPEN_TRAIN"] == "1"
 
     latest = latest_uploaded_build_number(bundle_id: bundle_id, marketing_version: marketing_version)
     selected = self.class.select_build_number(
@@ -96,6 +121,39 @@ class TestFlightBuildNumberSelector
   end
 
   private
+
+  # Fails fast — before the ~15-minute archive step — when App Store Connect
+  # would reject the upload anyway because marketing_version's pre-release
+  # train is closed by an approved App Store version.
+  def enforce_open_train!(bundle_id:, marketing_version:)
+    blocking = self.class.closed_train_version(
+      marketing_version: marketing_version,
+      approved_versions: approved_app_store_versions(bundle_id: bundle_id)
+    )
+
+    if blocking
+      raise SelectionError,
+            "The #{marketing_version} pre-release train is closed: App Store version #{blocking} is already approved. " \
+            "Bump MARKETING_VERSION in HermesMobile.xcodeproj/project.pbxproj above #{blocking}, land it on master, " \
+            "and re-run this workflow (see TESTFLIGHT.md, Upload External-Capable Build)."
+    end
+
+    warn "Pre-release train #{marketing_version} is open: no approved App Store version at or above it."
+  end
+
+  def approved_app_store_versions(bundle_id:)
+    app_id = app_id_for_bundle_id(bundle_id)
+    versions = fetch_paginated_json(
+      "/v1/apps/#{app_id}/appStoreVersions",
+      "fields[appStoreVersions]" => "versionString,appStoreState",
+      "limit" => "200"
+    )
+
+    versions
+      .select { |item| APPROVED_APP_STORE_STATES.include?(item.dig("attributes", "appStoreState")) }
+      .map { |item| item.dig("attributes", "versionString") }
+      .compact
+  end
 
   def latest_uploaded_build_number(bundle_id:, marketing_version:)
     app_id = app_id_for_bundle_id(bundle_id)
@@ -117,7 +175,16 @@ class TestFlightBuildNumberSelector
     build_numbers.max { |left, right| self.class.compare_build_numbers(left, right) }
   end
 
+  # Memoized: the train preflight and build-number selection both need it.
   def app_id_for_bundle_id(bundle_id)
+    @app_ids ||= {}
+    cached = @app_ids[bundle_id]
+    return cached if cached
+
+    @app_ids[bundle_id] = uncached_app_id_for_bundle_id(bundle_id)
+  end
+
+  def uncached_app_id_for_bundle_id(bundle_id)
     apps = fetch_paginated_json(
       "/v1/apps",
       "filter[bundleId]" => bundle_id,

--- a/ci/select_testflight_build_number_test.rb
+++ b/ci/select_testflight_build_number_test.rb
@@ -79,6 +79,95 @@ class TestFlightBuildNumberSelectorTest < Minitest::Test
     assert_includes(error.message, "digits and dots")
   end
 
+  def test_train_is_open_when_marketing_version_is_above_all_approved_versions
+    assert_nil(
+      TestFlightBuildNumberSelector.closed_train_version(
+        marketing_version: "1.5",
+        approved_versions: ["1.4", "1.0.1", "1.0"]
+      )
+    )
+  end
+
+  def test_train_is_closed_when_marketing_version_equals_an_approved_version
+    assert_equal(
+      "1.4",
+      TestFlightBuildNumberSelector.closed_train_version(
+        marketing_version: "1.4",
+        approved_versions: ["1.4", "1.0.1"]
+      )
+    )
+  end
+
+  def test_train_is_closed_when_marketing_version_is_below_an_approved_version
+    assert_equal(
+      "1.4",
+      TestFlightBuildNumberSelector.closed_train_version(
+        marketing_version: "1.3.9",
+        approved_versions: ["1.4"]
+      )
+    )
+  end
+
+  def test_train_comparison_is_numeric_not_lexicographic
+    assert_nil(
+      TestFlightBuildNumberSelector.closed_train_version(
+        marketing_version: "1.10",
+        approved_versions: ["1.9"]
+      )
+    )
+  end
+
+  def test_train_check_ignores_non_numeric_approved_version_strings
+    assert_nil(
+      TestFlightBuildNumberSelector.closed_train_version(
+        marketing_version: "1.5",
+        approved_versions: ["2.0-beta", "1.4"]
+      )
+    )
+  end
+
+  def test_train_check_with_no_approved_versions_is_open
+    assert_nil(
+      TestFlightBuildNumberSelector.closed_train_version(
+        marketing_version: "1.0",
+        approved_versions: []
+      )
+    )
+  end
+
+  def test_approved_versions_fetch_filters_to_approved_states
+    selector = TestFlightBuildNumberSelector.new(env: {})
+    captured = []
+
+    selector.define_singleton_method(:app_id_for_bundle_id) { |_bundle_id| "app-123" }
+    selector.define_singleton_method(:fetch_paginated_json) do |path, params|
+      captured << [path, params]
+      [
+        { "attributes" => { "versionString" => "1.4", "appStoreState" => "READY_FOR_SALE" } },
+        { "attributes" => { "versionString" => "1.5", "appStoreState" => "PREPARE_FOR_SUBMISSION" } },
+        { "attributes" => { "versionString" => "1.0.1", "appStoreState" => "REPLACED_WITH_NEW_VERSION" } },
+        { "attributes" => { "appStoreState" => "READY_FOR_SALE" } }
+      ]
+    end
+
+    versions = selector.send(:approved_app_store_versions, bundle_id: "com.uzairansar.hermesmobile")
+
+    assert_equal(["1.4"], versions)
+    assert_equal("/v1/apps/app-123/appStoreVersions", captured.first.first)
+  end
+
+  def test_enforce_open_train_raises_with_actionable_message_when_closed
+    selector = TestFlightBuildNumberSelector.new(env: {})
+    selector.define_singleton_method(:approved_app_store_versions) { |bundle_id:| ["1.4"] }
+
+    error = assert_raises(TestFlightBuildNumberSelector::SelectionError) do
+      selector.send(:enforce_open_train!, bundle_id: "com.uzairansar.hermesmobile", marketing_version: "1.4")
+    end
+
+    assert_includes(error.message, "train is closed")
+    assert_includes(error.message, "Bump MARKETING_VERSION")
+  end
+
   def test_app_lookup_uses_supported_bundle_id_filter_only
     selector = TestFlightBuildNumberSelector.new(env: {})
     captured = []


### PR DESCRIPTION
## What changed

- **`ci/select_testflight_build_number.rb`**: new opt-in preflight (`ENFORCE_OPEN_TRAIN=1`) that fetches the app's App Store versions in approved states (`READY_FOR_SALE`, `READY_FOR_DISTRIBUTION`, `PENDING_DEVELOPER_RELEASE`, `PENDING_APPLE_RELEASE`, `PROCESSING_FOR_APP_STORE`) and raises before the archive step when the detected `MARKETING_VERSION` is at or below any of them, with a message that names the blocking version and says exactly what to bump. App-id lookup is now memoized since two code paths need it. Non-numeric approved version strings are ignored rather than crashing the check.
- **`.github/workflows/external-testflight.yml`**: sets `ENFORCE_OPEN_TRAIN=1` on the (renamed) "Check release train and select build number" step. The step already runs before the archive, so a closed train now fails in seconds instead of ~15 minutes later at upload with cryptic ASC codes.
- **Internal workflow untouched**: it shares the script but does not set the flag, so its behavior is byte-for-byte unchanged.
- **`TESTFLIGHT.md`**: documents the train rule in step 12 plus the two defenses (bump `MARKETING_VERSION` at each App Store go-live; the workflow preflight as backstop).

## Why

The closed-train rejection has now happened twice: run 26831954965 (2026-06-02, `1.0` closed → bumped to `1.0.1`) and run 30883811600 (2026-08-04, `1.4` closed → bumped to `1.5`, PR #223). Both times the failure surfaced only after a full archive, as ASC errors 90186/90062.

## How it was tested

- `ruby ci/select_testflight_build_number_test.rb`: 17 runs, 34 assertions, 0 failures (8 new tests: open/closed/equal/below train, numeric-not-lexicographic compare, non-numeric approved strings ignored, empty approved set, approved-state filtering + request path shape, actionable error message).
- `ruby -e 'require "yaml"; YAML.load_file(...)'`: YAML OK.
- The live preflight path (real ASC API) exercises on the next External TestFlight dispatch; with 1.5 unapproved it should log the train as open and proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)