### PR TITLE
fix(approval): require explicit response success

### DIFF
--- a/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatPendingActionCoordinator.swift
@@ -113,11 +113,28 @@ final class ChatPendingActionCoordinator {
         defer { isRespondingToApproval = false }
 
         do {
-            _ = try await client.respondApproval(
+            let response = try await client.respondApproval(
                 sessionID: prompt.sessionID,
                 choice: choice,
                 approvalID: prompt.pending.approvalId
             )
+
+            // The protective refusals answer HTTP 200 with `{"ok": false}`
+            // (`_handle_approval_respond` → `j(handler, {"ok": ok, …})`,
+            // `api/routes.py:24549` @ 399cd7ab, and `j()` defaults to 200), so
+            // only a non-2xx status threw and a deliberate refusal read as
+            // success: the card was cleared, the user was told nothing, and the
+            // agent stayed blocked. `stale_cleared` is the one false that still
+            // means "this card is finished".
+            //
+            // Only an explicit success may clear a live card. A missing `ok`
+            // is unknown and must fail closed.
+            guard response.ok == true || response.staleCleared == true else {
+                approvalErrorMessage = String(localized: "The server did not accept that response. The request is still waiting.")
+                await refreshApprovalPending(sessionID: prompt.sessionID)
+                return false
+            }
+
             approvalPendingBySession[prompt.sessionID] = nil
             approvalPrompt = nil
             await refreshApprovalPending(sessionID: prompt.sessionID)

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -81438,6 +81438,112 @@
         }
       }
     },
