### PR TITLE
Fix saving transcript videos to Photos

### DIFF
--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -917,7 +917,10 @@ struct TranscriptMediaPreviewView: View {
                 }
                 try await PhotoLibrarySaver.saveImageData(payload.data)
             } else if payload.isVideo {
-                try await PhotoLibrarySaver.saveVideoData(payload.data, contentType: payload.contentType)
+                guard let videoFileURL = viewModel.videoFileURL else {
+                    throw PhotoLibrarySaveError.videoFileUnavailable
+                }
+                try await PhotoLibrarySaver.saveVideoFile(at: videoFileURL)
             } else {
                 throw PhotoLibrarySaveError.notPhotosMedia
             }

--- a/HermesMobile/Features/Workspace/FileExportSupport.swift
+++ b/HermesMobile/Features/Workspace/FileExportSupport.swift
@@ -44,23 +44,19 @@ enum PhotoLibrarySaver {
         }
     }
 
-    static func saveVideoData(_ data: Data, contentType: UTType) async throws {
+    static func saveVideoFile(at sourceURL: URL) async throws {
         let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
         guard status == .authorized || status == .limited else {
             throw PhotoLibrarySaveError.notAuthorized
         }
 
-        guard contentType.conforms(to: .movie) || contentType.conforms(to: .video) else {
-            throw PhotoLibrarySaveError.notVideo
-        }
-
-        let options = PHAssetResourceCreationOptions()
-        options.uniformTypeIdentifier = contentType.identifier
+        let stagedVideo = try StagedPhotoLibraryVideo(sourceURL: sourceURL)
+        defer { stagedVideo.cleanup() }
 
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             PHPhotoLibrary.shared().performChanges {
                 let request = PHAssetCreationRequest.forAsset()
-                request.addResource(with: .video, data: data, options: options)
+                request.addResource(with: .video, fileURL: stagedVideo.fileURL, options: nil)
             } completionHandler: { didSave, error in
                 if let error {
                     continuation.resume(throwing: error)
@@ -74,11 +70,54 @@ enum PhotoLibrarySaver {
     }
 }
 
-enum PhotoLibrarySaveError: LocalizedError {
+private struct StagedPhotoLibraryVideo {
+    let fileURL: URL
+
+    private let directoryURL: URL
+    private let fileManager: FileManager
+
+    init(sourceURL: URL, fileManager: FileManager = .default) throws {
+        guard sourceURL.isFileURL else {
+            throw PhotoLibrarySaveError.videoFileUnavailable
+        }
+
+        let values: URLResourceValues
+        do {
+            values = try sourceURL.resourceValues(forKeys: [.isRegularFileKey, .isReadableKey])
+        } catch {
+            throw PhotoLibrarySaveError.videoFileUnavailable
+        }
+
+        guard values.isRegularFile == true, values.isReadable != false else {
+            throw PhotoLibrarySaveError.videoFileUnavailable
+        }
+
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("Hermex-Photo-Import-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+            let filename = sourceURL.lastPathComponent.isEmpty ? "Hermex Video.mp4" : sourceURL.lastPathComponent
+            let fileURL = directoryURL.appendingPathComponent(filename, isDirectory: false)
+            try fileManager.copyItem(at: sourceURL, to: fileURL)
+            self.fileURL = fileURL
+            self.directoryURL = directoryURL
+            self.fileManager = fileManager
+        } catch {
+            try? fileManager.removeItem(at: directoryURL)
+            throw PhotoLibrarySaveError.videoFileUnavailable
+        }
+    }
+
+    func cleanup() {
+        try? fileManager.removeItem(at: directoryURL)
+    }
+}
+
+enum PhotoLibrarySaveError: LocalizedError, Equatable {
     case notAuthorized
     case notImage
-    case notVideo
     case notPhotosMedia
+    case videoFileUnavailable
     case saveFailed
 
     var errorDescription: String? {
@@ -87,10 +126,10 @@ enum PhotoLibrarySaveError: LocalizedError {
             String(localized: "Allow Photos access to save media from Hermex.")
         case .notImage:
             String(localized: "This file is not an image that can be saved to Photos.")
-        case .notVideo:
-            String(localized: "This file is not a video that can be saved to Photos.")
         case .notPhotosMedia:
             String(localized: "Photos can save images and videos. Export audio to Files instead.")
+        case .videoFileUnavailable:
+            String(localized: "This video is no longer available to save. Try loading it again.")
         case .saveFailed:
             String(localized: "Photos could not save this media.")
         }

--- a/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
+++ b/HermesMobileTests/TranscriptMediaPreviewViewModelTests.swift
@@ -1,6 +1,8 @@
-import XCTest
+import AVFoundation
+import Photos
 import UIKit
 import UniformTypeIdentifiers
+import XCTest
 @testable import HermesMobile
 
 @MainActor
@@ -252,6 +254,46 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canSaveMediaToPhotos)
     }
 
+    func testSaveVideoFileToPhotoLibraryIntegration() async throws {
+        guard ProcessInfo.processInfo.environment["HERMEX_RUN_PHOTOS_INTEGRATION"] == "1" else {
+            throw XCTSkip("Set HERMEX_RUN_PHOTOS_INTEGRATION=1 to modify the simulator photo library.")
+        }
+
+        let suppliedPath = ProcessInfo.processInfo.environment["HERMEX_PHOTOS_TEST_VIDEO_PATH"]
+        let fileURL: URL
+        if let suppliedPath {
+            fileURL = URL(fileURLWithPath: suppliedPath)
+        } else {
+            fileURL = try await Self.makeTestVideo()
+        }
+        defer {
+            if suppliedPath == nil {
+                try? FileManager.default.removeItem(at: fileURL)
+            }
+        }
+
+        try await PhotoLibrarySaver.saveVideoFile(at: fileURL)
+    }
+
+    func testInvalidVideoIsRejectedByPhotoLibraryIntegration() async throws {
+        guard ProcessInfo.processInfo.environment["HERMEX_RUN_PHOTOS_INTEGRATION"] == "1" else {
+            throw XCTSkip("Set HERMEX_RUN_PHOTOS_INTEGRATION=1 to modify the simulator photo library.")
+        }
+
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("invalid-video-\(UUID().uuidString).mp4")
+        try Data("not a movie".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        do {
+            try await PhotoLibrarySaver.saveVideoFile(at: fileURL)
+            XCTFail("PhotoKit accepted an invalid video")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, PHPhotosErrorDomain)
+            XCTAssertEqual((error as NSError).code, PHPhotosError.Code.invalidResource.rawValue)
+        }
+    }
+
     func testLoadLocalVideoWithoutSessionIDDoesNotRequestMediaEndpoint() async {
         let recorder = TranscriptMediaPreviewRequestRecorder()
         let client = makeClient { request in
@@ -382,6 +424,61 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
 
     private static let baseURL = URL(string: "https://example.test")!
 
+    private static func makeTestVideo() async throws -> URL {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("valid-video-\(UUID().uuidString).mp4")
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: 64,
+                AVVideoHeightKey: 64,
+            ]
+        )
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: 64,
+                kCVPixelBufferHeightKey as String: 64,
+            ]
+        )
+        guard writer.canAdd(input) else {
+            throw PhotoLibraryTestVideoError.cannotConfigureWriter
+        }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw writer.error ?? PhotoLibraryTestVideoError.cannotStartWriter
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        guard let pool = adaptor.pixelBufferPool else {
+            throw PhotoLibraryTestVideoError.cannotCreatePixelBuffer
+        }
+        var pixelBuffer: CVPixelBuffer?
+        guard CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pixelBuffer) == kCVReturnSuccess,
+              let pixelBuffer
+        else {
+            throw PhotoLibraryTestVideoError.cannotCreatePixelBuffer
+        }
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        if let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) {
+            memset(baseAddress, 0x30, CVPixelBufferGetDataSize(pixelBuffer))
+        }
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+
+        guard adaptor.append(pixelBuffer, withPresentationTime: .zero) else {
+            throw writer.error ?? PhotoLibraryTestVideoError.cannotAppendFrame
+        }
+        input.markAsFinished()
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writer.error ?? PhotoLibraryTestVideoError.cannotFinishWriter
+        }
+        return outputURL
+    }
+
     private func makeClient(
         cookieStorage: HTTPCookieStorage = HTTPCookieStorage(),
         handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
@@ -470,6 +567,14 @@ final class TranscriptMediaPreviewViewModelTests: XCTestCase {
             .secure: "TRUE"
         ])
     }
