### PR TITLE
feat(streaming): suppress "Checking stream" chip and status polls while transport heartbeats are fresh

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -13,12 +13,16 @@ struct ChatStreamCoordinatorTiming: Equatable {
     let reconnectInterval: TimeInterval
     let runningToolReconnectInterval: TimeInterval
     let statusPollCooldown: TimeInterval
+    // Transport quieter than this is treated as provably alive; must sit above
+    // the server's ~5s SSE heartbeat cadence and below reconnectInterval (#227).
+    let transportFreshInterval: TimeInterval
 
     static let standard = ChatStreamCoordinatorTiming(
         checkingInterval: 5,
         reconnectInterval: 18,
         runningToolReconnectInterval: 25,
-        statusPollCooldown: 4
+        statusPollCooldown: 4,
+        transportFreshInterval: 12
     )
 }
 
@@ -374,8 +378,17 @@ final class ChatStreamCoordinator {
             return
         }
 
-        recoveryState = .checking
         let transportElapsed = now.timeIntervalSince(lastTransportActivityDate ?? lastProgressDate)
+        guard transportElapsed >= timing.transportFreshInterval else {
+            // #227: heartbeats prove the connection is alive during a
+            // semantically quiet window (model thinking / slow tool call), so
+            // stay idle and skip status polls. A genuinely silent transport
+            // still escalates below once past transportFreshInterval.
+            recoveryState = .idle
+            return
+        }
+
+        recoveryState = .checking
         let shouldForceReconnect = transportElapsed >= reconnectInterval
         guard shouldForceReconnect || shouldPollStatus(now: now) else { return }
 
@@ -496,7 +509,13 @@ final class ChatStreamCoordinator {
         case .transportError(let message):
             handleTransportError(message)
         case .heartbeat:
-            break
+            // #227: a heartbeat proves the transport is alive without carrying
+            // semantic progress — drop an already-shown "Checking stream" state
+            // immediately. Never demote .reconnecting; that chip is owned by
+            // the reconnect flow until real progress lands.
+            if recoveryState == .checking {
+                recoveryState = .idle
+            }
         case .ignored:
             break
         }

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -575,10 +575,12 @@ final class ChatStreamCoordinator {
                 return
             }
 
-            guard forceReconnect else {
-                recoveryState = .checking
-                return
-            }
+            // PR #238 review: recoveryState was set to .checking before this
+            // await. If it changed mid-flight (a heartbeat or real progress
+            // demoted it to .idle), the transport just proved itself alive —
+            // don't resurrect the chip or churn a live connection; the next
+            // recovery tick re-evaluates from scratch.
+            guard recoveryState == .checking, forceReconnect else { return }
 
             reconnectStaleStream(
                 streamID: expectedStreamID,
@@ -599,13 +601,13 @@ final class ChatStreamCoordinator {
                 return
             }
 
-            guard forceReconnect,
+            // Same mid-flight demotion guard as the success path (PR #238
+            // review): only a still-.checking state may escalate.
+            guard recoveryState == .checking,
+                  forceReconnect,
                   activeStreamID == expectedStreamID,
                   !isConnectionSuspended
-            else {
-                recoveryState = .checking
-                return
-            }
+            else { return }
 
             reconnectStaleStream(streamID: expectedStreamID, usesReplay: true)
         }

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -388,6 +388,56 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(streamClient.stopCount, 0)
     }
 
+    // The MockURLProtocol handler runs on URLSession's protocol thread while the
+    // coordinator's status-poll await has suspended the main actor, so a
+    // main-queue sync hop delivers the heartbeat deterministically *mid-flight*
+    // — before the poll's continuation resumes (PR #238 review).
+    @MainActor
+    func testHeartbeatDuringStatusPollKeepsIdleStateWithoutReassertingChecking() async throws {
+        var statusRequests = 0
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient) { request in
+            statusRequests += 1
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated { streamClient.emit(.heartbeat) }
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.markProgress(now: Date().addingTimeInterval(-13))
+
+        await coordinator.recoverStaleStreamIfNeeded(now: Date())
+
+        XCTAssertEqual(statusRequests, 1)
+        XCTAssertEqual(coordinator.recoveryState, .idle)
+        XCTAssertEqual(streamClient.startedURLs.count, 1)
+        XCTAssertEqual(streamClient.stopCount, 0)
+    }
+
+    @MainActor
+    func testHeartbeatDuringForceReconnectStatusPollSkipsReconnect() async throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient) { request in
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated { streamClient.emit(.heartbeat) }
+            }
+            return apiTestJSONResponse(
+                #"{"active": true, "stream_id": "stream-123", "replay_available": true}"#,
+                for: request
+            )
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.markProgress(now: Date().addingTimeInterval(-19))
+
+        await coordinator.recoverStaleStreamIfNeeded(now: Date())
+
+        XCTAssertEqual(coordinator.recoveryState, .idle)
+        XCTAssertEqual(streamClient.startedURLs.count, 1)
+        XCTAssertEqual(streamClient.stopCount, 0)
+    }
+
     @MainActor
     func testHeartbeatDoesNotDemoteReconnectingState() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -300,7 +300,7 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