+    "The server did not accept that response. The request is still waiting." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لم يقبل الخادم هذا الرد. الطلب لا يزال في الانتظار."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Der Server hat diese Antwort nicht akzeptiert. Die Anfrage wartet weiterhin."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "El servidor no aceptó esa respuesta. La solicitud sigue pendiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Le serveur n'a pas accepté cette réponse. La demande est toujours en attente."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "השרת לא קיבל את התשובה הזו. הבקשה עדיין ממתינה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Il server non ha accettato questa risposta. La richiesta è ancora in attesa."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "サーバーはその応答を受け付けませんでした。リクエストはまだ保留中です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "서버가 그 응답을 받아들이지 않았어요. 요청은 아직 대기 중이에요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "De server heeft dat antwoord niet geaccepteerd. Het verzoek staat nog steeds open."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Serwer nie zaakceptował tej odpowiedzi. Żądanie nadal oczekuje."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O servidor não aceitou essa resposta. A solicitação continua pendente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сервер не принял этот ответ. Запрос всё ещё ожидает."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sunucu bu yanıtı kabul etmedi. İstek hâlâ bekliyor."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سرور نے یہ جواب قبول نہیں کیا۔ درخواست ابھی بھی زیرِ التوا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器未接受該回應。請求仍在等待中。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "服务器未接受该响应。请求仍在等待中。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器未接受該回應。請求仍在等待中。"
+          }
+        }
+      }
+    },
     "The server did not confirm the change." : {
       "localizations" : {
         "ar" : {

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -1515,6 +1515,105 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(viewModel.activeStreamID, "stream-123")
     }
 
+    /// The protective refusals answer HTTP 200 with `{"ok": false}` — `j()`
+    /// defaults to 200 — so only a non-2xx threw and a deliberate refusal read
+    /// as success. The card was cleared with no explanation while the agent
+    /// stayed blocked, and the next pending refresh made it reappear.
+    @MainActor
+    func testApprovalRespondRejectedWithOkFalseKeepsTheCardAndExplains() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let approvalStreamClient = SpySSEStreamingClient()
+
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            approvalStreamClient: approvalStreamClient,
+            clarifyStreamClient: SpySSEStreamingClient()
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(#"{"session_id": "session-abc", "stream_id": "stream-123"}"#, for: request)
+            case "/api/approval/respond":
+                // 200, not an error status — that is the whole trap.
+                return apiTestJSONResponse(#"{"ok": false, "choice": "once"}"#, for: request)
+            case "/api/approval/pending":
+                return apiTestJSONResponse("""
+                {"pending": {"approval_id": "approval-1", "command": "make install",
+                 "description": "Install command", "pattern_key": "install"},
+                 "pending_count": 1}
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Run the installer")
+        XCTAssertTrue(didStart)
+        approvalStreamClient.emit(.approvalPending(ApprovalPendingResponse(
+            pending: PendingApproval(
+                approvalId: "approval-1",
+                command: "make install",
+                description: "Install command",
+                patternKey: "install"
+            ),
+            pendingCount: 1
+        )))
+
+        let didRespond = await viewModel.respondToApproval(.once)
+
+        XCTAssertFalse(didRespond, "A refusal is not a success.")
+        XCTAssertNotNil(viewModel.approvalPrompt, "The agent is still waiting, so the card stays.")
+        XCTAssertNotNil(viewModel.approvalErrorMessage, "Silence here is what made this untraceable.")
+    }
+
+    /// A response without `ok: true` is not proof the server accepted the
+    /// choice, so the pending card must remain actionable.
+    @MainActor
+    func testApprovalRespondWithoutAnOkFieldKeepsTheCardAndExplains() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let approvalStreamClient = SpySSEStreamingClient()
+
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            approvalStreamClient: approvalStreamClient,
+            clarifyStreamClient: SpySSEStreamingClient()
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(#"{"session_id": "session-abc", "stream_id": "stream-123"}"#, for: request)
+            case "/api/approval/respond":
+                return apiTestJSONResponse(#"{"choice": "once"}"#, for: request)
+            case "/api/approval/pending":
+                return apiTestJSONResponse("""
+                {"pending": {"approval_id": "approval-1", "command": "make install",
+                 "description": "Install command", "pattern_key": "install"},
+                 "pending_count": 1}
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Run the installer")
+        XCTAssertTrue(didStart)
+        approvalStreamClient.emit(.approvalPending(ApprovalPendingResponse(
+            pending: PendingApproval(
+                approvalId: "approval-1",
+                command: "make install",
+                description: "Install command",
+                patternKey: "install"
+            ),
+            pendingCount: 1
+        )))
+
+        let didRespond = await viewModel.respondToApproval(.once)
+
+        XCTAssertFalse(didRespond)
+        XCTAssertNotNil(viewModel.approvalPrompt)
+        XCTAssertNotNil(viewModel.approvalErrorMessage)
+    }
+
     @MainActor
     func testApprovalFallbackPollingFailureStaysDiagnosticOnly() async throws {
         let streamClient = SpySSEStreamingClient()


### PR DESCRIPTION
## Linked issue

No upstream issue — this came out of a client/server contract audit rather than a filed bug report. Happy to open one if you would rather have it tracked separately. The raw audit note is [audichuang/hermex#5](https://github.com/audichuang/hermex/issues/5) (written in Chinese); everything relevant is reproduced in English below.

## What changed

- Inspect the approval response body instead of treating every HTTP 200 as acceptance.
- Keep the pending approval card and surface an error on explicit `ok: false` or on a missing success signal.
- Preserve the existing stale-cleared terminal path.
- Localize the new failure message into the catalog's 17-language cohort.

## Root cause

`ChatPendingActionCoordinator` discarded the response (`_ = try await client.respondApproval(...)`) and `APIClient` only throws on non-2xx. Upstream answers a protective refusal with **HTTP 200 and `ok: false`**, so the client reported success, cleared the card, and left the agent still blocked. `ok` and `staleCleared` were already decoded on `ApprovalRespondResponse` — they simply had no production consumer.

Failure case: two parallel approvals A and B in one session. A is already resolved elsewhere; the user answers the stale A card; the server deliberately declines with `200 + ok: false` and leaves B alone; the app clears the card and then `refreshApprovalPending` brings B back with different content and no explanation.

Because a missing `ok` is indistinguishable from a refusal the client can't interpret, this fails closed rather than assuming success.

## Contract evidence

Upstream `nesquena/hermes-webui`, read-only local checkout at `ecc47782e3e72a5bf3e848a8f09a2a5a838c71b1` (2026-07-22):

- `api/routes.py:15475` routes `POST /api/approval/respond` to `_handle_approval_respond` (`api/routes.py:24000`).
- `api/routes.py:24237` — the terminal return is `j(handler, {"ok": ok, "choice": choice})`, and `api/helpers.py:243` shows `j()` defaults to `status=200`. A refusal is therefore a 200.
- Every return path in that handler carries an explicit `ok`: the refusal branches at `:24092`, `:24113`, `:24131`, `:24149`, `:24164` return `ok: False`, and the success paths at `:24185` / `:24200` return `ok: True`.
- The reference web client does what this PR now does — when the response is not accepted it restores the card with an error instead of clearing it (`static/messages.js:7284`, calling `_restoreFailedApprovalResponse` defined at `:7219`).
- The compatibility pin `UPSTREAM_TESTED_SHA` (`f1d399b4`, v0.51.85) also makes its only successful 2xx response explicit with `ok: true`, so failing closed on a missing `ok` is safe across the pin and current upstream.

## How it was tested

- Focused: `ChatViewModelSendTests` — explicit `ok: false` keeps the card and explains, and a response with no `ok` field does the same.
- Full XCTest, iPhone 17 Simulator, iOS 26.5, `-parallel-testing-enabled NO`, run after the localization commit: **1,574 passed, 0 failed, 0 skipped**.
- `git diff --check origin/master...HEAD`: clean.
- Pushed SHA verified against `audichuang/hermex` with `git ls-remote`: `dec55bf1eadaf828e3b11ff92591747fcfeefbf2`.

## Need to verify

- **No live refusal exercised.** The deployment I can reach had no safe pending approval to answer, so the `200 + ok: false` path is covered by source reading and unit tests, not a captured response.
- **No signed-build UI walkthrough** of the error state, for the same reason — reproducing it needs two parallel approvals on a live agent.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (`ok` and `staleCleared` were already optional; this PR only adds consumers, and treats absence as failure rather than crashing)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (response shape verified against upstream source above)

## AI assistance

Built with Claude Code. The return-path review, the regression tests, the translations, and the test output were reviewed before publishing.
