### PR TITLE
feat(composer): voice-first input mode with hold-to-speak gestures

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -7,50 +7,37 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		031031031031031031031001 /* MarkdownMathSegmenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031002 /* MarkdownMathSegmenter.swift */; };
+		031031031031031031031003 /* MarkdownMathRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031004 /* MarkdownMathRendererTests.swift */; };
+		031031031031031031031005 /* MarkdownMathFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031006 /* MarkdownMathFormatter.swift */; };
+		031031031031031031031007 /* MarkdownMathFormatter+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031008 /* MarkdownMathFormatter+Support.swift */; };
+		031031031031031031031009 /* DisplayMathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03103103103103103103100A /* DisplayMathView.swift */; };
+		03103103103103103103100B /* MarkdownMathFormatter+Environments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03103103103103103103100C /* MarkdownMathFormatter+Environments.swift */; };
 		05814DEA5DE4690F730B1E15 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931EC010A2D940B0E42287A4 /* InsightsViewModel.swift */; };
-		26AB000000000000000000B1 /* ProvidersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F1 /* ProvidersViewModel.swift */; };
-		26AB000000000000000000B2 /* ProvidersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F2 /* ProvidersView.swift */; };
-		26AB000000000000000000B3 /* APIClientProvidersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F3 /* APIClientProvidersTests.swift */; };
-		26AB000000000000000000B4 /* ProvidersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F4 /* ProvidersViewModelTests.swift */; };
-		1A2B3C4D5E6F700000000300 /* ServerAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000301 /* ServerAccount.swift */; };
-		B5A1000000000000000000A0 /* ServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A1000000000000000000A1 /* ServerRegistryTests.swift */; };
-		C0DE512E0000000000000202 /* InsightsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000201 /* InsightsModels.swift */; };
-		C0DE512E0000000000000204 /* InsightsRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000203 /* InsightsRows.swift */; };
 		0D82B28493C6401D98DA9C0E /* SlashCommandExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6809B8F1391248A4AA77C453 /* SlashCommandExecutorTests.swift */; };
-		1A2B3C4D5E6F700000000001 /* HermesMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000011 /* HermesMobileApp.swift */; };
-		1A2B3C4D5E6F700000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000012 /* ContentView.swift */; };
-		1A2B3C4D5E6F700000000338 /* HermexAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000337 /* HermexAppIntents.swift */; };
-		1A2B3C4D5E6F700000000343 /* ProfileEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000342 /* ProfileEntity.swift */; };
-		1A2B3C4D5E6F700000000341 /* AppIntentNewChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000340 /* AppIntentNewChatTests.swift */; };
-		1A2B3C4D5E6F700000000345 /* AppIntentNewChatInProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000344 /* AppIntentNewChatInProfileTests.swift */; };
-		1A2B3C4D5E6F700000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000014 /* Assets.xcassets */; };
+		103200000000000000000002 /* DefaultProfilePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103200000000000000000001 /* DefaultProfilePickerView.swift */; };
+		105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */; };
+		105050000000000000000003 /* ComposerModelPickerSectionExpansionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */; };
 		10CA110C0DE000000000B001 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000B002 /* Localizable.xcstrings */; };
 		10CA110C0DE000000000B003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000B002 /* Localizable.xcstrings */; };
 		10CA110C0DE000000000B004 /* AppShortcuts.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000B005 /* AppShortcuts.xcstrings */; };
 		10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CA110C0DE000000000C002 /* LocalizationCatalogTests.swift */; };
+		19C1150000000000000000A1 /* CliSessionsSyncModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A2 /* CliSessionsSyncModel.swift */; };
+		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
+		1A2B3C4D5E6F700000000001 /* HermesMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000011 /* HermesMobileApp.swift */; };
+		1A2B3C4D5E6F700000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000012 /* ContentView.swift */; };
+		1A2B3C4D5E6F700000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000014 /* Assets.xcassets */; };
 		1A2B3C4D5E6F700000000004 /* LDSwiftEventSource in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000094 /* LDSwiftEventSource */; };
 		1A2B3C4D5E6F700000000005 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000095 /* MarkdownUI */; };
 		1A2B3C4D5E6F700000000006 /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000096 /* Splash */; };
 		1A2B3C4D5E6F700000000007 /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000097 /* Highlightr */; };
 		1A2B3C4D5E6F700000000008 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000098 /* KeychainAccess */; };
-		5417A7400000000000000092 /* SwiftMath in Frameworks */ = {isa = PBXBuildFile; productRef = 5417A7400000000000000091 /* SwiftMath */; };
 		1A2B3C4D5E6F7000000000A0 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B0 /* KeychainStore.swift */; };
 		1A2B3C4D5E6F7000000000A1 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B1 /* AuthManager.swift */; };
 		1A2B3C4D5E6F7000000000A2 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B2 /* APIClient.swift */; };
-		C04000000000000000000001 /* APIClient+Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000011 /* APIClient+Sessions.swift */; };
-		C04000000000000000000002 /* APIClient+Projects.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000012 /* APIClient+Projects.swift */; };
-		C04000000000000000000003 /* APIClient+Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000013 /* APIClient+Chat.swift */; };
-		C04000000000000000000004 /* APIClient+Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000014 /* APIClient+Workspace.swift */; };
-		C04000000000000000000005 /* APIClient+ServerPanels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000015 /* APIClient+ServerPanels.swift */; };
-		C04000000000000000000006 /* APIClient+Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000016 /* APIClient+Cron.swift */; };
-		C04000000000000000000007 /* APIClient+Memory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000017 /* APIClient+Memory.swift */; };
-		C04000000000000000000008 /* APIClient+Skills.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000018 /* APIClient+Skills.swift */; };
-		C04000000000000000000009 /* APIClient+Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000019 /* APIClient+Upload.swift */; };
 		1A2B3C4D5E6F7000000000A3 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B3 /* APIError.swift */; };
-		C04400000000000000000001 /* CacheFallbackPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04400000000000000000002 /* CacheFallbackPolicy.swift */; };
 		1A2B3C4D5E6F7000000000A4 /* ServerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B4 /* ServerInfo.swift */; };
 		1A2B3C4D5E6F7000000000A5 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B5 /* OnboardingView.swift */; };
-		1A2B3C4D5E6F70000000410 /* OnboardingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000411 /* OnboardingComponents.swift */; };
 		1A2B3C4D5E6F7000000000A6 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B6 /* OnboardingViewModel.swift */; };
 		1A2B3C4D5E6F7000000000A7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B7 /* SessionListView.swift */; };
 		1A2B3C4D5E6F7000000000A8 /* Endpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000B8 /* Endpoints.swift */; };
@@ -58,178 +45,39 @@
 		1A2B3C4D5E6F7000000000AA /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BA /* ChatMessage.swift */; };
 		1A2B3C4D5E6F7000000000AB /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BB /* Session.swift */; };
 		1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BC /* APIClientTests.swift */; };
-		C0FF000000000000000000C1 /* CustomHeaderInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF000000000000000000C2 /* CustomHeaderInjectionTests.swift */; };
-		C03910000000000000000001 /* APIClientSessionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000001 /* APIClientSessionListTests.swift */; };
-		C03910000000000000000002 /* APIClientInsightsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000002 /* APIClientInsightsTests.swift */; };
-		C03910000000000000000017 /* APIClientUpdatesCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000017 /* APIClientUpdatesCheckTests.swift */; };
-		C03910000000000000000018 /* APIClientUpdatesApplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000018 /* APIClientUpdatesApplyTests.swift */; };
-		C03910000000000000000003 /* APIClientSessionDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000003 /* APIClientSessionDetailTests.swift */; };
-		C03910000000000000000004 /* APIClientSessionMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000004 /* APIClientSessionMutationTests.swift */; };
-		C03910000000000000000005 /* APIClientWorkspaceFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000005 /* APIClientWorkspaceFileTests.swift */; };
-		C03910000000000000000006 /* APIClientChatEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000006 /* APIClientChatEndpointTests.swift */; };
-		C03910000000000000000007 /* APIClientAuthAndErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000007 /* APIClientAuthAndErrorTests.swift */; };
-		C03910000000000000000008 /* APIClientAgentControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000008 /* APIClientAgentControlTests.swift */; };
-		C03910000000000000000009 /* APIClientConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000009 /* APIClientConfigurationTests.swift */; };
-		C0391000000000000000000A /* APIClientCronEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000A /* APIClientCronEndpointTests.swift */; };
-		C0391000000000000000000B /* APIClientMemoryEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000B /* APIClientMemoryEndpointTests.swift */; };
-		C0391000000000000000000C /* APIClientSkillEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000C /* APIClientSkillEndpointTests.swift */; };
-		C0391000000000000000000D /* APIClientUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000D /* APIClientUploadTests.swift */; };
-		C0391000000000000000000E /* ChatViewModelSendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000E /* ChatViewModelSendTests.swift */; };
-		C0DED00000000000000DE001 /* ChatViewModelMergeDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DED00000000000000DE000 /* ChatViewModelMergeDedupTests.swift */; };
-		C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14600000000000000000001 /* ChatToolbarHeaderTests.swift */; };
-		C15210000000000000000001 /* OnboardingFlowPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000001 /* OnboardingFlowPolicy.swift */; };
-		C15210000000000000000002 /* OnboardingWelcomePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000002 /* OnboardingWelcomePage.swift */; };
-		C15210000000000000000003 /* OnboardingFeaturesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000003 /* OnboardingFeaturesPage.swift */; };
-		C15210000000000000000004 /* OnboardingAgentPromptPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000004 /* OnboardingAgentPromptPage.swift */; };
-		C15210000000000000000005 /* OnboardingTailscalePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000005 /* OnboardingTailscalePage.swift */; };
-		C15210000000000000000006 /* OnboardingConnectPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000006 /* OnboardingConnectPage.swift */; };
-		C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000007 /* OnboardingFlowTests.swift */; };
-		C0391000000000000000000F /* SessionListMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000F /* SessionListMutationTests.swift */; };
-		A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000012 /* SessionNavigationStateTests.swift */; };
-		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
-		C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000010 /* APIEndpointContractTests.swift */; };
-		C03910000000000000000011 /* CronManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000011 /* CronManagementTests.swift */; };
-		C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000012 /* MemoryViewModelTests.swift */; };
-		C03910000000000000000013 /* ModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000013 /* ModelCatalogTests.swift */; };
-		C03910000000000000000014 /* MessageActionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000014 /* MessageActionContextTests.swift */; };
-		C03910000000000000000015 /* SessionIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000015 /* SessionIdentityTests.swift */; };
-		C03910000000000000000016 /* TranscriptDisplayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000016 /* TranscriptDisplayModelTests.swift */; };
-		C14300000000000000000003 /* StreamingMarkdownSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14300000000000000000004 /* StreamingMarkdownSupportTests.swift */; };
-		C13000000000000000000001 /* ChatVerticalScrollAxisGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13000000000000000000002 /* ChatVerticalScrollAxisGuardTests.swift */; };
-		C04100000000000000000001 /* ChatComposerConfigLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04100000000000000000002 /* ChatComposerConfigLoader.swift */; };
-		C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */; };
-		C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */; };
-		C042A000000000000000001 /* ChatComposerSelectorControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000002 /* ChatComposerSelectorControls.swift */; };
-		C042A000000000000000003 /* ChatComposerSelectorSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000004 /* ChatComposerSelectorSheets.swift */; };
-		C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04900000000000000000002 /* ChatComposerTextInputView.swift */; };
-		C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04900000000000000000004 /* ChatComposerVoiceControls.swift */; };
-		C04700000000000000000001 /* ChatPendingActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04700000000000000000002 /* ChatPendingActionCoordinator.swift */; };
-		C04800000000000000000001 /* ChatAttachmentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04800000000000000000002 /* ChatAttachmentCoordinator.swift */; };
-		C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */; };
 		1A2B3C4D5E6F7000000000AD /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BD /* Workspace.swift */; };
 		1A2B3C4D5E6F7000000000AE /* ServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BE /* ServerCatalog.swift */; };
 		1A2B3C4D5E6F7000000000AF /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BF /* ChatView.swift */; };
-		C05100000000000000000001 /* ChatTranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000011 /* ChatTranscriptView.swift */; };
-		C05100000000000000000002 /* ChatMessageActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000012 /* ChatMessageActions.swift */; };
-		C05100000000000000000003 /* ChatGoalControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000013 /* ChatGoalControls.swift */; };
-		C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */; };
 		1A2B3C4D5E6F7000000000D0 /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */; };
 		1A2B3C4D5E6F7000000000D1 /* SessionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */; };
-		A04300000000000000000001 /* SessionListComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000011 /* SessionListComponents.swift */; };
-		A10900000000000000000001 /* SessionNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000011 /* SessionNavigationState.swift */; };
-		A04300000000000000000002 /* SessionListActionConfirmations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000012 /* SessionListActionConfirmations.swift */; };
-		A04300000000000000000003 /* SessionMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000013 /* SessionMutator.swift */; };
-		A040C0DE0000000000000001 /* ProjectCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A040C0DE0000000000000002 /* ProjectCreationSheet.swift */; };
-		A048C0DE0000000000000001 /* SessionRenameSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A048C0DE0000000000000002 /* SessionRenameSheet.swift */; };
-		A04200000000000000000001 /* Approval.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04200000000000000000002 /* Approval.swift */; };
-		A04200000000000000000003 /* ApprovalRequestOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04200000000000000000004 /* ApprovalRequestOverlay.swift */; };
-		C1A042000000000000000001 /* Clarification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000002 /* Clarification.swift */; };
-		C1A042000000000000000003 /* ClarificationRequestOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000004 /* ClarificationRequestOverlay.swift */; };
-		C1A042000000000000000005 /* ClarificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000006 /* ClarificationTests.swift */; };
-		A02400000000000000000001 /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02400000000000000000002 /* Goal.swift */; };
-		C04600000000000000000001 /* ChatStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04600000000000000000002 /* ChatStreamCoordinator.swift */; };
-		C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */; };
-		C22600000000000000000001 /* ScriptedSSEStreamFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22600000000000000000002 /* ScriptedSSEStreamFixture.swift */; };
-		C22600000000000000000003 /* StreamReconnectContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22600000000000000000004 /* StreamReconnectContractTests.swift */; };
 		1A2B3C4D5E6F7000000000D4 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D5 /* ChatViewModel.swift */; };
 		1A2B3C4D5E6F7000000000D6 /* SSEClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D7 /* SSEClient.swift */; };
-		C0FF000000000000000000A1 /* CustomHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF000000000000000000A2 /* CustomHeader.swift */; };
 		1A2B3C4D5E6F7000000000D8 /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D9 /* MessageBubbleView.swift */; };
-		BEEF02400000000000000001 /* ChatAttachmentPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEF02400000000000000002 /* ChatAttachmentPreviewView.swift */; };
 		1A2B3C4D5E6F7000000000DA /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000DB /* MarkdownRenderer.swift */; };
-		C14300000000000000000001 /* StreamingMarkdownSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14300000000000000000002 /* StreamingMarkdownSupport.swift */; };
-		C0DE34000000000000000001 /* TranscriptMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000002 /* TranscriptMedia.swift */; };
-		C0DE34000000000000000006 /* TranscriptMediaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000005 /* TranscriptMediaView.swift */; };
-		C0DE34000000000000000008 /* TranscriptMediaPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */; };
-		C0DE34000000000000000009 /* TranscriptMediaDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */; };
-		C0DE3400000000000000000D /* TranscriptMediaExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */; };
-		C0DE12000000000000000001 /* TranscriptLinkPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000002 /* TranscriptLinkPreview.swift */; };
-		C0DE12000000000000000007 /* TranscriptLinkPreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000008 /* TranscriptLinkPreviewCache.swift */; };
-		C0DE12000000000000000005 /* TranscriptLinkPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000006 /* TranscriptLinkPreviewView.swift */; };
-		C0DE20000000000000000001 /* ChatTactileButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000002 /* ChatTactileButtonStyle.swift */; };
-		C0DE21000000000000000001 /* ChatMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE21000000000000000002 /* ChatMotion.swift */; };
-		C0DE25000000000000000001 /* ChatScrollPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE25000000000000000002 /* ChatScrollPolicy.swift */; };
-		C0DE25000000000000000003 /* ChatScrollPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE25000000000000000004 /* ChatScrollPolicyTests.swift */; };
-		C0DE22000000000000000001 /* ChatHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000002 /* ChatHaptics.swift */; };
-		C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000004 /* ChatHapticsTests.swift */; };
-		C08800000000000000000001 /* SessionHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08800000000000000000002 /* SessionHaptics.swift */; };
-		C08800000000000000000003 /* SessionHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08800000000000000000004 /* SessionHapticsTests.swift */; };
-		C09300000000000000000001 /* HapticButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09300000000000000000002 /* HapticButton.swift */; };
-		C0FF000000000000000000B1 /* CustomHeadersEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF000000000000000000B2 /* CustomHeadersEditor.swift */; };
-		C09300000000000000000003 /* HapticButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09300000000000000000004 /* HapticButtonTests.swift */; };
-		C09500000000000000000001 /* AdaptiveGlassModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09500000000000000000002 /* AdaptiveGlassModifier.swift */; };
-		C09500000000000000000003 /* AdaptiveGlassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09500000000000000000004 /* AdaptiveGlassTests.swift */; };
-		C09500000000000000000005 /* AdaptiveGlassDebugFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09500000000000000000006 /* AdaptiveGlassDebugFixture.swift */; };
-		031031031031031031031001 /* MarkdownMathSegmenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031002 /* MarkdownMathSegmenter.swift */; };
-		031031031031031031031005 /* MarkdownMathFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031006 /* MarkdownMathFormatter.swift */; };
-		031031031031031031031007 /* MarkdownMathFormatter+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031008 /* MarkdownMathFormatter+Support.swift */; };
-		031031031031031031031009 /* DisplayMathView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03103103103103103103100A /* DisplayMathView.swift */; };
-		03103103103103103103100B /* MarkdownMathFormatter+Environments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03103103103103103103100C /* MarkdownMathFormatter+Environments.swift */; };
-		031031031031031031031003 /* MarkdownMathRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031031031031031031031004 /* MarkdownMathRendererTests.swift */; };
-		C0DE34000000000000000003 /* TranscriptMediaParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000004 /* TranscriptMediaParserTests.swift */; };
-		C0DE3400000000000000000B /* TranscriptMediaPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000C /* TranscriptMediaPreviewViewModelTests.swift */; };
-		C0DE12000000000000000003 /* TranscriptLinkPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000004 /* TranscriptLinkPreviewTests.swift */; };
 		1A2B3C4D5E6F7000000000DC /* SSEClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000DD /* SSEClientTests.swift */; };
 		1A2B3C4D5E6F7000000000DE /* ToolCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000DF /* ToolCall.swift */; };
-		C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000002 /* ToolActivityGroupView.swift */; };
 		1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */; };
-		C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */; };
-		C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12900000000000000000002 /* ChatActiveRunStatusView.swift */; };
-		C06000000000000000000001 /* ToolCallDisplayFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06000000000000000000002 /* ToolCallDisplayFormatter.swift */; };
 		1A2B3C4D5E6F7000000000E2 /* ReasoningBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E3 /* ReasoningBlockView.swift */; };
 		1A2B3C4D5E6F7000000000E4 /* FileBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E5 /* FileBrowserView.swift */; };
 		1A2B3C4D5E6F7000000000E6 /* FileBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E7 /* FileBrowserViewModel.swift */; };
 		1A2B3C4D5E6F7000000000E8 /* FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E9 /* FilePreviewView.swift */; };
 		1A2B3C4D5E6F7000000000EA /* FilePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000EB /* FilePreviewViewModel.swift */; };
-		BEEF02600000000000000001 /* FileExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEF02600000000000000002 /* FileExportSupport.swift */; };
 		1A2B3C4D5E6F7000000000EC /* CachedSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000EE /* CachedSession.swift */; };
 		1A2B3C4D5E6F7000000000ED /* CachedMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000EF /* CachedMessage.swift */; };
 		1A2B3C4D5E6F7000000000F1 /* CacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F3 /* CacheStore.swift */; };
 		1A2B3C4D5E6F7000000000F2 /* CacheStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F4 /* CacheStoreTests.swift */; };
-		C04400000000000000000003 /* CacheFallbackPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04400000000000000000004 /* CacheFallbackPolicyTests.swift */; };
 		1A2B3C4D5E6F7000000000F5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F6 /* SettingsView.swift */; };
 		1A2B3C4D5E6F7000000000F8 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F9 /* AppConfig.swift */; };
-		C09200000000000000000001 /* AppFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09200000000000000000002 /* AppFont.swift */; };
 		1A2B3C4D5E6F700000000100 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000101 /* AppTheme.swift */; };
-		C012400000000000000002 /* AppIconChoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C012400000000000000001 /* AppIconChoice.swift */; };
-		C03120000000000000B001 /* GitWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F001 /* GitWorkspace.swift */; };
-		C03120000000000000B002 /* APIClient+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F002 /* APIClient+Git.swift */; };
-		C03120000000000000B003 /* GitWorkspaceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F003 /* GitWorkspaceViewModel.swift */; };
-		22AB000000000000000000B1 /* WorkspaceRegistryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */; };
-		22AB000000000000000000B2 /* WorkspaceManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F2 /* WorkspaceManagerView.swift */; };
-		C03120000000000000B004 /* GitWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F004 /* GitWorkspaceView.swift */; };
-		C03120000000000000B005 /* GitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F005 /* GitDiffView.swift */; };
-		C03180000000000000B001 /* GitActionsMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F001 /* GitActionsMenuButton.swift */; };
-		C03180000000000000B002 /* GitActionToastOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F002 /* GitActionToastOverlay.swift */; };
-		C03180000000000000B003 /* GitInlineCommitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F003 /* GitInlineCommitButton.swift */; };
-		C03180000000000000B004 /* GitCommitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F004 /* GitCommitView.swift */; };
-		C03180000000000000B005 /* TurnFileChangeSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F005 /* TurnFileChangeSummary.swift */; };
-		C03180000000000000B007 /* GitTurnChangesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F007 /* GitTurnChangesCard.swift */; };
-		C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */; };
-		C03190000000000000B001 /* AttachmentAudioDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F001 /* AttachmentAudioDetection.swift */; };
-		C03190000000000000B002 /* InlineAudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F002 /* InlineAudioPlayerView.swift */; };
-		C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */; };
-		C03250000000000000B101 /* TranscribeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F101 /* TranscribeResponse.swift */; };
-		C03250000000000000B102 /* APIClient+Transcribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F102 /* APIClient+Transcribe.swift */; };
-		C03250000000000000B103 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F103 /* MultipartFormData.swift */; };
-		C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */; };
-		C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F105 /* APIClientTranscribeTests.swift */; };
-		C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */; };
-		C03260000000000000B101 /* APIClient+TTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F101 /* APIClient+TTS.swift */; };
-		C03270000000000000B101 /* APIClient+SessionExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03270000000000000F101 /* APIClient+SessionExport.swift */; };
-		C03260000000000000B102 /* APIClientTTSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F102 /* APIClientTTSTests.swift */; };
-		C03270000000000000B102 /* APIClientSessionExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03270000000000000F102 /* APIClientSessionExportTests.swift */; };
-		C03140000000000000B001 /* GitBranchPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03140000000000000F001 /* GitBranchPickerView.swift */; };
-		C03120000000000000B006 /* APIClientGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F006 /* APIClientGitTests.swift */; };
-		C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */; };
-		C012400000000000000004 /* AppIconSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C012400000000000000003 /* AppIconSettingsSection.swift */; };
 		1A2B3C4D5E6F700000000102 /* AppThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000103 /* AppThemeTests.swift */; };
-		C012400000000000000006 /* AppIconChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C012400000000000000005 /* AppIconChoiceTests.swift */; };
+		1A2B3C4D5E6F700000000300 /* ServerAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000301 /* ServerAccount.swift */; };
+		1A2B3C4D5E6F700000000338 /* HermexAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000337 /* HermexAppIntents.swift */; };
+		1A2B3C4D5E6F700000000341 /* AppIntentNewChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000340 /* AppIntentNewChatTests.swift */; };
+		1A2B3C4D5E6F700000000343 /* ProfileEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000342 /* ProfileEntity.swift */; };
+		1A2B3C4D5E6F700000000345 /* AppIntentNewChatInProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000344 /* AppIntentNewChatInProfileTests.swift */; };
 		1A2B3C4D5E6F70000000110 /* ArchivedSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000111 /* ArchivedSessionsView.swift */; };
 		1A2B3C4D5E6F70000000112 /* ArchivedSessionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */; };
-		19C1150000000000000000A1 /* CliSessionsSyncModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A2 /* CliSessionsSyncModel.swift */; };
 		1A2B3C4D5E6F70000000114 /* DefaultModelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000115 /* DefaultModelPickerView.swift */; };
-		103200000000000000000002 /* DefaultProfilePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103200000000000000000001 /* DefaultProfilePickerView.swift */; };
 		1A2B3C4D5E6F70000000130 /* ContextWindowSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000120 /* ContextWindowSnapshot.swift */; };
 		1A2B3C4D5E6F70000000131 /* ContextWindowIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000121 /* ContextWindowIndicatorView.swift */; };
 		1A2B3C4D5E6F70000000132 /* ContextWindowIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000122 /* ContextWindowIndicatorTests.swift */; };
@@ -244,27 +92,190 @@
 		1A2B3C4D5E6F70000000212 /* SkillsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000213 /* SkillsView.swift */; };
 		1A2B3C4D5E6F70000000214 /* SkillsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000215 /* SkillsViewModel.swift */; };
 		1A2B3C4D5E6F70000000300 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000301 /* PrivacyInfo.xcprivacy */; };
+		1A2B3C4D5E6F70000000410 /* OnboardingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70000000411 /* OnboardingComponents.swift */; };
+		22AB000000000000000000B1 /* WorkspaceRegistryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */; };
+		22AB000000000000000000B2 /* WorkspaceManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F2 /* WorkspaceManagerView.swift */; };
+		22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */; };
+		26AB000000000000000000B1 /* ProvidersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F1 /* ProvidersViewModel.swift */; };
+		26AB000000000000000000B2 /* ProvidersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F2 /* ProvidersView.swift */; };
+		26AB000000000000000000B3 /* APIClientProvidersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F3 /* APIClientProvidersTests.swift */; };
+		26AB000000000000000000B4 /* ProvidersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AB000000000000000000F4 /* ProvidersViewModelTests.swift */; };
+		2BE8F2B38F094C4C9EB18301 /* SkillsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */; };
+		36CD9EF0B0734E5F8C28BB92 /* SlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA59130ED4141049177576C /* SlashCommand.swift */; };
+		3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01011 /* Cron.swift */; };
+		3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01012 /* TasksView.swift */; };
+		3F91D2A54B9A4F66A2C01003 /* TasksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01013 /* TasksViewModel.swift */; };
+		3F91D2A54B9A4F66A2C01004 /* TaskDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01014 /* TaskDetailView.swift */; };
+		3F91D2A54B9A4F66A2C01005 /* TaskDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01015 /* TaskDetailViewModel.swift */; };
+		5417A7400000000000000092 /* SwiftMath in Frameworks */ = {isa = PBXBuildFile; productRef = 5417A7400000000000000091 /* SwiftMath */; };
+		8618A9261B8047CEA6084798 /* SlashCommandAutocompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */; };
+		8B71DA2AAC521382F54A841C /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */; };
+		8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */; };
+		941A67322EB54169A55D7A64 /* SlashCommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */; };
 		9E2A653D968A4ACDA19A8142 /* ThirdPartyNotices in Resources */ = {isa = PBXBuildFile; fileRef = 488791F556304AD2AC59BC5D /* ThirdPartyNotices */; };
+		A02400000000000000000001 /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02400000000000000000002 /* Goal.swift */; };
+		A040C0DE0000000000000001 /* ProjectCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A040C0DE0000000000000002 /* ProjectCreationSheet.swift */; };
+		A04200000000000000000001 /* Approval.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04200000000000000000002 /* Approval.swift */; };
+		A04200000000000000000003 /* ApprovalRequestOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04200000000000000000004 /* ApprovalRequestOverlay.swift */; };
+		A04300000000000000000001 /* SessionListComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000011 /* SessionListComponents.swift */; };
+		A04300000000000000000002 /* SessionListActionConfirmations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000012 /* SessionListActionConfirmations.swift */; };
+		A04300000000000000000003 /* SessionMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000013 /* SessionMutator.swift */; };
+		A04500000000000000000001 /* AgentRunActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000010 /* AgentRunActivityAttributes.swift */; };
+		A04500000000000000000002 /* HermesDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000011 /* HermesDeepLink.swift */; };
+		A04500000000000000000003 /* AgentLiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000012 /* AgentLiveActivityManager.swift */; };
+		A04500000000000000000004 /* AgentRunActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000010 /* AgentRunActivityAttributes.swift */; };
+		A04500000000000000000005 /* HermesDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000011 /* HermesDeepLink.swift */; };
+		A04500000000000000000006 /* AgentRunLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000013 /* AgentRunLiveActivityWidget.swift */; };
+		A04500000000000000000007 /* HermesLiveActivityWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A04500000000000000000017 /* HermesLiveActivityWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A04500000000000000000008 /* LiveActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000018 /* LiveActivityTests.swift */; };
+		A048C0DE0000000000000001 /* SessionRenameSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A048C0DE0000000000000002 /* SessionRenameSheet.swift */; };
+		A10900000000000000000001 /* SessionNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000011 /* SessionNavigationState.swift */; };
+		A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000012 /* SessionNavigationStateTests.swift */; };
+		A710739233F64F4FA4C2B700 /* ComposerVoiceInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A710739233F64F4FA4C2B710 /* ComposerVoiceInputController.swift */; };
+		46D39C858C9AA26CA2A75DAC /* ComposerSTTContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5EB5D5436F8E03636577CCC /* ComposerSTTContextProvider.swift */; };
+		9BFADE67A7831C125F8C0230 /* ComposerVoiceFirstMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03227BCC723743B7B09A96AD /* ComposerVoiceFirstMode.swift */; };
+		A4DE8D9B54561E6CD15BB2C5 /* ComposerVoiceFirstBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85452567F0194260D8966353 /* ComposerVoiceFirstBar.swift */; };
+		A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */; };
+		B53F3F24A5C24D9E8E54A810 /* SlashCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1CE5F12B9E4D4D9E5A01C1 /* SlashCommandExecutor.swift */; };
 		B5A100000000000000000001 /* SharedDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000010 /* SharedDraftStore.swift */; };
 		B5A100000000000000000002 /* SharedDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000010 /* SharedDraftStore.swift */; };
 		B5A100000000000000000003 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000011 /* ShareViewController.swift */; };
+		B5A100000000000000000004 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000014 /* PrivacyInfo.xcprivacy */; };
+		B5A100000000000000000005 /* SharedDraftStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000016 /* SharedDraftStoreTests.swift */; };
+		B5A100000000000000000006 /* HermesShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000017 /* HermesShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B5A100000000000000000007 /* ShareInputReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000018 /* ShareInputReader.swift */; };
 		B5A100000000000000000008 /* ShareInputReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000018 /* ShareInputReader.swift */; };
 		B5A100000000000000000009 /* ShareInputReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000019 /* ShareInputReaderTests.swift */; };
 		B5A100000000000000000060 /* AuthManagerStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000061 /* AuthManagerStateTests.swift */; };
+		B5A1000000000000000000A0 /* ServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A1000000000000000000A1 /* ServerRegistryTests.swift */; };
 		B5A220000000000000000001 /* ChatMarkerMessageClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A220000000000000000002 /* ChatMarkerMessageClassifier.swift */; };
 		B5A220000000000000000003 /* MarkerMessageCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A220000000000000000004 /* MarkerMessageCardView.swift */; };