-    func testStaleDetectionWaitsForCheckingIntervalThenPollsStatus() async throws {
+    func testStaleDetectionWaitsForTransportQuietThresholdThenPollsStatus() async throws {
         var statusRequests = 0
         let streamClient = CoordinatorSpySSEStreamingClient()
         let coordinator = makeCoordinator(
@@ -309,7 +309,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
                 checkingInterval: 5,
                 reconnectInterval: 18,
                 runningToolReconnectInterval: 25,
-                statusPollCooldown: 4
+                statusPollCooldown: 4,
+                transportFreshInterval: 12
             )
         ) { request in
             statusRequests += 1
@@ -325,7 +326,14 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(statusRequests, 0)
         XCTAssertEqual(coordinator.recoveryState, .idle)
 
+        // #227: semantically quiet past checkingInterval, but the transport was
+        // active 5.1s ago — still within transportFreshInterval, so no chip and
+        // no status poll yet.
         await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(5.1))
+        XCTAssertEqual(statusRequests, 0)
+        XCTAssertEqual(coordinator.recoveryState, .idle)
+
+        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(12.1))
         XCTAssertEqual(statusRequests, 1)
         XCTAssertEqual(coordinator.recoveryState, .checking)
     }
@@ -348,10 +356,57 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
 
         await coordinator.recoverStaleStreamIfNeeded(now: Date().addingTimeInterval(1))
 
-        XCTAssertEqual(statusRequests, 1)
+        // #227: the heartbeat 1s ago proves the transport is alive, so the
+        // semantically quiet stream stays idle with zero status polls — no
+        // "Checking stream" chip and no reconnect.
+        XCTAssertEqual(statusRequests, 0)
         XCTAssertEqual(streamClient.startedURLs.count, 1)
         XCTAssertEqual(streamClient.stopCount, 0)
+        XCTAssertEqual(coordinator.recoveryState, .idle)
+    }
+
+    @MainActor
+    func testHeartbeatDemotesCheckingStateToIdle() async throws {
+        var statusRequests = 0
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient) { request in
+            statusRequests += 1
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.markProgress(now: Date().addingTimeInterval(-13))
+
+        await coordinator.recoverStaleStreamIfNeeded(now: Date())
+        XCTAssertEqual(statusRequests, 1)
         XCTAssertEqual(coordinator.recoveryState, .checking)
+
+        streamClient.emit(.heartbeat)
+
+        XCTAssertEqual(coordinator.recoveryState, .idle)
+        XCTAssertEqual(streamClient.startedURLs.count, 1)
+        XCTAssertEqual(streamClient.stopCount, 0)
+    }
+
+    @MainActor
+    func testHeartbeatDoesNotDemoteReconnectingState() async throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient) { request in
+            apiTestJSONResponse(
+                #"{"active": true, "stream_id": "stream-123", "replay_available": true}"#,
+                for: request
+            )
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.markProgress(now: Date().addingTimeInterval(-20))
+
+        await coordinator.recoverStaleStreamIfNeeded(now: Date())
+        XCTAssertEqual(coordinator.recoveryState, .reconnecting)
+
+        streamClient.emit(.heartbeat)
+
+        XCTAssertEqual(coordinator.recoveryState, .reconnecting)
     }
 
     @MainActor
@@ -412,7 +467,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
                 checkingInterval: 5,
                 reconnectInterval: 18,
                 runningToolReconnectInterval: 25,
