### PR TITLE
fix(chat): render bare file URL artifacts

### DIFF
--- a/HermesMobile/Features/Chat/TranscriptMedia.swift
+++ b/HermesMobile/Features/Chat/TranscriptMedia.swift
@@ -148,13 +148,15 @@ enum TranscriptMediaParser {
     private static func appendMediaSegments(in line: String, to segments: inout [TranscriptMediaSegment]) {
         var cursor = line.startIndex
         var textStart = cursor
+        let inlineCodeRanges = inlineCodeRanges(in: line)
 
         while cursor < line.endIndex {
             if line[cursor...].hasPrefix("MEDIA:"),
                let referenceRange = referenceRange(
                    in: line,
                    markerStart: cursor,
-                   from: line.index(cursor, offsetBy: 6)
+                   from: line.index(cursor, offsetBy: 6),
+                   syntax: .mediaToken
                ) {
                 appendText(String(line[textStart..<cursor]), to: &segments)
 
@@ -162,6 +164,28 @@ enum TranscriptMediaParser {
                 segments.append(.media(reference))
 
                 cursor = referenceRange.upperBound
+                textStart = cursor
+                continue
+            }
+
+            if line[cursor...].hasPrefix(fileURLMarker),
+               isBareFileURLStart(cursor, in: line),
+               !inlineCodeRanges.contains(where: { $0.contains(cursor) }),
+               let pathRange = referenceRange(
+                   in: line,
+                   markerStart: cursor,
+                   from: line.index(cursor, offsetBy: fileURLMarker.count),
+                   syntax: .fileURL
+               ) {
+                appendText(String(line[textStart..<cursor]), to: &segments)
+
+                let rawURL = String(line[cursor..<pathRange.upperBound])
+                let reference = TranscriptMediaReference(
+                    rawReference: normalizedLocalPath(fromFileURL: rawURL)
+                )
+                segments.append(.media(reference))
+
+                cursor = pathRange.upperBound
                 textStart = cursor
                 continue
             }
@@ -185,12 +209,13 @@ enum TranscriptMediaParser {
     private static func referenceRange(
         in line: String,
         markerStart: String.Index,
-        from start: String.Index
+        from start: String.Index,
+        syntax: ReferenceSyntax
     ) -> Range<String.Index>? {
         guard start < line.endIndex else { return nil }
 
         var end = start
-        while end < line.endIndex, !isReferenceTerminator(line[end]) {
+        while end < line.endIndex, !isReferenceTerminator(line[end], syntax: syntax) {
             end = line.index(after: end)
         }
 
@@ -204,7 +229,8 @@ enum TranscriptMediaParser {
             }
         }
 
-        if let delimiter = emphasisDelimiter(in: line, immediatelyBefore: markerStart),
+        if syntax == .mediaToken,
+           let delimiter = emphasisDelimiter(in: line, immediatelyBefore: markerStart),
            line[start..<trimmedEnd].hasSuffix(delimiter) {
             trimmedEnd = line.index(trimmedEnd, offsetBy: -delimiter.count)
         }
@@ -234,8 +260,77 @@ enum TranscriptMediaParser {
         return nil
     }
 
-    private static func isReferenceTerminator(_ character: Character) -> Bool {
-        character.isWhitespace || character == ")" || character == "]"
+    private static func isReferenceTerminator(
+        _ character: Character,
+        syntax: ReferenceSyntax
+    ) -> Bool {
+        if character.isWhitespace || character == ")" || character == "]" {
+            return true
+        }
+
+        return syntax == .fileURL && fileURLTerminators.contains(character)
+    }
+
+    private static func isBareFileURLStart(_ index: String.Index, in line: String) -> Bool {
+        index == line.startIndex || line[line.index(before: index)].isWhitespace
+    }
+
+    private static func normalizedLocalPath(fromFileURL rawURL: String) -> String {
+        if let components = URLComponents(string: rawURL) {
+            let encodedPath = components.percentEncodedPath
+            if !encodedPath.isEmpty {
+                return encodedPath.removingPercentEncoding ?? encodedPath
+            }
+        }
+
+        let schemeStripped = String(rawURL.dropFirst(fileURLMarker.count))
+        return schemeStripped.removingPercentEncoding ?? schemeStripped
+    }
+
+    private static func inlineCodeRanges(in line: String) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var cursor = line.startIndex
+
+        while cursor < line.endIndex {
+            guard line[cursor] == "`" else {
+                cursor = line.index(after: cursor)
+                continue
+            }
+
+            let openingStart = cursor
+            let openingEnd = backtickRunEnd(in: line, from: cursor)
+            let delimiterLength = line.distance(from: openingStart, to: openingEnd)
+            var search = openingEnd
+            var closingEnd: String.Index?
+
+            while search < line.endIndex {
+                guard line[search] == "`" else {
+                    search = line.index(after: search)
+                    continue
+                }
+
+                let candidateEnd = backtickRunEnd(in: line, from: search)
+                if line.distance(from: search, to: candidateEnd) == delimiterLength {
+                    closingEnd = candidateEnd
+                    break
+                }
+                search = candidateEnd
+            }
+
+            guard let closingEnd else { break }
+            ranges.append(openingStart..<closingEnd)
+            cursor = closingEnd
+        }
+
+        return ranges
+    }
+
+    private static func backtickRunEnd(in line: String, from start: String.Index) -> String.Index {
+        var end = start
+        while end < line.endIndex, line[end] == "`" {
+            end = line.index(after: end)
+        }
+        return end
     }
 
     private static func fenceMarker(in line: String) -> Character? {
@@ -258,4 +353,11 @@ enum TranscriptMediaParser {
     }
 
     private static let trailingPunctuation: Set<Character> = [".", ",", ";", ":", "!", "?"]
+    private static let fileURLTerminators: Set<Character> = ["<", ">", "\"", "'"]
+    private static let fileURLMarker = "file://"
+
+    private enum ReferenceSyntax {
+        case mediaToken
+        case fileURL
+    }
 }

--- a/HermesMobileTests/TranscriptMediaParserTests.swift
+++ b/HermesMobileTests/TranscriptMediaParserTests.swift
@@ -104,6 +104,101 @@ final class TranscriptMediaParserTests: XCTestCase {
         XCTAssertTrue(textSegments(in: segments).joined().contains("MEDIA:/tmp/inside.png"))
     }
 
+    func testParsesBareFileURLsAtLineStartOrAfterWhitespace() {
+        let segments = TranscriptMediaParser.segments(
+            in: "file:///tmp/report.csv ready\nImage file:///tmp/chart.png."
+        )
+
+        XCTAssertEqual(
+            segments,
+            [
+                .media(.init(rawReference: "/tmp/report.csv")),
+                .text(" ready\nImage "),
+                .media(.init(rawReference: "/tmp/chart.png")),
+                .text(".")
+            ]
+        )
+    }
+
+    func testBareFileURLDecodesPercentEscapedPathComponents() {
+        let segments = TranscriptMediaParser.segments(
+            in: "Created file:///Users/hermes/workspace/Q3%20report%20%28final%29.csv"
+        )
+
+        XCTAssertEqual(
+            mediaReferences(in: segments).map(\.rawReference),
+            ["/Users/hermes/workspace/Q3 report (final).csv"]
+        )
+    }
+
+    func testBareFileURLKeepsSurroundingProseAndPunctuation() {
+        let segments = TranscriptMediaParser.segments(
+            in: "Created file:///tmp/report.csv, then shared file:///tmp/chart.webp!"
+        )
+
+        XCTAssertEqual(
+            segments,
+            [
+                .text("Created "),
+                .media(.init(rawReference: "/tmp/report.csv")),
+                .text(", then shared "),
+                .media(.init(rawReference: "/tmp/chart.webp")),
+                .text("!")
+            ]
+        )
+    }
+
+    func testBareFileURLRequiresWhitespaceOrLineStart() {
+        let markdown = "prefixfile:///tmp/hidden.txt and [report](file:///tmp/report.csv)"
+        let segments = TranscriptMediaParser.segments(in: markdown)
+
+        XCTAssertEqual(segments, [.text(markdown)])
+    }
+
+    func testBareFileURLInsideInlineOrFencedCodeStaysLiteral() {
+        let markdown = """
+        Before `open file:///tmp/inline.csv` after file:///tmp/outside.csv
+        ```text
+        file:///tmp/fenced.png
+        ```
+        """
+
+        let segments = TranscriptMediaParser.segments(in: markdown)
+
+        XCTAssertEqual(mediaReferences(in: segments).map(\.rawReference), ["/tmp/outside.csv"])
+        let text = textSegments(in: segments).joined()
+        XCTAssertTrue(text.contains("file:///tmp/inline.csv"))
+        XCTAssertTrue(text.contains("file:///tmp/fenced.png"))
+    }
+
+    func testBareFileURLUsesExistingMediaKindClassification() {
+        let segments = TranscriptMediaParser.segments(
+            in: "file:///tmp/image.png file:///tmp/audio.m4a file:///tmp/video.mp4 file:///tmp/data.zip"
+        )
+
+        XCTAssertEqual(
+            mediaReferences(in: segments).map(\.mediaKind),
+            [.image, .audio, .video, .unsupported]
+        )
+    }
+
+    func testBareFileURLSupportDoesNotChangeExistingMediaOrHTTPSBehavior() throws {
+        let segments = TranscriptMediaParser.segments(
+            in: "MEDIA:/tmp/local.png MEDIA:https://cdn.example.test/image.png"
+        )
+        let references = mediaReferences(in: segments)
+
+        XCTAssertEqual(references.map(\.rawReference), [
+            "/tmp/local.png",
+            "https://cdn.example.test/image.png"
+        ])
+        XCTAssertEqual(references[0].source, .localPath("/tmp/local.png"))
+        XCTAssertEqual(
+            references[1].source,
+            .remoteURL(try XCTUnwrap(URL(string: "https://cdn.example.test/image.png")))
+        )
+    }
+
     func testUnsupportedSVGIsNotRasterImageCandidate() {
         let segments = TranscriptMediaParser.segments(in: "MEDIA:/tmp/vector.svg")
         let media = mediaReferences(in: segments).first
@@ -162,6 +257,24 @@ final class TranscriptMediaParserTests: XCTestCase {
         XCTAssertEqual(payload.data, data)
         XCTAssertFalse(payload.isImage)
         XCTAssertFalse(payload.isVideo)
+    }
+
+    func testParsedGenericFileURLExportKeepsDecodedOriginalNameAndExtension() throws {
+        let segments = TranscriptMediaParser.segments(
+            in: "file:///tmp/final%20report.csv"
+        )
+        let reference = try XCTUnwrap(mediaReferences(in: segments).first)
+        let data = Data("heading,value".utf8)
+
+        let payload = TranscriptMediaExportSupport.payload(
+            for: reference,
+            data: data,
+            resolvedKind: .data
+        )
+
+        XCTAssertEqual(reference.rawReference, "/tmp/final report.csv")
+        XCTAssertEqual(payload.filename, "final report.csv")
+        XCTAssertEqual(payload.data, data)
     }
 
     func testExtensionlessUnsupportedFileExportsAsDataNotVideo() {

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -54,6 +54,43 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(recorder.requestCount, 1)
     }
 
+    func testParsedFileURLUsesSessionMediaEndpointAndDecodedExportFilename() async throws {
+        let recorder = TranscriptMediaPreviewRequestRecorder()
+        let imageData = try XCTUnwrap(Self.imageData())
+        let sessionID = "session-file-url"
+        let segments = TranscriptMediaParser.segments(
+            in: "Created file:///tmp/final%20chart.png"
+        )
+        let reference = try XCTUnwrap(segments.compactMap { segment in
+            if case let .media(reference) = segment {
+                return reference
+            }
+            return nil
+        }.first)
+        let client = makeClient { request in
+            recorder.record(request)
+            return self.response(statusCode: 200, data: imageData, for: request)
+        }
+        let viewModel = TranscriptMediaPreviewViewModel(
+            server: Self.baseURL,
+            sessionID: sessionID,
+            reference: reference,
+            apiClient: client
+        )
+
+        await viewModel.load()
+
+        XCTAssertNil(viewModel.errorMessage)
+        let queryItems = queryItems(for: try XCTUnwrap(recorder.firstURL))
+        XCTAssertEqual(queryItems["session_id"], sessionID)
+        XCTAssertEqual(queryItems["path"], "/tmp/final chart.png")
+
+        let payload = try await viewModel.exportPayload()
+        XCTAssertEqual(payload.filename, "final chart.png")
+        XCTAssertEqual(payload.data, imageData)
+        XCTAssertEqual(recorder.requestCount, 1)
+    }
+
     func testLoadSameServerRemoteImageUsesAuthenticatedSession() async throws {
         let recorder = TranscriptMediaPreviewRequestRecorder()
         let imageData = try XCTUnwrap(Self.imageData())


### PR DESCRIPTION
Fixes #247

## Summary

- recognize bare, line-start or whitespace-delimited `file://` assistant artifacts
- normalize them to percent-decoded server-local paths before using the existing transcript-media pipeline
- preserve surrounding prose and punctuation while leaving inline/fenced code, `MEDIA:`, and HTTP(S) behavior unchanged
- keep session-scoped `/api/media` loading and original filenames/extensions for export

Upstream behavior and the `/api/media` contract were validated against repo-local `hermes-webui` commit `399cd7ab19ce43f77d3c3a68bb575e9eed9cd6af` (`static/ui.js` and `api/routes.py`).

## Validation

- `git diff --check`
- focused `TranscriptMediaParserTests` + `TranscriptMediaPreviewViewModelTests`: 34 passed, 0 failed, 0 skipped
- full XCTest suite on iPhone 17 simulator: 1,572 passed, 0 failed, 0 skipped
- signed Debug build/install/launch on iPhone 17 simulator

## Owner manual checks

- replay an assistant message containing an allowed server-side `file://` generic artifact
- save it through Files and verify its filename, extension, and contents
- spot-check an image, audio, or video `file://` preview
- confirm `file://` references inside inline and fenced code remain literal text