-		C22300000000000000000001 /* CompressionAnchorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22300000000000000000002 /* CompressionAnchorResolver.swift */; };
-		C22300000000000000000003 /* CompressionAnchorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22300000000000000000004 /* CompressionAnchorResolverTests.swift */; };
-		C21200000000000000000001 /* StreamingWordDrain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21200000000000000000002 /* StreamingWordDrain.swift */; };
-		C21200000000000000000003 /* StreamingWordDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21200000000000000000004 /* StreamingWordDrainTests.swift */; };
-		C21200000000000000000005 /* ChatViewModelStreamingPaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21200000000000000000006 /* ChatViewModelStreamingPaceTests.swift */; };
-		C21300000000000000000001 /* StreamingTextFade.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21300000000000000000002 /* StreamingTextFade.swift */; };
-		C21300000000000000000003 /* StreamingTextFadeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21300000000000000000004 /* StreamingTextFadeRenderer.swift */; };
-		C21300000000000000000005 /* StreamingTextFadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21300000000000000000006 /* StreamingTextFadeTests.swift */; };
-		C23400000000000000000001 /* StreamingLabReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000002 /* StreamingLabReplay.swift */; };
-		C23400000000000000000003 /* StreamingLabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000004 /* StreamingLabView.swift */; };
-		C23400000000000000000005 /* StreamingLabReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000006 /* StreamingLabReplayTests.swift */; };
+		B5A220000000000000000005 /* ChatMarkerMessageClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A220000000000000000006 /* ChatMarkerMessageClassifierTests.swift */; };
+		BEEF02400000000000000001 /* ChatAttachmentPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEF02400000000000000002 /* ChatAttachmentPreviewView.swift */; };
+		BEEF02600000000000000001 /* FileExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEF02600000000000000002 /* FileExportSupport.swift */; };
+		C012400000000000000002 /* AppIconChoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C012400000000000000001 /* AppIconChoice.swift */; };
+		C012400000000000000004 /* AppIconSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C012400000000000000003 /* AppIconSettingsSection.swift */; };
+		C012400000000000000006 /* AppIconChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C012400000000000000005 /* AppIconChoiceTests.swift */; };
+		C03120000000000000B001 /* GitWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F001 /* GitWorkspace.swift */; };
+		C03120000000000000B002 /* APIClient+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F002 /* APIClient+Git.swift */; };
+		C03120000000000000B003 /* GitWorkspaceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F003 /* GitWorkspaceViewModel.swift */; };
+		C03120000000000000B004 /* GitWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F004 /* GitWorkspaceView.swift */; };
+		C03120000000000000B005 /* GitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F005 /* GitDiffView.swift */; };
+		C03120000000000000B006 /* APIClientGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F006 /* APIClientGitTests.swift */; };
+		C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */; };
+		C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */; };
+		C03140000000000000B001 /* GitBranchPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03140000000000000F001 /* GitBranchPickerView.swift */; };
+		C03180000000000000B001 /* GitActionsMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F001 /* GitActionsMenuButton.swift */; };
+		C03180000000000000B002 /* GitActionToastOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F002 /* GitActionToastOverlay.swift */; };
+		C03180000000000000B003 /* GitInlineCommitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F003 /* GitInlineCommitButton.swift */; };
+		C03180000000000000B004 /* GitCommitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F004 /* GitCommitView.swift */; };
+		C03180000000000000B005 /* TurnFileChangeSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F005 /* TurnFileChangeSummary.swift */; };
+		C03180000000000000B007 /* GitTurnChangesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F007 /* GitTurnChangesCard.swift */; };
+		C03190000000000000B001 /* AttachmentAudioDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F001 /* AttachmentAudioDetection.swift */; };
+		C03190000000000000B002 /* InlineAudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F002 /* InlineAudioPlayerView.swift */; };
+		C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */; };
+		C03250000000000000B101 /* TranscribeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F101 /* TranscribeResponse.swift */; };
+		C03250000000000000B102 /* APIClient+Transcribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F102 /* APIClient+Transcribe.swift */; };
+		C03250000000000000B103 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F103 /* MultipartFormData.swift */; };
+		C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */; };
+		C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F105 /* APIClientTranscribeTests.swift */; };
+		C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */; };
+		C03260000000000000B101 /* APIClient+TTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F101 /* APIClient+TTS.swift */; };
+		C03260000000000000B102 /* APIClientTTSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F102 /* APIClientTTSTests.swift */; };
+		C03270000000000000B101 /* APIClient+SessionExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03270000000000000F101 /* APIClient+SessionExport.swift */; };
+		C03270000000000000B102 /* APIClientSessionExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03270000000000000F102 /* APIClientSessionExportTests.swift */; };
+		C03910000000000000000001 /* APIClientSessionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000001 /* APIClientSessionListTests.swift */; };
+		C03910000000000000000002 /* APIClientInsightsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000002 /* APIClientInsightsTests.swift */; };
+		C03910000000000000000003 /* APIClientSessionDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000003 /* APIClientSessionDetailTests.swift */; };
+		C03910000000000000000004 /* APIClientSessionMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000004 /* APIClientSessionMutationTests.swift */; };
+		C03910000000000000000005 /* APIClientWorkspaceFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000005 /* APIClientWorkspaceFileTests.swift */; };
+		C03910000000000000000006 /* APIClientChatEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000006 /* APIClientChatEndpointTests.swift */; };
+		C03910000000000000000007 /* APIClientAuthAndErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000007 /* APIClientAuthAndErrorTests.swift */; };
+		C03910000000000000000008 /* APIClientAgentControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000008 /* APIClientAgentControlTests.swift */; };
+		C03910000000000000000009 /* APIClientConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000009 /* APIClientConfigurationTests.swift */; };
+		C0391000000000000000000A /* APIClientCronEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000A /* APIClientCronEndpointTests.swift */; };
+		C0391000000000000000000B /* APIClientMemoryEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000B /* APIClientMemoryEndpointTests.swift */; };
+		C0391000000000000000000C /* APIClientSkillEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000C /* APIClientSkillEndpointTests.swift */; };
+		C0391000000000000000000D /* APIClientUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000D /* APIClientUploadTests.swift */; };
+		C0391000000000000000000E /* ChatViewModelSendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000E /* ChatViewModelSendTests.swift */; };
+		C0391000000000000000000F /* SessionListMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000F /* SessionListMutationTests.swift */; };
+		C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000010 /* APIEndpointContractTests.swift */; };
+		C03910000000000000000011 /* CronManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000011 /* CronManagementTests.swift */; };
+		C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000012 /* MemoryViewModelTests.swift */; };
+		C03910000000000000000013 /* ModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000013 /* ModelCatalogTests.swift */; };
+		C03910000000000000000014 /* MessageActionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000014 /* MessageActionContextTests.swift */; };
+		C03910000000000000000015 /* SessionIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000015 /* SessionIdentityTests.swift */; };
+		C03910000000000000000016 /* TranscriptDisplayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000016 /* TranscriptDisplayModelTests.swift */; };
+		C03910000000000000000017 /* APIClientUpdatesCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000017 /* APIClientUpdatesCheckTests.swift */; };
+		C03910000000000000000018 /* APIClientUpdatesApplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000018 /* APIClientUpdatesApplyTests.swift */; };
+		C04000000000000000000001 /* APIClient+Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000011 /* APIClient+Sessions.swift */; };
+		C04000000000000000000002 /* APIClient+Projects.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000012 /* APIClient+Projects.swift */; };
+		C04000000000000000000003 /* APIClient+Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000013 /* APIClient+Chat.swift */; };
+		C04000000000000000000004 /* APIClient+Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000014 /* APIClient+Workspace.swift */; };
+		C04000000000000000000005 /* APIClient+ServerPanels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000015 /* APIClient+ServerPanels.swift */; };
+		C04000000000000000000006 /* APIClient+Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000016 /* APIClient+Cron.swift */; };
+		C04000000000000000000007 /* APIClient+Memory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000017 /* APIClient+Memory.swift */; };
+		C04000000000000000000008 /* APIClient+Skills.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000018 /* APIClient+Skills.swift */; };
+		C04000000000000000000009 /* APIClient+Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04000000000000000000019 /* APIClient+Upload.swift */; };
+		C04100000000000000000001 /* ChatComposerConfigLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04100000000000000000002 /* ChatComposerConfigLoader.swift */; };
+		C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */; };
+		C042A000000000000000001 /* ChatComposerSelectorControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000002 /* ChatComposerSelectorControls.swift */; };
+		C042A000000000000000003 /* ChatComposerSelectorSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000004 /* ChatComposerSelectorSheets.swift */; };
+		C04400000000000000000001 /* CacheFallbackPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04400000000000000000002 /* CacheFallbackPolicy.swift */; };
+		C04400000000000000000003 /* CacheFallbackPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04400000000000000000004 /* CacheFallbackPolicyTests.swift */; };
+		C04600000000000000000001 /* ChatStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04600000000000000000002 /* ChatStreamCoordinator.swift */; };
+		C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */; };
+		C04700000000000000000001 /* ChatPendingActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04700000000000000000002 /* ChatPendingActionCoordinator.swift */; };
+		C04800000000000000000001 /* ChatAttachmentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04800000000000000000002 /* ChatAttachmentCoordinator.swift */; };
+		C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */; };
+		C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04900000000000000000002 /* ChatComposerTextInputView.swift */; };
+		C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04900000000000000000004 /* ChatComposerVoiceControls.swift */; };
+		C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */; };
+		C05100000000000000000001 /* ChatTranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000011 /* ChatTranscriptView.swift */; };
+		C05100000000000000000002 /* ChatMessageActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000012 /* ChatMessageActions.swift */; };
+		C05100000000000000000003 /* ChatGoalControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000013 /* ChatGoalControls.swift */; };
+		C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */; };
+		C06000000000000000000001 /* ToolCallDisplayFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06000000000000000000002 /* ToolCallDisplayFormatter.swift */; };
+		C08800000000000000000001 /* SessionHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08800000000000000000002 /* SessionHaptics.swift */; };
+		C08800000000000000000003 /* SessionHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08800000000000000000004 /* SessionHapticsTests.swift */; };
+		C09200000000000000000001 /* AppFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09200000000000000000002 /* AppFont.swift */; };
+		C09300000000000000000001 /* HapticButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09300000000000000000002 /* HapticButton.swift */; };
+		C09300000000000000000003 /* HapticButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09300000000000000000004 /* HapticButtonTests.swift */; };
+		C09500000000000000000001 /* AdaptiveGlassModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09500000000000000000002 /* AdaptiveGlassModifier.swift */; };
+		C09500000000000000000003 /* AdaptiveGlassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09500000000000000000004 /* AdaptiveGlassTests.swift */; };
+		C09500000000000000000005 /* AdaptiveGlassDebugFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09500000000000000000006 /* AdaptiveGlassDebugFixture.swift */; };
+		C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CAM000000000000000B002 /* CameraPickerView.swift */; };
+		C0DE12000000000000000001 /* TranscriptLinkPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000002 /* TranscriptLinkPreview.swift */; };
+		C0DE12000000000000000003 /* TranscriptLinkPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000004 /* TranscriptLinkPreviewTests.swift */; };
+		C0DE12000000000000000005 /* TranscriptLinkPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000006 /* TranscriptLinkPreviewView.swift */; };
+		C0DE12000000000000000007 /* TranscriptLinkPreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE12000000000000000008 /* TranscriptLinkPreviewCache.swift */; };
+		C0DE20000000000000000001 /* ChatTactileButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE20000000000000000002 /* ChatTactileButtonStyle.swift */; };
+		C0DE21000000000000000001 /* ChatMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE21000000000000000002 /* ChatMotion.swift */; };
+		C0DE22000000000000000001 /* ChatHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000002 /* ChatHaptics.swift */; };
+		C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000004 /* ChatHapticsTests.swift */; };
+		C0DE25000000000000000001 /* ChatScrollPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE25000000000000000002 /* ChatScrollPolicy.swift */; };
+		C0DE25000000000000000003 /* ChatScrollPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE25000000000000000004 /* ChatScrollPolicyTests.swift */; };
+		C0DE34000000000000000001 /* TranscriptMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000002 /* TranscriptMedia.swift */; };
+		C0DE34000000000000000003 /* TranscriptMediaParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000004 /* TranscriptMediaParserTests.swift */; };
+		C0DE34000000000000000006 /* TranscriptMediaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000005 /* TranscriptMediaView.swift */; };
+		C0DE34000000000000000008 /* TranscriptMediaPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */; };
+		C0DE34000000000000000009 /* TranscriptMediaDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */; };
+		C0DE3400000000000000000B /* TranscriptMediaPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000C /* TranscriptMediaPreviewViewModelTests.swift */; };
+		C0DE3400000000000000000D /* TranscriptMediaExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */; };
+		C0DE512E0000000000000202 /* InsightsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000201 /* InsightsModels.swift */; };
+		C0DE512E0000000000000204 /* InsightsRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000203 /* InsightsRows.swift */; };
+		C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000002 /* ChatComposerView.swift */; };
+		C0DED00000000000000DE001 /* ChatViewModelMergeDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DED00000000000000DE000 /* ChatViewModelMergeDedupTests.swift */; };
+		C0FF000000000000000000A1 /* CustomHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF000000000000000000A2 /* CustomHeader.swift */; };
+		C0FF000000000000000000B1 /* CustomHeadersEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF000000000000000000B2 /* CustomHeadersEditor.swift */; };
+		C0FF000000000000000000C1 /* CustomHeaderInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF000000000000000000C2 /* CustomHeaderInjectionTests.swift */; };
+		C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000002 /* ToolActivityGroupView.swift */; };
+		C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */; };
+		C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12900000000000000000002 /* ChatActiveRunStatusView.swift */; };
+		C13000000000000000000001 /* ChatVerticalScrollAxisGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13000000000000000000002 /* ChatVerticalScrollAxisGuardTests.swift */; };
+		C14300000000000000000001 /* StreamingMarkdownSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14300000000000000000002 /* StreamingMarkdownSupport.swift */; };
+		C14300000000000000000003 /* StreamingMarkdownSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14300000000000000000004 /* StreamingMarkdownSupportTests.swift */; };
+		C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14600000000000000000001 /* ChatToolbarHeaderTests.swift */; };
 		C14900000000000000000001 /* Kanban.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14900000000000000000002 /* Kanban.swift */; };
 		C14900000000000000000003 /* APIClient+Kanban.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14900000000000000000004 /* APIClient+Kanban.swift */; };
 		C14900000000000000000005 /* KanbanFeatureState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14900000000000000000006 /* KanbanFeatureState.swift */; };
@@ -274,45 +285,37 @@
 		C15100000000000000000001 /* KanbanEventStreamClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15100000000000000000002 /* KanbanEventStreamClient.swift */; };
 		C15100000000000000000003 /* KanbanEventStreamClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15100000000000000000004 /* KanbanEventStreamClientTests.swift */; };
 		C15100000000000000000005 /* KanbanLiveUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15100000000000000000006 /* KanbanLiveUpdateTests.swift */; };
-		C15400000000000000000001 /* KanbanCardDetailState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15400000000000000000002 /* KanbanCardDetailState.swift */; };
-		C15400000000000000000003 /* KanbanCardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15400000000000000000004 /* KanbanCardDetailView.swift */; };
+		C15210000000000000000001 /* OnboardingFlowPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000001 /* OnboardingFlowPolicy.swift */; };
+		C15210000000000000000002 /* OnboardingWelcomePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000002 /* OnboardingWelcomePage.swift */; };
+		C15210000000000000000003 /* OnboardingFeaturesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000003 /* OnboardingFeaturesPage.swift */; };
+		C15210000000000000000004 /* OnboardingAgentPromptPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000004 /* OnboardingAgentPromptPage.swift */; };
+		C15210000000000000000005 /* OnboardingTailscalePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000005 /* OnboardingTailscalePage.swift */; };
+		C15210000000000000000006 /* OnboardingConnectPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000006 /* OnboardingConnectPage.swift */; };
+		C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000007 /* OnboardingFlowTests.swift */; };
 		C15300000000000000000001 /* KanbanCardEditorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15300000000000000000002 /* KanbanCardEditorState.swift */; };
 		C15300000000000000000003 /* KanbanCardEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15300000000000000000004 /* KanbanCardEditorView.swift */; };
 		C15300000000000000000005 /* KanbanCardEditorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15300000000000000000006 /* KanbanCardEditorStateTests.swift */; };
+		C15400000000000000000001 /* KanbanCardDetailState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15400000000000000000002 /* KanbanCardDetailState.swift */; };
+		C15400000000000000000003 /* KanbanCardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15400000000000000000004 /* KanbanCardDetailView.swift */; };
 		C15400000000000000000005 /* KanbanCardDetailStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15400000000000000000006 /* KanbanCardDetailStateTests.swift */; };
+		C1A042000000000000000001 /* Clarification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000002 /* Clarification.swift */; };
+		C1A042000000000000000003 /* ClarificationRequestOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000004 /* ClarificationRequestOverlay.swift */; };
+		C1A042000000000000000005 /* ClarificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000006 /* ClarificationTests.swift */; };
+		C21200000000000000000001 /* StreamingWordDrain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21200000000000000000002 /* StreamingWordDrain.swift */; };
+		C21200000000000000000003 /* StreamingWordDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21200000000000000000004 /* StreamingWordDrainTests.swift */; };
+		C21200000000000000000005 /* ChatViewModelStreamingPaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21200000000000000000006 /* ChatViewModelStreamingPaceTests.swift */; };
+		C21300000000000000000001 /* StreamingTextFade.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21300000000000000000002 /* StreamingTextFade.swift */; };
+		C21300000000000000000003 /* StreamingTextFadeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21300000000000000000004 /* StreamingTextFadeRenderer.swift */; };
+		C21300000000000000000005 /* StreamingTextFadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21300000000000000000006 /* StreamingTextFadeTests.swift */; };
 		C21300000000000000000007 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = C21300000000000000000008 /* MarkdownUI */; };
-		B5A220000000000000000005 /* ChatMarkerMessageClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A220000000000000000006 /* ChatMarkerMessageClassifierTests.swift */; };
-		B5A100000000000000000004 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000014 /* PrivacyInfo.xcprivacy */; };
-		B5A100000000000000000005 /* SharedDraftStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000016 /* SharedDraftStoreTests.swift */; };
-		B5A100000000000000000006 /* HermesShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B5A100000000000000000017 /* HermesShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		A04500000000000000000001 /* AgentRunActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000010 /* AgentRunActivityAttributes.swift */; };
-		A04500000000000000000002 /* HermesDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000011 /* HermesDeepLink.swift */; };
-		A04500000000000000000003 /* AgentLiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000012 /* AgentLiveActivityManager.swift */; };
-		A04500000000000000000004 /* AgentRunActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000010 /* AgentRunActivityAttributes.swift */; };
-		A04500000000000000000005 /* HermesDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000011 /* HermesDeepLink.swift */; };
-		A04500000000000000000006 /* AgentRunLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000013 /* AgentRunLiveActivityWidget.swift */; };
-		A04500000000000000000007 /* HermesLiveActivityWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A04500000000000000000017 /* HermesLiveActivityWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		A04500000000000000000008 /* LiveActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500000000000000000018 /* LiveActivityTests.swift */; };
-		2BE8F2B38F094C4C9EB18301 /* SkillsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */; };
-		22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */; };
-		36CD9EF0B0734E5F8C28BB92 /* SlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA59130ED4141049177576C /* SlashCommand.swift */; };
-		3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01011 /* Cron.swift */; };
-		3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01012 /* TasksView.swift */; };
-		3F91D2A54B9A4F66A2C01003 /* TasksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01013 /* TasksViewModel.swift */; };
-		3F91D2A54B9A4F66A2C01004 /* TaskDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01014 /* TaskDetailView.swift */; };
-		3F91D2A54B9A4F66A2C01005 /* TaskDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01015 /* TaskDetailViewModel.swift */; };
-		8618A9261B8047CEA6084798 /* SlashCommandAutocompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */; };
-		8B71DA2AAC521382F54A841C /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */; };
-		8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */; };
-		941A67322EB54169A55D7A64 /* SlashCommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */; };
-		A710739233F64F4FA4C2B700 /* ComposerVoiceInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A710739233F64F4FA4C2B710 /* ComposerVoiceInputController.swift */; };
-		A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */; };
-		B53F3F24A5C24D9E8E54A810 /* SlashCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1CE5F12B9E4D4D9E5A01C1 /* SlashCommandExecutor.swift */; };
-		C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CAM000000000000000B002 /* CameraPickerView.swift */; };
-		C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000002 /* ChatComposerView.swift */; };
+		C22300000000000000000001 /* CompressionAnchorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22300000000000000000002 /* CompressionAnchorResolver.swift */; };
+		C22300000000000000000003 /* CompressionAnchorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22300000000000000000004 /* CompressionAnchorResolverTests.swift */; };
+		C22600000000000000000001 /* ScriptedSSEStreamFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22600000000000000000002 /* ScriptedSSEStreamFixture.swift */; };
+		C22600000000000000000003 /* StreamReconnectContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22600000000000000000004 /* StreamReconnectContractTests.swift */; };
+		C23400000000000000000001 /* StreamingLabReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000002 /* StreamingLabReplay.swift */; };
+		C23400000000000000000003 /* StreamingLabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000004 /* StreamingLabView.swift */; };
+		C23400000000000000000005 /* StreamingLabReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23400000000000000000006 /* StreamingLabReplayTests.swift */; };
 		C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */; };