-                statusPollCooldown: 4
+                statusPollCooldown: 4,
+                transportFreshInterval: 12
             )
         ) { request in
             XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
@@ -426,7 +482,9 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         coordinator.start(streamID: "stream-123")
         coordinator.markProgress(now: start)
 
-        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(5.1))
+        // 12.1s: past transportFreshInterval, so the stale-recovery status poll
+        // actually fires (#227).
+        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(12.1))
 
         XCTAssertEqual(coordinator.activeStreamID, "stream-new")
         XCTAssertFalse(coordinator.isConnectionSuspended)
@@ -449,7 +507,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
                 checkingInterval: 5,
                 reconnectInterval: 18,
                 runningToolReconnectInterval: 25,
-                statusPollCooldown: 4
+                statusPollCooldown: 4,
+                transportFreshInterval: 12
             )
         ) { request in
             XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
@@ -465,7 +524,9 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         coordinator.start(streamID: "stream-123")
         coordinator.markProgress(now: start)
 
-        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(5.1))
+        // 12.1s: past transportFreshInterval, so the stale-recovery status poll
+        // actually fires (#227).
+        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(12.1))
 
         // PR #266 review #3: the run generation captured before the load changed
         // when `.done` finalized the run, so the now-stale stale-recovery path
@@ -490,7 +551,8 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
                 checkingInterval: 5,
                 reconnectInterval: 18,
                 runningToolReconnectInterval: 25,
-                statusPollCooldown: 4
+                statusPollCooldown: 4,
+                transportFreshInterval: 12
             )
         ) { request in
             XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
@@ -501,7 +563,9 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         coordinator.start(streamID: "stream-123")
         coordinator.markProgress(now: start)
 
-        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(5.1))
+        // 12.1s: past transportFreshInterval, so the stale-recovery status poll
+        // actually fires (#227).
+        await coordinator.recoverStaleStreamIfNeeded(now: start.addingTimeInterval(12.1))
 
         // Happy path: server reports the stale run inactive and no concurrent run or
         // completion intervened, so canFinalizeRunAfterLoad lets the stale-recovery

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -3728,7 +3728,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(didStart)
         streamClient.emit(.token("First "))
 
-        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(6))
+        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(13))
 
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .checking)
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
@@ -3765,7 +3765,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(didStart)
         streamClient.emit(.reasoning("I need to inspect the workspace first."))
 
-        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(6))
+        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(13))
 
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .checking)
         XCTAssertEqual(viewModel.liveReasoningText, "I need to inspect the workspace first.")
@@ -3863,7 +3863,9 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(didStart)
         streamClient.emit(.token("Partial "))
 
-        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(10))
+        // 13s: past transportFreshInterval (12), so stale recovery polls status
+        // and finalizes the inactive run (#227).
+        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(13))
 
         XCTAssertNil(viewModel.activeStreamID)
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .idle)
@@ -3922,7 +3924,9 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(didStart)
         streamClient.emit(.token("Partial "))
 
-        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(10))
+        // 13s: past transportFreshInterval (12), so stale recovery polls status
+        // and finalizes the inactive run (#227).
+        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(13))
 
         XCTAssertNil(viewModel.activeStreamID)
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .idle)
@@ -4102,7 +4106,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(didStart)
         streamClient.emit(.token("First "))
 
-        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(6))
+        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(13))
 
         XCTAssertEqual(statusRequestCount, 1)
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .checking)
@@ -4152,7 +4156,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(didStart)
         streamClient.emit(.token("First "))
 
-        let firstPollDate = Date().addingTimeInterval(6)
+        let firstPollDate = Date().addingTimeInterval(12.5)
         await viewModel.recoverStaleActiveStreamIfNeeded(now: firstPollDate)
         await viewModel.recoverStaleActiveStreamIfNeeded(now: firstPollDate.addingTimeInterval(2))
         await viewModel.recoverStaleActiveStreamIfNeeded(now: firstPollDate.addingTimeInterval(5))
@@ -4194,7 +4198,10 @@ final class ChatViewModelSendTests: XCTestCase {
 
         await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(10))
 
