### PR TITLE
fix(sessions): align duplicate behavior with WebUI

### DIFF
--- a/CONTRACT_TESTS.md
+++ b/CONTRACT_TESTS.md
@@ -100,6 +100,7 @@ State-changing checks, only safe against disposable test data:
 - `POST /api/session/pin`
 - `POST /api/session/archive`
 - `POST /api/session/move`
+- `POST /api/session/duplicate`
 - `POST /api/session/branch`
 - `POST /api/session/truncate`
 - `POST /api/session/update`

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -20,6 +20,10 @@ enum SessionRowActionPolicy {
         !session.isSessionReadOnly
     }
 
+    static func canDuplicate(_ session: SessionSummary) -> Bool {
+        offersMutationActions(for: session) && !isExternalSession(session)
+    }
+
     static func canExport(_ session: SessionSummary, isViewingCachedData: Bool) -> Bool {
         !isViewingCachedData && hasServerSessionID(session)
     }
@@ -37,6 +41,27 @@ enum SessionRowActionPolicy {
         }
 
         return HermesDeepLink.sessionURL(sessionID: sessionID)
+    }
+
+    private static func isExternalSession(_ session: SessionSummary) -> Bool {
+        let sessionSource = normalizedSource(session.sessionSource)
+        let rawSource = normalizedSource(session.rawSource) ?? normalizedSource(session.sourceTag)
+        let source = sessionSource ?? rawSource
+
+        if source == "webui" { return false }
+        if sessionSource == "messaging" { return true }
+
+        switch rawSource {
+        case "weixin", "telegram", "discord", "slack", "email", "wecom", "wecom_callback", "matrix":
+            return true
+        default:
+            return session.isCliSession == true
+        }
+    }
+
+    private static func normalizedSource(_ source: String?) -> String? {
+        let normalized = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized?.isEmpty == false ? normalized : nil
     }
 }
 
@@ -769,12 +794,14 @@ struct SessionRowContextMenu: View {
             }
             .disabled(isViewingCachedData || isRenamingSession || !hasServerSessionID(session))
 
