### PR TITLE
fix(kanban): decode run IDs from detail events

### DIFF
--- a/HermesMobile/Models/Kanban.swift
+++ b/HermesMobile/Models/Kanban.swift
@@ -823,7 +823,11 @@ struct KanbanDetailEvent: Decodable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case eventID = "id"
         case cardID = "taskId"
-        case runID, kind, createdAt, payload
+        // `runID` without a raw value spells the key "runID", but the decoder
+        // runs `.convertFromSnakeCase`, which turns the server's `run_id` into
+        // "runId" — so this never matched and `runID` was always nil.
+        case runID = "runId"
+        case kind, createdAt, payload
     }
 
     init(from decoder: Decoder) throws {

--- a/HermesMobileTests/APIClientKanbanTests.swift
+++ b/HermesMobileTests/APIClientKanbanTests.swift
@@ -862,6 +862,19 @@ final class APIClientKanbanTests: APIClientTestCase {
         XCTAssertEqual(exactStatusReport.warnings, [.unsupportedStatus("TRIAGE")])
     }
 
+    func testKanbanDetailEventDecodesTheRunID() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let event = try decoder.decode(KanbanDetailEvent.self, from: Data("""
+        {"id": 8, "task_id": "CARD-1", "run_id": "run-17", "kind": "status",
+         "created_at": 1700000000, "payload": {"status": "ready"}}
+        """.utf8))
+
+        XCTAssertEqual(event.runID, "run-17")
+        XCTAssertEqual(event.cardID, "CARD-1")
+    }
+
     private static let configurationJSON = """
     {"columns":["triage","todo","ready"],"assignees":["work"],"read_only":false}
     """


### PR DESCRIPTION
## Linked issue

No upstream issue — this came out of a client/server contract audit rather than a filed bug report, so there was nothing to link. Happy to open one if you would rather have it tracked separately. The raw audit note is [audichuang/hermex#13](https://github.com/audichuang/hermex/issues/13) (written in Chinese); everything relevant is reproduced in English below.

## What changed

- Decode `run_id` on Kanban detail events using the key the shared decoder actually produces.
- Move the regression test inside the `XCTestCase` so test discovery runs it.

## Root cause

`KanbanDetailEvent.CodingKeys` declared `case runID` with no raw value, so the literal key was `runID`. `APIClient` decodes with `.convertFromSnakeCase`, which maps the server's `run_id` to `runId`. The two never matched, so `runID` always decoded as `nil`. The sibling `CodingKeys` in the same file (`HermesMobile/Models/Kanban.swift:209`) already spells its raw value out, so this was an omission rather than a design choice.

The fix sits on the model every Kanban detail-event consumer decodes through, not on one call site.

## Contract evidence

- Upstream `nesquena/hermes-webui`, read-only local checkout at `ecc47782e3e72a5bf3e848a8f09a2a5a838c71b1` (2026-07-22): `api/kanban_bridge.py:322` writes detail events as `task_events (task_id, run_id, kind, payload, created_at)` — the wire field is `run_id`.
- This repo's compatibility pin `UPSTREAM_TESTED_SHA` is `f1d399b4` (v0.51.85). The checkout above is newer than the pin and is not itself the pin.
- No live wire capture for this path; see Need to verify.

## How it was tested

- Focused: `APIClientKanbanTests/testKanbanDetailEventDecodesTheRunID` — asserts the decode that the old key could never satisfy.
- Full XCTest, iPhone 17 Simulator, iOS 26.5, `-parallel-testing-enabled NO`: 1,573 passed, 0 failed, 0 skipped.
- `git diff --check origin/master...HEAD`: clean.
- Pushed SHA verified against `audichuang/hermex` with `git ls-remote`: `c608dfa6fc163b14a9cea44367d1bb1798dc36a3`.

## Need to verify

- No live Kanban detail event was available on the deployment I can reach, so the wire shape is source-backed only.
- No UI evidence: this is a decode-only change with no surface of its own — the decoded run ID feeds existing views unchanged.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (the field stays `String?`; only the key is fixed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (`run_id` verified against upstream source above)

## AI assistance

Built with Claude Code. The diff, the regression test, and the test output were reviewed before publishing.