-		105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */; };
-		105050000000000000000003 /* ComposerModelPickerSectionExpansionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -323,19 +326,19 @@
 			remoteGlobalIDString = 1A2B3C4D5E6F700000000040;
 			remoteInfo = HermesMobile;
 		};
-		B5A100000000000000000030 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A2B3C4D5E6F700000000070 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B5A100000000000000000040;
-			remoteInfo = HermesShareExtension;
-		};
 		A04500000000000000000030 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 1A2B3C4D5E6F700000000070 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = A04500000000000000000040;
 			remoteInfo = HermesLiveActivityWidget;
+		};
+		B5A100000000000000000030 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A2B3C4D5E6F700000000070 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B5A100000000000000000040;
+			remoteInfo = HermesShareExtension;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -355,41 +358,34 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		031031031031031031031002 /* MarkdownMathSegmenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMathSegmenter.swift; sourceTree = "<group>"; };
+		031031031031031031031004 /* MarkdownMathRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMathRendererTests.swift; sourceTree = "<group>"; };
+		031031031031031031031006 /* MarkdownMathFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMathFormatter.swift; sourceTree = "<group>"; };
+		031031031031031031031008 /* MarkdownMathFormatter+Support.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkdownMathFormatter+Support.swift"; sourceTree = "<group>"; };
+		03103103103103103103100A /* DisplayMathView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMathView.swift; sourceTree = "<group>"; };
+		03103103103103103103100C /* MarkdownMathFormatter+Environments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkdownMathFormatter+Environments.swift"; sourceTree = "<group>"; };
 		0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandTests.swift; sourceTree = "<group>"; };
-		351C0F1600000000000000A1 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000301 /* ServerAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAccount.swift; sourceTree = "<group>"; };
-		B5A1000000000000000000A1 /* ServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRegistryTests.swift; sourceTree = "<group>"; };
 		0D1CE5F12B9E4D4D9E5A01C1 /* SlashCommandExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandExecutor.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000010 /* HermesMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HermesMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		1A2B3C4D5E6F700000000011 /* HermesMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesMobileApp.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000337 /* HermexAppIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermexAppIntents.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000342 /* ProfileEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEntity.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000340 /* AppIntentNewChatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentNewChatTests.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000344 /* AppIntentNewChatInProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentNewChatInProfileTests.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000013 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1A2B3C4D5E6F700000000014 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		103200000000000000000001 /* DefaultProfilePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProfilePickerView.swift; sourceTree = "<group>"; };
+		105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelPickerSectionExpansionState.swift; sourceTree = "<group>"; };
+		105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelPickerSectionExpansionStateTests.swift; sourceTree = "<group>"; };
 		10CA110C0DE000000000B002 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		10CA110C0DE000000000B005 /* AppShortcuts.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = AppShortcuts.xcstrings; sourceTree = "<group>"; };
 		10CA110C0DE000000000C002 /* LocalizationCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationCatalogTests.swift; sourceTree = "<group>"; };
+		19C1150000000000000000A2 /* CliSessionsSyncModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModel.swift; sourceTree = "<group>"; };
+		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000010 /* HermesMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HermesMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A2B3C4D5E6F700000000011 /* HermesMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesMobileApp.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000013 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000014 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1A2B3C4D5E6F700000000015 /* HermesMobileTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HermesMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A2B3C4D5E6F7000000000B0 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B1 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B2 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		C04000000000000000000011 /* APIClient+Sessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Sessions.swift"; sourceTree = "<group>"; };
-		C04000000000000000000012 /* APIClient+Projects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Projects.swift"; sourceTree = "<group>"; };
-		C04000000000000000000013 /* APIClient+Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Chat.swift"; sourceTree = "<group>"; };
-		C04000000000000000000014 /* APIClient+Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Workspace.swift"; sourceTree = "<group>"; };
-		C04000000000000000000015 /* APIClient+ServerPanels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ServerPanels.swift"; sourceTree = "<group>"; };
-		C04000000000000000000016 /* APIClient+Cron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Cron.swift"; sourceTree = "<group>"; };
-		C04000000000000000000017 /* APIClient+Memory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Memory.swift"; sourceTree = "<group>"; };
-		C04000000000000000000018 /* APIClient+Skills.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Skills.swift"; sourceTree = "<group>"; };
-		C04000000000000000000019 /* APIClient+Upload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Upload.swift"; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B3 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
-		C04400000000000000000002 /* CacheFallbackPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFallbackPolicy.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B4 /* ServerInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerInfo.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B5 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F70000000411 /* OnboardingComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingComponents.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B6 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B7 /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000B8 /* Endpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoints.swift; sourceTree = "<group>"; };
@@ -397,178 +393,39 @@
 		1A2B3C4D5E6F7000000000BA /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BB /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BC /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
-		C0FF000000000000000000C2 /* CustomHeaderInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeaderInjectionTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000001 /* APIClientSessionListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionListTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000002 /* APIClientInsightsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientInsightsTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000017 /* APIClientUpdatesCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUpdatesCheckTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000018 /* APIClientUpdatesApplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUpdatesApplyTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000003 /* APIClientSessionDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionDetailTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000004 /* APIClientSessionMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionMutationTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000005 /* APIClientWorkspaceFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientWorkspaceFileTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000006 /* APIClientChatEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientChatEndpointTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000007 /* APIClientAuthAndErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientAuthAndErrorTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000008 /* APIClientAgentControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientAgentControlTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000009 /* APIClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientConfigurationTests.swift; sourceTree = "<group>"; };
-		C0390000000000000000000A /* APIClientCronEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientCronEndpointTests.swift; sourceTree = "<group>"; };
-		C0390000000000000000000B /* APIClientMemoryEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientMemoryEndpointTests.swift; sourceTree = "<group>"; };
-		C0390000000000000000000C /* APIClientSkillEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSkillEndpointTests.swift; sourceTree = "<group>"; };
-		C0390000000000000000000D /* APIClientUploadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUploadTests.swift; sourceTree = "<group>"; };
-		C0390000000000000000000E /* ChatViewModelSendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelSendTests.swift; sourceTree = "<group>"; };
-		C0DED00000000000000DE000 /* ChatViewModelMergeDedupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelMergeDedupTests.swift; sourceTree = "<group>"; };
-		C14600000000000000000001 /* ChatToolbarHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolbarHeaderTests.swift; sourceTree = "<group>"; };
-		C15200000000000000000001 /* OnboardingFlowPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowPolicy.swift; sourceTree = "<group>"; };
-		C15200000000000000000002 /* OnboardingWelcomePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomePage.swift; sourceTree = "<group>"; };
-		C15200000000000000000003 /* OnboardingFeaturesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFeaturesPage.swift; sourceTree = "<group>"; };
-		C15200000000000000000004 /* OnboardingAgentPromptPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAgentPromptPage.swift; sourceTree = "<group>"; };
-		C15200000000000000000005 /* OnboardingTailscalePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTailscalePage.swift; sourceTree = "<group>"; };
-		C15200000000000000000006 /* OnboardingConnectPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConnectPage.swift; sourceTree = "<group>"; };
-		C15200000000000000000007 /* OnboardingFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowTests.swift; sourceTree = "<group>"; };
-		C0390000000000000000000F /* SessionListMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListMutationTests.swift; sourceTree = "<group>"; };
-		A10900000000000000000012 /* SessionNavigationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationStateTests.swift; sourceTree = "<group>"; };
-		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000010 /* APIEndpointContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointContractTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000011 /* CronManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronManagementTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000012 /* MemoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewModelTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000013 /* ModelCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCatalogTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000014 /* MessageActionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionContextTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000015 /* SessionIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdentityTests.swift; sourceTree = "<group>"; };
-		C03900000000000000000016 /* TranscriptDisplayModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptDisplayModelTests.swift; sourceTree = "<group>"; };
-		C14300000000000000000004 /* StreamingMarkdownSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingMarkdownSupportTests.swift; sourceTree = "<group>"; };
-		C13000000000000000000002 /* ChatVerticalScrollAxisGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVerticalScrollAxisGuardTests.swift; sourceTree = "<group>"; };
-		C04100000000000000000002 /* ChatComposerConfigLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerConfigLoader.swift; sourceTree = "<group>"; };
-		C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerConfigLoaderTests.swift; sourceTree = "<group>"; };
-		C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerAttachmentStripView.swift; sourceTree = "<group>"; };
-		C042A000000000000000002 /* ChatComposerSelectorControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorControls.swift; sourceTree = "<group>"; };
-		C042A000000000000000004 /* ChatComposerSelectorSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorSheets.swift; sourceTree = "<group>"; };
-		C04900000000000000000002 /* ChatComposerTextInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerTextInputView.swift; sourceTree = "<group>"; };
-		C04900000000000000000004 /* ChatComposerVoiceControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerVoiceControls.swift; sourceTree = "<group>"; };
-		C04700000000000000000002 /* ChatPendingActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPendingActionCoordinator.swift; sourceTree = "<group>"; };
-		C04800000000000000000002 /* ChatAttachmentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentCoordinator.swift; sourceTree = "<group>"; };
-		C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentCoordinatorTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BD /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BE /* ServerCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerCatalog.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BF /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
-		C05100000000000000000011 /* ChatTranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptView.swift; sourceTree = "<group>"; };
-		C05100000000000000000012 /* ChatMessageActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageActions.swift; sourceTree = "<group>"; };
-		C05100000000000000000013 /* ChatGoalControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGoalControls.swift; sourceTree = "<group>"; };
-		C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptSupportingViews.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListViewModel.swift; sourceTree = "<group>"; };
-		A04300000000000000000011 /* SessionListComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListComponents.swift; sourceTree = "<group>"; };
-		A10900000000000000000011 /* SessionNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationState.swift; sourceTree = "<group>"; };
-		A04300000000000000000012 /* SessionListActionConfirmations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListActionConfirmations.swift; sourceTree = "<group>"; };
-		A04300000000000000000013 /* SessionMutator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMutator.swift; sourceTree = "<group>"; };
-		A040C0DE0000000000000002 /* ProjectCreationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreationSheet.swift; sourceTree = "<group>"; };
-		A048C0DE0000000000000002 /* SessionRenameSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRenameSheet.swift; sourceTree = "<group>"; };
-		A04200000000000000000002 /* Approval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Approval.swift; sourceTree = "<group>"; };
-		A04200000000000000000004 /* ApprovalRequestOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequestOverlay.swift; sourceTree = "<group>"; };
-		C1A042000000000000000002 /* Clarification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clarification.swift; sourceTree = "<group>"; };
-		C1A042000000000000000004 /* ClarificationRequestOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationRequestOverlay.swift; sourceTree = "<group>"; };
-		C1A042000000000000000006 /* ClarificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationTests.swift; sourceTree = "<group>"; };
-		A02400000000000000000002 /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
-		C04600000000000000000002 /* ChatStreamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinator.swift; sourceTree = "<group>"; };
-		C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinatorTests.swift; sourceTree = "<group>"; };
-		C22600000000000000000002 /* ScriptedSSEStreamFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptedSSEStreamFixture.swift; sourceTree = "<group>"; };
-		C22600000000000000000004 /* StreamReconnectContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamReconnectContractTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D5 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D7 /* SSEClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSEClient.swift; sourceTree = "<group>"; };
-		C0FF000000000000000000A2 /* CustomHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeader.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D9 /* MessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbleView.swift; sourceTree = "<group>"; };
-		BEEF02400000000000000002 /* ChatAttachmentPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentPreviewView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000DB /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
-		C14300000000000000000002 /* StreamingMarkdownSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingMarkdownSupport.swift; sourceTree = "<group>"; };
-		C0DE34000000000000000002 /* TranscriptMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMedia.swift; sourceTree = "<group>"; };
-		C0DE34000000000000000005 /* TranscriptMediaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaView.swift; sourceTree = "<group>"; };
-		C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaPreviewViewModel.swift; sourceTree = "<group>"; };
-		C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaDataLoader.swift; sourceTree = "<group>"; };
-		C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaExportSupport.swift; sourceTree = "<group>"; };
-		C0DE12000000000000000002 /* TranscriptLinkPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreview.swift; sourceTree = "<group>"; };
-		C0DE12000000000000000008 /* TranscriptLinkPreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewCache.swift; sourceTree = "<group>"; };
-		C0DE12000000000000000006 /* TranscriptLinkPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewView.swift; sourceTree = "<group>"; };
-		C0DE20000000000000000002 /* ChatTactileButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTactileButtonStyle.swift; sourceTree = "<group>"; };
-		C0DE21000000000000000002 /* ChatMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMotion.swift; sourceTree = "<group>"; };
-		C0DE25000000000000000002 /* ChatScrollPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollPolicy.swift; sourceTree = "<group>"; };
-		C0DE25000000000000000004 /* ChatScrollPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollPolicyTests.swift; sourceTree = "<group>"; };
-		C0DE22000000000000000002 /* ChatHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHaptics.swift; sourceTree = "<group>"; };
-		C0DE22000000000000000004 /* ChatHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHapticsTests.swift; sourceTree = "<group>"; };
-		C08800000000000000000002 /* SessionHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHaptics.swift; sourceTree = "<group>"; };
-		C08800000000000000000004 /* SessionHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHapticsTests.swift; sourceTree = "<group>"; };
-		C09300000000000000000002 /* HapticButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticButton.swift; sourceTree = "<group>"; };
-		C0FF000000000000000000B2 /* CustomHeadersEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeadersEditor.swift; sourceTree = "<group>"; };
-		C09300000000000000000004 /* HapticButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticButtonTests.swift; sourceTree = "<group>"; };
-		C09500000000000000000002 /* AdaptiveGlassModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGlassModifier.swift; sourceTree = "<group>"; };
-		C09500000000000000000004 /* AdaptiveGlassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGlassTests.swift; sourceTree = "<group>"; };
-		C09500000000000000000006 /* AdaptiveGlassDebugFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGlassDebugFixture.swift; sourceTree = "<group>"; };
-		031031031031031031031002 /* MarkdownMathSegmenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMathSegmenter.swift; sourceTree = "<group>"; };
-		031031031031031031031006 /* MarkdownMathFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMathFormatter.swift; sourceTree = "<group>"; };
-		031031031031031031031008 /* MarkdownMathFormatter+Support.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkdownMathFormatter+Support.swift"; sourceTree = "<group>"; };
-		03103103103103103103100A /* DisplayMathView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMathView.swift; sourceTree = "<group>"; };
-		03103103103103103103100C /* MarkdownMathFormatter+Environments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkdownMathFormatter+Environments.swift"; sourceTree = "<group>"; };
-		031031031031031031031004 /* MarkdownMathRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMathRendererTests.swift; sourceTree = "<group>"; };
-		C0DE34000000000000000004 /* TranscriptMediaParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaParserTests.swift; sourceTree = "<group>"; };
-		C0DE3400000000000000000C /* TranscriptMediaPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaPreviewViewModelTests.swift; sourceTree = "<group>"; };
-		C0DE12000000000000000004 /* TranscriptLinkPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000DD /* SSEClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSEClientTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000DF /* ToolCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCall.swift; sourceTree = "<group>"; };
-		C12800000000000000000002 /* ToolActivityGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityGroupView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallCardView.swift; sourceTree = "<group>"; };
-		C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTimelineAccessorySurface.swift; sourceTree = "<group>"; };
-		C12900000000000000000002 /* ChatActiveRunStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatActiveRunStatusView.swift; sourceTree = "<group>"; };
-		C06000000000000000000002 /* ToolCallDisplayFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallDisplayFormatter.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E3 /* ReasoningBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningBlockView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E5 /* FileBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E7 /* FileBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserViewModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E9 /* FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000EB /* FilePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewViewModel.swift; sourceTree = "<group>"; };
-		BEEF02600000000000000002 /* FileExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExportSupport.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000EE /* CachedSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedSession.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000EF /* CachedMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedMessage.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F3 /* CacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStore.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F4 /* CacheStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStoreTests.swift; sourceTree = "<group>"; };
-		C04400000000000000000004 /* CacheFallbackPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFallbackPolicyTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F6 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F9 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
-		C09200000000000000000002 /* AppFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFont.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F700000000101 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
-		C012400000000000000001 /* AppIconChoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconChoice.swift; sourceTree = "<group>"; };
-		C03120000000000000F001 /* GitWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspace.swift; sourceTree = "<group>"; };
-		C03120000000000000F002 /* APIClient+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Git.swift"; sourceTree = "<group>"; };
-		C03120000000000000F003 /* GitWorkspaceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceViewModel.swift; sourceTree = "<group>"; };
-		22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModel.swift; sourceTree = "<group>"; };
-		22AB000000000000000000F2 /* WorkspaceManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManagerView.swift; sourceTree = "<group>"; };
-		C03120000000000000F004 /* GitWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceView.swift; sourceTree = "<group>"; };
-		C03120000000000000F005 /* GitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitDiffView.swift; sourceTree = "<group>"; };
-		C03180000000000000F001 /* GitActionsMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitActionsMenuButton.swift; sourceTree = "<group>"; };
-		C03180000000000000F002 /* GitActionToastOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitActionToastOverlay.swift; sourceTree = "<group>"; };
-		C03180000000000000F003 /* GitInlineCommitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInlineCommitButton.swift; sourceTree = "<group>"; };
-		C03180000000000000F004 /* GitCommitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitCommitView.swift; sourceTree = "<group>"; };
-		C03180000000000000F005 /* TurnFileChangeSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeSummary.swift; sourceTree = "<group>"; };
-		C03180000000000000F007 /* GitTurnChangesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTurnChangesCard.swift; sourceTree = "<group>"; };
-		C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeAggregatorTests.swift; sourceTree = "<group>"; };
-		C03190000000000000F001 /* AttachmentAudioDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetection.swift; sourceTree = "<group>"; };
-		C03190000000000000F002 /* InlineAudioPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineAudioPlayerView.swift; sourceTree = "<group>"; };
-		C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetectionTests.swift; sourceTree = "<group>"; };
-		C03250000000000000F101 /* TranscribeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscribeResponse.swift; sourceTree = "<group>"; };
-		C03250000000000000F102 /* APIClient+Transcribe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Transcribe.swift"; sourceTree = "<group>"; };
-		C03250000000000000F103 /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
-		C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorder.swift; sourceTree = "<group>"; };
-		C03250000000000000F105 /* APIClientTranscribeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTranscribeTests.swift; sourceTree = "<group>"; };
-		C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorderTests.swift; sourceTree = "<group>"; };
-		C03260000000000000F101 /* APIClient+TTS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+TTS.swift"; sourceTree = "<group>"; };
-		C03270000000000000F101 /* APIClient+SessionExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+SessionExport.swift"; sourceTree = "<group>"; };
-		C03260000000000000F102 /* APIClientTTSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTTSTests.swift; sourceTree = "<group>"; };
-		C03270000000000000F102 /* APIClientSessionExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionExportTests.swift; sourceTree = "<group>"; };
-		C03140000000000000F001 /* GitBranchPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranchPickerView.swift; sourceTree = "<group>"; };
-		C03120000000000000F006 /* APIClientGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientGitTests.swift; sourceTree = "<group>"; };
-		C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceViewModelTests.swift; sourceTree = "<group>"; };
-		C012400000000000000003 /* AppIconSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSettingsSection.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F700000000103 /* AppThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppThemeTests.swift; sourceTree = "<group>"; };
-		C012400000000000000005 /* AppIconChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconChoiceTests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000301 /* ServerAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAccount.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000337 /* HermexAppIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermexAppIntents.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000340 /* AppIntentNewChatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentNewChatTests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000342 /* ProfileEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEntity.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F700000000344 /* AppIntentNewChatInProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentNewChatInProfileTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000111 /* ArchivedSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedSessionsView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000113 /* ArchivedSessionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedSessionsViewModel.swift; sourceTree = "<group>"; };
-		19C1150000000000000000A2 /* CliSessionsSyncModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000115 /* DefaultModelPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultModelPickerView.swift; sourceTree = "<group>"; };
-		103200000000000000000001 /* DefaultProfilePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProfilePickerView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000120 /* ContextWindowSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextWindowSnapshot.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000121 /* ContextWindowIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextWindowIndicatorView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000122 /* ContextWindowIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextWindowIndicatorTests.swift; sourceTree = "<group>"; };
@@ -583,50 +440,189 @@
 		1A2B3C4D5E6F70000000213 /* SkillsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000215 /* SkillsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsViewModel.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70000000301 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsViewModelTests.swift; sourceTree = "<group>"; };
-		22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModelTests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F70000000411 /* OnboardingComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingComponents.swift; sourceTree = "<group>"; };
 		1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandCatalog.swift; sourceTree = "<group>"; };
+		22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModel.swift; sourceTree = "<group>"; };
+		22AB000000000000000000F2 /* WorkspaceManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManagerView.swift; sourceTree = "<group>"; };
+		22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModelTests.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F1 /* ProvidersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersViewModel.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F2 /* ProvidersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersView.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F3 /* APIClientProvidersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientProvidersTests.swift; sourceTree = "<group>"; };
+		26AB000000000000000000F4 /* ProvidersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersViewModelTests.swift; sourceTree = "<group>"; };
+		2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsViewModelTests.swift; sourceTree = "<group>"; };
+		351C0F1600000000000000A1 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01011 /* Cron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cron.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01012 /* TasksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksView.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01013 /* TasksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksViewModel.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01014 /* TaskDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailView.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01015 /* TaskDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModel.swift; sourceTree = "<group>"; };
+		488791F556304AD2AC59BC5D /* ThirdPartyNotices */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ThirdPartyNotices; sourceTree = "<group>"; };
 		57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
