### PR TITLE
fix(sessions): isolate invalid rows from list consumers

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -218,7 +218,11 @@ final class SessionListViewModel {
         do {
             let response = try await client.sessions()
             let visibleSessions = (response.sessions ?? [])
-                .filter { $0.archived != true && $0.shouldAppearInSessionList }
+                .filter {
+                    Self.nonEmpty($0.sessionId) != nil
+                        && $0.archived != true
+                        && $0.shouldAppearInSessionList
+                }
             applySessions(visibleSessions, archivedCount: response.archivedCount, animation: animation)
             isViewingCachedData = false
 

--- a/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
+++ b/HermesMobile/Features/Settings/ArchivedSessionsViewModel.swift
@@ -36,7 +36,9 @@ final class ArchivedSessionsViewModel {
             // row carries an `archived` flag (verified against upstream routes.py
             // @312d3fab and the live server), so filter client-side.
             let response = try await client.sessions(includeArchived: true)
-            sessions = (response.sessions ?? []).filter { $0.archived == true }
+            sessions = (response.sessions ?? []).filter {
+                Self.nonEmpty($0.sessionId) != nil && $0.archived == true
+            }
         } catch {
             // A cancelled load (pull-to-refresh superseding `.task`, or the view
             // disappearing) is not a failure — don't flash an error state.

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -9,12 +9,50 @@ struct SessionsResponse: Decodable {
     let archivedCount: Int?
     let serverTime: Double?
     let serverTz: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sessions, cliCount, archivedCount, serverTime, serverTz
+    }
+
+    init(
+        sessions: [SessionSummary]? = nil,
+        cliCount: Int? = nil,
+        archivedCount: Int? = nil,
+        serverTime: Double? = nil,
+        serverTz: String? = nil
+    ) {
+        self.sessions = sessions
+        self.cliCount = cliCount
+        self.archivedCount = archivedCount
+        self.serverTime = serverTime
+        self.serverTz = serverTz
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessions = SessionSummary.decodingRowsIndependently(from: container, forKey: .sessions)
+        cliCount = container.decodeLossyIntIfPresent(forKey: .cliCount)
+        archivedCount = container.decodeLossyIntIfPresent(forKey: .archivedCount)
+        serverTime = container.decodeLossyDoubleIfPresent(forKey: .serverTime)
+        serverTz = container.decodeLossyStringIfPresent(forKey: .serverTz)
+    }
 }
 
 struct SessionSearchResponse: Decodable, Equatable {
     let sessions: [SessionSummary]?
     let query: String?
     let count: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case sessions, query, count
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessions = SessionSummary.decodingRowsIndependently(from: container, forKey: .sessions)
+        query = container.decodeLossyStringIfPresent(forKey: .query)
+        count = container.decodeLossyIntIfPresent(forKey: .count)
+    }
 }
 
 struct SessionResponse: Decodable {
@@ -251,6 +289,86 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         self.readOnly = readOnly
         self.isReadOnly = isReadOnly
         self.matchType = matchType
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId, title, workspace, model, modelProvider
+        case messageCount, createdAt, updatedAt, lastMessageAt
+        case pinned, archived, projectId, profile
+        case inputTokens, outputTokens, estimatedCost
+        case activeStreamId, isStreaming, isCliSession
+        case userMessageCount, hasPendingUserMessage, pendingStartedAt, worktreePath
+        case sourceTag, rawSource, sessionSource, sourceLabel
+        case parentSessionId, relationshipType, readOnly, isReadOnly, matchType
+    }
+
+    /// Lossy field by field, like `SessionDetail` and `ProjectSummary` already
+    /// are (`AGENTS.md` hard rule 3).
+    ///
+    /// The synthesized `Decodable` this replaces failed the whole value on one
+    /// mistyped field, and `SessionsResponse` decoded the array as a unit — so a
+    /// single malformed row emptied the entire session list, with pull-to-refresh
+    /// unable to recover it. The rows come from three different sources (sidecar
+    /// JSON, the state.db overlay, `get_cli_sessions()`), and upstream coerces
+    /// these same fields with `_numeric_count` / `_safe_first` on its way out,
+    /// which is the server conceding the inputs are not uniform.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = container.decodeLossyStringIfPresent(forKey: .sessionId)
+        title = container.decodeLossyStringIfPresent(forKey: .title)
+        workspace = container.decodeLossyStringIfPresent(forKey: .workspace)
+        model = container.decodeLossyStringIfPresent(forKey: .model)
+        modelProvider = container.decodeLossyStringIfPresent(forKey: .modelProvider)
+        messageCount = container.decodeLossyIntIfPresent(forKey: .messageCount)
+        createdAt = container.decodeLossyDoubleIfPresent(forKey: .createdAt)
+        updatedAt = container.decodeLossyDoubleIfPresent(forKey: .updatedAt)
+        lastMessageAt = container.decodeLossyDoubleIfPresent(forKey: .lastMessageAt)
+        pinned = container.decodeLossyBoolIfPresent(forKey: .pinned)
+        archived = container.decodeLossyBoolIfPresent(forKey: .archived)
+        projectId = container.decodeLossyStringIfPresent(forKey: .projectId)
+        profile = container.decodeLossyStringIfPresent(forKey: .profile)
+        inputTokens = container.decodeLossyIntIfPresent(forKey: .inputTokens)
+        outputTokens = container.decodeLossyIntIfPresent(forKey: .outputTokens)
+        estimatedCost = container.decodeLossyDoubleIfPresent(forKey: .estimatedCost)
+        activeStreamId = container.decodeLossyStringIfPresent(forKey: .activeStreamId)
+        isStreaming = container.decodeLossyBoolIfPresent(forKey: .isStreaming)
+        isCliSession = container.decodeLossyBoolIfPresent(forKey: .isCliSession)
+        userMessageCount = container.decodeLossyIntIfPresent(forKey: .userMessageCount)
+        hasPendingUserMessage = container.decodeLossyBoolIfPresent(forKey: .hasPendingUserMessage)
+        pendingStartedAt = container.decodeLossyDoubleIfPresent(forKey: .pendingStartedAt)
+        worktreePath = container.decodeLossyStringIfPresent(forKey: .worktreePath)
+        sourceTag = container.decodeLossyStringIfPresent(forKey: .sourceTag)
+        rawSource = container.decodeLossyStringIfPresent(forKey: .rawSource)
+        sessionSource = container.decodeLossyStringIfPresent(forKey: .sessionSource)
+        sourceLabel = container.decodeLossyStringIfPresent(forKey: .sourceLabel)
+        parentSessionId = container.decodeLossyStringIfPresent(forKey: .parentSessionId)
+        relationshipType = container.decodeLossyStringIfPresent(forKey: .relationshipType)
+        readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
+        isReadOnly = container.decodeLossyBoolIfPresent(forKey: .isReadOnly)
+        matchType = container.decodeLossyStringIfPresent(forKey: .matchType)
+    }
+
+    /// Decodes a session array a row at a time, so one unreadable row costs that
+    /// row instead of the whole list. Returns nil only when the key is absent
+    /// or is not an array at all.
+    static func decodingRowsIndependently<Key: CodingKey>(
+        from container: KeyedDecodingContainer<Key>,
+        forKey key: Key
+    ) -> [SessionSummary]? {
+        if let rows = try? container.decodeIfPresent([SessionSummary].self, forKey: key) {
+            return rows
+        }
+
+        guard let values = try? container.decodeIfPresent([JSONValue].self, forKey: key) else {
+            return nil
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return values.compactMap { value in
+            guard let data = try? JSONEncoder().encode(value) else { return nil }
+            return try? decoder.decode(SessionSummary.self, from: data)
+        }
     }
 
     init(from detail: SessionDetail) {

--- a/HermesMobileTests/APIClientSessionListTests.swift
+++ b/HermesMobileTests/APIClientSessionListTests.swift
@@ -197,4 +197,41 @@ final class APIClientSessionListTests: APIClientTestCase {
         XCTAssertNil(response.query)
         XCTAssertNil(response.count)
     }
+    /// One malformed row used to fail the whole array, so a single CLI or
+    /// subagent session with a drifted field emptied the entire list and
+    /// pull-to-refresh could never bring it back. Rows are decoded
+    /// independently and each field is lossy, matching `SessionDetail` and
+    /// `ProjectSummary`, which already worked this way.
+    func testSessionListSurvivesOneMalformedRow() async throws {
+        let client = makeClient { request in
+            apiTestJSONResponse("""
+            {"sessions": [
+              {"session_id": "good-1", "title": "Fine", "message_count": 3},
+              {"session_id": "drifted", "title": "Odd", "message_count": "12", "created_at": "not-a-number"},
+              {"session_id": 42},
+              {"title": "Missing server identity"},
+              {"session_id": "   ", "title": "Blank server identity"},
+              {"session_id": "good-2", "title": "Also fine"}
+            ]}
+            """, for: request)
+        }
+
+        let response = try await client.sessions()
+        let ids = (response.sessions ?? []).compactMap(\.sessionId)
+
+        XCTAssertEqual(response.sessions?.count, 6)
+        XCTAssertEqual(ids, ["good-1", "drifted", "42", "   ", "good-2"])
+        XCTAssertNil(response.sessions?[3].sessionId)
+        XCTAssertEqual(response.sessions?[4].sessionId, "   ")
+        XCTAssertEqual(
+            response.sessions?.first(where: { $0.sessionId == "drifted" })?.messageCount,
+            12,
+            "A numeric string still reads as a count."
+        )
+        XCTAssertEqual(
+            response.sessions?.first(where: { $0.sessionId == "42" })?.sessionId,
+            "42",
+            "A numeric id is coerced rather than dropped."
+        )
+    }
 }

--- a/HermesMobileTests/InsightsViewModelTests.swift
+++ b/HermesMobileTests/InsightsViewModelTests.swift
@@ -111,6 +111,49 @@ final class InsightsViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testFallbackTotalsIncludeSessionsWithoutUsableIDs() async throws {
+        let now = Date().timeIntervalSince1970
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try decoder.decode(SessionsResponse.self, from: Data("""
+        {
+          "sessions": [
+            {
+              "title": "Missing identity",
+              "created_at": \(now - 60),
+              "message_count": 4,
+              "input_tokens": 10,
+              "output_tokens": 20,
+              "estimated_cost": 0.12
+            },
+            {
+              "session_id": "   ",
+              "title": "Blank identity",
+              "created_at": \(now - 120),
+              "message_count": 2,
+              "input_tokens": 5,
+              "output_tokens": 7,
+              "estimated_cost": 0.03
+            }
+          ]
+        }
+        """.utf8))
+        let client = StubInsightsClient(
+            insightsResult: .failure(StubInsightsError()),
+            sessionsResult: .success(response)
+        )
+        let viewModel = InsightsViewModel(client: client)
+        viewModel.selectedTimeframe = .last7Days
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.sessionCount, 2)
+        XCTAssertEqual(viewModel.totalMessages, 6)
+        XCTAssertEqual(viewModel.totalTokens, 42)
+        XCTAssertEqual(viewModel.estimatedCost, 0.15, accuracy: 0.0001)
+    }
+
+    @MainActor
     func testLoadUsesServerInsightsWhenAvailable() async throws {
         let client = StubInsightsClient(
             insightsResult: .success(try decodeInsights("""

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -194,6 +194,17 @@ final class SessionListMutationTests: XCTestCase {
             {
               "sessions": [
                 {
+                  "title": "Missing identity",
+                  "message_count": 2,
+                  "archived": false
+                },
+                {
+                  "session_id": "   ",
+                  "title": "Blank identity",
+                  "message_count": 2,
+                  "archived": false
+                },
+                {
                   "session_id": "empty-placeholder",
                   "title": "Untitled Session",
                   "message_count": 0,
@@ -2835,6 +2846,15 @@ final class SessionListMutationTests: XCTestCase {
         """
         {
           "sessions": [
+            {
+              "title": "Missing archived identity",
+              "archived": true
+            },
+            {
+              "session_id": "   ",
+              "title": "Blank archived identity",
+              "archived": true
+            },
             {
               "session_id": "session-abc",
               "title": "Planning",


### PR DESCRIPTION
## Linked issue

No upstream issue — this came out of a client/server contract audit rather than a filed bug report. Happy to open one if you would rather have it tracked separately. The raw audit note is [audichuang/hermex#10](https://github.com/audichuang/hermex/issues/10) (written in Chinese); everything relevant is reproduced in English below.

## What changed

- Decode session-list rows field by field, so one drifting row no longer fails the whole response.
- Keep rows without a usable session ID available to read-only analytics aggregation.
- Filter unusable IDs at the interactive active/archived list consumers, where navigation and mutation need identity.

## Root cause

`SessionsResponse` and `SessionSummary` used the synthesized `Decodable`, so a single type-drifted field in a single row failed the entire session list — the user sees "all my conversations are gone", and pull-to-refresh never recovers it. This is exactly the case `AGENTS.md` hard rule 3 exists for, and `SessionDetail` / `ProjectSummary` in the same file already decode leniently; only the list was missed.

Where to enforce identity was the real decision. Dropping ID-less rows inside the decoder would fix the list but silently undercount Insights, which only aggregates. So the transport projection stays tolerant and identity is required at the two consumers that navigate and mutate.

## Contract evidence

- Upstream `nesquena/hermes-webui`, read-only local checkout at `ecc47782e3e72a5bf3e848a8f09a2a5a838c71b1` (2026-07-22): the server coerces these very fields on its own side rather than trusting them — `_numeric_count()` (`api/routes.py:8351`) is applied to `message_count` and `actual_message_count` at `:8396`–`:8397`, and `_safe_first()` (`api/routes.py:1062`) normalizes identity fields for externally sourced rows at `:1106`–`:1113`. The server hardening the same fields is upstream acknowledging that these rows are not uniformly typed.
- The list merges three sources (sidecar JSON, `state.db` overlay, and CLI sessions), so heterogeneous rows are structural rather than exceptional.
- This repo's compatibility pin `UPSTREAM_TESTED_SHA` is `f1d399b4` (v0.51.85). The checkout above is newer than the pin and is not itself the pin.

## How it was tested

- Focused: tolerant decoding of a drifted row, active-list filtering, archived-list filtering, and Insights totals that still include ID-less rows.
- Full XCTest, iPhone 17 Simulator, iOS 26.5, `-parallel-testing-enabled NO`: 1,574 passed, 0 failed, 0 skipped.
- `git diff --check origin/master...HEAD`: clean.
- Pushed SHA verified against `audichuang/hermex` with `git ls-remote`: `a7372da99422fccb508b85ff50c93be4626ed137`.

## Need to verify

- **No live malformed row.** I can't inject a drifted row into the server I reach without corrupting real data, so coverage uses observed heterogeneous server fields plus wire fixtures rather than a captured failure.
- **No signed-build UI walkthrough**, for the same reason: with a healthy server the before/after screens are identical, so a manual pass would not have distinguished them.

## Related

Touches `SessionListViewModel.swift` and `SessionListMutationTests.swift`, which #267 also touches. The hunks are disjoint and both currently merge cleanly; merging this one first leaves #267 clean, and I will rebase whichever lands second.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (this PR is that change: per-field lenient decoding with per-row recovery)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no request or endpoint changes; response handling only)

## AI assistance

Built with Claude Code. The diff, the consumer-boundary decision, and the test output were reviewed before publishing.