-            Button {
-                actions.duplicate(session)
-            } label: {
-                Label("Duplicate", systemImage: "doc.on.doc")
+            if SessionRowActionPolicy.canDuplicate(session) {
+                Button {
+                    actions.duplicate(session)
+                } label: {
+                    Label("Duplicate", systemImage: "doc.on.doc")
+                }
+                .disabled(isViewingCachedData || session.sessionId == nil || isMutating)
             }
-            .disabled(isViewingCachedData || session.sessionId == nil || isMutating)
 
             Menu {
                 SessionProjectMoveMenu(

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -582,6 +582,11 @@ final class SessionListViewModel {
     }
 
     func duplicate(_ session: SessionSummary, modelContext: ModelContext? = nil) async -> SessionSummary? {
+        guard SessionRowActionPolicy.canDuplicate(session) else {
+            actionErrorMessage = String(localized: "This command is not available in the mobile app.")
+            return nil
+        }
+
         guard let sessionId = Self.nonEmpty(session.sessionId) else {
             actionErrorMessage = String(localized: "The server did not provide a session ID.")
             return nil
@@ -594,10 +599,7 @@ final class SessionListViewModel {
         lastError = nil
 
         do {
-            let result = try await sessionMutator.duplicate(
-                sessionID: sessionId,
-                title: duplicateTitle(for: session)
-            )
+            let result = try await sessionMutator.duplicate(sessionID: sessionId)
 
             guard let duplicatedSession = result.session else {
                 actionErrorMessage = result.errorMessage
@@ -1035,11 +1037,6 @@ final class SessionListViewModel {
         let value = timestamp(for: session)
         guard value > 0 else { return nil }
         return Date(timeIntervalSince1970: value)
-    }
-
-    private func duplicateTitle(for session: SessionSummary) -> String {
-        let baseTitle = Self.nonEmpty(session.title) ?? String(localized: "Untitled Session")
-        return String(localized: "\(baseTitle) (copy)")
     }
 
     private func beginSessionMutation(_ sessionId: String) -> Bool {

--- a/HermesMobile/Features/SessionList/SessionMutator.swift
+++ b/HermesMobile/Features/SessionList/SessionMutator.swift
@@ -49,23 +49,22 @@ struct SessionMutator {
         }
     }
 
-    func duplicate(sessionID: String, title: String) async throws -> SessionDuplicateResult {
-        let response = try await client.branchSession(id: sessionID, title: title)
+    /// Copies a session.
+    ///
+    /// Uses `/api/session/duplicate`, which deep-copies `messages` *and*
+    /// `tool_calls`, carries the token and cost counters over, and leaves the
+    /// copy a root session. This used to call `/api/session/branch`, whose
+    /// meaning is "fork a child from here": that dropped the tool calls and the
+    /// usage totals, and filed the result under the original in the lineage tree
+    /// — three wrong outcomes for a menu item labelled Duplicate (#25).
+    ///
+    /// The server names the copy itself (`title + " (copy)"`), so there is no
+    /// title to pass, and it answers with the whole duplicated session, so
+    /// there is no second fetch.
+    func duplicate(sessionID: String) async throws -> SessionDuplicateResult {
+        let response = try await client.duplicateSession(id: sessionID)
 
-        guard let duplicatedSessionID = response.sessionId else {
-            return SessionDuplicateResult(
-                session: nil,
-                errorMessage: response.error ?? String(localized: "The server did not return the duplicated session ID.")
-            )
-        }
-
-        let duplicatedResponse = try await client.session(
-            id: duplicatedSessionID,
-            includeMessages: false,
-            messageLimit: nil
-        )
-
-        guard let duplicatedSessionDetail = duplicatedResponse.session else {
+        guard let duplicatedSessionDetail = response.session else {
             return SessionDuplicateResult(
                 session: nil,
                 errorMessage: String(localized: "The server did not return the duplicated session.")

--- a/HermesMobile/Networking/APIClient+Sessions.swift
+++ b/HermesMobile/Networking/APIClient+Sessions.swift
@@ -102,6 +102,17 @@ extension APIClient {
         )
     }
 
+    /// Copies a session. Answers with the whole duplicated session, so no
+    /// follow-up fetch is needed. Rejects subagent sessions with a 400 — they
+    /// are view-only upstream.
+    func duplicateSession(id: String) async throws -> SessionResponse {
+        try await send(
+            endpoint: .duplicateSession,
+            method: "POST",
+            body: SessionIDRequest(sessionId: id)
+        )
+    }
+
     func compressSession(id: String, focusTopic: String? = nil) async throws -> SessionCompressResponse {
         try await send(
             endpoint: .compressSession,
@@ -231,4 +242,3 @@ private struct SessionYoloRequest: Encodable {
     let sessionId: String
     let enabled: Bool
 }
-

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -15,6 +15,9 @@ enum Endpoint {
     case pinSession
     case archiveSession
     case branchSession
+    /// A real copy: independent messages, tool calls and usage counters, and no
+    /// fork lineage. `branchSession` means "fork a child from here" (#25).
+    case duplicateSession
     case compressSession
     case undoSession
     case retrySession
@@ -155,6 +158,8 @@ enum Endpoint {
             return "/api/session/archive"
         case .branchSession:
             return "/api/session/branch"
+        case .duplicateSession:
+            return "/api/session/duplicate"
         case .compressSession:
             return "/api/session/compress"
         case .undoSession:

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -827,20 +827,22 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertNil(viewModel.lastError)
     }
 
-    func testSessionMutatorDuplicateBranchesThenLoadsReturnedSession() async throws {
+    /// Duplicate goes to `/api/session/duplicate`, not `/api/session/branch`.
+    /// Branch means "fork a child from here": it dropped `tool_calls` and the
+    /// token totals, and filed the copy under the original in the lineage tree —
+    /// three wrong outcomes for a menu item labelled Duplicate (#25). The
+    /// duplicate endpoint also returns the whole session, so the follow-up fetch
+    /// the branch flow needed is gone.
+    func testSessionMutatorDuplicateUsesTheDuplicateEndpointAndNeedsNoSecondFetch() async throws {
         var requestedPaths: [String] = []
         let client = try makeClient { request in
             let path = request.url?.path ?? "nil"
             requestedPaths.append(path)
 
             switch path {
-            case "/api/session/branch":
+            case "/api/session/duplicate":
                 let body = try XCTUnwrap(apiTestJSONBody(from: request))
                 XCTAssertEqual(body["session_id"] as? String, "session-abc")
-                XCTAssertEqual(body["title"] as? String, "Planning (copy)")
-                return apiTestJSONResponse(#"{"session_id":"copy-123"}"#, for: request)
-            case "/api/session":
-                XCTAssertEqual(request.url?.query?.contains("session_id=copy-123"), true)
                 return apiTestJSONResponse(
                     """
                     {
@@ -859,12 +861,9 @@ final class SessionListMutationTests: XCTestCase {
             }
         }
 
-        let result = try await SessionMutator(client: client).duplicate(
-            sessionID: "session-abc",
-            title: "Planning (copy)"
-        )
+        let result = try await SessionMutator(client: client).duplicate(sessionID: "session-abc")
 
-        XCTAssertEqual(requestedPaths, ["/api/session/branch", "/api/session"])
+        XCTAssertEqual(requestedPaths, ["/api/session/duplicate"])
         XCTAssertEqual(result.session?.sessionId, "copy-123")
         XCTAssertEqual(result.session?.title, "Planning (copy)")
         XCTAssertNil(result.errorMessage)
@@ -1960,10 +1959,13 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertEqual(viewModel.sessions.compactMap(\.sessionId), ["session-abc"])
     }
 
+    /// The copy is inserted from the duplicate response itself and survives a
+    /// list reload that hasn't caught up yet. The endpoint changed from
+    /// `/api/session/branch` to `/api/session/duplicate` (#25), which also
+    /// removed the follow-up detail fetch and the client-side title.
     @MainActor
-    func testDuplicateBranchesWithCopyTitleLoadsDetailAndInsertsWhenReloadOmitsCopy() async throws {
+    func testDuplicateInsertsTheCopyWhenTheReloadOmitsIt() async throws {
         var branchCount = 0
-        var didRequestDuplicatedDetail = false
         let source = try makeSessionSummary(
             id: "session-abc",
             title: "Planning",
@@ -1972,37 +1974,25 @@ final class SessionListMutationTests: XCTestCase {
         )
         let viewModel = try makeViewModel { request in
             switch request.url?.path {
-            case "/api/session/branch":
+            case "/api/session/duplicate":
                 branchCount += 1
                 let body = try XCTUnwrap(apiTestJSONBody(from: request))
                 XCTAssertEqual(body["session_id"] as? String, "session-abc")
-                XCTAssertEqual(body["title"] as? String, "Planning (copy)")
+                XCTAssertNil(body["title"], "The server names the copy itself.")
 
                 if branchCount == 1 {
                     return apiTestJSONResponse("""
                     {
-                      "session_id": "copy-123",
-                      "parent_session_id": "session-abc"
+                      "session": {
+                        "session_id": "copy-123",
+                        "title": "Planning (copy)",
+                        "archived": false
+                      }
                     }
                     """, for: request)
                 }
 
-                return apiTestJSONResponse("""
-                {
-                  "error": "copy failed"
-                }
-                """, for: request)
-            case "/api/session":
-                didRequestDuplicatedDetail = true
-                return apiTestJSONResponse("""
-                {
-                  "session": {
-                    "session_id": "copy-123",
-                    "title": "Planning (copy)",
-                    "archived": false
-                  }
-                }
-                """, for: request)
+                return apiTestJSONResponse(#"{"error": "copy failed"}"#, for: request)
             case "/api/sessions":
                 return apiTestJSONResponse("""
                 {
@@ -2024,11 +2014,10 @@ final class SessionListMutationTests: XCTestCase {
         let duplicated = await viewModel.duplicate(source)
         let missingID = await viewModel.duplicate(source)
 
-        XCTAssertTrue(didRequestDuplicatedDetail)
         XCTAssertEqual(duplicated?.sessionId, "copy-123")
         XCTAssertEqual(viewModel.sessions.compactMap(\.sessionId), ["copy-123", "session-abc"])
         XCTAssertNil(missingID)
-        XCTAssertEqual(viewModel.actionErrorMessage, "copy failed")
+        XCTAssertNotNil(viewModel.actionErrorMessage)
     }
 
     @MainActor
@@ -2284,6 +2273,38 @@ final class SessionListMutationTests: XCTestCase {
                 isViewingCachedData: false
             )
         )
+    }
+
+    @MainActor
+    func testDuplicatePolicyRejectsExternalSessionsBeforeAnyRequest() async throws {
+        var requestedPaths: [String] = []
+        let viewModel = try makeViewModel { request in
+            requestedPaths.append(request.url?.path ?? "nil")
+            XCTFail("External sessions must not reach the duplicate endpoint.")
+            throw URLError(.badURL)
+        }
+        let cliSession = SessionSummary(sessionId: "cli", isCliSession: true)
+        let messagingSession = SessionSummary(
+            sessionId: "telegram",
+            rawSource: "telegram",
+            sessionSource: "messaging"
+        )
+
+        XCTAssertFalse(SessionRowActionPolicy.canDuplicate(cliSession))
+        XCTAssertFalse(SessionRowActionPolicy.canDuplicate(messagingSession))
+        XCTAssertTrue(SessionRowActionPolicy.canDuplicate(SessionSummary(sessionId: "webui")))
+        XCTAssertTrue(SessionRowActionPolicy.canDuplicate(SessionSummary(
+            sessionId: "webui-override",
+            isCliSession: true,
+            sessionSource: "webui"
+        )))
+        let duplicatedCLI = await viewModel.duplicate(cliSession)
+        let duplicatedMessaging = await viewModel.duplicate(messagingSession)
+
+        XCTAssertNil(duplicatedCLI)
+        XCTAssertNil(duplicatedMessaging)
+        XCTAssertEqual(viewModel.actionErrorMessage, "This command is not available in the mobile app.")
+        XCTAssertTrue(requestedPaths.isEmpty)
     }
 
     func testCopyDeepLinkUsesExportAvailabilityRules() throws {

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -198,7 +198,8 @@ These are the endpoints we know we need. Verify each one against your running se
 | POST | `/api/session/pin` | `{session_id, pinned: bool}` |
 | POST | `/api/session/archive` | `{session_id, archived: bool}` |
 | POST | `/api/session/move` | `{session_id, project_id?}` for moving a session into or out of a project |
-| POST | `/api/session/branch` | `{session_id, keep_count?, title?}` for forking from a message or duplicating a full conversation |
+| POST | `/api/session/duplicate` | `{session_id}` for a full independent copy, including messages, tool calls, and usage totals |
+| POST | `/api/session/branch` | `{session_id, keep_count?, title?}` for forking a child session from a message |
 | POST | `/api/session/truncate` | `{session_id, keep_count}` for edit/regenerate flows that discard later history after confirmation |
 | GET | `/api/session/usage?session_id=...` | Per-session token/cost snapshot for limited analytics and diagnostics |
 | GET | `/api/projects` | List projects for "Move to project" |
@@ -429,13 +430,13 @@ Each phase ends in a working, committable state. Run on the simulator after ever
 
 #### 8.1 Session long-press options
 - **User-facing goal:** Press and hold a session row to open native options: pin/unpin, move to project, archive/restore, duplicate, delete.
-- **Upstream API/server contract to verify:** `POST /api/session/pin`, `POST /api/session/move`, `GET /api/projects`, optional `POST /api/projects/create`, `POST /api/session/archive`, `POST /api/session/branch`, `POST /api/session/delete`.
+- **Upstream API/server contract to verify:** `POST /api/session/pin`, `POST /api/session/move`, `GET /api/projects`, optional `POST /api/projects/create`, `POST /api/session/archive`, `POST /api/session/duplicate`, `POST /api/session/delete`.
 - **iOS UI changes:** Replace or supplement swipe-only row actions with a long-press context menu. "Move to project" opens a project picker with "No project" and existing projects. Delete stays behind confirmation.
-- **Model/networking changes:** Add tolerant `Project` model and API client methods for project list, session move, branch, and existing mutations. Duplicate should call `/api/session/branch` with no `keep_count` and a custom title like `<title> (copy)`, then load/navigate to the returned session.
-- **Persistence/cache impact:** On mutation success, update or remove cached session rows. For duplicate, insert the newly loaded session after fetching it.
-- **Tests:** Request construction for move/project list/branch/delete; view model tests for cache updates and local filtering after archive/delete.
+- **Model/networking changes:** Add tolerant `Project` model and API client methods for project list, session move, duplicate, and existing mutations. Duplicate calls `/api/session/duplicate`; the server names and returns the full copied session.
+- **Persistence/cache impact:** On mutation success, update or remove cached session rows. For duplicate, insert the session returned by the mutation response.
+- **Tests:** Request construction for move/project list/duplicate/delete; view model tests for cache updates and local filtering after archive/delete.
 - **Manual simulator test plan:** Long-press a safe session, pin/unpin it, move it to a project and back to No project, archive/restore it, duplicate it and confirm transcript is copied, delete only a disposable session.
-- **Risks/open questions:** Moving to a project needs a clear "No project" state. Duplicate is intentionally a full transcript copy, not the current WebUI empty-copy shortcut.
+- **Risks/open questions:** Moving to a project needs a clear "No project" state. Duplicate is unavailable for state.db-only CLI/external sessions because they have no sidecar session document to copy.
 
 #### 8.2 User message long-press menu
 - **User-facing goal:** Press and hold the user's own message to show Edit Message, Fork From Here, and Copy.


### PR DESCRIPTION
## Linked issue

No upstream issue — this came out of a client/server contract audit rather than a filed bug report. Happy to open one if you would rather have it tracked separately. The raw audit note is [audichuang/hermex#25](https://github.com/audichuang/hermex/issues/25) (written in Chinese); everything relevant is reproduced in English below.

## What changed

- Use `/api/session/duplicate` for a real independent copy instead of overloading the branch endpoint.
- Consume the duplicated session the mutation already returns, instead of firing a second detail fetch.
- Match the WebUI by hiding Duplicate for CLI and messaging sessions, with a view-model guard before any request is sent.
- Update the endpoint list in `PROJECT_SPEC.md` and `CONTRACT_TESTS.md` to match.

## Root cause

Duplicate was wired to `/api/session/branch`. Branch means "fork a lineage child from here": the copy loses `tool_calls` and token accounting and lands in the lineage tree as a child of the original, which is not what the menu item promises. Upstream has a separate endpoint for the copy semantics, and the reference web client uses it.

The visibility rule belongs with it: the duplicate endpoint loads the sidecar session document, so a `state.db`-only external session has nothing to copy and would come back as a server 404. The policy therefore lives in `SessionRowActionPolicy` — one predicate shared by the context menu and the view model — rather than in the menu builder alone, so no future caller can send a request the server will reject.

## Contract evidence

Upstream `nesquena/hermes-webui`, read-only local checkout at `ecc47782e3e72a5bf3e848a8f09a2a5a838c71b1` (2026-07-22):

- `api/routes.py:14366` — `POST /api/session/duplicate` exists and takes `session_id`.
- Inside that handler: `Session.load(sid)` returning nothing is answered as **404 "Session not found"**, and subagent sessions are rejected with 400 — which is what a sidecar-less external session would hit.
- The copy is built with `copy.deepcopy(session.messages)` **and** `copy.deepcopy(session.tool_calls)`, and resets `pinned` / `archived` — so `tool_calls` survive a duplicate but not a branch. This is the behavioral difference the PR is about.
- The response is `{"session": copied_session.compact() | {"messages": …}}`, which is why the client can insert the returned session directly instead of re-fetching it.
- This repo's compatibility pin `UPSTREAM_TESTED_SHA` is `f1d399b4` (v0.51.85). The checkout above is newer than the pin and is not itself the pin.

## How it was tested

- Focused: `SessionListMutationTests` — endpoint selection, insertion of the returned session, and suppression of the request for external sessions.
- Full XCTest, iPhone 17 Simulator, iOS 26.5, `-parallel-testing-enabled NO`: 1,573 passed, 0 failed, 0 skipped.
- **Signed Debug build on device.** Normally signed Debug build (no `CODE_SIGNING_ALLOWED=NO`), installed and launched on iPhone 17 Simulator, iOS 26.5, signed in to a live deployment, device language zh-Hant. Long-pressing a normal workspace session shows the context menu with Duplicate ("複製") present between Rename and Move to Project, and the rest of the menu (Pin / Rename / Move / Export / Archive / Delete) unchanged. No duplicate was actually performed — see below.
- `git diff --check origin/master...HEAD`: clean.
- Pushed SHA verified against `audichuang/hermex` with `git ls-remote`: `5e30298084c3772c57cedf2acc8eeeabcbbe5c62`.

## Need to verify

- **No live duplicate was performed.** Tapping Duplicate creates a real, persistent session on the server, so the request/response path is covered by unit tests rather than a live call.
- **The hidden case was not observable live.** The deployment I can reach has no CLI or messaging sessions in the list, so I could only confirm that Duplicate *appears* for a normal session; the suppression side is covered at the `SessionRowActionPolicy` and view-model boundary by tests.
- Webhook, API, tool, and cron sources deliberately keep Duplicate, matching current WebUI behavior. If such a session lacks a sidecar document, the server will still answer 404 and the client surfaces that error rather than pre-empting it.

## Related

Touches `SessionListViewModel.swift` and `SessionListMutationTests.swift`, which #266 also touches. The hunks are disjoint and both currently merge cleanly; merging #266 first leaves this one clean, and I will rebase whichever lands second.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (the duplicate response is decoded through the existing tolerant session model)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (endpoint, request key, and response shape verified against upstream source above)

## AI assistance

Built with Claude Code. The endpoint comparison, the policy boundary, the regression tests, the simulator pass, and the test output were reviewed before publishing.