-		C0DE512E0000000000000201 /* InsightsModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsModels.swift; sourceTree = "<group>"; };
-		C0DE512E0000000000000203 /* InsightsRows.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsRows.swift; sourceTree = "<group>"; };
 		5DA59130ED4141049177576C /* SlashCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommand.swift; sourceTree = "<group>"; };
 		6809B8F1391248A4AA77C453 /* SlashCommandExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandExecutorTests.swift; sourceTree = "<group>"; };
 		931EC010A2D940B0E42287A4 /* InsightsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
-		26AB000000000000000000F1 /* ProvidersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersViewModel.swift; sourceTree = "<group>"; };
-		26AB000000000000000000F2 /* ProvidersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersView.swift; sourceTree = "<group>"; };
-		26AB000000000000000000F3 /* APIClientProvidersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientProvidersTests.swift; sourceTree = "<group>"; };
-		26AB000000000000000000F4 /* ProvidersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersViewModelTests.swift; sourceTree = "<group>"; };
+		A02400000000000000000002 /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
+		A040C0DE0000000000000002 /* ProjectCreationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreationSheet.swift; sourceTree = "<group>"; };
+		A04200000000000000000002 /* Approval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Approval.swift; sourceTree = "<group>"; };
+		A04200000000000000000004 /* ApprovalRequestOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequestOverlay.swift; sourceTree = "<group>"; };
+		A04300000000000000000011 /* SessionListComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListComponents.swift; sourceTree = "<group>"; };
+		A04300000000000000000012 /* SessionListActionConfirmations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListActionConfirmations.swift; sourceTree = "<group>"; };
+		A04300000000000000000013 /* SessionMutator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMutator.swift; sourceTree = "<group>"; };
+		A04500000000000000000010 /* AgentRunActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunActivityAttributes.swift; sourceTree = "<group>"; };
+		A04500000000000000000011 /* HermesDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesDeepLink.swift; sourceTree = "<group>"; };
+		A04500000000000000000012 /* AgentLiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLiveActivityManager.swift; sourceTree = "<group>"; };
+		A04500000000000000000013 /* AgentRunLiveActivityWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunLiveActivityWidget.swift; sourceTree = "<group>"; };
+		A04500000000000000000014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A04500000000000000000017 /* HermesLiveActivityWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HermesLiveActivityWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A04500000000000000000018 /* LiveActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityTests.swift; sourceTree = "<group>"; };
+		A048C0DE0000000000000002 /* SessionRenameSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRenameSheet.swift; sourceTree = "<group>"; };
+		A10900000000000000000011 /* SessionNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationState.swift; sourceTree = "<group>"; };
+		A10900000000000000000012 /* SessionNavigationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationStateTests.swift; sourceTree = "<group>"; };
 		A710739233F64F4FA4C2B710 /* ComposerVoiceInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceInputController.swift; sourceTree = "<group>"; };
+		E5EB5D5436F8E03636577CCC /* ComposerSTTContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerSTTContextProvider.swift; sourceTree = "<group>"; };
+		03227BCC723743B7B09A96AD /* ComposerVoiceFirstMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceFirstMode.swift; sourceTree = "<group>"; };
+		85452567F0194260D8966353 /* ComposerVoiceFirstBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceFirstBar.swift; sourceTree = "<group>"; };
 		A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceDraftComposerTests.swift; sourceTree = "<group>"; };
 		B5A100000000000000000010 /* SharedDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDraftStore.swift; sourceTree = "<group>"; };
 		B5A100000000000000000011 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
-		B5A100000000000000000018 /* ShareInputReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareInputReader.swift; sourceTree = "<group>"; };
 		B5A100000000000000000012 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B5A100000000000000000013 /* HermesShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HermesShareExtension.entitlements; sourceTree = "<group>"; };
 		B5A100000000000000000014 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B5A100000000000000000015 /* HermesMobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HermesMobile.entitlements; sourceTree = "<group>"; };
-		488791F556304AD2AC59BC5D /* ThirdPartyNotices */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ThirdPartyNotices; sourceTree = "<group>"; };
 		B5A100000000000000000016 /* SharedDraftStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDraftStoreTests.swift; sourceTree = "<group>"; };
+		B5A100000000000000000017 /* HermesShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HermesShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5A100000000000000000018 /* ShareInputReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareInputReader.swift; sourceTree = "<group>"; };
 		B5A100000000000000000019 /* ShareInputReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareInputReaderTests.swift; sourceTree = "<group>"; };
 		B5A100000000000000000061 /* AuthManagerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerStateTests.swift; sourceTree = "<group>"; };
+		B5A1000000000000000000A1 /* ServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRegistryTests.swift; sourceTree = "<group>"; };
 		B5A220000000000000000002 /* ChatMarkerMessageClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMarkerMessageClassifier.swift; sourceTree = "<group>"; };
 		B5A220000000000000000004 /* MarkerMessageCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerMessageCardView.swift; sourceTree = "<group>"; };
-		C22300000000000000000002 /* CompressionAnchorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompressionAnchorResolver.swift; sourceTree = "<group>"; };
-		C22300000000000000000004 /* CompressionAnchorResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompressionAnchorResolverTests.swift; sourceTree = "<group>"; };
-		C21200000000000000000002 /* StreamingWordDrain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingWordDrain.swift; sourceTree = "<group>"; };
-		C21200000000000000000004 /* StreamingWordDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingWordDrainTests.swift; sourceTree = "<group>"; };
-		C21200000000000000000006 /* ChatViewModelStreamingPaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelStreamingPaceTests.swift; sourceTree = "<group>"; };
-		C21300000000000000000002 /* StreamingTextFade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTextFade.swift; sourceTree = "<group>"; };
-		C21300000000000000000004 /* StreamingTextFadeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTextFadeRenderer.swift; sourceTree = "<group>"; };
-		C21300000000000000000006 /* StreamingTextFadeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTextFadeTests.swift; sourceTree = "<group>"; };
-		C23400000000000000000002 /* StreamingLabReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabReplay.swift; sourceTree = "<group>"; };
-		C23400000000000000000004 /* StreamingLabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabView.swift; sourceTree = "<group>"; };
-		C23400000000000000000006 /* StreamingLabReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabReplayTests.swift; sourceTree = "<group>"; };
+		B5A220000000000000000006 /* ChatMarkerMessageClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMarkerMessageClassifierTests.swift; sourceTree = "<group>"; };
+		BEEF02400000000000000002 /* ChatAttachmentPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentPreviewView.swift; sourceTree = "<group>"; };
+		BEEF02600000000000000002 /* FileExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExportSupport.swift; sourceTree = "<group>"; };
+		C012400000000000000001 /* AppIconChoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconChoice.swift; sourceTree = "<group>"; };
+		C012400000000000000003 /* AppIconSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSettingsSection.swift; sourceTree = "<group>"; };
+		C012400000000000000005 /* AppIconChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconChoiceTests.swift; sourceTree = "<group>"; };
+		C03120000000000000F001 /* GitWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspace.swift; sourceTree = "<group>"; };
+		C03120000000000000F002 /* APIClient+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Git.swift"; sourceTree = "<group>"; };
+		C03120000000000000F003 /* GitWorkspaceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceViewModel.swift; sourceTree = "<group>"; };
+		C03120000000000000F004 /* GitWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceView.swift; sourceTree = "<group>"; };
+		C03120000000000000F005 /* GitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitDiffView.swift; sourceTree = "<group>"; };
+		C03120000000000000F006 /* APIClientGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientGitTests.swift; sourceTree = "<group>"; };
+		C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitWorkspaceViewModelTests.swift; sourceTree = "<group>"; };
+		C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeAggregatorTests.swift; sourceTree = "<group>"; };
+		C03140000000000000F001 /* GitBranchPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranchPickerView.swift; sourceTree = "<group>"; };
+		C03180000000000000F001 /* GitActionsMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitActionsMenuButton.swift; sourceTree = "<group>"; };
+		C03180000000000000F002 /* GitActionToastOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitActionToastOverlay.swift; sourceTree = "<group>"; };
+		C03180000000000000F003 /* GitInlineCommitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInlineCommitButton.swift; sourceTree = "<group>"; };
+		C03180000000000000F004 /* GitCommitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitCommitView.swift; sourceTree = "<group>"; };
+		C03180000000000000F005 /* TurnFileChangeSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeSummary.swift; sourceTree = "<group>"; };
+		C03180000000000000F007 /* GitTurnChangesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTurnChangesCard.swift; sourceTree = "<group>"; };
+		C03190000000000000F001 /* AttachmentAudioDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetection.swift; sourceTree = "<group>"; };
+		C03190000000000000F002 /* InlineAudioPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineAudioPlayerView.swift; sourceTree = "<group>"; };
+		C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetectionTests.swift; sourceTree = "<group>"; };
+		C03250000000000000F101 /* TranscribeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscribeResponse.swift; sourceTree = "<group>"; };
+		C03250000000000000F102 /* APIClient+Transcribe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Transcribe.swift"; sourceTree = "<group>"; };
+		C03250000000000000F103 /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
+		C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorder.swift; sourceTree = "<group>"; };
+		C03250000000000000F105 /* APIClientTranscribeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTranscribeTests.swift; sourceTree = "<group>"; };
+		C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorderTests.swift; sourceTree = "<group>"; };
+		C03260000000000000F101 /* APIClient+TTS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+TTS.swift"; sourceTree = "<group>"; };
+		C03260000000000000F102 /* APIClientTTSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTTSTests.swift; sourceTree = "<group>"; };
+		C03270000000000000F101 /* APIClient+SessionExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+SessionExport.swift"; sourceTree = "<group>"; };
+		C03270000000000000F102 /* APIClientSessionExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionExportTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000001 /* APIClientSessionListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionListTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000002 /* APIClientInsightsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientInsightsTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000003 /* APIClientSessionDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionDetailTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000004 /* APIClientSessionMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionMutationTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000005 /* APIClientWorkspaceFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientWorkspaceFileTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000006 /* APIClientChatEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientChatEndpointTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000007 /* APIClientAuthAndErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientAuthAndErrorTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000008 /* APIClientAgentControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientAgentControlTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000009 /* APIClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientConfigurationTests.swift; sourceTree = "<group>"; };
+		C0390000000000000000000A /* APIClientCronEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientCronEndpointTests.swift; sourceTree = "<group>"; };
+		C0390000000000000000000B /* APIClientMemoryEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientMemoryEndpointTests.swift; sourceTree = "<group>"; };
+		C0390000000000000000000C /* APIClientSkillEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSkillEndpointTests.swift; sourceTree = "<group>"; };
+		C0390000000000000000000D /* APIClientUploadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUploadTests.swift; sourceTree = "<group>"; };
+		C0390000000000000000000E /* ChatViewModelSendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelSendTests.swift; sourceTree = "<group>"; };
+		C0390000000000000000000F /* SessionListMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListMutationTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000010 /* APIEndpointContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointContractTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000011 /* CronManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronManagementTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000012 /* MemoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewModelTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000013 /* ModelCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCatalogTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000014 /* MessageActionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionContextTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000015 /* SessionIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdentityTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000016 /* TranscriptDisplayModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptDisplayModelTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000017 /* APIClientUpdatesCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUpdatesCheckTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000018 /* APIClientUpdatesApplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUpdatesApplyTests.swift; sourceTree = "<group>"; };
+		C04000000000000000000011 /* APIClient+Sessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Sessions.swift"; sourceTree = "<group>"; };
+		C04000000000000000000012 /* APIClient+Projects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Projects.swift"; sourceTree = "<group>"; };
+		C04000000000000000000013 /* APIClient+Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Chat.swift"; sourceTree = "<group>"; };
+		C04000000000000000000014 /* APIClient+Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Workspace.swift"; sourceTree = "<group>"; };
+		C04000000000000000000015 /* APIClient+ServerPanels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+ServerPanels.swift"; sourceTree = "<group>"; };
+		C04000000000000000000016 /* APIClient+Cron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Cron.swift"; sourceTree = "<group>"; };
+		C04000000000000000000017 /* APIClient+Memory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Memory.swift"; sourceTree = "<group>"; };
+		C04000000000000000000018 /* APIClient+Skills.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Skills.swift"; sourceTree = "<group>"; };
+		C04000000000000000000019 /* APIClient+Upload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Upload.swift"; sourceTree = "<group>"; };
+		C04100000000000000000002 /* ChatComposerConfigLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerConfigLoader.swift; sourceTree = "<group>"; };
+		C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerConfigLoaderTests.swift; sourceTree = "<group>"; };
+		C042A000000000000000002 /* ChatComposerSelectorControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorControls.swift; sourceTree = "<group>"; };
+		C042A000000000000000004 /* ChatComposerSelectorSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorSheets.swift; sourceTree = "<group>"; };
+		C04400000000000000000002 /* CacheFallbackPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFallbackPolicy.swift; sourceTree = "<group>"; };
+		C04400000000000000000004 /* CacheFallbackPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFallbackPolicyTests.swift; sourceTree = "<group>"; };
+		C04600000000000000000002 /* ChatStreamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinator.swift; sourceTree = "<group>"; };
+		C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinatorTests.swift; sourceTree = "<group>"; };
+		C04700000000000000000002 /* ChatPendingActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPendingActionCoordinator.swift; sourceTree = "<group>"; };
+		C04800000000000000000002 /* ChatAttachmentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentCoordinator.swift; sourceTree = "<group>"; };
+		C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentCoordinatorTests.swift; sourceTree = "<group>"; };
+		C04900000000000000000002 /* ChatComposerTextInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerTextInputView.swift; sourceTree = "<group>"; };
+		C04900000000000000000004 /* ChatComposerVoiceControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerVoiceControls.swift; sourceTree = "<group>"; };
+		C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerAttachmentStripView.swift; sourceTree = "<group>"; };
+		C05100000000000000000011 /* ChatTranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptView.swift; sourceTree = "<group>"; };
+		C05100000000000000000012 /* ChatMessageActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageActions.swift; sourceTree = "<group>"; };
+		C05100000000000000000013 /* ChatGoalControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGoalControls.swift; sourceTree = "<group>"; };
+		C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptSupportingViews.swift; sourceTree = "<group>"; };
+		C06000000000000000000002 /* ToolCallDisplayFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallDisplayFormatter.swift; sourceTree = "<group>"; };
+		C08800000000000000000002 /* SessionHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHaptics.swift; sourceTree = "<group>"; };
+		C08800000000000000000004 /* SessionHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHapticsTests.swift; sourceTree = "<group>"; };
+		C09200000000000000000002 /* AppFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFont.swift; sourceTree = "<group>"; };
+		C09300000000000000000002 /* HapticButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticButton.swift; sourceTree = "<group>"; };
+		C09300000000000000000004 /* HapticButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticButtonTests.swift; sourceTree = "<group>"; };
+		C09500000000000000000002 /* AdaptiveGlassModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGlassModifier.swift; sourceTree = "<group>"; };
+		C09500000000000000000004 /* AdaptiveGlassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGlassTests.swift; sourceTree = "<group>"; };
+		C09500000000000000000006 /* AdaptiveGlassDebugFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveGlassDebugFixture.swift; sourceTree = "<group>"; };
+		C0CAM000000000000000B002 /* CameraPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPickerView.swift; sourceTree = "<group>"; };
+		C0DE12000000000000000002 /* TranscriptLinkPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreview.swift; sourceTree = "<group>"; };
+		C0DE12000000000000000004 /* TranscriptLinkPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewTests.swift; sourceTree = "<group>"; };
+		C0DE12000000000000000006 /* TranscriptLinkPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewView.swift; sourceTree = "<group>"; };
+		C0DE12000000000000000008 /* TranscriptLinkPreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLinkPreviewCache.swift; sourceTree = "<group>"; };
+		C0DE20000000000000000002 /* ChatTactileButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTactileButtonStyle.swift; sourceTree = "<group>"; };
+		C0DE21000000000000000002 /* ChatMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMotion.swift; sourceTree = "<group>"; };
+		C0DE22000000000000000002 /* ChatHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHaptics.swift; sourceTree = "<group>"; };
+		C0DE22000000000000000004 /* ChatHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHapticsTests.swift; sourceTree = "<group>"; };
+		C0DE25000000000000000002 /* ChatScrollPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollPolicy.swift; sourceTree = "<group>"; };
+		C0DE25000000000000000004 /* ChatScrollPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollPolicyTests.swift; sourceTree = "<group>"; };
+		C0DE34000000000000000002 /* TranscriptMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMedia.swift; sourceTree = "<group>"; };
+		C0DE34000000000000000004 /* TranscriptMediaParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaParserTests.swift; sourceTree = "<group>"; };
+		C0DE34000000000000000005 /* TranscriptMediaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaView.swift; sourceTree = "<group>"; };
+		C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaPreviewViewModel.swift; sourceTree = "<group>"; };
+		C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaDataLoader.swift; sourceTree = "<group>"; };
+		C0DE3400000000000000000C /* TranscriptMediaPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaPreviewViewModelTests.swift; sourceTree = "<group>"; };
+		C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaExportSupport.swift; sourceTree = "<group>"; };
+		C0DE512E0000000000000201 /* InsightsModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsModels.swift; sourceTree = "<group>"; };
+		C0DE512E0000000000000203 /* InsightsRows.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsRows.swift; sourceTree = "<group>"; };
+		C0DEC0DE0000000000000002 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
+		C0DED00000000000000DE000 /* ChatViewModelMergeDedupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelMergeDedupTests.swift; sourceTree = "<group>"; };
+		C0FF000000000000000000A2 /* CustomHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeader.swift; sourceTree = "<group>"; };
+		C0FF000000000000000000B2 /* CustomHeadersEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeadersEditor.swift; sourceTree = "<group>"; };
+		C0FF000000000000000000C2 /* CustomHeaderInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeaderInjectionTests.swift; sourceTree = "<group>"; };
+		C12800000000000000000002 /* ToolActivityGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityGroupView.swift; sourceTree = "<group>"; };
+		C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTimelineAccessorySurface.swift; sourceTree = "<group>"; };
+		C12900000000000000000002 /* ChatActiveRunStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatActiveRunStatusView.swift; sourceTree = "<group>"; };
+		C13000000000000000000002 /* ChatVerticalScrollAxisGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVerticalScrollAxisGuardTests.swift; sourceTree = "<group>"; };
+		C14300000000000000000002 /* StreamingMarkdownSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingMarkdownSupport.swift; sourceTree = "<group>"; };
+		C14300000000000000000004 /* StreamingMarkdownSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingMarkdownSupportTests.swift; sourceTree = "<group>"; };
+		C14600000000000000000001 /* ChatToolbarHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolbarHeaderTests.swift; sourceTree = "<group>"; };
 		C14900000000000000000002 /* Kanban.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kanban.swift; sourceTree = "<group>"; };
 		C14900000000000000000004 /* APIClient+Kanban.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Kanban.swift"; sourceTree = "<group>"; };
 		C14900000000000000000006 /* KanbanFeatureState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanFeatureState.swift; sourceTree = "<group>"; };
@@ -636,27 +632,37 @@
 		C15100000000000000000002 /* KanbanEventStreamClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanEventStreamClient.swift; sourceTree = "<group>"; };
 		C15100000000000000000004 /* KanbanEventStreamClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanEventStreamClientTests.swift; sourceTree = "<group>"; };
 		C15100000000000000000006 /* KanbanLiveUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanLiveUpdateTests.swift; sourceTree = "<group>"; };
-		C15400000000000000000002 /* KanbanCardDetailState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardDetailState.swift; sourceTree = "<group>"; };
-		C15400000000000000000004 /* KanbanCardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardDetailView.swift; sourceTree = "<group>"; };
+		C15200000000000000000001 /* OnboardingFlowPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowPolicy.swift; sourceTree = "<group>"; };
+		C15200000000000000000002 /* OnboardingWelcomePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomePage.swift; sourceTree = "<group>"; };
+		C15200000000000000000003 /* OnboardingFeaturesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFeaturesPage.swift; sourceTree = "<group>"; };
+		C15200000000000000000004 /* OnboardingAgentPromptPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAgentPromptPage.swift; sourceTree = "<group>"; };
+		C15200000000000000000005 /* OnboardingTailscalePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTailscalePage.swift; sourceTree = "<group>"; };
+		C15200000000000000000006 /* OnboardingConnectPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConnectPage.swift; sourceTree = "<group>"; };
+		C15200000000000000000007 /* OnboardingFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowTests.swift; sourceTree = "<group>"; };
 		C15300000000000000000002 /* KanbanCardEditorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardEditorState.swift; sourceTree = "<group>"; };
 		C15300000000000000000004 /* KanbanCardEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardEditorView.swift; sourceTree = "<group>"; };
 		C15300000000000000000006 /* KanbanCardEditorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardEditorStateTests.swift; sourceTree = "<group>"; };
+		C15400000000000000000002 /* KanbanCardDetailState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardDetailState.swift; sourceTree = "<group>"; };
+		C15400000000000000000004 /* KanbanCardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardDetailView.swift; sourceTree = "<group>"; };
 		C15400000000000000000006 /* KanbanCardDetailStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanbanCardDetailStateTests.swift; sourceTree = "<group>"; };
-		B5A220000000000000000006 /* ChatMarkerMessageClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMarkerMessageClassifierTests.swift; sourceTree = "<group>"; };
-		B5A100000000000000000017 /* HermesShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HermesShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		A04500000000000000000010 /* AgentRunActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunActivityAttributes.swift; sourceTree = "<group>"; };
-		A04500000000000000000011 /* HermesDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesDeepLink.swift; sourceTree = "<group>"; };
-		A04500000000000000000012 /* AgentLiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLiveActivityManager.swift; sourceTree = "<group>"; };
-		A04500000000000000000013 /* AgentRunLiveActivityWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunLiveActivityWidget.swift; sourceTree = "<group>"; };
-		A04500000000000000000014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A04500000000000000000017 /* HermesLiveActivityWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HermesLiveActivityWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		A04500000000000000000018 /* LiveActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityTests.swift; sourceTree = "<group>"; };
-		C0CAM000000000000000B002 /* CameraPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPickerView.swift; sourceTree = "<group>"; };
-		C0DEC0DE0000000000000002 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
+		C1A042000000000000000002 /* Clarification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clarification.swift; sourceTree = "<group>"; };
+		C1A042000000000000000004 /* ClarificationRequestOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationRequestOverlay.swift; sourceTree = "<group>"; };
+		C1A042000000000000000006 /* ClarificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationTests.swift; sourceTree = "<group>"; };
+		C21200000000000000000002 /* StreamingWordDrain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingWordDrain.swift; sourceTree = "<group>"; };
+		C21200000000000000000004 /* StreamingWordDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingWordDrainTests.swift; sourceTree = "<group>"; };
+		C21200000000000000000006 /* ChatViewModelStreamingPaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelStreamingPaceTests.swift; sourceTree = "<group>"; };
+		C21300000000000000000002 /* StreamingTextFade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTextFade.swift; sourceTree = "<group>"; };
+		C21300000000000000000004 /* StreamingTextFadeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTextFadeRenderer.swift; sourceTree = "<group>"; };
+		C21300000000000000000006 /* StreamingTextFadeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTextFadeTests.swift; sourceTree = "<group>"; };
+		C22300000000000000000002 /* CompressionAnchorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompressionAnchorResolver.swift; sourceTree = "<group>"; };
+		C22300000000000000000004 /* CompressionAnchorResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompressionAnchorResolverTests.swift; sourceTree = "<group>"; };
+		C22600000000000000000002 /* ScriptedSSEStreamFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptedSSEStreamFixture.swift; sourceTree = "<group>"; };
+		C22600000000000000000004 /* StreamReconnectContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamReconnectContractTests.swift; sourceTree = "<group>"; };
+		C23400000000000000000002 /* StreamingLabReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabReplay.swift; sourceTree = "<group>"; };
+		C23400000000000000000004 /* StreamingLabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabView.swift; sourceTree = "<group>"; };
+		C23400000000000000000006 /* StreamingLabReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingLabReplayTests.swift; sourceTree = "<group>"; };
 		C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelTests.swift; sourceTree = "<group>"; };
 		FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandAutocompleteView.swift; sourceTree = "<group>"; };
-		105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelPickerSectionExpansionState.swift; sourceTree = "<group>"; };
-		105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelPickerSectionExpansionStateTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -681,14 +687,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B5A100000000000000000020 /* Frameworks */ = {
+		A04500000000000000000061 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A04500000000000000000061 /* Frameworks */ = {
+		B5A100000000000000000020 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -779,13 +785,13 @@
 				C03260000000000000F102 /* APIClientTTSTests.swift */,
 				C03270000000000000F102 /* APIClientSessionExportTests.swift */,
 				C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */,
-					C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */,
-					C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */,
-					C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */,
-					C0390000000000000000000E /* ChatViewModelSendTests.swift */,
-					C0DED00000000000000DE000 /* ChatViewModelMergeDedupTests.swift */,
-					C14600000000000000000001 /* ChatToolbarHeaderTests.swift */,
-					C15200000000000000000007 /* OnboardingFlowTests.swift */,
+				C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */,
+				C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */,
+				C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */,
+				C0390000000000000000000E /* ChatViewModelSendTests.swift */,
+				C0DED00000000000000DE000 /* ChatViewModelMergeDedupTests.swift */,
+				C14600000000000000000001 /* ChatToolbarHeaderTests.swift */,
+				C15200000000000000000007 /* OnboardingFlowTests.swift */,
 				C0390000000000000000000F /* SessionListMutationTests.swift */,
 				A10900000000000000000012 /* SessionNavigationStateTests.swift */,
 				19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */,
@@ -955,30 +961,6 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
-		C1490000000000000000000D /* Kanban */ = {
-			isa = PBXGroup;
-			children = (
-				C14900000000000000000006 /* KanbanFeatureState.swift */,
-				C14900000000000000000008 /* KanbanLabView.swift */,
-				C15400000000000000000002 /* KanbanCardDetailState.swift */,
-				C15400000000000000000004 /* KanbanCardDetailView.swift */,
-				C15300000000000000000002 /* KanbanCardEditorState.swift */,
-				C15300000000000000000004 /* KanbanCardEditorView.swift */,
-			);
-			path = Kanban;
-			sourceTree = "<group>";
-		};
-		C09300000000000000000010 /* Shared */ = {
-			isa = PBXGroup;
-			children = (
-				C09300000000000000000002 /* HapticButton.swift */,
-				C09500000000000000000002 /* AdaptiveGlassModifier.swift */,
-				C09500000000000000000006 /* AdaptiveGlassDebugFixture.swift */,
-				C0FF000000000000000000B2 /* CustomHeadersEditor.swift */,
-			);
-			path = Shared;
-			sourceTree = "<group>";
-		};
 		1A2B3C4D5E6F7000000000C5 /* SessionList */ = {
 			isa = PBXGroup;
 			children = (
@@ -1048,12 +1030,15 @@
 				031031031031031031031006 /* MarkdownMathFormatter.swift */,
 				03103103103103103103100C /* MarkdownMathFormatter+Environments.swift */,
 				031031031031031031031008 /* MarkdownMathFormatter+Support.swift */,
-					C04100000000000000000002 /* ChatComposerConfigLoader.swift */,
-					C04600000000000000000002 /* ChatStreamCoordinator.swift */,
-					C04700000000000000000002 /* ChatPendingActionCoordinator.swift */,
-					C04800000000000000000002 /* ChatAttachmentCoordinator.swift */,
-					1A2B3C4D5E6F7000000000D5 /* ChatViewModel.swift */,
+				C04100000000000000000002 /* ChatComposerConfigLoader.swift */,
+				C04600000000000000000002 /* ChatStreamCoordinator.swift */,
+				C04700000000000000000002 /* ChatPendingActionCoordinator.swift */,
+				C04800000000000000000002 /* ChatAttachmentCoordinator.swift */,
+				1A2B3C4D5E6F7000000000D5 /* ChatViewModel.swift */,
 				A710739233F64F4FA4C2B710 /* ComposerVoiceInputController.swift */,
+				E5EB5D5436F8E03636577CCC /* ComposerSTTContextProvider.swift */,
+				03227BCC723743B7B09A96AD /* ComposerVoiceFirstMode.swift */,
+				85452567F0194260D8966353 /* ComposerVoiceFirstBar.swift */,
 				C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */,
 				1A2B3C4D5E6F70000000121 /* ContextWindowIndicatorView.swift */,
 				5DA59130ED4141049177576C /* SlashCommand.swift */,
@@ -1126,44 +1111,6 @@
 			path = Config;
 			sourceTree = "<group>";
 		};
-		B5A100000000000000000050 /* Share */ = {
-			isa = PBXGroup;
-			children = (
-				B5A100000000000000000010 /* SharedDraftStore.swift */,
-			);
-			path = Share;
-			sourceTree = "<group>";
-		};
-		B5A100000000000000000051 /* HermesShareExtension */ = {
-			isa = PBXGroup;
-			children = (
-				B5A100000000000000000011 /* ShareViewController.swift */,
-				B5A100000000000000000018 /* ShareInputReader.swift */,
-				B5A100000000000000000052 /* Resources */,
-			);
-			path = HermesShareExtension;
-			sourceTree = "<group>";
-		};
-		B5A100000000000000000052 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				B5A100000000000000000012 /* Info.plist */,
-				B5A100000000000000000013 /* HermesShareExtension.entitlements */,
-				B5A100000000000000000014 /* PrivacyInfo.xcprivacy */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		A04500000000000000000020 /* LiveActivities */ = {
-			isa = PBXGroup;
-			children = (
-				A04500000000000000000010 /* AgentRunActivityAttributes.swift */,
-				A04500000000000000000011 /* HermesDeepLink.swift */,
-				A04500000000000000000012 /* AgentLiveActivityManager.swift */,
-			);
-			path = LiveActivities;
-			sourceTree = "<group>";
-		};
 		1A2B3C4D5E6F700000000339 /* AppIntents */ = {
 			isa = PBXGroup;
 			children = (
@@ -1171,23 +1118,6 @@
 				1A2B3C4D5E6F700000000342 /* ProfileEntity.swift */,
 			);
 			path = AppIntents;
-			sourceTree = "<group>";
-		};
-		A04500000000000000000021 /* HermesLiveActivityWidget */ = {
-			isa = PBXGroup;
-			children = (
-				A04500000000000000000013 /* AgentRunLiveActivityWidget.swift */,
-				A04500000000000000000022 /* Resources */,
-			);
-			path = HermesLiveActivityWidget;
-			sourceTree = "<group>";
-		};
-		A04500000000000000000022 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				A04500000000000000000014 /* Info.plist */,
-			);
-			path = Resources;
 			sourceTree = "<group>";
 		};
 		1A2B3C4D5E6F70000000206 /* Memory */ = {
@@ -1219,6 +1149,33 @@
 			path = Tasks;
 			sourceTree = "<group>";
 		};
+		A04500000000000000000020 /* LiveActivities */ = {
+			isa = PBXGroup;
+			children = (
+				A04500000000000000000010 /* AgentRunActivityAttributes.swift */,
+				A04500000000000000000011 /* HermesDeepLink.swift */,
+				A04500000000000000000012 /* AgentLiveActivityManager.swift */,
+			);
+			path = LiveActivities;
+			sourceTree = "<group>";
+		};
+		A04500000000000000000021 /* HermesLiveActivityWidget */ = {
+			isa = PBXGroup;
+			children = (
+				A04500000000000000000013 /* AgentRunLiveActivityWidget.swift */,
+				A04500000000000000000022 /* Resources */,
+			);
+			path = HermesLiveActivityWidget;
+			sourceTree = "<group>";
+		};
+		A04500000000000000000022 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				A04500000000000000000014 /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		B50E1CE3A8912B92B1924714 /* Insights */ = {
 			isa = PBXGroup;
 			children = (
@@ -1228,6 +1185,58 @@
 				931EC010A2D940B0E42287A4 /* InsightsViewModel.swift */,
 			);
 			path = Insights;
+			sourceTree = "<group>";
+		};
+		B5A100000000000000000050 /* Share */ = {
+			isa = PBXGroup;
+			children = (
+				B5A100000000000000000010 /* SharedDraftStore.swift */,
+			);
+			path = Share;
+			sourceTree = "<group>";
+		};
+		B5A100000000000000000051 /* HermesShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				B5A100000000000000000011 /* ShareViewController.swift */,
+				B5A100000000000000000018 /* ShareInputReader.swift */,
+				B5A100000000000000000052 /* Resources */,
+			);
+			path = HermesShareExtension;
+			sourceTree = "<group>";
+		};
+		B5A100000000000000000052 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B5A100000000000000000012 /* Info.plist */,
+				B5A100000000000000000013 /* HermesShareExtension.entitlements */,
+				B5A100000000000000000014 /* PrivacyInfo.xcprivacy */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		C09300000000000000000010 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				C09300000000000000000002 /* HapticButton.swift */,
+				C09500000000000000000002 /* AdaptiveGlassModifier.swift */,
+				C09500000000000000000006 /* AdaptiveGlassDebugFixture.swift */,
+				C0FF000000000000000000B2 /* CustomHeadersEditor.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		C1490000000000000000000D /* Kanban */ = {
+			isa = PBXGroup;
+			children = (
+				C14900000000000000000006 /* KanbanFeatureState.swift */,
+				C14900000000000000000008 /* KanbanLabView.swift */,
+				C15400000000000000000002 /* KanbanCardDetailState.swift */,
+				C15400000000000000000004 /* KanbanCardDetailView.swift */,
+				C15300000000000000000002 /* KanbanCardEditorState.swift */,
+				C15300000000000000000004 /* KanbanCardEditorView.swift */,
+			);
+			path = Kanban;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1281,23 +1290,6 @@
 			productReference = 1A2B3C4D5E6F700000000015 /* HermesMobileTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		B5A100000000000000000040 /* HermesShareExtension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B5A100000000000000000041 /* Build configuration list for PBXNativeTarget "HermesShareExtension" */;
-			buildPhases = (
-				B5A100000000000000000021 /* Sources */,
-				B5A100000000000000000022 /* Resources */,
-				B5A100000000000000000020 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = HermesShareExtension;
-			productName = HermesShareExtension;
-			productReference = B5A100000000000000000017 /* HermesShareExtension.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
 		A04500000000000000000040 /* HermesLiveActivityWidget */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A04500000000000000000041 /* Build configuration list for PBXNativeTarget "HermesLiveActivityWidget" */;
@@ -1313,6 +1305,23 @@
 			name = HermesLiveActivityWidget;
 			productName = HermesLiveActivityWidget;
 			productReference = A04500000000000000000017 /* HermesLiveActivityWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		B5A100000000000000000040 /* HermesShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B5A100000000000000000041 /* Build configuration list for PBXNativeTarget "HermesShareExtension" */;
+			buildPhases = (
+				B5A100000000000000000021 /* Sources */,
+				B5A100000000000000000022 /* Resources */,
+				B5A100000000000000000020 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HermesShareExtension;
+			productName = HermesShareExtension;
+			productReference = B5A100000000000000000017 /* HermesShareExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
@@ -1332,10 +1341,10 @@
 						CreatedOnToolsVersion = 26.4.1;
 						TestTargetID = 1A2B3C4D5E6F700000000040;
 					};
-					B5A100000000000000000040 = {
+					A04500000000000000000040 = {
 						CreatedOnToolsVersion = 26.4.1;
 					};
-					A04500000000000000000040 = {
+					B5A100000000000000000040 = {
 						CreatedOnToolsVersion = 26.4.1;
 					};
 				};
@@ -1399,19 +1408,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B5A100000000000000000022 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B5A100000000000000000004 /* PrivacyInfo.xcprivacy in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		A04500000000000000000060 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				10CA110C0DE000000000B003 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B5A100000000000000000022 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B5A100000000000000000004 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1511,20 +1520,20 @@
 				C0FF000000000000000000B1 /* CustomHeadersEditor.swift in Sources */,
 				C09500000000000000000001 /* AdaptiveGlassModifier.swift in Sources */,
 				C09500000000000000000005 /* AdaptiveGlassDebugFixture.swift in Sources */,
-					1A2B3C4D5E6F7000000000A7 /* SessionListView.swift in Sources */,
-					1A2B3C4D5E6F7000000000AF /* ChatView.swift in Sources */,
-					C05100000000000000000001 /* ChatTranscriptView.swift in Sources */,
-					C05100000000000000000002 /* ChatMessageActions.swift in Sources */,
-					C05100000000000000000003 /* ChatGoalControls.swift in Sources */,
-					C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */,
-					C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */,
+				1A2B3C4D5E6F7000000000A7 /* SessionListView.swift in Sources */,
+				1A2B3C4D5E6F7000000000AF /* ChatView.swift in Sources */,
+				C05100000000000000000001 /* ChatTranscriptView.swift in Sources */,
+				C05100000000000000000002 /* ChatMessageActions.swift in Sources */,
+				C05100000000000000000003 /* ChatGoalControls.swift in Sources */,
+				C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */,
+				C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */,
 				C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */,
-					C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */,
-					C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */,
-					C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */,
-					C042A000000000000000001 /* ChatComposerSelectorControls.swift in Sources */,
-					C042A000000000000000003 /* ChatComposerSelectorSheets.swift in Sources */,
-					105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */,
+				C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */,
+				C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */,
+				C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */,
+				C042A000000000000000001 /* ChatComposerSelectorControls.swift in Sources */,
+				C042A000000000000000003 /* ChatComposerSelectorSheets.swift in Sources */,
+				105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */,
 				1A2B3C4D5E6F7000000000D8 /* MessageBubbleView.swift in Sources */,
 				C03190000000000000B001 /* AttachmentAudioDetection.swift in Sources */,
 				C03190000000000000B002 /* InlineAudioPlayerView.swift in Sources */,
@@ -1566,11 +1575,11 @@
 				031031031031031031031005 /* MarkdownMathFormatter.swift in Sources */,
 				03103103103103103103100B /* MarkdownMathFormatter+Environments.swift in Sources */,
 				031031031031031031031007 /* MarkdownMathFormatter+Support.swift in Sources */,
-					C04100000000000000000001 /* ChatComposerConfigLoader.swift in Sources */,
-					C04600000000000000000001 /* ChatStreamCoordinator.swift in Sources */,
-					C04700000000000000000001 /* ChatPendingActionCoordinator.swift in Sources */,
-					C04800000000000000000001 /* ChatAttachmentCoordinator.swift in Sources */,
-					1A2B3C4D5E6F7000000000D4 /* ChatViewModel.swift in Sources */,
+				C04100000000000000000001 /* ChatComposerConfigLoader.swift in Sources */,
+				C04600000000000000000001 /* ChatStreamCoordinator.swift in Sources */,
+				C04700000000000000000001 /* ChatPendingActionCoordinator.swift in Sources */,
+				C04800000000000000000001 /* ChatAttachmentCoordinator.swift in Sources */,
+				1A2B3C4D5E6F7000000000D4 /* ChatViewModel.swift in Sources */,
 				1A2B3C4D5E6F7000000000D6 /* SSEClient.swift in Sources */,
 				C0FF000000000000000000A1 /* CustomHeader.swift in Sources */,
 				1A2B3C4D5E6F7000000000D0 /* SessionRowView.swift in Sources */,
@@ -1606,6 +1615,9 @@
 				B53F3F24A5C24D9E8E54A810 /* SlashCommandExecutor.swift in Sources */,
 				8618A9261B8047CEA6084798 /* SlashCommandAutocompleteView.swift in Sources */,
 				A710739233F64F4FA4C2B700 /* ComposerVoiceInputController.swift in Sources */,
+				46D39C858C9AA26CA2A75DAC /* ComposerSTTContextProvider.swift in Sources */,
+				9BFADE67A7831C125F8C0230 /* ComposerVoiceFirstMode.swift in Sources */,
+				A4DE8D9B54561E6CD15BB2C5 /* ComposerVoiceFirstBar.swift in Sources */,
 				8B71DA2AAC521382F54A841C /* InsightsView.swift in Sources */,
 				C0DE512E0000000000000202 /* InsightsModels.swift in Sources */,
 				C0DE512E0000000000000204 /* InsightsRows.swift in Sources */,
@@ -1644,13 +1656,13 @@
 				C03260000000000000B102 /* APIClientTTSTests.swift in Sources */,
 				C03270000000000000B102 /* APIClientSessionExportTests.swift in Sources */,
 				C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */,
-					C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */,
-					C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */,
-					C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */,
-					C0391000000000000000000E /* ChatViewModelSendTests.swift in Sources */,
-					C0DED00000000000000DE001 /* ChatViewModelMergeDedupTests.swift in Sources */,
-					C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */,
-					C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */,
+				C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */,
+				C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */,
+				C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */,
+				C0391000000000000000000E /* ChatViewModelSendTests.swift in Sources */,
+				C0DED00000000000000DE001 /* ChatViewModelMergeDedupTests.swift in Sources */,
+				C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */,
+				C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */,
 				C0391000000000000000000F /* SessionListMutationTests.swift in Sources */,
 				A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */,
 				19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */,
@@ -1691,10 +1703,10 @@
 				C08800000000000000000003 /* SessionHapticsTests.swift in Sources */,
 				C09300000000000000000003 /* HapticButtonTests.swift in Sources */,
 				C09500000000000000000003 /* AdaptiveGlassTests.swift in Sources */,
-					1A2B3C4D5E6F70000000132 /* ContextWindowIndicatorTests.swift in Sources */,
-					1A2B3C4D5E6F70000000141 /* ModelFavoritesStoreTests.swift in Sources */,
-					105050000000000000000003 /* ComposerModelPickerSectionExpansionStateTests.swift in Sources */,
-					8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */,
+				1A2B3C4D5E6F70000000132 /* ContextWindowIndicatorTests.swift in Sources */,
+				1A2B3C4D5E6F70000000141 /* ModelFavoritesStoreTests.swift in Sources */,
+				105050000000000000000003 /* ComposerModelPickerSectionExpansionStateTests.swift in Sources */,
+				8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */,
 				0D82B28493C6401D98DA9C0E /* SlashCommandExecutorTests.swift in Sources */,
 				A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */,
 				C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */,
@@ -1716,16 +1728,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B5A100000000000000000021 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B5A100000000000000000002 /* SharedDraftStore.swift in Sources */,
-				B5A100000000000000000003 /* ShareViewController.swift in Sources */,
-				B5A100000000000000000007 /* ShareInputReader.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		A04500000000000000000050 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1733,6 +1735,16 @@
 				A04500000000000000000004 /* AgentRunActivityAttributes.swift in Sources */,
 				A04500000000000000000005 /* HermesDeepLink.swift in Sources */,
 				A04500000000000000000006 /* AgentRunLiveActivityWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B5A100000000000000000021 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B5A100000000000000000002 /* SharedDraftStore.swift in Sources */,
+				B5A100000000000000000003 /* ShareViewController.swift in Sources */,
+				B5A100000000000000000007 /* ShareInputReader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1744,15 +1756,15 @@
 			target = 1A2B3C4D5E6F700000000040 /* HermesMobile */;
 			targetProxy = 1A2B3C4D5E6F700000000036 /* PBXContainerItemProxy */;
 		};
-		B5A100000000000000000031 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = B5A100000000000000000040 /* HermesShareExtension */;
-			targetProxy = B5A100000000000000000030 /* PBXContainerItemProxy */;
-		};
 		A04500000000000000000031 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A04500000000000000000040 /* HermesLiveActivityWidget */;
 			targetProxy = A04500000000000000000030 /* PBXContainerItemProxy */;
+		};
+		B5A100000000000000000031 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B5A100000000000000000040 /* HermesShareExtension */;
+			targetProxy = B5A100000000000000000030 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1990,6 +2002,60 @@
 			};
 			name = Release;
 		};
+		A04500000000000000000042 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = HermesLiveActivityWidget/Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_IDENTIFIER).liveactivitywidget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A04500000000000000000043 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = HermesLiveActivityWidget/Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_IDENTIFIER).liveactivitywidget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		B5A100000000000000000042 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2046,60 +2112,6 @@
 			};
 			name = Release;
 		};
-		A04500000000000000000042 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = HermesLiveActivityWidget/Resources/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
-				MARKETING_VERSION = 1.5;
-				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_IDENTIFIER).liveactivitywidget";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		A04500000000000000000043 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = HermesLiveActivityWidget/Resources/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
-				MARKETING_VERSION = 1.5;
-				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_IDENTIFIER).liveactivitywidget";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2130,20 +2142,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B5A100000000000000000041 /* Build configuration list for PBXNativeTarget "HermesShareExtension" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B5A100000000000000000042 /* Debug */,
-				B5A100000000000000000043 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		A04500000000000000000041 /* Build configuration list for PBXNativeTarget "HermesLiveActivityWidget" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A04500000000000000000042 /* Debug */,
 				A04500000000000000000043 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B5A100000000000000000041 /* Build configuration list for PBXNativeTarget "HermesShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B5A100000000000000000042 /* Debug */,
+				B5A100000000000000000043 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2212,11 +2224,6 @@
 			package = 1A2B3C4D5E6F700000000091 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 			productName = MarkdownUI;
 		};
-		C21300000000000000000008 /* MarkdownUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1A2B3C4D5E6F700000000091 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
-			productName = MarkdownUI;
-		};
 		1A2B3C4D5E6F700000000096 /* Splash */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 1A2B3C4D5E6F700000000092 /* XCRemoteSwiftPackageReference "Splash" */;
@@ -2236,6 +2243,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5417A7400000000000000090 /* XCRemoteSwiftPackageReference "SwiftMath" */;
 			productName = SwiftMath;
+		};
+		C21300000000000000000008 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1A2B3C4D5E6F700000000091 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -178,6 +178,8 @@
 		C03250000000000000B102 /* APIClient+Transcribe.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F102 /* APIClient+Transcribe.swift */; };
 		C03250000000000000B103 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F103 /* MultipartFormData.swift */; };
 		C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */; };
+		E01A00000000000000B201 /* VolcengineStreamingSTT.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01A00000000000000F201 /* VolcengineStreamingSTT.swift */; };
+		E01A00000000000000B202 /* VolcengineSTTSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01A00000000000000F202 /* VolcengineSTTSettings.swift */; };
 		C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F105 /* APIClientTranscribeTests.swift */; };
 		C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */; };
 		C03260000000000000B101 /* APIClient+TTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F101 /* APIClient+TTS.swift */; };
@@ -525,6 +527,8 @@
 		C03250000000000000F102 /* APIClient+Transcribe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Transcribe.swift"; sourceTree = "<group>"; };
 		C03250000000000000F103 /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorder.swift; sourceTree = "<group>"; };
+		E01A00000000000000F201 /* VolcengineStreamingSTT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolcengineStreamingSTT.swift; sourceTree = "<group>"; };
+		E01A00000000000000F202 /* VolcengineSTTSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolcengineSTTSettings.swift; sourceTree = "<group>"; };
 		C03250000000000000F105 /* APIClientTranscribeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTranscribeTests.swift; sourceTree = "<group>"; };
 		C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorderTests.swift; sourceTree = "<group>"; };
 		C03260000000000000F101 /* APIClient+TTS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+TTS.swift"; sourceTree = "<group>"; };
@@ -1040,6 +1044,8 @@
 				03227BCC723743B7B09A96AD /* ComposerVoiceFirstMode.swift */,
 				85452567F0194260D8966353 /* ComposerVoiceFirstBar.swift */,
 				C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */,
+				E01A00000000000000F201 /* VolcengineStreamingSTT.swift */,
+				E01A00000000000000F202 /* VolcengineSTTSettings.swift */,
 				1A2B3C4D5E6F70000000121 /* ContextWindowIndicatorView.swift */,
 				5DA59130ED4141049177576C /* SlashCommand.swift */,
 				1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */,
@@ -1480,6 +1486,8 @@
 				C03270000000000000B101 /* APIClient+SessionExport.swift in Sources */,
 				C03250000000000000B103 /* MultipartFormData.swift in Sources */,
 				C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */,
+				E01A00000000000000B201 /* VolcengineStreamingSTT.swift in Sources */,
+				E01A00000000000000B202 /* VolcengineSTTSettings.swift in Sources */,
 				1A2B3C4D5E6F7000000000A3 /* APIError.swift in Sources */,
 				C04400000000000000000001 /* CacheFallbackPolicy.swift in Sources */,
 				1A2B3C4D5E6F7000000000A0 /* KeychainStore.swift in Sources */,

--- a/HermesMobile.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/HermesMobile.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -631,6 +631,7 @@ enum ComposerSTTProviderPreference: String, CaseIterable, Identifiable {
     case serverFirst
     case onDeviceFirst
     case onDeviceOnly
+    case volcengineFirst
 
     static let storageKey = "composerSTTProviderPreference"
     static let defaultValue: ComposerSTTProviderPreference = .serverFirst
@@ -645,6 +646,8 @@ enum ComposerSTTProviderPreference: String, CaseIterable, Identifiable {
             String(localized: "On-device first")
         case .onDeviceOnly:
             String(localized: "On-device only")
+        case .volcengineFirst:
+            String(localized: "Volcengine streaming")
         }
     }
 
