### PR TITLE
fix(models): preserve provider identity when matching

### DIFF
--- a/HermesMobile/Features/Settings/DefaultModelPickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultModelPickerView.swift
@@ -165,7 +165,7 @@ struct DefaultModelPickerView: View {
 
                 if isSaving && selectedModel == model.id {
                     ProgressView()
-                } else if model.id == defaultModel || model.id == selectedModel {
+                } else if isCurrentDefault(model) {
                     Image(systemName: "checkmark")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(Color.accentColor)
@@ -179,7 +179,19 @@ struct DefaultModelPickerView: View {
         .buttonStyle(.plain)
         .disabled(isSaving)
         .accessibilityLabel(modelAccessibilityLabel(for: model))
-        .accessibilityValue(model.id == defaultModel || model.id == selectedModel ? "Selected" : "")
+        .accessibilityValue(isCurrentDefault(model) ? "Selected" : "")
+    }
+
+    /// Whether this row is the current default.
+    ///
+    /// Compared through `matchesSelection`, which normalizes the `@provider:`
+    /// prefix the server adds to models outside the active provider. A raw `==`
+    /// left the checkmark off every row whose saved spelling differed from the
+    /// catalog's current one, so the picker could not answer "which one am I on"
+    /// at all.
+    private func isCurrentDefault(_ model: ModelCatalogOption) -> Bool {
+        model.matchesSelection(modelID: selectedModel, providerID: nil)
+            || model.matchesSelection(modelID: defaultModel, providerID: nil)
     }
 
     private func modelAccessibilityLabel(for model: ModelCatalogOption) -> String {

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -693,11 +693,73 @@ struct ModelCatalogOption: Identifiable, Equatable, Hashable, Sendable {
     let providerID: String?
 }
 
+extension String {
+    /// The model id without the `@provider:` prefix the server adds to models
+    /// that belong to a provider other than the active one
+    /// (`_apply_provider_prefix`, `api/config.py:2279` @ 399cd7ab — verified on
+    /// the live deployment, where `openai-codex` is active and its models are
+    /// bare while `@deepseek:` and `@gemini:` ones are prefixed).
+    ///
+    /// The same model is therefore spelled differently depending on which
+    /// provider happens to be active, so a saved default written under one
+    /// spelling stopped matching the catalog under the other and the picker
+    /// showed no checkmark at all.
+    var bareModelID: String {
+        guard hasPrefix("@"), let separator = lastIndex(of: ":") else { return self }
+        return String(self[index(after: separator)...])
+    }
+
+    /// The provider named by an `@provider:` prefix, if there is one. The
+    /// provider may itself contain colons, so the final separator begins the
+    /// model id.
+    var modelIDProviderPrefix: String? {
+        guard hasPrefix("@"), let separator = lastIndex(of: ":") else { return nil }
+        let provider = self[index(after: startIndex)..<separator]
+        return provider.isEmpty ? nil : String(provider)
+    }
+}
+
 extension ModelCatalogOption {
     func matchesSelection(modelID: String?, providerID: String?) -> Bool {
-        guard id == modelID else { return false }
-        guard let providerID else { return true }
-        return self.providerID == providerID
+        guard let modelID else { return false }
+
+        let optionProvider = self.providerID ?? id.modelIDProviderPrefix
+        let selectionProvider = providerID
+            ?? optionProvider.flatMap { modelID.hasPrefix("@\($0):") ? $0 : nil }
+            ?? modelID.modelIDProviderPrefix
+        guard normalizedModelID(id, providerID: optionProvider)
+                == normalizedModelID(modelID, providerID: selectionProvider)
+        else { return false }
+
+        // A provider named on either side has to agree, so two providers
+        // offering the same bare id can't be confused — this deployment really
+        // does serve `@gemini:gemini-2.5-flash` and `@google:gemini-2.5-flash`
+        // side by side. The `@provider:` prefix counts as naming one.
+        guard let selectionProvider else {
+            // A selection that names no provider is the active provider's
+            // spelling, because the prefix is exactly what the server adds to
+            // everyone else. Matching it against a prefixed option would tick
+            // every provider that happens to offer the same bare id.
+            return id.modelIDProviderPrefix == nil
+        }
+        // Same rule in the other direction. An option carrying no provider at
+        // all cannot be shown to belong to the named one, and guessing "yes"
+        // here is the exact mirror of the double-checkmark bug the selection
+        // side above was just fixed for. This also restores what the original
+        // `self.providerID == providerID` comparison did before the prefix
+        // normalization was added, so it is not a new restriction.
+        //
+        // `parseModelOptions` fills `providerID` from the group's `provider_id`,
+        // so this is only reachable if a server returns a group without one.
+        guard let optionProvider else { return false }
+        return optionProvider == selectionProvider
+    }
+
+    private func normalizedModelID(_ modelID: String, providerID: String?) -> String {
+        guard let providerID else { return modelID.bareModelID }
+        let prefix = "@\(providerID):"
+        guard modelID.hasPrefix(prefix) else { return modelID.bareModelID }
+        return String(modelID.dropFirst(prefix.count))
     }
 }
 
@@ -705,11 +767,13 @@ extension Collection where Element == ModelCatalogOption {
     func firstMatchingSelection(modelID: String?, providerID: String?) -> ModelCatalogOption? {
         guard let modelID, !modelID.isEmpty else { return nil }
 
-        if let providerID {
-            return first { $0.id == modelID && $0.providerID == providerID }
+        // Prefer the identical spelling; only then fall back to the normalized
+        // comparison, so an exact match is never lost to a same-named model.
+        if let exact = first(where: { $0.id == modelID && (providerID == nil || $0.providerID == providerID) }) {
+            return exact
         }
 
-        return first { $0.id == modelID }
+        return first { $0.matchesSelection(modelID: modelID, providerID: providerID) }
     }
 }
 

--- a/HermesMobileTests/ModelCatalogTests.swift
+++ b/HermesMobileTests/ModelCatalogTests.swift
@@ -222,6 +222,116 @@ final class ModelCatalogTests: XCTestCase {
             groups
         )
     }
+    /// The server prefixes every model of a non-active provider with
+    /// `@provider:`, so the same model is spelled two different ways depending
+    /// on which provider is active. Comparing raw ids left the picker unable to
+    /// mark the current default at all. Confirmed against the live
+    /// deployment: `openai-codex` is active and its ids are bare, while
+    /// `@deepseek:` and `@gemini:` ones carry the prefix.
+    func testModelSelectionMatchesAcrossTheProviderPrefix() {
+        let prefixed = ModelCatalogOption(
+            id: "@gemini:gemini-3.5-flash",
+            displayName: "Gemini 3.5 Flash",
+            providerID: "gemini"
+        )
+
+        XCTAssertTrue(prefixed.matchesSelection(modelID: "@gemini:gemini-3.5-flash", providerID: nil))
+        XCTAssertTrue(prefixed.matchesSelection(modelID: "gemini-3.5-flash", providerID: "gemini"))
+        XCTAssertFalse(
+            prefixed.matchesSelection(modelID: "gemini-3.5-flash", providerID: nil),
+            "A bare selection belongs to the active provider, whose models are the unprefixed ones."
+        )
+
+        let bare = ModelCatalogOption(id: "gemini-3.5-flash", displayName: "Gemini 3.5 Flash", providerID: "gemini")
+        XCTAssertTrue(bare.matchesSelection(modelID: "@gemini:gemini-3.5-flash", providerID: nil))
+    }
+
+    /// Normalizing must not merge two providers that offer the same bare id.
+    /// The live deployment really does list `@gemini:gemini-2.5-flash` and
+    /// `@google:gemini-2.5-flash` side by side, and an earlier version of this
+    /// fix ticked both.
+    func testModelSelectionStillSeparatesProvidersSharingABareID() {
+        let other = ModelCatalogOption(
+            id: "@deepseek:gemini-3.5-flash",
+            displayName: "Look-alike",
+            providerID: "deepseek"
+        )
+
+        XCTAssertFalse(other.matchesSelection(modelID: "@gemini:gemini-3.5-flash", providerID: nil))
+        XCTAssertFalse(other.matchesSelection(modelID: "gemini-3.5-flash", providerID: "gemini"))
+
+        // A bare selection is the ACTIVE provider's spelling — the prefix is
+        // precisely what the server adds to everyone else — so it must not tick
+        // a prefixed look-alike.
+        let prefixedLookAlike = ModelCatalogOption(
+            id: "@google:gemini-2.5-flash",
+            displayName: "Gemini 2.5 Flash",
+            providerID: "google"
+        )
+        let activeProviderOption = ModelCatalogOption(
+            id: "gemini-2.5-flash",
+            displayName: "Gemini 2.5 Flash",
+            providerID: "gemini"
+        )
+
+        XCTAssertFalse(prefixedLookAlike.matchesSelection(modelID: "gemini-2.5-flash", providerID: nil))
+
+        // The mirror direction: an option carrying no provider at all cannot be
+        // shown to belong to a named one either. Guessing "yes" here would be
+        // the same bug pointed the other way.
+        let providerlessOption = ModelCatalogOption(
+            id: "gemini-2.5-flash",
+            displayName: "Gemini 2.5 Flash",
+            providerID: nil
+        )
+        XCTAssertFalse(providerlessOption.matchesSelection(modelID: "gemini-2.5-flash", providerID: "gemini"))
+        XCTAssertFalse(providerlessOption.matchesSelection(modelID: "@gemini:gemini-2.5-flash", providerID: nil))
+        XCTAssertTrue(
+            providerlessOption.matchesSelection(modelID: "gemini-2.5-flash", providerID: nil),
+            "Neither side naming a provider is still a match."
+        )
+        XCTAssertTrue(activeProviderOption.matchesSelection(modelID: "gemini-2.5-flash", providerID: nil))
+        XCTAssertTrue(
+            activeProviderOption.matchesSelection(modelID: "@gemini:gemini-2.5-flash", providerID: nil),
+            "Saving through the app leaves the prefixed spelling while the server stores the bare one."
+        )
+    }
+
+    /// An exact spelling wins over a normalized one so a same-named model from
+    /// another provider can never be picked in its place.
+    func testFirstMatchingSelectionPrefersTheExactSpelling() {
+        let options = [
+            ModelCatalogOption(id: "@gemini:flash", displayName: "Prefixed", providerID: "gemini"),
+            ModelCatalogOption(id: "flash", displayName: "Bare", providerID: "gemini")
+        ]
+
+        XCTAssertEqual(options.firstMatchingSelection(modelID: "flash", providerID: nil)?.displayName, "Bare")
+        XCTAssertEqual(
+            options.firstMatchingSelection(modelID: "@gemini:flash", providerID: nil)?.displayName,
+            "Prefixed"
+        )
+    }
+
+    func testModelSelectionPreservesNamedCustomProviderIdentity() {
+        let beta = ModelCatalogOption(
+            id: "@custom:beta:model-a",
+            displayName: "Beta Model A",
+            providerID: "custom:beta"
+        )
+        let gamma = ModelCatalogOption(
+            id: "@custom:gamma:model-a",
+            displayName: "Gamma Model A",
+            providerID: "custom:gamma"
+        )
+
+        XCTAssertEqual("@custom:beta:model-a".bareModelID, "model-a")
+        XCTAssertEqual("@custom:beta:model-a".modelIDProviderPrefix, "custom:beta")
+        XCTAssertTrue(beta.matchesSelection(modelID: "@custom:beta:model-a", providerID: nil))
+        XCTAssertTrue(beta.matchesSelection(modelID: "model-a", providerID: "custom:beta"))
+        XCTAssertFalse(gamma.matchesSelection(modelID: "@custom:beta:model-a", providerID: nil))
+        XCTAssertFalse(gamma.matchesSelection(modelID: "model-a", providerID: "custom:beta"))
+    }
+
 }
 
 final class PersonalityAutocompleteTests: XCTestCase {


### PR DESCRIPTION
## Linked issue

No upstream issue — this came out of a client/server contract audit rather than a filed bug report. Happy to open one if you would rather have it tracked separately. The raw audit note is [audichuang/hermex#27](https://github.com/audichuang/hermex/issues/27) (written in Chinese); everything relevant is reproduced in English below.

## What changed

- Match a saved model selection across the server's bare and `@provider:` spellings.
- Preserve provider identity when two providers expose the same bare model id.
- Parse named custom-provider prefixes at the final colon, so a provider name containing a colon survives.
- Use the shared matcher for both the default-model checkmark and its accessibility value.

## Root cause

The picker compared raw model ids, but the server prefixes every model outside the active provider as `@provider:<id>`. A default saved in one spelling never matched the row rendered in the other, so the checkmark landed nowhere and the user could not tell which default was active.

Normalizing to the bare id alone would have traded one bug for a worse one: two providers exposing the same bare id would both light up. So the matcher compares provider identity and model id together, and the same helper feeds the accessibility value so VoiceOver cannot disagree with the checkmark.

## Contract evidence

- Upstream `nesquena/hermes-webui`, read-only local checkout at `ecc47782e3e72a5bf3e848a8f09a2a5a838c71b1` (2026-07-22): `api/config.py:2278` `_apply_provider_prefix()` returns the raw ids when the provider is the active one and otherwise rewrites each entry to `@{provider_id}:{model_id}`. It is applied when the catalog groups are built, for both named custom providers (`api/config.py:5404`, whose display name comes from `custom_group["name"]` and whose id is a `custom:`-prefixed string) and the remaining providers (`:5425`) — so a provider name can itself contain a colon, which is why this PR splits at the final one.
- This repo's compatibility pin `UPSTREAM_TESTED_SHA` is `f1d399b4` (v0.51.85). The checkout above is newer than the pin and is not itself the pin.
- **Observed live** during the simulator pass below: the deployment returns bare `gpt-5.6-*` ids for the active provider alongside `@gemini:`, `@deepseek:`, and `@moa:` prefixed ids — the mixed spelling this PR exists to reconcile.

## How it was tested

- Focused: `ModelCatalogTests` — 4 passed, 0 failed: `testModelSelectionMatchesAcrossTheProviderPrefix`, `testModelSelectionStillSeparatesProvidersSharingABareID`, `testFirstMatchingSelectionPrefersTheExactSpelling`, `testModelSelectionPreservesNamedCustomProviderIdentity`.
- Full XCTest, iPhone 17 Pro Max Simulator, iOS 26.5, `-parallel-testing-enabled NO`: 1,576 passed, 0 failed, 0 skipped.
- **Signed Debug build on device.** Normally signed Debug build (no `CODE_SIGNING_ALLOWED=NO`), installed and launched on iPhone 17 Simulator, iOS 26.5, signed in to a live hermes-webui deployment, device language zh-Hant:
  - Settings → Default Model row reports the resolved default in its accessibility label ("預設模型、gpt-5.6-luna").
  - In the picker, the saved default `GPT 5.6 Luna / gpt-5.6-luna` carries accessibility value "已選取" and shows the checkmark, while the near-miss rows `gpt-5.6-luna-pro` and `openai/gpt-5.6-luna` carry an empty value and no checkmark.
  - The prefixed sections (`@gemini:…`, `@deepseek:…`, `@moa:default`) render alongside the bare active-provider ids; every prefixed row I inspected carried an empty accessibility value, i.e. no spurious second selection.
- `git diff --check origin/master...HEAD`: clean.
- Pushed SHA verified against `audichuang/hermex` with `git ls-remote`: `e1da13f0a32f2f6e8d810d6dfa524d80881f2f3f`.

## Need to verify

- **The cross-provider default was not saved live.** Selecting a default that lives under a non-active provider writes to the real server, so the live pass only confirms the active-provider case renders correctly; the prefixed-default case is covered by unit tests.
- **No colon-in-provider-name deployment.** No reachable server defines a custom provider whose name contains a colon, so that regression case is source-backed and synthetic.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (no wire model changed; this is client-side matching over already-decoded ids)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (prefix format verified against upstream source and observed on the wire)

## AI assistance

Built with Claude Code. The matcher, the regression tests, the simulator pass, and the test output were reviewed before publishing.
