### PR TITLE
fix(auth): handle trusted-header and OIDC sign-in honestly

### DIFF
--- a/HermesMobile/Auth/AuthManager.swift
+++ b/HermesMobile/Auth/AuthManager.swift
@@ -24,6 +24,36 @@ final class AuthManager {
     nonisolated static let passkeyOnlyMessage =
         String(localized: "This server signs in with passkeys, which Hermex doesn't support yet.")
 
+    /// Single sign-on. Hermex cannot run the OIDC redirect flow yet, and an
+    /// external browser's session is not shared with the app.
+    nonisolated static let oidcOnlyMessage =
+        String(localized: "This server signs in with single sign-on, which Hermex doesn't support yet.")
+
+    /// Trusted-header mode where the proxy did *not* authenticate this request,
+    /// so the server reports the mode but not a session.
+    nonisolated static let trustedAuthNotSignedInMessage =
+        String(localized: "This server signs in through an identity proxy, which didn't authorize this request. Open the server in a browser, or check the custom headers.")
+
+    /// Why the app can't complete sign-in on its own, or nil when it can —
+    /// either there's no auth, the server already signed this client in, or a
+    /// password login is available.
+    ///
+    /// Replaces the "auth on and password auth off ⇒ passkeys" inference that
+    /// used to live in three places. `is_auth_enabled()` upstream
+    /// (`api/auth.py:563`) also covers OIDC and trusted-header, so that
+    /// inference locked out working deployments and told them the wrong reason
+    /// (#3).
+    nonisolated static func unsupportedSignInMessage(for status: AuthStatusResponse) -> String? {
+        guard status.authEnabled == true, !status.isAlreadySignedIn else { return nil }
+        // A missing value means an older server that doesn't report it; fall
+        // through to the password path rather than block a working user.
+        guard status.passwordAuthEnabled == false else { return nil }
+
+        if status.oidcEnabled == true { return oidcOnlyMessage }
+        if status.trustedAuthEnabled == true { return trustedAuthNotSignedInMessage }
+        return passkeyOnlyMessage
+    }
+
     private(set) var state: State = .unconfigured
     private(set) var lastErrorMessage: String?
 
@@ -121,16 +151,15 @@ final class AuthManager {
             let client = clientFactory(serverURL)
             let authStatus = try await testConnection(client: client)
 
-            // Passkey-only: auth is on but the server explicitly reports password
-            // auth off. Only an explicit false counts — a missing field means an
-            // older server that doesn't report it, so we must fall through to the
-            // password path and never block a working password user (#255).
-            if authStatus.authEnabled == true, authStatus.passwordAuthEnabled == false {
-                lastErrorMessage = Self.passkeyOnlyMessage
+            if let message = Self.unsupportedSignInMessage(for: authStatus) {
+                lastErrorMessage = message
                 return
             }
 
-            if authStatus.authEnabled == true {
+            // `logged_in` means the server already authenticated this client —
+            // trusted-header mode does it at the proxy — so there is nothing to
+            // log in with and the server is saved as signed in (#3).
+            if authStatus.authEnabled == true, !authStatus.isAlreadySignedIn {
                 guard !password.isEmpty else {
                     lastErrorMessage = String(localized: "Enter the server password.")
                     return
@@ -208,12 +237,12 @@ final class AuthManager {
         do {
             let authStatus = try await testConnection(client: client)
 
-            if authStatus.authEnabled == true, authStatus.passwordAuthEnabled == false {
-                lastErrorMessage = Self.passkeyOnlyMessage
+            if let message = Self.unsupportedSignInMessage(for: authStatus) {
+                lastErrorMessage = message
                 return .failed
             }
 
-            if authStatus.authEnabled == true {
+            if authStatus.authEnabled == true, !authStatus.isAlreadySignedIn {
                 guard !password.isEmpty else {
                     // Not an error — the UI reveals the password field and retries.
                     return .needsPassword

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -27,10 +27,12 @@ final class OnboardingViewModel {
     }
 
     var isPasswordRequired: Bool {
-        // No auth → no password. Passkey-only (auth on, password auth explicitly
-        // off) → hide the password field; connect() surfaces the unsupported
-        // message instead. Unknown (nil) keeps today's "show the field" default.
+        // No auth → no password. Already signed in (trusted-header proxy) → no
+        // password either. Passkey/OIDC-only → hide the field; connect()
+        // surfaces the specific unsupported message instead. Unknown (nil)
+        // keeps today's "show the field" default.
         guard authStatus?.authEnabled != false else { return false }
+        guard authStatus?.isAlreadySignedIn != true else { return false }
         return authStatus?.passwordAuthEnabled != false
     }
 
@@ -46,8 +48,10 @@ final class OnboardingViewModel {
                 customHeaders: customHeaders
             )
             authStatus = status
-            if status.authEnabled == true, status.passwordAuthEnabled == false {
-                errorMessage = AuthManager.passkeyOnlyMessage
+            if let message = AuthManager.unsupportedSignInMessage(for: status) {
+                errorMessage = message
+            } else if status.isAlreadySignedIn {
+                connectionMessage = String(localized: "Connection ok. Already signed in by this server.")
             } else {
                 connectionMessage = status.authEnabled == true
                     ? String(localized: "Connection ok. Password required.")
@@ -97,8 +101,12 @@ final class OnboardingViewModel {
 
     nonisolated static func passwordValidationMessage(authStatus: AuthStatusResponse?, password: String) -> String? {
         guard authStatus?.authEnabled == true else { return nil }
-        // Passkey-only servers don't take a password — let configure() report the
-        // specific unsupported message instead of demanding one here (#255).
+        // A server that already signed this client in (trusted-header proxy)
+        // has no password to demand (#3).
+        guard authStatus?.isAlreadySignedIn != true else { return nil }
+        // Passkey/OIDC-only servers don't take a password either — let
+        // configure() report the specific unsupported message instead of
+        // demanding one here (#255, #3).
         guard authStatus?.passwordAuthEnabled != false else { return nil }
 
         let trimmedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/HermesMobile/Models/ServerInfo.swift
+++ b/HermesMobile/Models/ServerInfo.swift
@@ -17,19 +17,36 @@ struct AuthStatusResponse: Decodable {
     let passwordAuthEnabled: Bool?
     let passkeysEnabled: Bool?
     let passwordlessEnabled: Bool?
+    /// Set when the server offers single sign-on. `is_auth_enabled()` upstream
+    /// covers password, OIDC *and* trusted-header, so "auth on, password off"
+    /// on its own never meant passkeys (#3).
+    let oidcEnabled: Bool?
+    /// Set when an identity proxy in front of the server authenticates the
+    /// request (Cloudflare Access, Authentik). Present only when that mode is
+    /// on, so nil means "not that kind of server".
+    let trustedAuthEnabled: Bool?
+
+    /// The server already considers this client signed in. Trusted-header
+    /// deployments authenticate at the proxy, so there is no credential for the
+    /// app to send and no login step to perform.
+    var isAlreadySignedIn: Bool { loggedIn == true }
 
     init(
         authEnabled: Bool? = nil,
         loggedIn: Bool? = nil,
         passwordAuthEnabled: Bool? = nil,
         passkeysEnabled: Bool? = nil,
-        passwordlessEnabled: Bool? = nil
+        passwordlessEnabled: Bool? = nil,
+        oidcEnabled: Bool? = nil,
+        trustedAuthEnabled: Bool? = nil
     ) {
         self.authEnabled = authEnabled
         self.loggedIn = loggedIn
         self.passwordAuthEnabled = passwordAuthEnabled
         self.passkeysEnabled = passkeysEnabled
         self.passwordlessEnabled = passwordlessEnabled
+        self.oidcEnabled = oidcEnabled
+        self.trustedAuthEnabled = trustedAuthEnabled
     }
 }
 

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -87904,6 +87904,324 @@
         }
       }
     },
+    "This server signs in with single sign-on, which Hermex doesn't support yet." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يستخدم هذا الخادم تسجيل الدخول الموحّد، الذي لا يدعمه Hermex حتى الآن."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Server nutzt Single Sign-on, das Hermex noch nicht unterstützt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este servidor usa inicio de sesión único, que Hermex aún no admite."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce serveur utilise l’authentification unique, que Hermex ne prend pas encore en charge."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "השרת הזה משתמש בכניסה יחידה, שבה Hermex עדיין לא תומך."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo server usa il single sign-on, che Hermex non supporta ancora."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このサーバーはシングルサインオンを使用しますが、Hermex はまだ対応していません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 서버는 싱글 사인온을 사용하지만 Hermex는 아직 지원하지 않습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deze server gebruikt eenmalige aanmelding, wat Hermex nog niet ondersteunt."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ten serwer używa logowania jednokrotnego, którego Hermex jeszcze nie obsługuje."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este servidor usa logon único, que o Hermex ainda não oferece suporte."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот сервер использует единый вход, который Hermex пока не поддерживает."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sunucu tek oturum açma kullanıyor, ancak Hermex bunu henüz desteklemiyor."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ سرور سنگل سائن آن استعمال کرتا ہے، جسے Hermex ابھی سپورٹ نہیں کرتا۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "呢部伺服器使用單一登入，但 Hermex 暫時未支援。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此服务器使用单点登录，但 Hermex 尚不支持。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這台伺服器使用單一登入，但 Hermex 尚未支援。"
+          }
+        }
+      }
+    },
+    "This server signs in through an identity proxy, which didn't authorize this request. Open the server in a browser, or check the custom headers." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يسجّل هذا الخادم الدخول عبر وكيل هوية لم يصرّح بهذا الطلب. افتح الخادم في المتصفح أو تحقّق من الترويسات المخصّصة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Server meldet über einen Identitäts-Proxy an, der diese Anfrage nicht autorisiert hat. Öffne den Server im Browser oder prüfe die eigenen Header."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este servidor inicia sesión a través de un proxy de identidad que no autorizó esta solicitud. Abre el servidor en un navegador o revisa las cabeceras personalizadas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce serveur s’authentifie via un proxy d’identité qui n’a pas autorisé cette requête. Ouvrez le serveur dans un navigateur ou vérifiez les en-têtes personnalisés."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "השרת הזה מתחבר דרך פרוקסי זהות שלא אישר את הבקשה הזו. פתח את השרת בדפדפן, או בדוק את הכותרות המותאמות."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo server accede tramite un proxy di identità che non ha autorizzato questa richiesta. Apri il server in un browser o controlla le intestazioni personalizzate."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このサーバーは ID プロキシ経由でサインインしますが、そのプロキシがこのリクエストを承認しませんでした。ブラウザでサーバーを開くか、カスタムヘッダーを確認してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 서버는 ID 프록시를 통해 로그인하지만 이 요청은 승인되지 않았습니다. 브라우저에서 서버를 열거나 사용자 지정 헤더를 확인하세요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deze server meldt aan via een identiteitsproxy die dit verzoek niet heeft geautoriseerd. Open de server in een browser of controleer de aangepaste headers."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ten serwer loguje przez proxy tożsamości, które nie autoryzowało tego żądania. Otwórz serwer w przeglądarce lub sprawdź własne nagłówki."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este servidor autentica por um proxy de identidade que não autorizou esta requisição. Abra o servidor em um navegador ou verifique os cabeçalhos personalizados."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот сервер выполняет вход через прокси идентификации, который не авторизовал этот запрос. Откройте сервер в браузере или проверьте пользовательские заголовки."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sunucu, bu isteği yetkilendirmeyen bir kimlik proxy’si üzerinden oturum açıyor. Sunucuyu tarayıcıda açın veya özel başlıkları kontrol edin."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ سرور شناختی پراکسی کے ذریعے سائن اِن کرتا ہے، جس نے اس درخواست کی اجازت نہیں دی۔ سرور کو براؤزر میں کھولیں یا کسٹم ہیڈرز چیک کریں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "呢部伺服器透過身分代理登入，但該代理未授權今次請求。請喺瀏覽器開啟伺服器，或檢查自訂標頭。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此服务器通过身份代理登录，但该代理未授权此请求。请在浏览器中打开服务器，或检查自定义标头。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這台伺服器透過身分代理登入，但該代理未授權這次請求。請在瀏覽器中開啟伺服器，或檢查自訂標頭。"
+          }
+        }
+      }
+    },
+    "Connection ok. Already signed in by this server." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم الاتصال. هذا الخادم سجّل دخولك بالفعل."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbindung ok. Dieser Server hat dich bereits angemeldet."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conexión correcta. Este servidor ya te ha iniciado sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connexion établie. Ce serveur vous a déjà authentifié."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "החיבור תקין. השרת הזה כבר חיבר אותך."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connessione riuscita. Questo server ti ha già autenticato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続できました。このサーバーではすでにサインイン済みです。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결되었습니다. 이 서버에 이미 로그인되어 있습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinding oké. Deze server heeft je al aangemeld."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Połączenie działa. Ten serwer już Cię zalogował."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conexão ok. Este servidor já fez seu login."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Соединение установлено. Этот сервер уже выполнил вход."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlantı başarılı. Bu sunucu sizi zaten oturum açtırmış."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کنیکشن ٹھیک ہے۔ یہ سرور آپ کو پہلے ہی سائن اِن کر چکا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線正常。呢部伺服器已經幫你登入咗。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接正常。此服务器已为你登录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線正常。這台伺服器已為你登入。"
+          }
+        }
+      }
+    },
     "This server signs in with passkeys, which Hermex doesn't support yet." : {
       "localizations" : {
         "ar" : {

--- a/HermesMobileTests/CustomHeaderInjectionTests.swift
+++ b/HermesMobileTests/CustomHeaderInjectionTests.swift
@@ -401,6 +401,87 @@ final class CustomHeaderAuthManagerTests: XCTestCase {
         XCTAssertNil(keychain.savedValues[.serverURL])
     }
 
+    /// Trusted-header deployments — the reverse-proxy setups the custom-header
+    /// feature exists for — authenticate at the proxy and answer
+    /// `logged_in: true` with no password auth. Reading that as "passkeys" shut
+    /// them out of a server they were already signed in to (#3).
+    func testTrustedHeaderServerThatAlreadySignedUsInIsSavedWithoutLogin() async throws {
+        let keychain = InMemoryKeychainStore()
+        let client = MockAuthAPIClient(authStatus: AuthStatusResponse(
+            authEnabled: true,
+            loggedIn: true,
+            passwordAuthEnabled: false,
+            trustedAuthEnabled: true
+        ))
+        let manager = makeManager(keychain: keychain, store: CustomHeaderStore(), client: client)
+
+        await manager.configure(serverURLString: "https://example.test", password: "")
+
+        XCTAssertNil(manager.lastErrorMessage)
+        XCTAssertEqual(client.loginPasswords, [], "There is no credential to send.")
+        XCTAssertEqual(manager.state, .loggedIn(server: try XCTUnwrap(URL(string: "https://example.test"))))
+        XCTAssertEqual(keychain.savedValues[.serverURL], "https://example.test")
+    }
+
+    /// Browser and app cookie jars are separate, so external browser sign-in
+    /// cannot be presented as a way to authenticate Hermex.
+    func testOIDCServerReportsSingleSignOnRatherThanPasskeys() async throws {
+        let client = MockAuthAPIClient(authStatus: AuthStatusResponse(
+            authEnabled: true,
+            loggedIn: false,
+            passwordAuthEnabled: false,
+            oidcEnabled: true
+        ))
+        let manager = makeManager(keychain: InMemoryKeychainStore(), store: CustomHeaderStore(), client: client)
+
+        await manager.configure(serverURLString: "https://example.test", password: "")
+
+        XCTAssertEqual(
+            manager.lastErrorMessage,
+            "This server signs in with single sign-on, which Hermex doesn't support yet."
+        )
+        XCTAssertNotEqual(manager.lastErrorMessage, AuthManager.passkeyOnlyMessage)
+        XCTAssertEqual(manager.state, .unconfigured)
+    }
+
+    /// Trusted-header mode where the proxy did not authorize this request is a
+    /// different problem again, with a different thing to try.
+    func testTrustedHeaderServerWithoutASessionExplainsTheProxy() async throws {
+        let client = MockAuthAPIClient(authStatus: AuthStatusResponse(
+            authEnabled: true,
+            loggedIn: false,
+            passwordAuthEnabled: false,
+            trustedAuthEnabled: true
+        ))
+        let manager = makeManager(keychain: InMemoryKeychainStore(), store: CustomHeaderStore(), client: client)
+
+        await manager.configure(serverURLString: "https://example.test", password: "")
+
+        XCTAssertEqual(manager.lastErrorMessage, AuthManager.trustedAuthNotSignedInMessage)
+        XCTAssertEqual(manager.state, .unconfigured)
+    }
+
+    /// `addServer` carried a verbatim copy of the same inference and has to
+    /// behave identically.
+    func testAddServerAcceptsAServerThatAlreadySignedUsIn() async throws {
+        let client = MockAuthAPIClient(authStatus: AuthStatusResponse(
+            authEnabled: true,
+            loggedIn: true,
+            passwordAuthEnabled: false,
+            trustedAuthEnabled: true
+        ))
+        let manager = AuthManager(
+            keychain: InMemoryKeychainStore(),
+            probeClientFactory: { _, _ in client },
+            serverRegistry: ServerRegistry.inMemory()
+        )
+
+        let outcome = await manager.addServer(serverURLString: "https://example.test", password: "")
+
+        XCTAssertEqual(outcome, .added(try XCTUnwrap(URL(string: "https://example.test"))))
+        XCTAssertEqual(client.loginPasswords, [])
+    }
+
     func testMissingPasswordFlagFallsThroughToPasswordLogin() async throws {
         let keychain = InMemoryKeychainStore()
         // authEnabled true but passwordAuthEnabled nil (older server) must NOT be


### PR DESCRIPTION
## Linked issue

No upstream issue — this came out of a client/server contract audit rather than a filed bug report. Happy to open one if you would rather have it tracked separately. The raw audit note is [audichuang/hermex#3](https://github.com/audichuang/hermex/issues/3) (written in Chinese); everything relevant is reproduced in English below. Different root cause from #220 ("Can't login to VPS hosted Hermes"), which is an older server returning HTML.

## What changed

- Distinguish trusted-header, OIDC, passkey-only, and password servers instead of treating every password-disabled server as passkey-only.
- Accept a trusted-header server that has already authenticated the request, without attempting a password login.
- Report OIDC as unsupported in the app instead of implying a browser session will carry over.
- Add the copy to the existing 17-language catalog cohort.

## Root cause

The client inferred `auth_enabled == true && password_auth_enabled == false` ⇒ passkeys. Upstream's `is_auth_enabled()` also covers OIDC and trusted-header deployments, and a trusted-header server may already report the request as logged in — a field the client decoded but never consumed.

That inference was copied in three places (`AuthManager.configure()`, `AuthManager.addServer()`, and `OnboardingViewModel`, which additionally hid the password field). The fix replaces all three with one shared decision over the explicit mode and logged-in fields, so no caller can drift again.

## Contract evidence

- Upstream `nesquena/hermes-webui`, read-only local checkout at `ecc47782e3e72a5bf3e848a8f09a2a5a838c71b1` (2026-07-22):
  - `api/routes.py:12142`, `:12152` — `/api/auth/status` returns `oidc_enabled` as its own field, independent of password auth.
  - `api/routes.py:12160` — the trusted branch keys off `is_trusted_auth_enabled()` or a session whose `auth_type == "trusted"`.
  - `api/auth.py:538` — `is_auth_enabled()` returns true for password auth **or** passkeys **or** OIDC **or** trusted-header, which is why the client's "no password ⇒ passkeys" inference was wrong.
- This repo's compatibility pin `UPSTREAM_TESTED_SHA` is `f1d399b4` (v0.51.85). The checkout above is newer than the pin and is not itself the pin.
- The OIDC entry point creates a browser cookie; that cookie jar is not shared with the app, which is why this PR reports OIDC as unsupported rather than pretending to sign in.

## How it was tested

- Focused: `CustomHeaderAuthManagerTests` (in `HermesMobileTests/CustomHeaderInjectionTests.swift`) — trusted-header server saved without login, trusted-header without a session explains the proxy, OIDC server reports SSO rather than passkeys, and `addServer` accepts an already-authenticated server.
- Full XCTest, iPhone 17 Simulator, iOS 26.5, `-parallel-testing-enabled NO`: 1,576 passed, 0 failed, 0 skipped.
- `jq empty HermesMobile/Resources/Localizable.xcstrings`: clean.
- `git diff --check origin/master...HEAD`: clean.
- Pushed SHA verified against `audichuang/hermex` with `git ls-remote`: `4fc004a50885a65764647a95a95200d00f99c9eb`.

## Need to verify

- **No live sign-in proof.** The deployment I can reach has auth disabled, so neither the OIDC nor the trusted-header path was exercised against a real server. The decision boundary is covered by unit tests over the decoded status; the end-to-end flow is not.
- **No signed-build UI walkthrough** for the onboarding screens for the same reason — with auth disabled, the new states are unreachable in the running app. Both new strings are in the catalog in all 17 languages, but they were not seen rendered on device.
- Contract evidence is source-based rather than captured from the wire.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (`oidcEnabled` / `trustedAuthEnabled` / `loggedIn` are optional; older servers that omit them fall back to the previous behavior)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (fields verified against upstream source above)

## AI assistance

Built with Claude Code. The diff, the contract reading, the localized copy, and the test output were reviewed before publishing.