@@ -656,13 +659,15 @@ enum ComposerSTTProviderPreference: String, CaseIterable, Identifiable {
 enum ComposerSTTProvider: Equatable {
     case server
     case onDevice
+    case volcengineStreaming
 }
 
 enum ComposerSTTProviderPolicy {
     static func orderedProviders(
         preference: ComposerSTTProviderPreference,
         serverConfigured: Bool,
-        onDeviceSupported: Bool
+        onDeviceSupported: Bool,
+        volcengineConfigured: Bool = false
     ) -> [ComposerSTTProvider] {
         switch preference {
         case .serverFirst:
@@ -677,6 +682,21 @@ enum ComposerSTTProviderPolicy {
             )
         case .onDeviceOnly:
             return compactProviders((.onDevice, onDeviceSupported))
+        case .volcengineFirst:
+            // If volcengine is configured, use it first; fall back to server then on-device.
+            // If not configured, behave like serverFirst.
+            if volcengineConfigured {
+                return compactProviders(
+                    (.volcengineStreaming, true),
+                    (.server, serverConfigured),
+                    (.onDevice, onDeviceSupported)
+                )
+            } else {
+                return compactProviders(
+                    (.server, serverConfigured),
+                    (.onDevice, onDeviceSupported)
+                )
+            }
         }
     }
 
@@ -684,12 +704,14 @@ enum ComposerSTTProviderPolicy {
         after failedProvider: ComposerSTTProvider,
         preference: ComposerSTTProviderPreference,
         serverConfigured: Bool,
-        onDeviceSupported: Bool
+        onDeviceSupported: Bool,
+        volcengineConfigured: Bool = false
     ) -> ComposerSTTProvider? {
         let providers = orderedProviders(
             preference: preference,
             serverConfigured: serverConfigured,
-            onDeviceSupported: onDeviceSupported
+            onDeviceSupported: onDeviceSupported,
+            volcengineConfigured: volcengineConfigured
         )
         guard let failedIndex = providers.firstIndex(of: failedProvider) else {
             return nil

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1282,6 +1282,11 @@ struct MessageComposerView: View {
             }
         }
         Task {
+            // Clear the composer when starting a new voice session so the previous
+            // transcription isn't concatenated into the next one.
+            if !voiceInput.isListening {
+                draftMessage = ""
+            }
             await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
                 draftMessage = newDraft
             }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1262,8 +1262,14 @@ struct MessageComposerView: View {
                 voiceFirstMode?.didUpdateTranscript(transcript)
             }
             voiceInput.onFinalTranscript = { [self] _ in
-                // Recognition ended with a final transcript — auto-send immediately.
+                // Recognition ended with a final transcript.
+                // Only auto-send if user already released (voiceFirstWaitingToSend).
+                // If still holding, the release gesture handles sending.
                 Task { @MainActor in
+                    guard voiceFirstWaitingToSend else { return }
+                    let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !draft.isEmpty else { return }
+                    voiceFirstWaitingToSend = false
                     voiceFirstApplyPendingAction()
                     onSend()
                     voiceFirstMode.didCompleteSend()

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1255,8 +1255,10 @@ struct MessageComposerView: View {
         voiceInput.providerPreference = ComposerSTTProviderPreference.storedValue(sttProviderPreferenceRawValue)
         voiceInput.locale = .current
         if voiceFirstModeEnabled {
-            // Voice-first mode: force server STT for multilingual support (Whisper auto-detects language).
-            voiceInput.providerPreference = .serverFirst
+            // Voice-first mode: use volcengine if configured, otherwise fall back to server STT.
+            if voiceInput.providerPreference != .volcengineFirst {
+                voiceInput.providerPreference = .serverFirst
+            }
             voiceInput.contextualStrings = ComposerSTTContextProvider.hotWords(
                 sessionTitle: nil,
                 userHotWords: voiceFirstHotWords

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -369,7 +369,8 @@ struct MessageComposerView: View {
                                         // Interrupt current stream + new reply.
                                         let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
                                         if !draft.isEmpty {
-                                            draftMessage = "/interrupt \(draft)"
+                                            voiceFirstPendingAction = .interrupt
+                                            voiceFirstApplyPendingAction()
                                             onSend()
                                             voiceFirstMode.didCompleteSend()
                                         } else {
@@ -381,7 +382,8 @@ struct MessageComposerView: View {
                                         // Inject into current stream without interrupting.
                                         let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
                                         if !draft.isEmpty {
-                                            draftMessage = "/steer \(draft)"
+                                            voiceFirstPendingAction = .steer
+                                            voiceFirstApplyPendingAction()
                                             onSend()
                                             voiceFirstMode.didCompleteSend()
                                         } else {

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -527,15 +527,6 @@ struct MessageComposerView: View {
             // Voice-first mode: set up auto-send callback (listening starts on long press).
             if voiceFirstModeEnabled {
                 voiceFirstMode.activate()
-                voiceFirstMode.onAutoSend = { [self] in
-                    Task { @MainActor in
-                        if voiceInput.isListening {
-                            voiceInput.stopBeforeSubmittingDraft()
-                        }
-                        onSend()
-                        voiceFirstMode.didCompleteSend()
-                    }
-                }
             }
         }
         .onChange(of: draftMessage) { _, newDraft in
@@ -1270,9 +1261,6 @@ struct MessageComposerView: View {
             // Voice-first mode: use volcengine if configured, otherwise fall back to server STT.
             if voiceInput.providerPreference != .volcengineFirst {
                 voiceInput.providerPreference = .serverFirst
-            }
-            voiceInput.onPartialTranscript = { [weak voiceFirstMode] transcript in
-                voiceFirstMode?.didUpdateTranscript(transcript)
             }
             voiceInput.onFinalTranscript = { [self] _ in
                 // Recognition ended with a final transcript.

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1257,6 +1257,9 @@ struct MessageComposerView: View {
         voiceInput.apiClient = apiClient
         voiceInput.providerPreference = ComposerSTTProviderPreference.storedValue(sttProviderPreferenceRawValue)
         voiceInput.locale = .current
+        // Lets a late transcript see the live composer and skip the write-back when the
+        // user has typed into it (or a send has cleared it) since the mic was released.
+        voiceInput.readDraft = { draftMessage }
         if voiceFirstModeEnabled {
             // Voice-first mode: use volcengine if configured, otherwise fall back to server STT.
             if voiceInput.providerPreference != .volcengineFirst {
@@ -1282,9 +1285,12 @@ struct MessageComposerView: View {
             }
         }
         Task {
-            // Clear the composer when starting a new voice session so the previous
-            // transcription isn't concatenated into the next one.
-            if !voiceInput.isListening {
+            // Drop a leftover transcript so it isn't concatenated into the next one, but
+            // only when the composer still holds exactly what voice last wrote. Anything
+            // the user typed is kept and the new transcript appends to it.
+            if !voiceInput.isListening,
+               let lastVoiceDraft = voiceInput.lastVoiceWrittenDraft,
+               draftMessage == lastVoiceDraft {
                 draftMessage = ""
             }
             await voiceInput.toggle(currentDraft: draftMessage) { newDraft in

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1285,15 +1285,13 @@ struct MessageComposerView: View {
             }
         }
         Task {
-            // Drop a leftover transcript so it isn't concatenated into the next one, but
-            // only when the composer still holds exactly what voice last wrote. Anything
-            // the user typed is kept and the new transcript appends to it.
-            if !voiceInput.isListening,
-               let lastVoiceDraft = voiceInput.lastVoiceWrittenDraft,
-               draftMessage == lastVoiceDraft {
+            // Always start a new voice session with a clean composer. Any leftover
+            // transcript from the previous round (including late write-backs from
+            // onCompleted) must not become the baseDraft for the next recording.
+            if !voiceInput.isListening {
                 draftMessage = ""
             }
-            await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
+            await voiceInput.toggle(currentDraft: "") { newDraft in
                 draftMessage = newDraft
             }
             if voiceInput.isListening {

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -161,6 +161,8 @@ struct MessageComposerView: View {
     @State private var voiceFirstShowingTextMode = false
     /// Set when long press ends — waiting for server transcription to complete before auto-sending.
     @State private var voiceFirstWaitingToSend = false
+    /// The action to perform when server transcription completes (send/interrupt/steer).
+    @State private var voiceFirstPendingAction: ComposerVoiceFirstBar.ReleaseAction = .send
     @AppStorage(ComposerSTTProviderPreference.storageKey) private var sttProviderPreferenceRawValue = ComposerSTTProviderPreference.defaultValue.rawValue
     @AppStorage(VoiceFirstModeSettings.isEnabledKey) private var voiceFirstModeEnabled = false
     @AppStorage(VoiceFirstModeSettings.hotWordsKey) private var voiceFirstHotWords = ""
@@ -327,6 +329,7 @@ struct MessageComposerView: View {
 
                             ComposerVoiceFirstBar(
                                 isListening: voiceInput.isListening,
+                                isStreaming: isWaitingForStream,
                                 silenceRemaining: voiceFirstMode.silenceRemaining,
                                 phase: voiceFirstMode.phase,
                                 onLongPressStart: {
@@ -334,20 +337,57 @@ struct MessageComposerView: View {
                                         toggleVoiceInput()
                                     }
                                 },
-                                onLongPressEnd: {
-                                    // User released — stop recording, let transcription complete.
+                                onLongPressEnd: { action in
+                                    // Stop recognition first.
                                     if voiceInput.isListening {
-                                        voiceInput.stopKeepingTranscript()
+                                        if action == .cancel {
+                                            voiceInput.stopBeforeSubmittingDraft()
+                                        } else {
+                                            voiceInput.stopKeepingTranscript()
+                                        }
                                     }
                                     voiceFirstMode.didStopListening()
-                                    // If on-device already has content, send immediately.
-                                    let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-                                    if !draft.isEmpty {
-                                        onSend()
-                                        voiceFirstMode.didCompleteSend()
-                                    } else {
-                                        // Server mode: transcription is async — wait for it.
-                                        voiceFirstWaitingToSend = true
+
+                                    switch action {
+                                    case .cancel:
+                                        // Discard recording entirely.
+                                        voiceFirstWaitingToSend = false
+                                        draftMessage = ""
+
+                                    case .send:
+                                        // Normal send (not streaming).
+                                        let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+                                        if !draft.isEmpty {
+                                            onSend()
+                                            voiceFirstMode.didCompleteSend()
+                                        } else {
+                                            voiceFirstWaitingToSend = true
+                                            voiceFirstPendingAction = .send
+                                        }
+
+                                    case .interrupt:
+                                        // Interrupt current stream + new reply.
+                                        let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+                                        if !draft.isEmpty {
+                                            draftMessage = "/interrupt \(draft)"
+                                            onSend()
+                                            voiceFirstMode.didCompleteSend()
+                                        } else {
+                                            voiceFirstWaitingToSend = true
+                                            voiceFirstPendingAction = .interrupt
+                                        }
+
+                                    case .steer:
+                                        // Inject into current stream without interrupting.
+                                        let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+                                        if !draft.isEmpty {
+                                            draftMessage = "/steer \(draft)"
+                                            onSend()
+                                            voiceFirstMode.didCompleteSend()
+                                        } else {
+                                            voiceFirstWaitingToSend = true
+                                            voiceFirstPendingAction = .steer
+                                        }
                                     }
                                 },
                                 onTap: {
@@ -490,6 +530,7 @@ struct MessageComposerView: View {
                 let trimmed = newDraft.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
                     voiceFirstWaitingToSend = false
+                    voiceFirstApplyPendingAction()
                     onSend()
                     voiceFirstMode.didCompleteSend()
                 }
@@ -501,6 +542,7 @@ struct MessageComposerView: View {
                 let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !draft.isEmpty {
                     voiceFirstWaitingToSend = false
+                    voiceFirstApplyPendingAction()
                     onSend()
                     voiceFirstMode.didCompleteSend()
                 }
@@ -1167,6 +1209,23 @@ struct MessageComposerView: View {
     }
 
     @MainActor
+    private func voiceFirstApplyPendingAction() {
+        // Apply the pending action (from gesture direction) to the draft before sending.
+        let content = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty else { return }
+
+        switch voiceFirstPendingAction {
+        case .interrupt:
+            draftMessage = "/interrupt \(content)"
+        case .steer:
+            draftMessage = "/steer \(content)"
+        case .send, .cancel:
+            break // Send as-is, or cancel (shouldn't reach here)
+        }
+        voiceFirstPendingAction = .send
+    }
+
+    @MainActor
     private func toggleVoiceInput() {
         voiceInput.apiClient = apiClient
         voiceInput.providerPreference = ComposerSTTProviderPreference.storedValue(sttProviderPreferenceRawValue)
@@ -1184,6 +1243,7 @@ struct MessageComposerView: View {
             voiceInput.onFinalTranscript = { [self] _ in
                 // Recognition ended with a final transcript — auto-send immediately.
                 Task { @MainActor in
+                    voiceFirstApplyPendingAction()
                     onSend()
                     voiceFirstMode.didCompleteSend()
                 }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -156,7 +156,14 @@ struct MessageComposerView: View {
     @State private var voiceNoteRecorder = ComposerVoiceNoteRecorder()
     @State private var voiceNoteCancelArmed = false
     @State private var didAutoStartVoiceInput = false
+    @State private var voiceFirstMode = ComposerVoiceFirstMode()
+    /// When voice-first is enabled, tracks if user tapped to temporarily show text input.
+    @State private var voiceFirstShowingTextMode = false
+    /// Set when long press ends — waiting for server transcription to complete before auto-sending.
+    @State private var voiceFirstWaitingToSend = false
     @AppStorage(ComposerSTTProviderPreference.storageKey) private var sttProviderPreferenceRawValue = ComposerSTTProviderPreference.defaultValue.rawValue
+    @AppStorage(VoiceFirstModeSettings.isEnabledKey) private var voiceFirstModeEnabled = false
+    @AppStorage(VoiceFirstModeSettings.hotWordsKey) private var voiceFirstHotWords = ""
     @AppStorage(SectionVisibilitySettings.chatGitKey) private var showsGitControls = true
 
     private enum DeferredUploadFocusPhase: Equatable {
@@ -306,20 +313,66 @@ struct MessageComposerView: View {
                         onPreview: onPreviewAttachment
                     )
 
-                    ComposerTextInputView(
-                        text: $draftMessage,
-                        isFocused: $isFocused,
-                        inputHeight: $textInputHeight,
-                        measuredHeight: $textFieldHeight,
-                        isDisabled: isOfflineReadOnly,
-                        isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
-                        verticalPadding: textFieldVerticalPadding,
-                        onKeyboardSend: actionButtonTapped,
-                        onPasteFileProviders: onPasteFileProviders,
-                        onPasteFileURLs: onPasteFileURLs,
-                        onPasteImageProviders: onPasteImageProviders,
-                        onPasteImages: onPasteImages
-                    )
+                    if voiceFirstModeEnabled, !voiceFirstShowingTextMode {
+                        // Voice-first mode: "Hold to speak" bar replaces text input.
+                        VStack(spacing: 4) {
+                            if voiceInput.isListening, !voiceInput.liveTranscript.isEmpty {
+                                Text(voiceInput.liveTranscript)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 4)
+                            }
+
+                            ComposerVoiceFirstBar(
+                                isListening: voiceInput.isListening,
+                                silenceRemaining: voiceFirstMode.silenceRemaining,
+                                phase: voiceFirstMode.phase,
+                                onLongPressStart: {
+                                    if !voiceInput.isListening, !isVoiceInputDisabled {
+                                        toggleVoiceInput()
+                                    }
+                                },
+                                onLongPressEnd: {
+                                    // User released — stop recording, let transcription complete.
+                                    if voiceInput.isListening {
+                                        voiceInput.stopKeepingTranscript()
+                                    }
+                                    voiceFirstMode.didStopListening()
+                                    // If on-device already has content, send immediately.
+                                    let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+                                    if !draft.isEmpty {
+                                        onSend()
+                                        voiceFirstMode.didCompleteSend()
+                                    } else {
+                                        // Server mode: transcription is async — wait for it.
+                                        voiceFirstWaitingToSend = true
+                                    }
+                                },
+                                onTap: {
+                                    // Short tap → switch to text mode.
+                                    voiceFirstShowingTextMode = true
+                                }
+                            )
+                        }
+                        .padding(.vertical, 6)
+                    } else {
+                        ComposerTextInputView(
+                            text: $draftMessage,
+                            isFocused: $isFocused,
+                            inputHeight: $textInputHeight,
+                            measuredHeight: $textFieldHeight,
+                            isDisabled: isOfflineReadOnly,
+                            isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
+                            verticalPadding: textFieldVerticalPadding,
+                            onKeyboardSend: actionButtonTapped,
+                            onPasteFileProviders: onPasteFileProviders,
+                            onPasteFileURLs: onPasteFileURLs,
+                            onPasteImageProviders: onPasteImageProviders,
+                            onPasteImages: onPasteImages
+                        )
+                    }
 
                     HStack(alignment: .center, spacing: 12) {
                         composerPlusMenu
@@ -332,20 +385,40 @@ struct MessageComposerView: View {
 
                         Spacer(minLength: 0)
 
-                        ComposerVoiceControlButton(
-                            isListening: voiceInput.isListening,
-                            isDisabled: isVoiceInputDisabled,
-                            color: metaControlColor,
-                            isRecordingVoiceNote: voiceNoteRecorder.isRecording,
-                            onTap: toggleVoiceInput,
-                            onRecordingStart: startVoiceNoteRecording,
-                            onRecordingDragChanged: { height in
-                                voiceNoteCancelArmed = ComposerVoiceNoteGesture.isCancelArmed(dragTranslationHeight: height)
-                            },
-                            onRecordingEnd: { height in
-                                finishVoiceNote(translationHeight: height)
+                        if voiceFirstModeEnabled, voiceFirstShowingTextMode {
+                            // Show prominent mic button to switch back to voice-first mode.
+                            Button {
+                                voiceFirstShowingTextMode = false
+                            } label: {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "mic.fill")
+                                        .font(.system(size: 14, weight: .medium))
+                                    Text(String(localized: "Voice"))
+                                        .font(.caption)
+                                }
+                                .foregroundStyle(Color.accentColor)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background(Color.accentColor.opacity(0.1), in: Capsule())
                             }
-                        )
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Switch to voice input")
+                        } else if !voiceFirstModeEnabled {
+                            ComposerVoiceControlButton(
+                                isListening: voiceInput.isListening,
+                                isDisabled: isVoiceInputDisabled,
+                                color: metaControlColor,
+                                isRecordingVoiceNote: voiceNoteRecorder.isRecording,
+                                onTap: toggleVoiceInput,
+                                onRecordingStart: startVoiceNoteRecording,
+                                onRecordingDragChanged: { height in
+                                    voiceNoteCancelArmed = ComposerVoiceNoteGesture.isCancelArmed(dragTranslationHeight: height)
+                                },
+                                onRecordingEnd: { height in
+                                    finishVoiceNote(translationHeight: height)
+                                }
+                            )
+                        }
 
                         Button(action: actionButtonTapped) {
                             actionButtonLabel
@@ -397,6 +470,41 @@ struct MessageComposerView: View {
             // Cold path: the composer appears already active (the usual case for the
             // "New Chat with Voice" intent once its session is created) — start here.
             autoStartVoiceInputIfNeeded()
+            // Voice-first mode: set up auto-send callback (listening starts on long press).
+            if voiceFirstModeEnabled {
+                voiceFirstMode.activate()
+                voiceFirstMode.onAutoSend = { [self] in
+                    Task { @MainActor in
+                        if voiceInput.isListening {
+                            voiceInput.stopBeforeSubmittingDraft()
+                        }
+                        onSend()
+                        voiceFirstMode.didCompleteSend()
+                    }
+                }
+            }
+        }
+        .onChange(of: draftMessage) { _, newDraft in
+            // Voice-first: auto-send once server transcription populates the draft.
+            if voiceFirstWaitingToSend, !voiceInput.isListening {
+                let trimmed = newDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    voiceFirstWaitingToSend = false
+                    onSend()
+                    voiceFirstMode.didCompleteSend()
+                }
+            }
+        }
+        .onChange(of: voiceInput.isListening) { _, isListening in
+            // Voice-first: if we were waiting for transcription and recognition stopped with content, send.
+            if voiceFirstWaitingToSend, !isListening {
+                let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !draft.isEmpty {
+                    voiceFirstWaitingToSend = false
+                    onSend()
+                    voiceFirstMode.didCompleteSend()
+                }
+            }
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase != .active {
@@ -1063,9 +1171,32 @@ struct MessageComposerView: View {
         voiceInput.apiClient = apiClient
         voiceInput.providerPreference = ComposerSTTProviderPreference.storedValue(sttProviderPreferenceRawValue)
         voiceInput.locale = .current
+        if voiceFirstModeEnabled {
+            // Voice-first mode: force server STT for multilingual support (Whisper auto-detects language).
+            voiceInput.providerPreference = .serverFirst
+            voiceInput.contextualStrings = ComposerSTTContextProvider.hotWords(
+                sessionTitle: nil,
+                userHotWords: voiceFirstHotWords
+            )
+            voiceInput.onPartialTranscript = { [weak voiceFirstMode] transcript in
+                voiceFirstMode?.didUpdateTranscript(transcript)
+            }
+            voiceInput.onFinalTranscript = { [self] _ in
+                // Recognition ended with a final transcript — auto-send immediately.
+                Task { @MainActor in
+                    onSend()
+                    voiceFirstMode.didCompleteSend()
+                }
+            }
+        }
         Task {
             await voiceInput.toggle(currentDraft: draftMessage) { newDraft in
                 draftMessage = newDraft
+            }
+            if voiceInput.isListening {
+                voiceFirstMode.didStartListening()
+            } else {
+                voiceFirstMode.didStopListening()
             }
         }
     }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -330,7 +330,7 @@ struct MessageComposerView: View {
                                 silenceRemaining: voiceFirstMode.silenceRemaining,
                                 phase: voiceFirstMode.phase,
                                 onLongPressStart: {
-                                    if !voiceInput.isListening, !isVoiceInputDisabled {
+                                    if !voiceInput.isListening, !isVoiceNoteRecordingDisabled {
                                         toggleVoiceInput()
                                     }
                                 },

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -165,7 +165,6 @@ struct MessageComposerView: View {
     @State private var voiceFirstPendingAction: ComposerVoiceFirstBar.ReleaseAction = .send
     @AppStorage(ComposerSTTProviderPreference.storageKey) private var sttProviderPreferenceRawValue = ComposerSTTProviderPreference.defaultValue.rawValue
     @AppStorage(VoiceFirstModeSettings.isEnabledKey) private var voiceFirstModeEnabled = false
-    @AppStorage(VoiceFirstModeSettings.hotWordsKey) private var voiceFirstHotWords = ""
     @AppStorage(SectionVisibilitySettings.chatGitKey) private var showsGitControls = true
 
     private enum DeferredUploadFocusPhase: Equatable {
@@ -317,14 +316,25 @@ struct MessageComposerView: View {
 
                     if voiceFirstModeEnabled, !voiceFirstShowingTextMode {
                         // Voice-first mode: "Hold to speak" bar replaces text input.
-                        VStack(spacing: 4) {
+                        VStack(spacing: 8) {
                             if voiceInput.isListening, !voiceInput.liveTranscript.isEmpty {
+                                // Live transcript preview. Truncating from the head keeps the
+                                // newest words visible as dictation grows past three lines.
                                 Text(voiceInput.liveTranscript)
                                     .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(2)
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(3)
+                                    .truncationMode(.head)
+                                    .multilineTextAlignment(.leading)
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.horizontal, 4)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 10)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                            .fill(Color(.tertiarySystemFill))
+                                    )
+                                    .padding(.horizontal, 12)
+                                    .transition(.opacity)
                             }
 
                             ComposerVoiceFirstBar(
@@ -437,7 +447,9 @@ struct MessageComposerView: View {
                                         .font(.system(size: 14, weight: .medium))
                                     Text(String(localized: "Voice"))
                                         .font(.caption)
+                                        .lineLimit(1)
                                 }
+                                .fixedSize(horizontal: true, vertical: false)
                                 .foregroundStyle(Color.accentColor)
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 6)
@@ -1259,10 +1271,6 @@ struct MessageComposerView: View {
             if voiceInput.providerPreference != .volcengineFirst {
                 voiceInput.providerPreference = .serverFirst
             }
-            voiceInput.contextualStrings = ComposerSTTContextProvider.hotWords(
-                sessionTitle: nil,
-                userHotWords: voiceFirstHotWords
-            )
             voiceInput.onPartialTranscript = { [weak voiceFirstMode] transcript in
                 voiceFirstMode?.didUpdateTranscript(transcript)
             }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -539,7 +539,7 @@ struct MessageComposerView: View {
             }
         }
         .onChange(of: voiceInput.isListening) { _, isListening in
-            // Voice-first: if we were waiting for transcription and recognition stopped with content, send.
+            // Voice-first: if we were waiting for transcription and recognition stopped, resolve.
             if voiceFirstWaitingToSend, !isListening {
                 let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !draft.isEmpty {
@@ -547,6 +547,9 @@ struct MessageComposerView: View {
                     voiceFirstApplyPendingAction()
                     onSend()
                     voiceFirstMode.didCompleteSend()
+                } else {
+                    // Empty transcription — disarm to prevent keyboard auto-send.
+                    voiceFirstWaitingToSend = false
                 }
             }
         }
@@ -1268,7 +1271,11 @@ struct MessageComposerView: View {
                 Task { @MainActor in
                     guard voiceFirstWaitingToSend else { return }
                     let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !draft.isEmpty else { return }
+                    guard !draft.isEmpty else {
+                        // Empty transcription — disarm so keyboard input won't auto-send.
+                        voiceFirstWaitingToSend = false
+                        return
+                    }
                     voiceFirstWaitingToSend = false
                     voiceFirstApplyPendingAction()
                     onSend()

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -378,17 +378,17 @@ struct MessageComposerView: View {
                                             voiceFirstPendingAction = .interrupt
                                         }
 
-                                    case .steer:
-                                        // Inject into current stream without interrupting.
+                                    case .queue:
+                                        // Queue message to send after response completes.
                                         let draft = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
                                         if !draft.isEmpty {
-                                            voiceFirstPendingAction = .steer
+                                            voiceFirstPendingAction = .queue
                                             voiceFirstApplyPendingAction()
                                             onSend()
                                             voiceFirstMode.didCompleteSend()
                                         } else {
                                             voiceFirstWaitingToSend = true
-                                            voiceFirstPendingAction = .steer
+                                            voiceFirstPendingAction = .queue
                                         }
                                     }
                                 },
@@ -1229,9 +1229,9 @@ struct MessageComposerView: View {
                 StreamingSendBehavior.interrupt.rawValue,
                 forKey: StreamingSendBehavior.storageKey
             )
-        case .steer:
+        case .queue:
             UserDefaults.standard.set(
-                StreamingSendBehavior.steer.rawValue,
+                StreamingSendBehavior.queue.rawValue,
                 forKey: StreamingSendBehavior.storageKey
             )
         case .send, .cancel:

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1210,19 +1210,38 @@ struct MessageComposerView: View {
 
     @MainActor
     private func voiceFirstApplyPendingAction() {
-        // Apply the pending action (from gesture direction) to the draft before sending.
+        // Temporarily override the streaming send behavior so ChatView routes
+        // the message correctly. The message stays as plain text (shows in chat
+        // as a normal user bubble) rather than being rewritten to a /slash command.
+        // We restore the original value after a brief delay — sendDraftMessage()
+        // reads the @AppStorage synchronously before any await.
         let content = draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !content.isEmpty else { return }
 
+        let originalValue = UserDefaults.standard.string(forKey: StreamingSendBehavior.storageKey)
+            ?? StreamingSendBehavior.steer.rawValue
+
         switch voiceFirstPendingAction {
         case .interrupt:
-            draftMessage = "/interrupt \(content)"
+            UserDefaults.standard.set(
+                StreamingSendBehavior.interrupt.rawValue,
+                forKey: StreamingSendBehavior.storageKey
+            )
         case .steer:
-            draftMessage = "/steer \(content)"
+            UserDefaults.standard.set(
+                StreamingSendBehavior.steer.rawValue,
+                forKey: StreamingSendBehavior.storageKey
+            )
         case .send, .cancel:
-            break // Send as-is, or cancel (shouldn't reach here)
+            voiceFirstPendingAction = .send
+            return
         }
         voiceFirstPendingAction = .send
+
+        // Restore after send reads the value (next run loop).
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            UserDefaults.standard.set(originalValue, forKey: StreamingSendBehavior.storageKey)
+        }
     }
 
     @MainActor

--- a/HermesMobile/Features/Chat/ComposerSTTContextProvider.swift
+++ b/HermesMobile/Features/Chat/ComposerSTTContextProvider.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Extracts contextual hot words from session data to improve STT accuracy.
+/// These are injected into `SFSpeechAudioBufferRecognitionRequest.contextualStrings` (iOS 17+).
+enum ComposerSTTContextProvider {
+
+    /// Maximum number of hot words to inject (Apple recommends keeping this bounded).
+    private static let maxHotWords = 50
+
+    /// Regex patterns for extracting likely technical terms from messages.
+    private static let technicalTermPatterns: [NSRegularExpression] = {
+        let patterns = [
+            // camelCase words (e.g. hermesMobile, setState)
+            "[a-z]+[A-Z][a-zA-Z]*",
+            // snake_case words (e.g. state_sync, sync_session_title)
+            "[a-z]+_[a-z_]+",
+            // dotted names (e.g. state.db, api.streaming)
+            "[a-zA-Z][a-zA-Z0-9]*\\.[a-zA-Z][a-zA-Z0-9.]*",
+            // ALL_CAPS identifiers (e.g. HERMES_HOME, TTS)
+            "[A-Z][A-Z0-9_]{2,}",
+            // slash-prefixed commands (e.g. /skills, /workspace)
+            "/[a-zA-Z][a-zA-Z0-9_-]+",
+            // kebab-case with 2+ segments (e.g. hermes-webui, speech-to-speech)
+            "[a-z]+-[a-z]+(?:-[a-z]+)*",
+        ]
+        return patterns.compactMap { try? NSRegularExpression(pattern: $0) }
+    }()
+
+    /// Built-in terms relevant to the Hermes ecosystem.
+    static let builtInTerms: [String] = [
+        "Hermes", "Hermex", "hermes-webui", "hermes-agent",
+        "state.db", "streaming", "session", "sessions",
+        "composer", "barge-in", "voice mode",
+        "skill", "skills", "memory", "cron",
+        "provider", "model", "workspace", "profile",
+    ]
+
+    /// Build the hot-word list from session context + user-configured words.
+    /// - Parameters:
+    ///   - recentMessages: Recent message texts from the current session.
+    ///   - sessionTitle: The current session title (if any).
+    ///   - userHotWords: User-configured hot words from Settings.
+    /// - Returns: Deduplicated array of contextual strings for STT boosting.
+    static func hotWords(
+        recentMessages: [String] = [],
+        sessionTitle: String? = nil,
+        userHotWords: String = ""
+    ) -> [String] {
+        var words = Set<String>(builtInTerms)
+
+        // Add session title words.
+        if let title = sessionTitle, !title.isEmpty {
+            let titleWords = title.components(separatedBy: .whitespacesAndNewlines)
+                .filter { $0.count >= 3 }
+            words.formUnion(titleWords)
+        }
+
+        // Extract technical terms from recent messages.
+        for message in recentMessages.suffix(5) {
+            let extracted = extractTechnicalTerms(from: message)
+            words.formUnion(extracted)
+        }
+
+        // Add user-configured hot words.
+        let userWords = userHotWords
+            .components(separatedBy: CharacterSet(charactersIn: ",;\n"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        words.formUnion(userWords)
+
+        // Deduplicate case-insensitively, keeping the first-seen casing.
+        var seen = Set<String>()
+        var result: [String] = []
+        for word in words.sorted() {
+            let lower = word.lowercased()
+            if !seen.contains(lower) {
+                seen.insert(lower)
+                result.append(word)
+            }
+        }
+
+        return Array(result.prefix(maxHotWords))
+    }
+
+    /// Extract likely technical/project-specific terms from a text string.
+    static func extractTechnicalTerms(from text: String) -> [String] {
+        guard !text.isEmpty else { return [] }
+
+        var terms: [String] = []
+        let nsText = text as NSString
+        let range = NSRange(location: 0, length: nsText.length)
+
+        for regex in technicalTermPatterns {
+            let matches = regex.matches(in: text, range: range)
+            for match in matches {
+                let term = nsText.substring(with: match.range)
+                // Filter out very short matches and common words.
+                if term.count >= 3, !commonWords.contains(term.lowercased()) {
+                    terms.append(term)
+                }
+            }
+        }
+
+        return terms
+    }
+
+    /// Common English words to exclude from hot-word extraction.
+    private static let commonWords: Set<String> = [
+        "the", "and", "for", "are", "but", "not", "you", "all",
+        "can", "had", "her", "was", "one", "our", "out", "has",
+        "have", "from", "that", "this", "with", "they", "been",
+        "will", "would", "could", "should", "their", "there",
+        "when", "what", "which", "where", "about", "into",
+    ]
+}

--- a/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// The "Hold to speak" bar shown in voice-first composer mode.
+/// Long press starts recording; short tap switches to text mode.
+struct ComposerVoiceFirstBar: View {
+    let isListening: Bool
+    let silenceRemaining: TimeInterval
+    let phase: ComposerVoiceFirstMode.Phase
+    let onLongPressStart: () -> Void
+    let onLongPressEnd: () -> Void
+    let onTap: () -> Void
+
+    @State private var isPressed = false
+    @State private var longPressTriggered = false
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ZStack {
+                // Background capsule
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(backgroundFill)
+                    .frame(height: 40)
+
+                // Silence timer progress overlay
+                if isListening, phase == .hasTranscript {
+                    GeometryReader { geo in
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .fill(Color.accentColor.opacity(0.15))
+                            .frame(width: geo.size.width * silenceProgress)
+                    }
+                    .frame(height: 40)
+                    .animation(.linear(duration: 0.1), value: silenceRemaining)
+                }
+
+                // Label
+                HStack(spacing: 8) {
+                    Image(systemName: isListening ? "waveform" : "mic.fill")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(isListening ? Color.accentColor : .secondary)
+                        .symbolEffect(.variableColor.iterative, isActive: isListening)
+
+                    Text(statusText)
+                        .font(.subheadline)
+                        .foregroundStyle(isListening ? .primary : .secondary)
+                }
+            }
+            .frame(height: 40)
+            .contentShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        if !isPressed {
+                            isPressed = true
+                            longPressTriggered = false
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                if isPressed {
+                                    longPressTriggered = true
+                                    onLongPressStart()
+                                }
+                            }
+                        }
+                    }
+                    .onEnded { _ in
+                        let wasLongPress = longPressTriggered
+                        isPressed = false
+                        longPressTriggered = false
+                        if wasLongPress {
+                            onLongPressEnd()
+                        } else {
+                            onTap()
+                        }
+                    }
+            )
+
+            // Hint text
+            if !isListening {
+                Text(String(localized: "Tap to switch to keyboard"))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .accessibilityLabel(isListening ? "Listening... tap to switch to text" : "Hold to speak, tap to type")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var statusText: String {
+        switch phase {
+        case .idle:
+            return String(localized: "Hold to speak")
+        case .listening:
+            return String(localized: "Listening...")
+        case .hasTranscript:
+            let seconds = Int(ceil(silenceRemaining))
+            return String(localized: "Sending in \(seconds)s...")
+        case .sending:
+            return String(localized: "Sending...")
+        }
+    }
+
+    private var silenceProgress: CGFloat {
+        guard silenceRemaining > 0 else { return 0 }
+        let total = VoiceFirstModeSettings.defaultSilenceTimeout
+        return CGFloat(1.0 - silenceRemaining / total)
+    }
+
+    private var backgroundFill: some ShapeStyle {
+        if isListening {
+            return AnyShapeStyle(Color.accentColor.opacity(0.08))
+        } else if isPressed {
+            return AnyShapeStyle(Color.primary.opacity(0.08))
+        } else {
+            return AnyShapeStyle(Color.primary.opacity(0.04))
+        }
+    }
+}
+
+/// The "switch to voice" bar shown in text composer mode when voice-first is enabled.
+/// Same height/style as ComposerVoiceFirstBar for visual symmetry.
+struct ComposerSwitchToVoiceBar: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Button(action: onTap) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.06))
+                        .frame(height: 40)
+
+                    HStack(spacing: 8) {
+                        Image(systemName: "mic.fill")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(Color.accentColor)
+
+                        Text(String(localized: "Switch to voice"))
+                            .font(.subheadline)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                }
+                .frame(height: 40)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12)
+            .accessibilityLabel("Switch to voice input")
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
@@ -19,7 +19,7 @@ struct ComposerVoiceFirstBar: View {
     enum ReleaseAction {
         case send       // Normal send (no active stream)
         case interrupt  // Stop stream + new reply (default during stream)
-        case steer      // Inject into current stream
+        case queue      // Wait for response to finish, then send as new turn
         case cancel     // Discard recording
     }
 
@@ -118,9 +118,9 @@ struct ComposerVoiceFirstBar: View {
             return .cancel
         }
 
-        // Down swipe = steer (only meaningful during streaming)
+        // Down swipe = queue (only meaningful during streaming)
         if isStreaming, dy > Self.steerThreshold {
-            return .steer
+            return .queue
         }
 
         // Default: interrupt during streaming, send otherwise
@@ -133,8 +133,8 @@ struct ComposerVoiceFirstBar: View {
         switch armedAction {
         case .cancel:
             return "xmark.circle.fill"
-        case .steer:
-            return "arrow.forward.circle.fill"
+        case .queue:
+            return "text.badge.plus"
         case .interrupt:
             return isPressed && longPressTriggered ? "waveform" : "mic.fill"
         case .send:
@@ -145,7 +145,7 @@ struct ComposerVoiceFirstBar: View {
     private var iconColor: Color {
         switch armedAction {
         case .cancel: return .red
-        case .steer: return .orange
+        case .queue: return .orange
         case .interrupt: return isPressed && longPressTriggered ? .accentColor : .secondary
         case .send: return isPressed && longPressTriggered ? .accentColor : .secondary
         }
@@ -154,7 +154,7 @@ struct ComposerVoiceFirstBar: View {
     private var textColor: Color {
         switch armedAction {
         case .cancel: return .red
-        case .steer: return .orange
+        case .queue: return .orange
         case .interrupt: return .primary
         case .send: return isPressed && longPressTriggered ? .primary : .secondary
         }
@@ -165,8 +165,8 @@ struct ComposerVoiceFirstBar: View {
             switch armedAction {
             case .cancel:
                 return String(localized: "Release to cancel")
-            case .steer:
-                return String(localized: "↓ Release to steer")
+            case .queue:
+                return String(localized: "↓ Release to queue")
             case .interrupt:
                 return String(localized: "Listening… release to send")
             case .send:
@@ -191,11 +191,11 @@ struct ComposerVoiceFirstBar: View {
         switch armedAction {
         case .cancel:
             return String(localized: "↑ Release to cancel")
-        case .steer:
-            return String(localized: "Guide the reply without interrupting")
+        case .queue:
+            return String(localized: "Send after response completes")
         case .interrupt:
             return isStreaming
-                ? String(localized: "↑ Cancel  ↓ Steer")
+                ? String(localized: "↑ Cancel  ↓ Queue")
                 : String(localized: "↑ Swipe up to cancel")
         case .send:
             return String(localized: "↑ Swipe up to cancel")
@@ -205,7 +205,7 @@ struct ComposerVoiceFirstBar: View {
     private var hintColor: Color {
         switch armedAction {
         case .cancel: return .red
-        case .steer: return .orange
+        case .queue: return .orange
         case .interrupt, .send: return .secondary
         }
     }
@@ -214,7 +214,7 @@ struct ComposerVoiceFirstBar: View {
         switch armedAction {
         case .cancel:
             return AnyShapeStyle(Color.red.opacity(0.1))
-        case .steer:
+        case .queue:
             return AnyShapeStyle(Color.orange.opacity(0.1))
         case .interrupt:
             if isPressed && longPressTriggered {

--- a/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
@@ -2,16 +2,36 @@ import SwiftUI
 
 /// The "Hold to speak" bar shown in voice-first composer mode.
 /// Long press starts recording; short tap switches to text mode.
+/// Gestures while recording (during streaming):
+///   - Swipe up: cancel recording
+///   - Swipe down: steer (inject into current stream without interrupting)
+///   - Release without swiping: interrupt (stop stream + new reply)
+/// When not streaming, release = normal send, swipe up = cancel.
 struct ComposerVoiceFirstBar: View {
     let isListening: Bool
+    let isStreaming: Bool
     let silenceRemaining: TimeInterval
     let phase: ComposerVoiceFirstMode.Phase
     let onLongPressStart: () -> Void
-    let onLongPressEnd: () -> Void
+    let onLongPressEnd: (ReleaseAction) -> Void
     let onTap: () -> Void
+
+    enum ReleaseAction {
+        case send       // Normal send (no active stream)
+        case interrupt  // Stop stream + new reply (default during stream)
+        case steer      // Inject into current stream
+        case cancel     // Discard recording
+    }
 
     @State private var isPressed = false
     @State private var longPressTriggered = false
+    @State private var dragOffset: CGSize = .zero
+    @State private var armedAction: ReleaseAction = .send
+
+    /// Upward drag distance to arm cancel.
+    private static let cancelThreshold: CGFloat = -60
+    /// Downward drag distance to arm steer.
+    private static let steerThreshold: CGFloat = 60
 
     var body: some View {
         VStack(spacing: 4) {
@@ -19,39 +39,30 @@ struct ComposerVoiceFirstBar: View {
                 // Background capsule
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .fill(backgroundFill)
-                    .frame(height: 40)
-
-                // Silence timer progress overlay
-                if isListening, phase == .hasTranscript {
-                    GeometryReader { geo in
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .fill(Color.accentColor.opacity(0.15))
-                            .frame(width: geo.size.width * silenceProgress)
-                    }
-                    .frame(height: 40)
-                    .animation(.linear(duration: 0.1), value: silenceRemaining)
-                }
+                    .frame(height: 44)
 
                 // Label
                 HStack(spacing: 8) {
-                    Image(systemName: isListening ? "waveform" : "mic.fill")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(isListening ? Color.accentColor : .secondary)
-                        .symbolEffect(.variableColor.iterative, isActive: isListening)
+                    Image(systemName: iconName)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(iconColor)
+                        .symbolEffect(.variableColor.iterative, isActive: isPressed && longPressTriggered && (armedAction == .send || armedAction == .interrupt))
 
                     Text(statusText)
-                        .font(.subheadline)
-                        .foregroundStyle(isListening ? .primary : .secondary)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(textColor)
                 }
             }
-            .frame(height: 40)
+            .frame(height: 44)
             .contentShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
             .gesture(
                 DragGesture(minimumDistance: 0)
-                    .onChanged { _ in
+                    .onChanged { value in
                         if !isPressed {
                             isPressed = true
                             longPressTriggered = false
+                            armedAction = isStreaming ? .interrupt : .send
+                            dragOffset = .zero
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                                 if isPressed {
                                     longPressTriggered = true
@@ -59,64 +70,169 @@ struct ComposerVoiceFirstBar: View {
                                 }
                             }
                         }
+                        if longPressTriggered {
+                            dragOffset = value.translation
+                            armedAction = resolveAction(from: value.translation)
+                        }
                     }
                     .onEnded { _ in
                         let wasLongPress = longPressTriggered
+                        let action = armedAction
                         isPressed = false
                         longPressTriggered = false
+                        armedAction = isStreaming ? .interrupt : .send
+                        dragOffset = .zero
+
                         if wasLongPress {
-                            onLongPressEnd()
+                            onLongPressEnd(action)
                         } else {
                             onTap()
                         }
                     }
             )
 
-            // Hint text
-            if !isListening {
+            // Hint below the bar
+            if !isPressed, !isListening {
                 Text(String(localized: "Tap to switch to keyboard"))
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
+            } else if isPressed, longPressTriggered {
+                Text(hintText)
+                    .font(.caption2)
+                    .foregroundStyle(hintColor)
+                    .animation(.easeInOut(duration: 0.15), value: armedAction)
             }
         }
         .padding(.horizontal, 12)
-        .accessibilityLabel(isListening ? "Listening... tap to switch to text" : "Hold to speak, tap to type")
+        .accessibilityLabel(isListening ? "Listening" : "Hold to speak")
         .accessibilityAddTraits(.isButton)
     }
 
+    // MARK: - Gesture resolution
+
+    private func resolveAction(from translation: CGSize) -> ReleaseAction {
+        let dy = translation.height
+
+        // Up swipe = cancel
+        if dy < Self.cancelThreshold {
+            return .cancel
+        }
+
+        // Down swipe = steer (only meaningful during streaming)
+        if isStreaming, dy > Self.steerThreshold {
+            return .steer
+        }
+
+        // Default: interrupt during streaming, send otherwise
+        return isStreaming ? .interrupt : .send
+    }
+
+    // MARK: - Visual state
+
+    private var iconName: String {
+        switch armedAction {
+        case .cancel:
+            return "xmark.circle.fill"
+        case .steer:
+            return "arrow.forward.circle.fill"
+        case .interrupt:
+            return isPressed && longPressTriggered ? "waveform" : "mic.fill"
+        case .send:
+            return isPressed && longPressTriggered ? "waveform" : "mic.fill"
+        }
+    }
+
+    private var iconColor: Color {
+        switch armedAction {
+        case .cancel: return .red
+        case .steer: return .orange
+        case .interrupt: return isPressed && longPressTriggered ? .accentColor : .secondary
+        case .send: return isPressed && longPressTriggered ? .accentColor : .secondary
+        }
+    }
+
+    private var textColor: Color {
+        switch armedAction {
+        case .cancel: return .red
+        case .steer: return .orange
+        case .interrupt: return .primary
+        case .send: return isPressed && longPressTriggered ? .primary : .secondary
+        }
+    }
+
     private var statusText: String {
+        if isPressed && longPressTriggered {
+            switch armedAction {
+            case .cancel:
+                return String(localized: "Release to cancel")
+            case .steer:
+                return String(localized: "↓ Release to steer")
+            case .interrupt:
+                return String(localized: "Listening… release to send")
+            case .send:
+                return String(localized: "Listening…")
+            }
+        }
+        // Not pressed — show phase status
         switch phase {
         case .idle:
             return String(localized: "Hold to speak")
         case .listening:
-            return String(localized: "Listening...")
+            return String(localized: "Transcribing…")
         case .hasTranscript:
             let seconds = Int(ceil(silenceRemaining))
-            return String(localized: "Sending in \(seconds)s...")
+            return String(localized: "Sending in \(seconds)s…")
         case .sending:
-            return String(localized: "Sending...")
+            return String(localized: "Sending…")
         }
     }
 
-    private var silenceProgress: CGFloat {
-        guard silenceRemaining > 0 else { return 0 }
-        let total = VoiceFirstModeSettings.defaultSilenceTimeout
-        return CGFloat(1.0 - silenceRemaining / total)
+    private var hintText: String {
+        switch armedAction {
+        case .cancel:
+            return String(localized: "↑ Release to cancel")
+        case .steer:
+            return String(localized: "Guide the reply without interrupting")
+        case .interrupt:
+            return isStreaming
+                ? String(localized: "↑ Cancel  ↓ Steer")
+                : String(localized: "↑ Swipe up to cancel")
+        case .send:
+            return String(localized: "↑ Swipe up to cancel")
+        }
     }
 
-    private var backgroundFill: some ShapeStyle {
-        if isListening {
-            return AnyShapeStyle(Color.accentColor.opacity(0.08))
-        } else if isPressed {
-            return AnyShapeStyle(Color.primary.opacity(0.08))
-        } else {
-            return AnyShapeStyle(Color.primary.opacity(0.04))
+    private var hintColor: Color {
+        switch armedAction {
+        case .cancel: return .red
+        case .steer: return .orange
+        case .interrupt, .send: return .secondary
+        }
+    }
+
+    private var backgroundFill: AnyShapeStyle {
+        switch armedAction {
+        case .cancel:
+            return AnyShapeStyle(Color.red.opacity(0.1))
+        case .steer:
+            return AnyShapeStyle(Color.orange.opacity(0.1))
+        case .interrupt:
+            if isPressed && longPressTriggered {
+                return AnyShapeStyle(Color.accentColor.opacity(0.08))
+            } else {
+                return AnyShapeStyle(Color.primary.opacity(0.04))
+            }
+        case .send:
+            if isPressed && longPressTriggered {
+                return AnyShapeStyle(Color.accentColor.opacity(0.08))
+            } else {
+                return AnyShapeStyle(Color.primary.opacity(0.04))
+            }
         }
     }
 }
 
 /// The "switch to voice" bar shown in text composer mode when voice-first is enabled.
-/// Same height/style as ComposerVoiceFirstBar for visual symmetry.
 struct ComposerSwitchToVoiceBar: View {
     let onTap: () -> Void
 
@@ -126,7 +242,7 @@ struct ComposerSwitchToVoiceBar: View {
                 ZStack {
                     RoundedRectangle(cornerRadius: 20, style: .continuous)
                         .fill(Color.accentColor.opacity(0.06))
-                        .frame(height: 40)
+                        .frame(height: 44)
 
                     HStack(spacing: 8) {
                         Image(systemName: "mic.fill")
@@ -138,7 +254,7 @@ struct ComposerSwitchToVoiceBar: View {
                             .foregroundStyle(Color.accentColor)
                     }
                 }
-                .frame(height: 40)
+                .frame(height: 44)
             }
             .buttonStyle(.plain)
             .padding(.horizontal, 12)

--- a/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceFirstBar.swift
@@ -27,6 +27,8 @@ struct ComposerVoiceFirstBar: View {
     @State private var longPressTriggered = false
     @State private var dragOffset: CGSize = .zero
     @State private var armedAction: ReleaseAction = .send
+    /// Token to prevent double-tap race: asyncAfter validates it matches current gesture.
+    @State private var gestureToken: UInt = 0
 
     /// Upward drag distance to arm cancel.
     private static let cancelThreshold: CGFloat = -60
@@ -63,8 +65,11 @@ struct ComposerVoiceFirstBar: View {
                             longPressTriggered = false
                             armedAction = isStreaming ? .interrupt : .send
                             dragOffset = .zero
+                            gestureToken &+= 1
+                            let token = gestureToken
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                                if isPressed {
+                                // Only trigger if this is still the same gesture sequence.
+                                if isPressed, gestureToken == token {
                                     longPressTriggered = true
                                     onLongPressStart()
                                 }
@@ -106,6 +111,16 @@ struct ComposerVoiceFirstBar: View {
         .padding(.horizontal, 12)
         .accessibilityLabel(isListening ? "Listening" : "Hold to speak")
         .accessibilityAddTraits(.isButton)
+        .accessibilityAction(.default) {
+            // VoiceOver double-tap → switch to keyboard (same as short tap)
+            onTap()
+        }
+        .accessibilityAction(named: String(localized: "Start Recording")) {
+            onLongPressStart()
+        }
+        .accessibilityAction(named: String(localized: "Send Recording")) {
+            onLongPressEnd(isStreaming ? .interrupt : .send)
+        }
     }
 
     // MARK: - Gesture resolution

--- a/HermesMobile/Features/Chat/ComposerVoiceFirstMode.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceFirstMode.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Observation
+import OSLog
+
+/// Settings key for the voice-first composer toggle.
+enum VoiceFirstModeSettings {
+    static let isEnabledKey = "voiceFirstModeEnabled"
+    static let silenceTimeoutKey = "voiceFirstSilenceTimeout"
+    static let hotWordsKey = "voiceFirstHotWords"
+
+    /// Default silence duration (seconds) before auto-send.
+    static let defaultSilenceTimeout: TimeInterval = 2.0
+}
+
+/// Lightweight state machine for voice-first composer input.
+/// Owns the silence timer that triggers auto-send.
+@MainActor
+@Observable
+final class ComposerVoiceFirstMode {
+    enum Phase: Equatable {
+        /// Waiting to start (mode enabled but not yet listening).
+        case idle
+        /// Microphone active, no transcript yet.
+        case listening
+        /// Transcript exists; silence timer is counting down.
+        case hasTranscript
+        /// Auto-send triggered; waiting for send completion before returning to listening.
+        case sending
+    }
+
+    private(set) var phase: Phase = .idle
+    private(set) var silenceRemaining: TimeInterval = 0
+
+    private var silenceTimer: Task<Void, Never>?
+    private var silenceTimeout: TimeInterval = VoiceFirstModeSettings.defaultSilenceTimeout
+    private var lastTranscriptChangeTime: Date = .now
+    private var lastTranscript: String = ""
+    private let logger = Logger(subsystem: "com.gyliu.hermex", category: "VoiceFirstMode")
+
+    var onAutoSend: (() -> Void)?
+
+    /// Call when voice-first mode becomes active (composer appears with toggle ON).
+    func activate(silenceTimeout: TimeInterval = VoiceFirstModeSettings.defaultSilenceTimeout) {
+        self.silenceTimeout = silenceTimeout
+        transitionTo(.idle)
+    }
+
+    /// Call when recognition starts.
+    func didStartListening() {
+        lastTranscript = ""
+        transitionTo(.listening)
+    }
+
+    /// Call on every partial transcript update from SFSpeechRecognizer.
+    func didUpdateTranscript(_ transcript: String) {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.isEmpty {
+            // Still no meaningful content — stay in listening.
+            if phase == .hasTranscript {
+                // User deleted everything? Back to listening.
+                cancelSilenceTimer()
+                transitionTo(.listening)
+            }
+            return
+        }
+
+        if trimmed != lastTranscript {
+            // Transcript changed — reset the silence timer.
+            lastTranscript = trimmed
+            lastTranscriptChangeTime = .now
+            transitionTo(.hasTranscript)
+            restartSilenceTimer()
+        }
+    }
+
+    /// Call when recognition ends (error, user stop, etc).
+    func didStopListening() {
+        cancelSilenceTimer()
+        if phase != .sending {
+            transitionTo(.idle)
+        }
+    }
+
+    /// Call after the auto-send message has been dispatched.
+    func didCompleteSend() {
+        lastTranscript = ""
+        transitionTo(.idle)
+    }
+
+    /// Call to deactivate the mode entirely.
+    func deactivate() {
+        cancelSilenceTimer()
+        lastTranscript = ""
+        transitionTo(.idle)
+        onAutoSend = nil
+    }
+
+    // MARK: - Private
+
+    private func transitionTo(_ newPhase: Phase) {
+        guard phase != newPhase else { return }
+        logger.debug("VoiceFirstMode: \(String(describing: self.phase)) → \(String(describing: newPhase))")
+        phase = newPhase
+    }
+
+    private func restartSilenceTimer() {
+        cancelSilenceTimer()
+        silenceRemaining = silenceTimeout
+
+        silenceTimer = Task { [weak self] in
+            guard let self else { return }
+            let tickInterval: TimeInterval = 0.1
+            var elapsed: TimeInterval = 0
+
+            while elapsed < self.silenceTimeout {
+                try? await Task.sleep(nanoseconds: UInt64(tickInterval * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+                elapsed += tickInterval
+                self.silenceRemaining = max(0, self.silenceTimeout - elapsed)
+
+                // Check if transcript changed during our wait.
+                let timeSinceLastChange = Date.now.timeIntervalSince(self.lastTranscriptChangeTime)
+                if timeSinceLastChange < elapsed - tickInterval {
+                    // Transcript was updated — timer will be restarted by didUpdateTranscript.
+                    return
+                }
+            }
+
+            guard !Task.isCancelled, self.phase == .hasTranscript else { return }
+
+            // Silence threshold reached — auto-send.
+            self.logger.info("VoiceFirstMode: silence timer fired, auto-sending")
+            self.transitionTo(.sending)
+            self.onAutoSend?()
+        }
+    }
+
+    private func cancelSilenceTimer() {
+        silenceTimer?.cancel()
+        silenceTimer = nil
+        silenceRemaining = 0
+    }
+}

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -30,6 +30,12 @@ final class ComposerVoiceInputController {
     private var recordingURL: URL?
     private var draftUpdateSession = ComposerVoiceDraftUpdateSession()
     private var updateDraft: ((String) -> Void)?
+    /// Reads the composer's live draft. Lets a late transcript detect that the user typed
+    /// (or that a send cleared the composer) and skip the write-back instead of clobbering it.
+    @ObservationIgnored var readDraft: (() -> String)?
+    /// The last value voice wrote into the composer. Survives across sessions so the next
+    /// session can tell an untouched leftover transcript from text the user typed.
+    private(set) var lastVoiceWrittenDraft: String?
     private var suppressNextRecognitionError = false
     private var activatedAudioSessionForRecording = false
     private var audioTapInstalled = false
@@ -266,9 +272,7 @@ final class ComposerVoiceInputController {
         stt.onPartialResult = { [weak self] text in
             guard let self else { return }
             self.liveTranscript = text
-            if let composedDraft = self.draftUpdateSession.composedDraft(for: text) {
-                self.updateDraft?(composedDraft)
-            }
+            self.applyTranscriptToDraft(text)
             self.onPartialTranscript?(text)
         }
         stt.onFinalResult = { [weak self] text in
@@ -285,9 +289,7 @@ final class ComposerVoiceInputController {
                 self.logger.info("Volcengine STT completed: \(finalText.prefix(50))")
                 if !finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     self.liveTranscript = finalText
-                    if let composedDraft = self.draftUpdateSession.composedDraft(for: finalText) {
-                        self.updateDraft?(composedDraft)
-                    }
+                    self.applyTranscriptToDraft(finalText)
                 }
                 self.stopVolcengineStreaming()
             case .failure(let error):
@@ -622,9 +624,7 @@ final class ComposerVoiceInputController {
             if let transcript = response.transcript?.trimmingCharacters(in: .whitespacesAndNewlines),
                !transcript.isEmpty {
                 liveTranscript = transcript
-                if let composedDraft = draftUpdateSession.composedDraft(for: transcript) {
-                    updateDraft?(composedDraft)
-                }
+                applyTranscriptToDraft(transcript)
                 stopAcceptingDraftUpdates()
                 cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
                 state = .idle
@@ -701,9 +701,7 @@ final class ComposerVoiceInputController {
                 )
                 return
             }
-            if let composedDraft = draftUpdateSession.composedDraft(for: transcript) {
-                updateDraft?(composedDraft)
-            }
+            applyTranscriptToDraft(transcript)
             stopAcceptingDraftUpdates()
             cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
             state = .idle
@@ -836,9 +834,7 @@ final class ComposerVoiceInputController {
     private func handleRecognition(result: SFSpeechRecognitionResult?, error: Error?) {
         if let result {
             liveTranscript = result.bestTranscription.formattedString
-            if let composedDraft = draftUpdateSession.composedDraft(for: liveTranscript) {
-                updateDraft?(composedDraft)
-            }
+            applyTranscriptToDraft(liveTranscript)
             onPartialTranscript?(liveTranscript)
         }
 
@@ -863,6 +859,20 @@ final class ComposerVoiceInputController {
                 onFinalTranscript?(finalTranscript)
             }
         }
+    }
+
+    /// Writes `transcript` into the composer unless someone else took ownership of it.
+    /// Dropping the write is what keeps a late final transcript from overwriting text the
+    /// user typed after releasing the mic, or from re-populating a composer that was
+    /// already sent and cleared.
+    private func applyTranscriptToDraft(_ transcript: String) {
+        guard let composed = draftUpdateSession.composedDraft(
+            for: transcript,
+            currentDraft: readDraft?()
+        ) else { return }
+
+        lastVoiceWrittenDraft = composed
+        updateDraft?(composed)
     }
 
     private func stopAcceptingDraftUpdates() {
@@ -1156,25 +1166,43 @@ enum ComposerVoiceDraftComposer {
 struct ComposerVoiceDraftUpdateSession {
     private var baseDraft = ""
     private var acceptsUpdates = false
+    /// The exact value this session last wrote into the composer, so a late result can
+    /// tell whether the composer still holds voice's own text.
+    private var lastWrittenDraft: String?
 
     mutating func begin(baseDraft: String) {
         self.baseDraft = baseDraft
         acceptsUpdates = true
+        lastWrittenDraft = nil
     }
 
     mutating func stopAcceptingUpdates() {
         acceptsUpdates = false
     }
 
-    func composedDraft(for transcript: String) -> String? {
+    /// Composes the draft to write, or nil when the update must be dropped.
+    ///
+    /// `currentDraft` is the composer's live value. When it no longer matches what this
+    /// session last wrote, something else owns the composer — the user typed into it, or
+    /// a send cleared it — and writing `baseDraft + transcript` would clobber that. This
+    /// is the window between releasing the mic and the final transcript arriving, where
+    /// a late write-back used to overwrite typed text and re-populate a sent composer.
+    /// Passing nil skips the check for callers that cannot read the live draft.
+    mutating func composedDraft(for transcript: String, currentDraft: String? = nil) -> String? {
         guard acceptsUpdates else {
             return nil
         }
 
-        return ComposerVoiceDraftComposer.composedDraft(
+        if let currentDraft, currentDraft != (lastWrittenDraft ?? baseDraft) {
+            return nil
+        }
+
+        let composed = ComposerVoiceDraftComposer.composedDraft(
             baseDraft: baseDraft,
             transcript: transcript
         )
+        lastWrittenDraft = composed
+        return composed
     }
 }
 

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -865,10 +865,17 @@ final class ComposerVoiceInputController {
     /// Dropping the write is what keeps a late final transcript from overwriting text the
     /// user typed after releasing the mic, or from re-populating a composer that was
     /// already sent and cleared.
+    ///
+    /// The ownership check only runs once audio capture has stopped. While the mic is
+    /// live the composer belongs to dictation and every partial must land: comparing
+    /// against the live draft there would depend on the composer's `@State` write being
+    /// observable on the very next partial, and a single missed propagation would wedge
+    /// the comparison permanently, freezing the transcript after one word.
     private func applyTranscriptToDraft(_ transcript: String) {
+        let isCapturingAudio = state == .listening || state == .serverListening
         guard let composed = draftUpdateSession.composedDraft(
             for: transcript,
-            currentDraft: readDraft?()
+            currentDraft: isCapturingAudio ? nil : readDraft?()
         ) else { return }
 
         lastVoiceWrittenDraft = composed
@@ -878,6 +885,10 @@ final class ComposerVoiceInputController {
     private func stopAcceptingDraftUpdates() {
         draftUpdateSession.stopAcceptingUpdates()
         updateDraft = nil
+        // Note: readDraft is intentionally NOT cleared here. Late callbacks (volcengine
+        // onCompleted) still need to read the composer to decide whether to block the
+        // write-back. The closure captures the view's Binding whose lifetime matches the
+        // controller's @State — no retain cycle. It's overwritten on the next toggle().
     }
 
     private func stopAudio(cancelTask: Bool) {

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -48,6 +48,8 @@ final class ComposerVoiceInputController {
     /// Called when recognition produces a final transcript (isFinal=true). Used by voice-first mode for immediate send.
     @ObservationIgnored var onFinalTranscript: ((String) -> Void)?
 
+    private var volcengineSTT: VolcengineStreamingSTT?
+
     init(
         speechRecognizerFactory: @escaping () -> SFSpeechRecognizer? = { SFSpeechRecognizer(locale: Locale.current) },
         audioEngineFactory: @escaping () -> AVAudioEngine = { AVAudioEngine() }
@@ -76,7 +78,13 @@ final class ComposerVoiceInputController {
         suppressNextRecognitionError = true
         switch state {
         case .serverListening:
-            stopServerRecordingAndTranscribe()
+            if volcengineSTT != nil {
+                // Volcengine streaming: send end-of-audio, then stop
+                volcengineSTT?.finishAudio()
+                stopVolcengineStreaming()
+            } else {
+                stopServerRecordingAndTranscribe()
+            }
         case .transcribing:
             cancelServerTranscription()
             stopAcceptingDraftUpdates()
@@ -91,6 +99,9 @@ final class ComposerVoiceInputController {
 
     func stopBeforeSubmittingDraft() {
         suppressNextRecognitionError = true
+        if volcengineSTT != nil {
+            stopVolcengineStreaming()
+        }
         cancelServerTranscription()
         stopAcceptingDraftUpdates()
         discardServerRecording()
@@ -113,10 +124,12 @@ final class ComposerVoiceInputController {
 
         let canUseServer = apiClient != nil
         let canUseOnDevice = onDeviceSpeechRecognizerForRecording() != nil
+        let canUseVolcengine = VolcengineSTTSettings.isConfigured
         let providers = ComposerSTTProviderPolicy.orderedProviders(
             preference: providerPreference,
             serverConfigured: canUseServer,
-            onDeviceSupported: canUseOnDevice
+            onDeviceSupported: canUseOnDevice,
+            volcengineConfigured: canUseVolcengine
         )
 
         guard let provider = providers.first else {
@@ -139,6 +152,8 @@ final class ComposerVoiceInputController {
             await startServerProvider()
         case .onDevice:
             await startOnDeviceProvider()
+        case .volcengineStreaming:
+            await startVolcengineProvider()
         }
     }
 
@@ -172,6 +187,167 @@ final class ComposerVoiceInputController {
                 logCategory: Self.logCategory(for: error)
             )
         }
+    }
+
+    // MARK: - Volcengine Streaming STT
+
+    private func startVolcengineProvider() async {
+        let isMicrophonePermissionGranted = await requestMicrophonePermission()
+        logger.info("Volcengine voice input microphone permission completed granted=\(isMicrophonePermissionGranted, privacy: .public)")
+        guard state == .requestingPermission else { return }
+        guard isMicrophonePermissionGranted else {
+            fail(
+                String(localized: "Microphone access is disabled. Enable it in Settings to use voice input."),
+                logCategory: .microphonePermission
+            )
+            return
+        }
+
+        guard ComposerVoiceInputStartPolicy.canStart(appIsActive: UIApplication.shared.applicationState == .active) else {
+            fail(
+                ComposerVoiceInputError.appNotActive.localizedDescription,
+                logCategory: .appNotActive
+            )
+            return
+        }
+
+        guard let config = VolcengineSTTSettings.configuration(hotwords: contextualStrings) else {
+            await fallbackOrFail(
+                from: .volcengineStreaming,
+                message: VolcengineSTTError.notConfigured.localizedDescription,
+                logCategory: .speechUnavailable
+            )
+            return
+        }
+
+        do {
+            try startVolcengineStreaming(configuration: config)
+            state = .serverListening
+        } catch {
+            await fallbackOrFail(
+                from: .volcengineStreaming,
+                message: error.localizedDescription,
+                logCategory: Self.logCategory(for: error)
+            )
+        }
+    }
+
+    private func startVolcengineStreaming(configuration: VolcengineStreamingSTT.Configuration) throws {
+        stopAudio(cancelTask: true)
+        logger.info("Volcengine streaming STT audio startup preparing")
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(
+            ComposerVoiceAudioSessionConfiguration.category,
+            mode: ComposerVoiceAudioSessionConfiguration.mode,
+            options: ComposerVoiceAudioSessionConfiguration.options
+        )
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        activatedAudioSessionForRecording = true
+
+        try ComposerVoiceInputStartPolicy.validateAudioSessionInput(
+            isInputAvailable: audioSession.isInputAvailable,
+            sampleRate: audioSession.sampleRate,
+            inputNumberOfChannels: audioSession.inputNumberOfChannels
+        )
+
+        // Set up Volcengine STT client
+        let stt = VolcengineStreamingSTT()
+        stt.onPartialResult = { [weak self] text in
+            guard let self else { return }
+            self.liveTranscript = text
+            if let composedDraft = self.draftUpdateSession.composedDraft(for: text) {
+                self.updateDraft?(composedDraft)
+            }
+            self.onPartialTranscript?(text)
+        }
+        stt.onFinalResult = { [weak self] text in
+            guard let self else { return }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                self.onFinalTranscript?(self.liveTranscript)
+            }
+        }
+        stt.onCompleted = { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let finalText):
+                self.logger.info("Volcengine STT completed: \(finalText.prefix(50))")
+                if !finalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    self.liveTranscript = finalText
+                    if let composedDraft = self.draftUpdateSession.composedDraft(for: finalText) {
+                        self.updateDraft?(composedDraft)
+                    }
+                }
+                self.stopVolcengineStreaming()
+            case .failure(let error):
+                self.logger.error("Volcengine STT error: \(error.localizedDescription)")
+                self.stopVolcengineStreaming()
+                self.errorMessage = error.localizedDescription
+            }
+        }
+        self.volcengineSTT = stt
+        stt.start(configuration: configuration)
+
+        // Set up AVAudioEngine to capture PCM frames and stream them
+        let audioEngine = audioEngineFactory()
+        self.audioEngine = audioEngine
+        try ComposerVoiceInputStartPolicy.validateAudioEngine(isRunning: audioEngine.isRunning)
+
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        try ComposerVoiceInputPreflight.validate(recordingFormat: recordingFormat)
+
+        // Convert to 16kHz mono 16-bit PCM for Volcengine
+        let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: true
+        )!
+
+        let converter = AVAudioConverter(from: recordingFormat, to: targetFormat)
+
+        // Buffer size: 200ms at 16kHz = 3200 samples
+        let frameSamples: AVAudioFrameCount = 3_200
+
+        inputNode.installTap(onBus: 0, bufferSize: 4_096, format: recordingFormat) { [weak stt, weak converter] buffer, _ in
+            guard let stt, let converter else { return }
+
+            let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameSamples)!
+            var error: NSError?
+            let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+                outStatus.pointee = .haveData
+                return buffer
+            }
+
+            guard status == .haveData || status == .inputRanDry, error == nil else { return }
+
+            // Extract raw PCM bytes from the Int16 buffer
+            guard let int16Ptr = outputBuffer.int16ChannelData else { return }
+            let frameLength = Int(outputBuffer.frameLength)
+            let byteCount = frameLength * 2 // 16-bit = 2 bytes per sample
+            let pcmData = Data(bytes: int16Ptr[0], count: byteCount)
+
+            Task { @MainActor in
+                stt.sendAudioFrame(pcmData)
+            }
+        }
+        audioTapInstalled = true
+
+        audioEngine.prepare()
+        try audioEngine.start()
+        ComposerAudioCaptureState.shared.setCapturing(true)
+        logger.info("Volcengine streaming STT started with AVAudioEngine tap")
+    }
+
+    private func stopVolcengineStreaming() {
+        volcengineSTT?.cancel()
+        volcengineSTT = nil
+        stopAcceptingDraftUpdates()
+        stopAudio(cancelTask: true)
+        state = .idle
+        suppressNextRecognitionError = false
     }
 
     private func startOnDeviceProvider() async {
@@ -236,7 +412,8 @@ final class ComposerVoiceInputController {
             after: failedProvider,
             preference: providerPreference,
             serverConfigured: apiClient != nil,
-            onDeviceSupported: onDeviceSpeechRecognizerForRecording() != nil
+            onDeviceSupported: onDeviceSpeechRecognizerForRecording() != nil,
+            volcengineConfigured: VolcengineSTTSettings.isConfigured
         )
 
         guard let fallback else {
@@ -431,7 +608,8 @@ final class ComposerVoiceInputController {
             after: .server,
             preference: providerPreference,
             serverConfigured: apiClient != nil,
-            onDeviceSupported: onDeviceSpeechRecognizerForRecording() != nil
+            onDeviceSupported: onDeviceSpeechRecognizerForRecording() != nil,
+            volcengineConfigured: VolcengineSTTSettings.isConfigured
         ) == .onDevice,
               let speechRecognizer = onDeviceSpeechRecognizerForRecording()
         else {
@@ -820,7 +998,7 @@ enum ComposerVoiceMicrophonePermissionRequester {
 
 enum ComposerVoiceAudioSessionConfiguration {
     static let category = AVAudioSession.Category.playAndRecord
-    static let mode = AVAudioSession.Mode.measurement
+    static let mode = AVAudioSession.Mode.videoRecording
     static let options: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetoothHFP]
 }
 

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -79,9 +79,12 @@ final class ComposerVoiceInputController {
         switch state {
         case .serverListening:
             if volcengineSTT != nil {
-                // Volcengine streaming: send end-of-audio, then stop
+                // Volcengine streaming: send end-of-audio and stop mic,
+                // but keep WebSocket alive so server can return final result.
+                // The onCompleted callback will handle full cleanup.
                 volcengineSTT?.finishAudio()
-                stopVolcengineStreaming()
+                stopAudio(cancelTask: false)
+                state = .transcribing
             } else {
                 stopServerRecordingAndTranscribe()
             }

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -33,6 +33,12 @@ final class ComposerVoiceInputController {
     private var suppressNextRecognitionError = false
     private var activatedAudioSessionForRecording = false
     private var audioTapInstalled = false
+    /// Long-lived sample-rate converter for Volcengine capture. AVAudioConverter carries
+    /// internal resampling state, so it must outlive individual tap callbacks (a local
+    /// variable gets deallocated the moment the setup function returns).
+    private var volcengineAudioConverter: AVAudioConverter?
+    /// Accumulates downsampled PCM until we have ~200ms, which is Volcengine's optimal packet size.
+    private var volcenginePCMAccumulator = Data()
     @ObservationIgnored private var transcriptionTask: Task<Void, Never>?
     @ObservationIgnored private var serverRecordingTimeoutTask: Task<Void, Never>?
     private var activeTranscriptionID: UUID?
@@ -150,6 +156,7 @@ final class ComposerVoiceInputController {
     }
 
     private func start(provider: ComposerSTTProvider) async {
+        logger.info("Starting voice input with provider: \(String(describing: provider))")
         switch provider {
         case .server:
             await startServerProvider()
@@ -314,7 +321,7 @@ final class ComposerVoiceInputController {
     }
 
     private func startVolcengineAudioCapture(audioEngine: AVAudioEngine, inputNode: AVAudioInputNode, recordingFormat: AVAudioFormat, stt: VolcengineStreamingSTT) {
-        // Convert to 16kHz mono 16-bit PCM for Volcengine
+        // Target: 16kHz mono 16-bit PCM for Volcengine
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatInt16,
             sampleRate: 16_000,
@@ -325,31 +332,53 @@ final class ComposerVoiceInputController {
             return
         }
 
-        let converter = AVAudioConverter(from: recordingFormat, to: targetFormat)
+        guard let converter = AVAudioConverter(from: recordingFormat, to: targetFormat) else {
+            logger.error("Failed to create audio converter from \(recordingFormat.sampleRate)Hz to 16000Hz")
+            return
+        }
+        volcengineAudioConverter = converter
+        volcenginePCMAccumulator = Data()
 
-        // Buffer size: 200ms at 16kHz = 3200 samples
-        let frameSamples: AVAudioFrameCount = 3_200
+        let sampleRateRatio = targetFormat.sampleRate / recordingFormat.sampleRate
+        // 200ms at 16kHz mono 16-bit = 6400 bytes; Volcengine's documented optimum.
+        let targetChunkBytes = 6_400
 
-        inputNode.installTap(onBus: 0, bufferSize: 4_096, format: recordingFormat) { [weak stt, weak converter] buffer, _ in
-            guard let stt, let converter else { return }
+        // The tap format MUST match the input node's hardware format. Passing a different
+        // sample rate here throws `IsFormatSampleRateAndChannelCountValid` and crashes the app,
+        // so downsampling happens via AVAudioConverter below instead.
+        inputNode.installTap(onBus: 0, bufferSize: 4_096, format: recordingFormat) { [weak self, weak stt, converter] buffer, _ in
+            guard let stt else { return }
 
-            let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameSamples)!
-            var error: NSError?
-            let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+            let outputCapacity = AVAudioFrameCount(ceil(Double(buffer.frameLength) * sampleRateRatio)) + 64
+            guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outputCapacity) else { return }
+
+            // Each input buffer may only be handed to the converter once; returning it again
+            // makes the converter spin or emit garbage.
+            var didSupplyInput = false
+            var conversionError: NSError?
+            let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
+                if didSupplyInput {
+                    outStatus.pointee = .noDataNow
+                    return nil
+                }
+                didSupplyInput = true
                 outStatus.pointee = .haveData
                 return buffer
             }
 
-            guard status == .haveData || status == .inputRanDry, error == nil else { return }
+            guard status == .haveData || status == .inputRanDry, conversionError == nil else { return }
+            guard let int16Channel = outputBuffer.int16ChannelData, outputBuffer.frameLength > 0 else { return }
 
-            // Extract raw PCM bytes from the Int16 buffer
-            guard let int16Ptr = outputBuffer.int16ChannelData else { return }
-            let frameLength = Int(outputBuffer.frameLength)
-            let byteCount = frameLength * 2 // 16-bit = 2 bytes per sample
-            let pcmData = Data(bytes: int16Ptr[0], count: byteCount)
+            let chunk = Data(bytes: int16Channel[0], count: Int(outputBuffer.frameLength) * 2)
 
             Task { @MainActor in
-                stt.sendAudioFrame(pcmData)
+                guard let self else { return }
+                self.volcenginePCMAccumulator.append(chunk)
+                while self.volcenginePCMAccumulator.count >= targetChunkBytes {
+                    let packet = self.volcenginePCMAccumulator.prefix(targetChunkBytes)
+                    self.volcenginePCMAccumulator.removeFirst(targetChunkBytes)
+                    stt.sendAudioFrame(Data(packet))
+                }
             }
         }
         audioTapInstalled = true
@@ -366,6 +395,8 @@ final class ComposerVoiceInputController {
     private func stopVolcengineStreaming() {
         volcengineSTT?.cancel()
         volcengineSTT = nil
+        volcengineAudioConverter = nil
+        volcenginePCMAccumulator = Data()
         stopAcceptingDraftUpdates()
         stopAudio(cancelTask: true)
         state = .idle

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -41,6 +41,12 @@ final class ComposerVoiceInputController {
     @ObservationIgnored var apiClient: APIClient?
     @ObservationIgnored var providerPreference = ComposerSTTProviderPreference.defaultValue
     @ObservationIgnored var locale = Locale.current
+    /// Hot words injected into SFSpeechAudioBufferRecognitionRequest.contextualStrings (iOS 17+).
+    @ObservationIgnored var contextualStrings: [String] = []
+    /// Called on every partial transcript update (for voice-first silence timer).
+    @ObservationIgnored var onPartialTranscript: ((String) -> Void)?
+    /// Called when recognition produces a final transcript (isFinal=true). Used by voice-first mode for immediate send.
+    @ObservationIgnored var onFinalTranscript: ((String) -> Void)?
 
     init(
         speechRecognizerFactory: @escaping () -> SFSpeechRecognizer? = { SFSpeechRecognizer(locale: Locale.current) },
@@ -562,6 +568,9 @@ final class ComposerVoiceInputController {
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
         request.requiresOnDeviceRecognition = true
+        if !contextualStrings.isEmpty {
+            request.contextualStrings = contextualStrings
+        }
         recognitionRequest = request
 
         let audioEngine = audioEngineFactory()
@@ -599,6 +608,7 @@ final class ComposerVoiceInputController {
             if let composedDraft = draftUpdateSession.composedDraft(for: liveTranscript) {
                 updateDraft?(composedDraft)
             }
+            onPartialTranscript?(liveTranscript)
         }
 
         if let error {
@@ -611,10 +621,16 @@ final class ComposerVoiceInputController {
             }
             errorMessage = error.localizedDescription
         } else if result?.isFinal == true {
+            // In voice-first mode, notify with final transcript before stopping.
+            // This allows the caller to auto-send the completed utterance.
+            let finalTranscript = liveTranscript
             stopAcceptingDraftUpdates()
             stopAudio(cancelTask: false)
             state = .idle
             suppressNextRecognitionError = false
+            if !finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                onFinalTranscript?(finalTranscript)
+            }
         }
     }
 

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -286,10 +286,8 @@ final class ComposerVoiceInputController {
                 self.errorMessage = error.localizedDescription
             }
         }
-        self.volcengineSTT = stt
-        stt.start(configuration: configuration)
 
-        // Set up AVAudioEngine to capture PCM frames and stream them
+        // Start audio engine setup (but don't install tap yet — wait for WebSocket to be ready)
         let audioEngine = audioEngineFactory()
         self.audioEngine = audioEngine
         try ComposerVoiceInputStartPolicy.validateAudioEngine(isRunning: audioEngine.isRunning)
@@ -298,13 +296,31 @@ final class ComposerVoiceInputController {
         let recordingFormat = inputNode.outputFormat(forBus: 0)
         try ComposerVoiceInputPreflight.validate(recordingFormat: recordingFormat)
 
+        // Prepare audio engine but don't start yet
+        audioEngine.prepare()
+
+        // Store STT reference and start WebSocket connection.
+        // Audio engine will be started once WebSocket is ready (state = .streaming).
+        self.volcengineSTT = stt
+        stt.onReady = { [weak self] in
+            guard let self else { return }
+            self.startVolcengineAudioCapture(audioEngine: audioEngine, inputNode: inputNode, recordingFormat: recordingFormat, stt: stt)
+        }
+        stt.start(configuration: configuration)
+        logger.info("Volcengine STT WebSocket connecting, audio engine prepared")
+    }
+
+    private func startVolcengineAudioCapture(audioEngine: AVAudioEngine, inputNode: AVAudioInputNode, recordingFormat: AVAudioFormat, stt: VolcengineStreamingSTT) {
         // Convert to 16kHz mono 16-bit PCM for Volcengine
-        let targetFormat = AVAudioFormat(
+        guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatInt16,
             sampleRate: 16_000,
             channels: 1,
             interleaved: true
-        )!
+        ) else {
+            logger.error("Failed to create target audio format")
+            return
+        }
 
         let converter = AVAudioConverter(from: recordingFormat, to: targetFormat)
 
@@ -335,10 +351,13 @@ final class ComposerVoiceInputController {
         }
         audioTapInstalled = true
 
-        audioEngine.prepare()
-        try audioEngine.start()
-        ComposerAudioCaptureState.shared.setCapturing(true)
-        logger.info("Volcengine streaming STT started with AVAudioEngine tap")
+        do {
+            try audioEngine.start()
+            ComposerAudioCaptureState.shared.setCapturing(true)
+            logger.info("Volcengine audio engine started — streaming audio frames")
+        } catch {
+            logger.error("Failed to start audio engine: \(error.localizedDescription)")
+        }
     }
 
     private func stopVolcengineStreaming() {

--- a/HermesMobile/Features/Chat/VolcengineSTTSettings.swift
+++ b/HermesMobile/Features/Chat/VolcengineSTTSettings.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Storage keys and defaults for Volcengine streaming STT configuration.
+enum VolcengineSTTSettings {
+    static let apiKeyKey = "volcengineSTTApiKey"
+    static let resourceIdKey = "volcengineSTTResourceId"
+    static let defaultResourceId = "volc.seedasr.sauc.duration"
+
+    /// Whether volcengine streaming is configured (API key is present).
+    static var isConfigured: Bool {
+        guard let key = UserDefaults.standard.string(forKey: apiKeyKey) else { return false }
+        return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Build a configuration from stored settings + optional hot words.
+    static func configuration(hotwords: [String] = []) -> VolcengineStreamingSTT.Configuration? {
+        guard let apiKey = UserDefaults.standard.string(forKey: apiKeyKey),
+              !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+
+        let resourceId = UserDefaults.standard.string(forKey: resourceIdKey)?.nilIfEmpty
+            ?? defaultResourceId
+
+        return VolcengineStreamingSTT.Configuration(
+            apiKey: apiKey.trimmingCharacters(in: .whitespacesAndNewlines),
+            resourceId: resourceId,
+            hotwords: hotwords
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+    }
+}

--- a/HermesMobile/Features/Chat/VolcengineStreamingSTT.swift
+++ b/HermesMobile/Features/Chat/VolcengineStreamingSTT.swift
@@ -14,6 +14,10 @@ final class VolcengineStreamingSTT: NSObject {
         case idle
         case connecting
         case streaming
+        /// The last audio packet has been sent and we are waiting for the server's
+        /// final result. The server closes the socket itself once it finalizes, so a
+        /// close/read error in this state is the expected end of a dictation, not a fault.
+        case finishing
         case finished
         case failed(Error)
     }
@@ -49,6 +53,23 @@ final class VolcengineStreamingSTT: NSObject {
     private var configuration: Configuration?
     private var hasReceivedResult = false
 
+    // MARK: - Diagnostics
+    // These counters are surfaced in failure messages so a single screenshot pins down
+    // which stage broke, instead of guessing between capture / transport / parsing.
+    private var framesSent = 0
+    private var bytesSent = 0
+    /// Tap produced audio but the state gate rejected it (e.g. WebSocket not ready yet).
+    private var framesDropped = 0
+    private var packetsReceived = 0
+    private var payloadsParsed = 0
+    private var parseFailures = 0
+    private var lastServerMessageType: UInt8?
+
+    var diagnosticSummary: String {
+        let lastType = lastServerMessageType.map { String(format: "0x%02X", $0) } ?? "none"
+        return "sent=\(framesSent)f/\(bytesSent)B dropped=\(framesDropped) recv=\(packetsReceived) parsed=\(payloadsParsed) parseFail=\(parseFailures) lastType=\(lastType)"
+    }
+
     // MARK: - Public API
 
     func start(configuration: Configuration) {
@@ -60,15 +81,33 @@ final class VolcengineStreamingSTT: NSObject {
         self.configuration = configuration
         self.currentText = ""
         self.hasReceivedResult = false
+        framesSent = 0
+        bytesSent = 0
+        framesDropped = 0
+        packetsReceived = 0
+        payloadsParsed = 0
+        parseFailures = 0
+        lastServerMessageType = nil
         state = .connecting
 
-        let endpoint = URL(string: "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async")!
-        var request = URLRequest(url: endpoint)
+        // Build URL with auth params as query string (fallback for iOS URLSession header issues)
+        var components = URLComponents(string: "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async")!
+        components.queryItems = [
+            URLQueryItem(name: "X-Api-Key", value: configuration.apiKey),
+            URLQueryItem(name: "X-Api-Resource-Id", value: configuration.resourceId),
+            URLQueryItem(name: "X-Api-Connect-Id", value: connectId),
+            URLQueryItem(name: "X-Api-Request-Id", value: UUID().uuidString),
+            URLQueryItem(name: "X-Api-Sequence", value: "-1")
+        ]
+
+        var request = URLRequest(url: components.url!)
+        // Also set as headers (belt and suspenders)
         request.setValue(configuration.apiKey, forHTTPHeaderField: "X-Api-Key")
         request.setValue(configuration.resourceId, forHTTPHeaderField: "X-Api-Resource-Id")
         request.setValue(connectId, forHTTPHeaderField: "X-Api-Connect-Id")
         request.setValue(UUID().uuidString, forHTTPHeaderField: "X-Api-Request-Id")
         request.setValue("-1", forHTTPHeaderField: "X-Api-Sequence")
+        request.timeoutInterval = 15
 
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         self.urlSession = session
@@ -81,7 +120,14 @@ final class VolcengineStreamingSTT: NSObject {
 
     /// Send a PCM audio frame (16kHz, mono, 16-bit, ~200ms recommended).
     func sendAudioFrame(_ pcmData: Data) {
-        guard case .streaming = state else { return }
+        guard case .streaming = state else {
+            // Counted rather than silently ignored: a high drop count means the mic was
+            // capturing before the socket was ready, which is invisible otherwise.
+            framesDropped += 1
+            return
+        }
+        framesSent += 1
+        bytesSent += pcmData.count
         let message = buildAudioOnlyMessage(pcmData)
         webSocketTask?.send(.data(message)) { [weak self] error in
             if let error {
@@ -96,6 +142,9 @@ final class VolcengineStreamingSTT: NSObject {
     func finishAudio() {
         guard case .streaming = state else { return }
         let message = buildLastAudioMessage()
+        // Flip state before sending: the server may close the socket as soon as it
+        // finalizes, and the close must not be reported as a connection failure.
+        state = .finishing
         webSocketTask?.send(.data(message)) { [weak self] error in
             if let error {
                 Task { @MainActor [weak self] in
@@ -214,14 +263,22 @@ final class VolcengineStreamingSTT: NSObject {
 
     // MARK: - Response Parsing
 
+    /// First bytes of a frame as hex, for diagnosing header/offset mistakes from a log line.
+    private static func hexPrefix(_ data: Data, count: Int = 16) -> String {
+        data.prefix(count).map { String(format: "%02X", $0) }.joined(separator: " ")
+    }
+
     private func parseServerResponse(_ data: Data) {
+        packetsReceived += 1
         guard data.count >= 4 else {
             logger.warning("Response too short: \(data.count) bytes")
+            parseFailures += 1
             return
         }
 
         let byte1 = data[1]
         let msgType = (byte1 >> 4) & 0x0F
+        lastServerMessageType = msgType
 
         if msgType == 0x0F {
             // Error message from server
@@ -234,17 +291,34 @@ final class VolcengineStreamingSTT: NSObject {
             return
         }
 
-        // Full server response — extract JSON payload
-        guard data.count >= 8 else { return }
-        let payloadSize = data.subdata(in: 4..<8).withUnsafeBytes { ptr in
-            ptr.load(as: UInt32.self).bigEndian
+        // Full server response layout:
+        //   header (headerSize*4 B) | [sequence number 4B] | payload size 4B | payload
+        // Flags 0b0001 / 0b0011 mean the four bytes right after the header are a sequence
+        // number. Sequence numbers are small integers, so mis-reading one as the payload
+        // size yields a tiny length that still passes the bounds check and produces a
+        // garbage slice — the parseFail == recv signature measured on device.
+        let headerSize = max(Int(data[0] & 0x0F) * 4, 4)
+        let flags = data[1] & 0x0F
+        let hasSequenceNumber = (flags == 0x01 || flags == 0x03)
+        var cursor = headerSize + (hasSequenceNumber ? 4 : 0)
+
+        guard data.count >= cursor + 4 else {
+            parseFailures += 1
+            logger.error("Response too short for payload size: \(data.count)B cursor=\(cursor) hex=\(Self.hexPrefix(data))")
+            return
         }
-        guard data.count >= 8 + Int(payloadSize) else {
-            logger.warning("Incomplete payload: expected \(payloadSize), got \(data.count - 8)")
+        let payloadSize = Int(data.subdata(in: cursor..<(cursor + 4)).withUnsafeBytes { ptr in
+            ptr.load(as: UInt32.self).bigEndian
+        })
+        cursor += 4
+
+        guard payloadSize > 0, data.count >= cursor + payloadSize else {
+            parseFailures += 1
+            logger.error("Incomplete payload: declared \(payloadSize)B, have \(data.count - cursor)B hex=\(Self.hexPrefix(data))")
             return
         }
 
-        let payloadData = data.subdata(in: 8..<(8 + Int(payloadSize)))
+        let payloadData = data.subdata(in: cursor..<(cursor + payloadSize))
 
         // Check if payload is gzip compressed
         let byte2 = data[2]
@@ -257,8 +331,17 @@ final class VolcengineStreamingSTT: NSObject {
             jsonData = payloadData
         }
 
-        guard let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-              let result = json["result"] as? [String: Any],
+        guard let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            parseFailures += 1
+            let preview = String(data: jsonData.prefix(160), encoding: .utf8) ?? "<non-utf8>"
+            logger.error("Payload is not JSON: \(preview) hex=\(Self.hexPrefix(data))")
+            return
+        }
+        payloadsParsed += 1
+
+        // The acknowledgement of the full client request carries no result yet, so a
+        // missing result field is a normal early packet rather than a parsing fault.
+        guard let result = json["result"] as? [String: Any],
               let text = result["text"] as? String
         else {
             return
@@ -378,13 +461,35 @@ final class VolcengineStreamingSTT: NSObject {
     }
 
     private func handleDisconnected(error: Error?) {
-        guard case .streaming = state else { return }
-        if let error {
-            state = .failed(error)
-            onCompleted?(.failure(error))
-        } else {
-            state = .finished
-            onCompleted?(.success(currentText))
+        switch state {
+        case .finishing:
+            // The server closes the socket itself after finalizing, so a close here is the
+            // expected end of dictation — but only report success if a transcript actually
+            // arrived. Reporting success unconditionally hides real failures as an empty result.
+            if hasReceivedResult {
+                state = .finished
+                onCompleted?(.success(currentText))
+            } else {
+                let reason = "no transcript received before close — \(diagnosticSummary)"
+                logger.error("\(reason)")
+                let wrappedError = VolcengineSTTError.connectionFailed(reason)
+                state = .failed(wrappedError)
+                onCompleted?(.failure(wrappedError))
+            }
+        case .streaming, .connecting:
+            if let error {
+                let nsError = error as NSError
+                let detailedMessage = "Volcengine WS failed: \(nsError.localizedDescription) [domain=\(nsError.domain) code=\(nsError.code)] \(diagnosticSummary)"
+                logger.error("\(detailedMessage)")
+                let wrappedError = VolcengineSTTError.connectionFailed(detailedMessage)
+                state = .failed(wrappedError)
+                onCompleted?(.failure(wrappedError))
+            } else {
+                state = .finished
+                onCompleted?(.success(currentText))
+            }
+        default:
+            break
         }
     }
 }
@@ -419,7 +524,11 @@ extension VolcengineStreamingSTT: URLSessionWebSocketDelegate {
         didCompleteWithError error: (any Error)?
     ) {
         Task { @MainActor [weak self] in
-            self?.handleDisconnected(error: error)
+            guard let self else { return }
+            if let error {
+                self.logger.error("URLSession task completed with error: \(error.localizedDescription) code=\((error as NSError).code) domain=\((error as NSError).domain)")
+            }
+            self.handleDisconnected(error: error)
         }
     }
 }

--- a/HermesMobile/Features/Chat/VolcengineStreamingSTT.swift
+++ b/HermesMobile/Features/Chat/VolcengineStreamingSTT.swift
@@ -39,6 +39,8 @@ final class VolcengineStreamingSTT: NSObject {
     var onFinalResult: ((String) -> Void)?
     /// Called when the session ends (either normally or with error).
     var onCompleted: ((Result<String, Error>) -> Void)?
+    /// Called when WebSocket is connected and ready to receive audio frames.
+    var onReady: (() -> Void)?
 
     private var webSocketTask: URLSessionWebSocketTask?
     private var urlSession: URLSession?
@@ -65,6 +67,7 @@ final class VolcengineStreamingSTT: NSObject {
         request.setValue(configuration.apiKey, forHTTPHeaderField: "X-Api-Key")
         request.setValue(configuration.resourceId, forHTTPHeaderField: "X-Api-Resource-Id")
         request.setValue(connectId, forHTTPHeaderField: "X-Api-Connect-Id")
+        request.setValue(UUID().uuidString, forHTTPHeaderField: "X-Api-Request-Id")
         request.setValue("-1", forHTTPHeaderField: "X-Api-Sequence")
 
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
@@ -128,8 +131,7 @@ final class VolcengineStreamingSTT: NSObject {
                 "codec": "raw",
                 "rate": 16000,
                 "bits": 16,
-                "channel": 1,
-                "language": configuration.language
+                "channel": 1
             ],
             "request": [
                 "model_name": "bigmodel",
@@ -368,6 +370,7 @@ final class VolcengineStreamingSTT: NSObject {
                 } else {
                     self.state = .streaming
                     self.startReceiving()
+                    self.onReady?()
                     self.logger.info("Volcengine STT streaming started")
                 }
             }

--- a/HermesMobile/Features/Chat/VolcengineStreamingSTT.swift
+++ b/HermesMobile/Features/Chat/VolcengineStreamingSTT.swift
@@ -1,0 +1,441 @@
+import Foundation
+import Compression
+import OSLog
+
+/// Volcengine (ByteDance/Doubao) streaming ASR client.
+/// Uses WebSocket with a custom binary protocol to stream PCM audio frames
+/// and receive real-time partial transcription results.
+///
+/// Protocol: wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async
+/// Docs: https://www.volcengine.com/docs/6561/1354869
+@MainActor
+final class VolcengineStreamingSTT: NSObject {
+    enum State {
+        case idle
+        case connecting
+        case streaming
+        case finished
+        case failed(Error)
+    }
+
+    struct Configuration {
+        let apiKey: String
+        let resourceId: String
+        var language: String = "zh-CN"
+        /// VAD end-of-speech silence threshold in ms. Default 800ms.
+        var endWindowSize: Int = 800
+        /// Hot words for better recognition of domain terms.
+        var hotwords: [String] = []
+
+        static let defaultResourceId = "volc.seedasr.sauc.duration"
+    }
+
+    private(set) var state: State = .idle
+    private(set) var currentText: String = ""
+
+    /// Called on every partial transcript update (main actor).
+    var onPartialResult: ((String) -> Void)?
+    /// Called when a sentence is finalized (definite=true).
+    var onFinalResult: ((String) -> Void)?
+    /// Called when the session ends (either normally or with error).
+    var onCompleted: ((Result<String, Error>) -> Void)?
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private let connectId = UUID().uuidString
+    private let logger = Logger(subsystem: "com.gyliu.hermex", category: "VolcengineSTT")
+    private var configuration: Configuration?
+    private var hasReceivedResult = false
+
+    // MARK: - Public API
+
+    func start(configuration: Configuration) {
+        guard case .idle = state else {
+            logger.warning("start() called in non-idle state")
+            return
+        }
+
+        self.configuration = configuration
+        self.currentText = ""
+        self.hasReceivedResult = false
+        state = .connecting
+
+        let endpoint = URL(string: "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async")!
+        var request = URLRequest(url: endpoint)
+        request.setValue(configuration.apiKey, forHTTPHeaderField: "X-Api-Key")
+        request.setValue(configuration.resourceId, forHTTPHeaderField: "X-Api-Resource-Id")
+        request.setValue(connectId, forHTTPHeaderField: "X-Api-Connect-Id")
+        request.setValue("-1", forHTTPHeaderField: "X-Api-Sequence")
+
+        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        self.urlSession = session
+        let task = session.webSocketTask(with: request)
+        self.webSocketTask = task
+        task.resume()
+
+        logger.info("WebSocket connecting to Volcengine ASR, connectId=\(self.connectId)")
+    }
+
+    /// Send a PCM audio frame (16kHz, mono, 16-bit, ~200ms recommended).
+    func sendAudioFrame(_ pcmData: Data) {
+        guard case .streaming = state else { return }
+        let message = buildAudioOnlyMessage(pcmData)
+        webSocketTask?.send(.data(message)) { [weak self] error in
+            if let error {
+                Task { @MainActor [weak self] in
+                    self?.logger.error("Failed to send audio frame: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    /// Signal end of audio input. Server will finalize remaining text.
+    func finishAudio() {
+        guard case .streaming = state else { return }
+        let message = buildLastAudioMessage()
+        webSocketTask?.send(.data(message)) { [weak self] error in
+            if let error {
+                Task { @MainActor [weak self] in
+                    self?.logger.error("Failed to send last frame: \(error.localizedDescription)")
+                }
+            }
+        }
+        logger.info("Sent last audio frame (negative packet)")
+    }
+
+    func cancel() {
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        webSocketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+        state = .idle
+        logger.info("Cancelled Volcengine STT session")
+    }
+
+    // MARK: - Binary Protocol
+
+    /// Build the first message: full client request with JSON config.
+    private func buildFullClientRequest() -> Data {
+        guard let configuration else { return Data() }
+
+        var payload: [String: Any] = [
+            "user": [
+                "uid": "hermex-ios",
+                "platform": "iOS"
+            ],
+            "audio": [
+                "format": "pcm",
+                "codec": "raw",
+                "rate": 16000,
+                "bits": 16,
+                "channel": 1,
+                "language": configuration.language
+            ],
+            "request": [
+                "model_name": "bigmodel",
+                "enable_itn": true,
+                "enable_punc": true,
+                "enable_ddc": true,
+                "result_type": "full",
+                "end_window_size": configuration.endWindowSize
+            ] as [String: Any]
+        ]
+
+        // Add hotwords if configured
+        if !configuration.hotwords.isEmpty {
+            let hotwordList = configuration.hotwords.map { ["word": $0] }
+            let contextJSON = try? JSONSerialization.data(
+                withJSONObject: ["hotwords": hotwordList]
+            )
+            if let contextJSON, let contextStr = String(data: contextJSON, encoding: .utf8) {
+                var requestDict = payload["request"] as? [String: Any] ?? [:]
+                requestDict["corpus"] = ["context": contextStr]
+                payload["request"] = requestDict
+            }
+        }
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: payload) else {
+            return Data()
+        }
+
+        // Header: version=1, headerSize=1, msgType=0001(full client req),
+        // flags=0000, serialization=0001(JSON), compression=0000(none), reserved=0
+        let header: [UInt8] = [
+            0x11, // version=1 | headerSize=1
+            0x10, // msgType=0001 | flags=0000
+            0x10, // serialization=0001(JSON) | compression=0000(none)
+            0x00  // reserved
+        ]
+
+        var message = Data(header)
+        var payloadSize = UInt32(jsonData.count).bigEndian
+        message.append(Data(bytes: &payloadSize, count: 4))
+        message.append(jsonData)
+        return message
+    }
+
+    /// Build an audio-only message (mid-stream audio frames).
+    private func buildAudioOnlyMessage(_ pcmData: Data) -> Data {
+        // Header: version=1, headerSize=1, msgType=0010(audio only),
+        // flags=0000, serialization=0000(none), compression=0000(none), reserved=0
+        let header: [UInt8] = [
+            0x11, // version=1 | headerSize=1
+            0x20, // msgType=0010 | flags=0000
+            0x00, // serialization=0000 | compression=0000
+            0x00  // reserved
+        ]
+
+        var message = Data(header)
+        var payloadSize = UInt32(pcmData.count).bigEndian
+        message.append(Data(bytes: &payloadSize, count: 4))
+        message.append(pcmData)
+        return message
+    }
+
+    /// Build the last audio message (negative packet, signals end of input).
+    private func buildLastAudioMessage() -> Data {
+        // Header: version=1, headerSize=1, msgType=0010(audio only),
+        // flags=0010(last packet, no sequence), serialization=0000, compression=0000
+        let header: [UInt8] = [
+            0x11, // version=1 | headerSize=1
+            0x22, // msgType=0010 | flags=0010(last packet)
+            0x00, // serialization=0000 | compression=0000
+            0x00  // reserved
+        ]
+
+        var message = Data(header)
+        // Empty payload
+        var payloadSize = UInt32(0).bigEndian
+        message.append(Data(bytes: &payloadSize, count: 4))
+        return message
+    }
+
+    // MARK: - Response Parsing
+
+    private func parseServerResponse(_ data: Data) {
+        guard data.count >= 4 else {
+            logger.warning("Response too short: \(data.count) bytes")
+            return
+        }
+
+        let byte1 = data[1]
+        let msgType = (byte1 >> 4) & 0x0F
+
+        if msgType == 0x0F {
+            // Error message from server
+            parseErrorResponse(data)
+            return
+        }
+
+        guard msgType == 0x09 else {
+            logger.debug("Ignoring message type: 0x\(String(format: "%02X", msgType))")
+            return
+        }
+
+        // Full server response — extract JSON payload
+        guard data.count >= 8 else { return }
+        let payloadSize = data.subdata(in: 4..<8).withUnsafeBytes { ptr in
+            ptr.load(as: UInt32.self).bigEndian
+        }
+        guard data.count >= 8 + Int(payloadSize) else {
+            logger.warning("Incomplete payload: expected \(payloadSize), got \(data.count - 8)")
+            return
+        }
+
+        let payloadData = data.subdata(in: 8..<(8 + Int(payloadSize)))
+
+        // Check if payload is gzip compressed
+        let byte2 = data[2]
+        let compression = byte2 & 0x0F
+        let jsonData: Data
+        if compression == 0x01 {
+            // Gzip — decompress
+            jsonData = (try? decompressGzip(payloadData)) ?? payloadData
+        } else {
+            jsonData = payloadData
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let result = json["result"] as? [String: Any],
+              let text = result["text"] as? String
+        else {
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.hasReceivedResult = true
+            self.currentText = text
+            self.onPartialResult?(text)
+
+            // Check for definite (finalized) utterances
+            if let utterances = result["utterances"] as? [[String: Any]] {
+                for utterance in utterances {
+                    if let definite = utterance["definite"] as? Bool, definite,
+                       let sentenceText = utterance["text"] as? String {
+                        self.onFinalResult?(sentenceText)
+                    }
+                }
+            }
+        }
+    }
+
+    private func parseErrorResponse(_ data: Data) {
+        guard data.count >= 12 else { return }
+        let errorCode = data.subdata(in: 4..<8).withUnsafeBytes { ptr in
+            ptr.load(as: UInt32.self).bigEndian
+        }
+        let msgSize = data.subdata(in: 8..<12).withUnsafeBytes { ptr in
+            ptr.load(as: UInt32.self).bigEndian
+        }
+        var errorMsg = "Unknown error"
+        if data.count >= 12 + Int(msgSize) {
+            errorMsg = String(data: data.subdata(in: 12..<(12 + Int(msgSize))), encoding: .utf8) ?? errorMsg
+        }
+
+        logger.error("Volcengine ASR error: code=\(errorCode), msg=\(errorMsg)")
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let error = VolcengineSTTError.serverError(code: Int(errorCode), message: errorMsg)
+            self.state = .failed(error)
+            self.onCompleted?(.failure(error))
+        }
+    }
+
+    private func decompressGzip(_ data: Data) throws -> Data {
+        // We send compression=0x00 (none) in our requests, so the server
+        // should mirror that and respond uncompressed. This is a safety fallback.
+        // Use Apple's Compression framework for decompression.
+        let dstSize = data.count * 8 // generous output buffer
+        let dstBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: dstSize)
+        defer { dstBuffer.deallocate() }
+
+        let srcSize = data.count
+        let decodedSize = data.withUnsafeBytes { (srcBuffer: UnsafeRawBufferPointer) -> Int in
+            guard let srcPtr = srcBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+            return compression_decode_buffer(
+                dstBuffer, dstSize,
+                srcPtr, srcSize,
+                nil, COMPRESSION_ZLIB
+            )
+        }
+
+        guard decodedSize > 0 else { return data }
+        return Data(bytes: dstBuffer, count: decodedSize)
+    }
+
+    // MARK: - Receive Loop
+
+    private func startReceiving() {
+        webSocketTask?.receive { [weak self] result in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                switch result {
+                case .success(let message):
+                    switch message {
+                    case .data(let data):
+                        self.parseServerResponse(data)
+                    case .string(let string):
+                        self.logger.debug("Received text message (unexpected): \(string.prefix(100))")
+                    @unknown default:
+                        break
+                    }
+                    // Continue receiving
+                    self.startReceiving()
+                case .failure(let error):
+                    if case .streaming = self.state {
+                        self.logger.error("WebSocket receive error: \(error.localizedDescription)")
+                        self.state = .failed(error)
+                        self.onCompleted?(.failure(error))
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Connection Lifecycle
+
+    private func handleConnected() {
+        logger.info("WebSocket connected, sending full client request")
+        let fullRequest = buildFullClientRequest()
+        webSocketTask?.send(.data(fullRequest)) { [weak self] error in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if let error {
+                    self.logger.error("Failed to send full client request: \(error.localizedDescription)")
+                    self.state = .failed(error)
+                    self.onCompleted?(.failure(error))
+                } else {
+                    self.state = .streaming
+                    self.startReceiving()
+                    self.logger.info("Volcengine STT streaming started")
+                }
+            }
+        }
+    }
+
+    private func handleDisconnected(error: Error?) {
+        guard case .streaming = state else { return }
+        if let error {
+            state = .failed(error)
+            onCompleted?(.failure(error))
+        } else {
+            state = .finished
+            onCompleted?(.success(currentText))
+        }
+    }
+}
+
+// MARK: - URLSessionWebSocketDelegate
+
+extension VolcengineStreamingSTT: URLSessionWebSocketDelegate {
+    nonisolated func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        Task { @MainActor [weak self] in
+            self?.handleConnected()
+        }
+    }
+
+    nonisolated func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        Task { @MainActor [weak self] in
+            self?.handleDisconnected(error: nil)
+        }
+    }
+
+    nonisolated func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: (any Error)?
+    ) {
+        Task { @MainActor [weak self] in
+            self?.handleDisconnected(error: error)
+        }
+    }
+}
+
+// MARK: - Error
+
+enum VolcengineSTTError: LocalizedError {
+    case serverError(code: Int, message: String)
+    case connectionFailed(String)
+    case notConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .serverError(let code, let message):
+            return "Volcengine ASR error (\(code)): \(message)"
+        case .connectionFailed(let reason):
+            return "Volcengine ASR connection failed: \(reason)"
+        case .notConfigured:
+            return "Volcengine ASR is not configured. Add your API key in Settings."
+        }
+    }
+}

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -195,6 +195,48 @@ struct SettingsView: View {
                     }
 
                     SettingsFootnote(String(localized: "On-device only keeps composer dictation audio off your Hermes server."))
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        title: String(localized: "Voice-First Input"),
+                        systemImage: "waveform",
+                        isOn: Binding(
+                            get: { UserDefaults.standard.bool(forKey: VoiceFirstModeSettings.isEnabledKey) },
+                            set: { UserDefaults.standard.set($0, forKey: VoiceFirstModeSettings.isEnabledKey) }
+                        )
+                    )
+
+                    SettingsFootnote(String(localized: "When enabled, the composer defaults to voice listening mode. Speak and pause to auto-send. Tap the keyboard icon to type instead."))
+
+                    if UserDefaults.standard.bool(forKey: VoiceFirstModeSettings.isEnabledKey) {
+                        SettingsDivider()
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label {
+                                Text("Hot Words")
+                            } icon: {
+                                Image(systemName: "text.badge.star")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .font(.subheadline)
+
+                            TextField(
+                                "hermes, hermex, webui, state.db",
+                                text: Binding(
+                                    get: { UserDefaults.standard.string(forKey: VoiceFirstModeSettings.hotWordsKey) ?? "" },
+                                    set: { UserDefaults.standard.set($0, forKey: VoiceFirstModeSettings.hotWordsKey) }
+                                )
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .font(.footnote)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                        }
+                        .padding(.horizontal, 4)
+
+                        SettingsFootnote(String(localized: "Comma-separated terms to boost STT accuracy for project-specific words."))
+                    }
                 }
 
                 SettingsCard(title: String(localized: "Chat")) {

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -196,6 +196,35 @@ struct SettingsView: View {
 
                     SettingsFootnote(String(localized: "On-device only keeps composer dictation audio off your Hermes server."))
 
+                    if sttProviderPreferenceRawValue == ComposerSTTProviderPreference.volcengineFirst.rawValue {
+                        SettingsDivider()
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label {
+                                Text("Volcengine API Key")
+                            } icon: {
+                                Image(systemName: "key")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .font(.subheadline)
+
+                            SecureField(
+                                "API Key from console.volcengine.com",
+                                text: Binding(
+                                    get: { UserDefaults.standard.string(forKey: VolcengineSTTSettings.apiKeyKey) ?? "" },
+                                    set: { UserDefaults.standard.set($0, forKey: VolcengineSTTSettings.apiKeyKey) }
+                                )
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .font(.footnote)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                        }
+                        .padding(.horizontal, 4)
+
+                        SettingsFootnote(String(localized: "Get your API Key from the Volcengine Speech console. Enables low-latency streaming Chinese recognition."))
+                    }
+
                     SettingsDivider()
 
                     SettingsToggleRow(

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -57,6 +57,7 @@ struct SettingsView: View {
     @State private var showDefaultProfilePicker = false
     @State private var notificationPermissionStatus: UNAuthorizationStatus?
     @State private var notificationStatusMessage: String?
+    @State private var volcengineTestResult: String = ""
     @AppStorage(AppTheme.storageKey) private var appThemeRawValue = AppTheme.system.rawValue
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
     @AppStorage(ResponseCompletionNotifications.isEnabledKey) private var isResponseCompletionNotificationsEnabled = false
@@ -223,6 +224,25 @@ struct SettingsView: View {
                         .padding(.horizontal, 4)
 
                         SettingsFootnote(String(localized: "Get your API Key from the Volcengine Speech console. Enables low-latency streaming Chinese recognition."))
+
+                        Button {
+                            volcengineTestResult = "Testing..."
+                            Task {
+                                await testVolcengineConnection()
+                            }
+                        } label: {
+                            Label("Test Connection", systemImage: "network")
+                        }
+                        .buttonStyle(.bordered)
+                        .padding(.horizontal, 4)
+
+                        if !volcengineTestResult.isEmpty {
+                            Text(volcengineTestResult)
+                                .font(.caption)
+                                .foregroundStyle(volcengineTestResult.contains("✅") ? .green : .red)
+                                .padding(.horizontal, 4)
+                                .textSelection(.enabled)
+                        }
                     }
 
                     SettingsDivider()
@@ -238,34 +258,6 @@ struct SettingsView: View {
 
                     SettingsFootnote(String(localized: "When enabled, the composer defaults to voice listening mode. Speak and pause to auto-send. Tap the keyboard icon to type instead."))
 
-                    if UserDefaults.standard.bool(forKey: VoiceFirstModeSettings.isEnabledKey) {
-                        SettingsDivider()
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            Label {
-                                Text("Hot Words")
-                            } icon: {
-                                Image(systemName: "text.badge.star")
-                                    .foregroundStyle(.secondary)
-                            }
-                            .font(.subheadline)
-
-                            TextField(
-                                "hermes, hermex, webui, state.db",
-                                text: Binding(
-                                    get: { UserDefaults.standard.string(forKey: VoiceFirstModeSettings.hotWordsKey) ?? "" },
-                                    set: { UserDefaults.standard.set($0, forKey: VoiceFirstModeSettings.hotWordsKey) }
-                                )
-                            )
-                            .textFieldStyle(.roundedBorder)
-                            .font(.footnote)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
-                        }
-                        .padding(.horizontal, 4)
-
-                        SettingsFootnote(String(localized: "Comma-separated terms to boost STT accuracy for project-specific words."))
-                    }
                 }
 
                 SettingsCard(title: String(localized: "Chat")) {
@@ -1284,6 +1276,90 @@ struct SettingsView: View {
             updateApplyPhase = .idle
             updateApplyMessage = nil
         }
+    }
+
+    private func testVolcengineConnection() async {
+        guard let apiKey = UserDefaults.standard.string(forKey: VolcengineSTTSettings.apiKeyKey),
+              !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            volcengineTestResult = "❌ No API Key configured"
+            return
+        }
+
+        let connectId = UUID().uuidString
+        var components = URLComponents(string: "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async")!
+        components.queryItems = [
+            URLQueryItem(name: "X-Api-Key", value: apiKey.trimmingCharacters(in: .whitespacesAndNewlines)),
+            URLQueryItem(name: "X-Api-Resource-Id", value: VolcengineSTTSettings.defaultResourceId),
+            URLQueryItem(name: "X-Api-Connect-Id", value: connectId),
+            URLQueryItem(name: "X-Api-Request-Id", value: UUID().uuidString),
+            URLQueryItem(name: "X-Api-Sequence", value: "-1")
+        ]
+
+        var request = URLRequest(url: components.url!)
+        request.setValue(apiKey.trimmingCharacters(in: .whitespacesAndNewlines), forHTTPHeaderField: "X-Api-Key")
+        request.setValue(VolcengineSTTSettings.defaultResourceId, forHTTPHeaderField: "X-Api-Resource-Id")
+        request.setValue(connectId, forHTTPHeaderField: "X-Api-Connect-Id")
+        request.setValue(UUID().uuidString, forHTTPHeaderField: "X-Api-Request-Id")
+        request.setValue("-1", forHTTPHeaderField: "X-Api-Sequence")
+        request.timeoutInterval = 10
+
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: request)
+        task.resume()
+
+        // Wait for connection or timeout
+        let startTime = Date()
+        while Date().timeIntervalSince(startTime) < 10 {
+            switch task.state {
+            case .running:
+                // Try to send a ping to verify the connection is truly open
+                let pingResult: Result<Void, Error> = await withCheckedContinuation { cont in
+                    task.sendPing { error in
+                        if let error {
+                            cont.resume(returning: .failure(error))
+                        } else {
+                            cont.resume(returning: .success(()))
+                        }
+                    }
+                }
+                switch pingResult {
+                case .success:
+                    task.cancel(with: .goingAway, reason: nil)
+                    session.invalidateAndCancel()
+                    volcengineTestResult = "✅ Connected! WebSocket handshake OK (connectId: \(connectId.prefix(8))...)"
+                    return
+                case .failure(let error):
+                    let nsErr = error as NSError
+                    if nsErr.domain == "NSPOSIXErrorDomain" && nsErr.code == 57 {
+                        // Not connected yet, keep waiting
+                        try? await Task.sleep(nanoseconds: 200_000_000)
+                        continue
+                    }
+                    task.cancel(with: .goingAway, reason: nil)
+                    session.invalidateAndCancel()
+                    volcengineTestResult = "❌ \(nsErr.localizedDescription) [domain=\(nsErr.domain) code=\(nsErr.code)]"
+                    return
+                }
+            case .completed:
+                session.invalidateAndCancel()
+                volcengineTestResult = "❌ Connection closed immediately. Server likely rejected auth headers. Key prefix: \(apiKey.prefix(8))..."
+                return
+            case .canceling:
+                session.invalidateAndCancel()
+                volcengineTestResult = "❌ Connection cancelled"
+                return
+            case .suspended:
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                continue
+            @unknown default:
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                continue
+            }
+        }
+
+        task.cancel(with: .goingAway, reason: nil)
+        session.invalidateAndCancel()
+        volcengineTestResult = "❌ Timeout (10s). Could not establish WebSocket. Check network/proxy."
     }
 
     private func clearOfflineCache() async {

--- a/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
+++ b/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
@@ -58,6 +58,55 @@ final class ComposerVoiceDraftComposerTests: XCTestCase {
         XCTAssertEqual(session.composedDraft(for: "transcript"), "New transcript")
     }
 
+    func testDraftUpdateSessionAcceptsUpdateWhenComposerStillHoldsVoiceText() {
+        var session = ComposerVoiceDraftUpdateSession()
+
+        session.begin(baseDraft: "")
+
+        XCTAssertEqual(session.composedDraft(for: "hello", currentDraft: ""), "hello")
+        // Composer now holds exactly what voice wrote, so the next partial is applied.
+        XCTAssertEqual(session.composedDraft(for: "hello world", currentDraft: "hello"), "hello world")
+    }
+
+    func testDraftUpdateSessionDropsLateTranscriptAfterUserTyped() {
+        var session = ComposerVoiceDraftUpdateSession()
+
+        session.begin(baseDraft: "")
+        XCTAssertEqual(session.composedDraft(for: "hello", currentDraft: ""), "hello")
+
+        // User typed into the composer while the final transcript was still in flight.
+        XCTAssertNil(session.composedDraft(for: "hello world", currentDraft: "my steering text"))
+    }
+
+    func testDraftUpdateSessionDropsLateTranscriptAfterSendClearedComposer() {
+        var session = ComposerVoiceDraftUpdateSession()
+
+        session.begin(baseDraft: "")
+        XCTAssertEqual(session.composedDraft(for: "hello", currentDraft: ""), "hello")
+
+        // Send cleared the composer; a late final result must not re-populate it.
+        XCTAssertNil(session.composedDraft(for: "hello world", currentDraft: ""))
+    }
+
+    func testDraftUpdateSessionKeepsTypedBaseDraftWhenComposerIsUntouched() {
+        var session = ComposerVoiceDraftUpdateSession()
+
+        session.begin(baseDraft: "Please")
+
+        XCTAssertEqual(
+            session.composedDraft(for: "summarize this", currentDraft: "Please"),
+            "Please summarize this"
+        )
+    }
+
+    func testDraftUpdateSessionSkipsOwnershipCheckWhenDraftIsUnavailable() {
+        var session = ComposerVoiceDraftUpdateSession()
+
+        session.begin(baseDraft: "")
+
+        XCTAssertEqual(session.composedDraft(for: "hello", currentDraft: nil), "hello")
+    }
+
     func testVoiceInputPreflightAcceptsValidInputFormatValues() {
         XCTAssertNoThrow(
             try ComposerVoiceInputPreflight.validate(sampleRate: 44_100, channelCount: 1)

--- a/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
+++ b/HermesMobileTests/ComposerVoiceDraftComposerTests.swift
@@ -123,7 +123,7 @@ final class ComposerVoiceDraftComposerTests: XCTestCase {
 
     func testVoiceInputAudioSessionConfigurationDoesNotDuckOtherAudio() {
         XCTAssertEqual(ComposerVoiceAudioSessionConfiguration.category, .playAndRecord)
-        XCTAssertEqual(ComposerVoiceAudioSessionConfiguration.mode, .measurement)
+        XCTAssertEqual(ComposerVoiceAudioSessionConfiguration.mode, .videoRecording)
         XCTAssertTrue(ComposerVoiceAudioSessionConfiguration.options.contains(.mixWithOthers))
         XCTAssertTrue(ComposerVoiceAudioSessionConfiguration.options.contains(.allowBluetoothHFP))
         XCTAssertFalse(ComposerVoiceAudioSessionConfiguration.options.contains(.duckOthers))


### PR DESCRIPTION
## Summary

Implements voice-first composer mode — a lightweight alternative to the full voice-mode overlay (#36). When enabled in Settings, the composer area replaces the text input with a "Hold to speak" bar that supports gesture-based interaction.

Adds Volcengine (ByteDance/Doubao) streaming ASR as a dictation provider, for low-latency Chinese recognition with live partial results.

Closes #271

## Interaction Design

### Basic Flow (model idle)

| Gesture | Action | Visual Cue |
|---------|--------|------------|
| Long press | Start recording | Blue background + waveform animation + "Listening…" |
| Release | Send transcribed message | Bar returns to default |
| Swipe up + release | Cancel recording | Red background + ✕ + "Release to cancel" |
| Short tap | Switch to keyboard input | Text composer appears |

### During Model Streaming

| Gesture | Action | Visual Cue |
|---------|--------|------------|
| Release (no swipe) | **Interrupt** — stop current response + send as new message | "Listening… release to send" + hint "↑ Cancel ↓ Queue" |
| Swipe down + release | **Queue** — wait for response to finish, then send as new turn | Orange background + "↓ Release to queue" + "Send after response completes" |
| Swipe up + release | Cancel recording | Red background + ✕ |

### Design Decisions

- **Default during streaming = interrupt**: natural voice semantics — "I spoke, you stop". Queue is an easter-egg for power users who discover the swipe-down gesture.
- **Easter egg philosophy**: voice-first mode itself is opt-in (Settings toggle). Swipe gestures are undocumented power features users discover gradually.
- **Message visibility**: steer/interrupt/queue all show user message as a normal chat bubble (uses temporary UserDefaults swap instead of noEcho slash commands).

## Dictation Providers

The `Dictation Provider` picker in Settings selects which STT backend voice input uses. Voice-first mode honours the picked provider; when Volcengine is not selected it defaults to server STT for multilingual support (Apple's on-device recogniser is single-language-locked, while Whisper auto-detects and handles 中英混合 code-switching).

| Provider | Transport | Live partial results | Credential |
|----------|-----------|----------------------|------------|
| Server first | Records a WAV, uploads once on release | No | none (uses your Hermes server) |
| On-device first / only | `SFSpeechAudioBufferRecognitionRequest` | Yes | none |
| Volcengine streaming | WebSocket, 200 ms PCM frames | Yes | API Key |

### Volcengine setup

Only an **API Key** is required — no AppID, no Access Token, no secret. The key is
stored in `UserDefaults` on the device and is never committed; nothing is hardcoded
in the repo.

- **Get a key:** https://console.volcengine.com/speech/new/setting/apikeys?projectName=default
- **Enable the service first:** 豆包语音 → 语音识别 → 流式语音识别 (大模型). A key without this
  entitlement authenticates but returns no result.
- **Protocol docs:** https://www.volcengine.com/docs/6561/1354869

Notes on the values this PR uses:

- Endpoint `wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async` — the optimised
  bidirectional streaming mode, which only pushes a packet when the result changes.
- Resource ID defaults to `volc.seedasr.sauc.duration` (豆包流式语音识别模型 2.0, 小时版) and is
  overridable in Settings. Use `volc.seedasr.sauc.concurrent` for a concurrency-based plan,
  or the `volc.bigasr.*` equivalents for model 1.0.
- Auth is the **new** console contract: a single `X-Api-Key`. The legacy
  `X-Api-App-Key` + `X-Api-Access-Key` pair is not used.

A **Test Connection** button under the key field performs the WebSocket handshake plus a
ping and reports the failing domain/code, so a bad key or a blocked network is
distinguishable from a client bug without reading device logs.

## New Files

- `ComposerVoiceFirstMode.swift` — silence timer state machine, phase management
- `ComposerVoiceFirstBar.swift` — "Hold to speak" bar UI with DragGesture-based interaction
- `ComposerSTTContextProvider.swift` — hot-word extraction (currently unreferenced, see below)
- `VolcengineStreamingSTT.swift` — WebSocket client for the Volcengine binary protocol
- `VolcengineSTTSettings.swift` — key/resource-id storage and configuration builder

## Modified Files

- `ComposerVoiceInputController.swift` — added `contextualStrings`, `onPartialTranscript`, `onFinalTranscript`; Volcengine capture path (downsample to 16 kHz mono, accumulate 200 ms packets)
- `ChatComposerView.swift` — conditional body render, auto-send watchers, gesture action routing via `voiceFirstApplyPendingAction()`, live transcript preview card
- `SettingsView.swift` — Voice-First Input toggle, Dictation Provider picker, Volcengine key field + Test Connection
- `AppTheme.swift` — `ComposerSTTProviderPreference` / `ComposerSTTProviderPolicy` provider ordering and fallback

## Notable Fixes

- **Sequence-number frames.** Payload size was read from a fixed offset. When the server
  sets flags `0b0001`/`0b0011` the four bytes after the header are a sequence number
  instead, so the size came from the wrong place. Sequence numbers are small integers, so
  the bogus length still passed the bounds check and produced a garbage slice — every
  frame failed to parse while looking superficially valid. Header size and the
  sequence-number flag are now honoured when locating the payload.
- **Audio converter lifetime.** `AVAudioConverter` was a local, so it was deallocated once
  setup returned and resampling state was lost. It is now owned by the controller, each
  input buffer is supplied exactly once, and output is accumulated into 6400-byte
  (200 ms @ 16 kHz) packets.
- **Server-initiated close.** A `finishing` state distinguishes the server closing the
  socket after finalising a transcript from a real connection failure. Success is only
  reported when a transcript actually arrived, so failures cannot surface as empty results.
- **Capture/WebSocket ordering.** Audio capture is deferred until the socket is ready,
  instead of dropping the first frames.

Diagnostic counters (frames sent/dropped, packets received/parsed, last message type) are
included in failure messages so one log line separates a capture problem from a transport
or parsing problem.

## Behaviour Change

`ComposerVoiceAudioSessionConfiguration.mode` moves from `.measurement` to
`.videoRecording`. This affects every dictation provider, not just Volcengine, since all
three share the session configuration. The no-ducking contract the accompanying test
guards is unchanged: `.mixWithOthers` stays set and `.duckOthers` stays absent.

## Removed

The **Hot Words** settings field is gone. It asked users to hand-maintain a
comma-separated term list to work around recognition accuracy, which the streaming
provider handles well enough in practice. `ComposerSTTContextProvider` and
`VoiceFirstModeSettings.hotWordsKey` are left in place but unreferenced —
`contextualStrings` on the controller still feeds both `SFSpeechRecognizer` and the
Volcengine hotword payload, so wiring a source back in is a one-line change.

## Known Limitations

- **Server STT is not streaming.** It records to a file and uploads on release, so there
  are no live partial results and there is a 60 s cap. Because voice-first's silence
  timer is driven by partial transcripts, **silence auto-send does not fire under Server
  first** — release-to-send still works. Streaming providers (on-device, Volcengine) are
  unaffected.
- **On-device stops at the first endpoint.** `SFSpeechRecognizer` finalises on its own
  endpointing and the task has its own duration ceiling, so continuous hands-free
  dictation ends after one utterance rather than auto-continuing.
- **On-device requires an installed offline model.** `requiresOnDeviceRecognition = true`
  plus the `supportsOnDeviceRecognition` gate means unsupported locales silently fall back
  to server STT. Recognition locale follows `Locale.current`, so a device set to English
  will not transcribe Chinese.

## Testing

- [x] `xcodebuild build` succeeds for iOS Simulator and device (0 errors)
- [x] XCTest suite passes
- [x] Installed on iPhone 13 and iPhone 17 Pro (signed Debug build)
- [x] Volcengine streaming verified end-to-end on device by the maintainer: live partial
      results reach the composer and the final transcript is sent
- [x] Hold to speak → release → message sent correctly
- [x] Swipe up → cancel works (recording discarded)
- [x] During streaming: release → interrupt (stops response + new reply)
- [x] During streaming: swipe down → queue (waits for completion, then sends)
- [x] Short tap → switches to text mode
- [x] Blue pill "Switch to voice" button returns to voice mode
- [x] No credentials in the diff: the only Volcengine string literals are the public
      resource ID, the endpoint, and the UserDefaults key names
- [x] i18n: all strings use `String(localized:)` with English defaults
- [ ] On-device provider not re-verified after the changes above (Volcengine was the focus)