-        XCTAssertEqual(viewModel.activeStreamRecoveryState, .checking)
+        // #227: 10s of quiet is still inside transportFreshInterval, so the
+        // slow-but-alive stream shows no recovery chip at all — and is
+        // certainly not force-reconnected.
+        XCTAssertEqual(viewModel.activeStreamRecoveryState, .idle)
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
         XCTAssertEqual(streamClient.stopCount, 0)
         XCTAssertEqual(streamClient.startedURLs.count, 1)
@@ -4474,7 +4481,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .reconnecting)
         XCTAssertEqual(viewModel.messages.compactMap(\.content), ["Keep working", "First "])
 
-        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(6))
+        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(13))
 
         XCTAssertEqual(statusRequestCount, 2)
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .checking)
@@ -4731,7 +4738,7 @@ final class ChatViewModelSendTests: XCTestCase {
             isError: nil
         )))
 
-        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(10))
+        await viewModel.recoverStaleActiveStreamIfNeeded(now: Date().addingTimeInterval(13))
 
         XCTAssertEqual(viewModel.activeStreamRecoveryState, .checking)
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")


### PR DESCRIPTION
Fixes #227

## Summary

Follow-up to #186 / PR #216. Heartbeats already prevented forced reconnects, but the `.checking` recovery state and the ~4s `/api/chat/stream/status` polls were still driven purely by *semantic* silence (no tokens/tools for 5s). During long model-thinking pauses or slow tool calls the user saw a "Checking stream" chip and the server got a status poll every ~4s, despite SSE comment heartbeats (~5s server cadence, `_SSE_HEARTBEAT_INTERVAL_SECONDS = 5` upstream) proving the connection alive.

- New `ChatStreamCoordinatorTiming.transportFreshInterval` (standard **12s** — comfortably above the ~5s heartbeat cadence, below `reconnectInterval` 18s).
- In `recoverStaleStreamIfNeeded`, once semantically quiet past `checkingInterval`, the coordinator now stays `.idle` and skips status polls while `now − lastTransportActivityDate < transportFreshInterval`. The existing `.checking` → poll → 18s/25s force-reconnect escalation is unchanged once transport itself has been quiet ≥ 12s.
- A `.heartbeat` event demotes an already-shown `.checking` back to `.idle` immediately (never `.reconnecting`, which stays owned by the reconnect flow until real progress lands).

## Safety-net trade-off (issue care point)

Skipping polls while heartbeat-fresh narrows the missed-`done` net only in a double-fault scenario. Verified against the pinned upstream source:

- Normal completion enqueues `done` then `stream_end` — the latter inside a `finally:` when the background title worker runs — and the server drain loop closes the socket on `stream_end`/`error`/`cancel`.
- A worker exception enqueues `apperror`; the client maps `error`/`apperror` to the terminal `.error` path even when the payload is malformed, so the client finalizes without any poll.
- A dropped socket stops heartbeats: either `.transportError` fires (suspend/reconnect path, untouched) or transport goes quiet and polling resumes within ~12s.

The residual gap requires the worker to die *and* its terminal-event enqueue itself to fail while the separate handler thread keeps heartbeating the open socket — previously caught by the ~4s polls via `active=false`, now only by the untouched foreground `refreshTranscriptIfCompleted` net on the next background/foreground cycle.

## Validation

- `git diff --check` clean.
- Focused `ChatStreamCoordinatorTests` + `ChatViewModelSendTests`: 168 passed, 0 failed.
- Full XCTest suite: **1,561 passed, 0 failed, 0 skipped** (iPhone 17 simulator).
- Test changes called out in the issue as intentional: `testHeartbeatKeepsSemanticallyQuietStreamOnOriginalConnection` now expects `.idle` + zero polls; the stale-detection test (renamed to `testStaleDetectionWaitsForTransportQuietThresholdThenPollsStatus`) documents the 5s→idle / 12s→checking timeline; single-clock tests moved from +5.1/+6/+10 to past the 12s threshold. New tests: heartbeat-fresh stays idle with zero polls, heartbeat demotes `.checking`, heartbeat never demotes `.reconnecting`.

## Owner manual checks

1. Start a long response on the live server (something with a long thinking pause or slow tool call): the "Checking stream" chip should no longer appear while the connection is healthy, and the transcript should still stream normally when output resumes.
2. Kill/restart the server (or drop the network) mid-stream: the chip and the reconnect/finalize behavior should appear as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)