### PR TITLE
feat: render markdown files as formatted preview in workspace browser

### DIFF
--- a/HermesMobile/Features/Chat/ChatMessageActions.swift
+++ b/HermesMobile/Features/Chat/ChatMessageActions.swift
@@ -1,13 +1,17 @@
 import SwiftUI
 import UIKit
 
-struct SelectableResponseText: Identifiable, Equatable {
+struct SelectableTextPresentation: Identifiable, Equatable {
     let id: String
     let text: String
 
+    init(id: String, text: String) {
+        self.id = id
+        self.text = text
+    }
+
     init(context: MessageActionContext) {
-        id = context.messageID
-        text = context.copyText
+        self.init(id: context.messageID, text: context.copyText)
     }
 }
 
@@ -79,8 +83,8 @@ struct ChatMessageActionMenu: View {
     }
 }
 
-struct SelectableResponseTextView: View {
-    let selection: SelectableResponseText
+struct SelectableTextPresentationView: View {
+    let selection: SelectableTextPresentation
 
     @Environment(\.dismiss) private var dismiss
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -299,7 +299,7 @@ struct ChatView: View {
     @State private var showEditDiscardConfirmation = false
     @State private var regenerateContext: MessageActionContext?
     @State private var showRegenerateDiscardConfirmation = false
-    @State private var selectableResponseText: SelectableResponseText?
+    @State private var selectableResponseText: SelectableTextPresentation?
     @State private var attachmentPreviewItem: ChatAttachmentPreviewItem?
     @State private var transcriptMediaPreviewItem: TranscriptMediaPreviewItem?
     @State private var pendingProfileSelection: ProfileSummary?
@@ -665,7 +665,7 @@ struct ChatView: View {
                 ChatView(session: session, server: server, onAPIError: onAPIError)
             }
             .fullScreenCover(item: $selectableResponseText) { selectableText in
-                SelectableResponseTextView(selection: selectableText)
+                SelectableTextPresentationView(selection: selectableText)
             }
             .sheet(item: $attachmentPreviewItem) { item in
                 ChatAttachmentPreviewView(
@@ -1161,7 +1161,7 @@ struct ChatView: View {
                 }
             },
             onSelectText: { context in
-                selectableResponseText = SelectableResponseText(context: context)
+                selectableResponseText = SelectableTextPresentation(context: context)
             },
             onRegenerate: beginRegenerateResponse,
             onEdit: beginEditMessage,

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
+import MarkdownUI
 
 struct FilePreviewView: View {
     let onAPIError: (Error) -> Void
@@ -155,18 +156,44 @@ struct FilePreviewView: View {
     }
 
     private func fileContent(_ content: String) -> some View {
-        ScrollView([.vertical, .horizontal]) {
+        ScrollView(isMarkdownFile ? .vertical : [.vertical, .horizontal]) {
             VStack(alignment: .leading, spacing: 12) {
                 fileHeader
 
-                Text(content)
-                    .font(.system(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                if isMarkdownFile {
+                    markdownContent(content)
+                } else {
+                    Text(content)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
             .padding()
         }
         .background(Color(.systemBackground))
+    }
+
+    @ViewBuilder
+    private func markdownContent(_ content: String) -> some View {
+        Markdown(content)
+            .markdownTextStyle {
+                ForegroundColor(.primary)
+                BackgroundColor(nil)
+            }
+            .markdownTextStyle(\.code) {
+                FontFamilyVariant(.monospaced)
+                FontSize(.em(0.88))
+                BackgroundColor(Color(.tertiarySystemGroupedBackground))
+            }
+            .markdownCodeSyntaxHighlighter(.plainText)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var isMarkdownFile: Bool {
+        guard let path = entry.path else { return false }
+        return ["md", "markdown", "mdown", "mkd"].contains((path as NSString).pathExtension.lowercased())
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
-import MarkdownUI
 
 struct FilePreviewView: View {
     let onAPIError: (Error) -> Void
@@ -161,7 +160,8 @@ struct FilePreviewView: View {
                 fileHeader
 
                 if isMarkdownFile {
-                    markdownContent(content)
+                    MarkdownRenderer(content: content, isStreaming: false)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
                     Text(content)
                         .font(.system(.body, design: .monospaced))
@@ -172,23 +172,6 @@ struct FilePreviewView: View {
             .padding()
         }
         .background(Color(.systemBackground))
-    }
-
-    @ViewBuilder
-    private func markdownContent(_ content: String) -> some View {
-        Markdown(content)
-            .markdownTextStyle {
-                ForegroundColor(.primary)
-                BackgroundColor(nil)
-            }
-            .markdownTextStyle(\.code) {
-                FontFamilyVariant(.monospaced)
-                FontSize(.em(0.88))
-                BackgroundColor(Color(.tertiarySystemGroupedBackground))
-            }
-            .markdownCodeSyntaxHighlighter(.plainText)
-            .textSelection(.enabled)
-            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var isMarkdownFile: Bool {

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -7,6 +7,7 @@ struct FilePreviewView: View {
 
     private let entry: WorkspaceEntry
     @State private var viewModel: FilePreviewViewModel
+    @State private var selectableText: SelectableTextPresentation?
     @State private var exportDocument = ExportedFileDocument(data: Data())
     @State private var exportContentType = UTType.data
     @State private var exportFilename = String(localized: "Hermes File")
@@ -87,6 +88,9 @@ struct FilePreviewView: View {
             if case let .failure(error) = result {
                 exportErrorMessage = error.localizedDescription
             }
+        }
+        .fullScreenCover(item: $selectableText) { selection in
+            SelectableTextPresentationView(selection: selection)
         }
         .alert(
             "Export Failed",
@@ -170,6 +174,23 @@ struct FilePreviewView: View {
                 }
             }
             .padding()
+        }
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button {
+                selectableText = SelectableTextPresentation(
+                    id: "file-preview:\(displayPath)",
+                    text: content
+                )
+            } label: {
+                Label("Select Text", systemImage: "text.cursor")
+            }
+
+            Button {
+                UIPasteboard.general.string = content
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
         }
         .background(Color(.systemBackground))
     }


### PR DESCRIPTION
Markdown files (.md, .markdown, .mdown, .mkd) now render through MarkdownUI with the same text styling as chat messages, instead of showing raw monospace source. Other file types keep the existing raw text preview.

Uses the already-bundled MarkdownUI dependency — no new packages. Rendered documents scroll vertically; raw text keeps horizontal scrolling for long lines.

<!-- Thanks for contributing! Please read CONTRIBUTING.md before opening a PR. -->

## Linked issue

<!-- Every PR should close an issue, e.g. "Fixes #123". If there is no issue yet, open one first. -->

Fixes #

## What changed

<!-- A short, plain-English summary of the change and why it's the right fix. -->

## How it was tested

<!-- e.g. full XCTest suite (command + result), manual simulator steps, screenshots for UI changes. -->

## Checklist

- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [ ] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [ ] No new third-party dependencies (the list in `PROJECT_SPEC.md` is locked)
- [ ] No invented API endpoints or JSON shapes (verified against upstream source or a running server)