+}
+
+private enum PhotoLibraryTestVideoError: Error {
+    case cannotConfigureWriter
+    case cannotStartWriter
+    case cannotCreatePixelBuffer
+    case cannotAppendFrame
+    case cannotFinishWriter
 }
 
 private final class TranscriptMediaPreviewRequestRecorder {


### PR DESCRIPTION
## Summary
- import transcript videos into Photos from a staged file URL instead of an in-memory `Data` resource
- keep the staged file alive until PhotoKit completes, then clean it up without touching the preview file
- surface a clear error when the preview video is no longer available
- add opt-in PhotoKit integration coverage for valid and malformed videos

## Why
PhotoKit can reject the data-based video creation request with `PHPhotosErrorDomain` code 3300 (`changeNotSupported`) even when the MP4 itself is valid and playable. The file-URL resource path is supported for simple movie imports and succeeds with the reported H.264/AAC MP4.

## Verification
- Full XCTest suite: 1,575 passed, 0 failed (2 opt-in Photos-mutating tests skipped) on iPhone 17 Pro / iOS 26.4.1 simulator
- Opt-in PhotoKit integration: generated valid H.264 MP4 passed; malformed MP4 rejected with `invalidResource`
- Exact reported 3.8 MB H.264/AAC reel passed the PhotoKit import test
- `git diff --check` passed