### PR TITLE
fix(chat): keep scroll position when a turn-end reload widens the transcript window

### DIFF
--- a/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
@@ -8,14 +8,29 @@ struct ChatScrollMetrics: Equatable {
 
 struct ChatScrollObserver: UIViewRepresentable {
     let isStreaming: Bool
+    let prependScrollPositionController: ChatPrependScrollPositionController?
     let onMetrics: @MainActor (ChatScrollMetrics) -> Void
+
+    init(
+        isStreaming: Bool,
+        prependScrollPositionController: ChatPrependScrollPositionController? = nil,
+        onMetrics: @escaping @MainActor (ChatScrollMetrics) -> Void
+    ) {
+        self.isStreaming = isStreaming
+        self.prependScrollPositionController = prependScrollPositionController
+        self.onMetrics = onMetrics
+    }
 
     private var metricContext: MetricContext {
         MetricContext(isStreaming: isStreaming)
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(metricContext: metricContext, onMetrics: onMetrics)
+        Coordinator(
+            metricContext: metricContext,
+            prependScrollPositionController: prependScrollPositionController,
+            onMetrics: onMetrics
+        )
     }
 
     func makeUIView(context: Context) -> ObserverView {
@@ -24,6 +39,7 @@ struct ChatScrollObserver: UIViewRepresentable {
 
     func updateUIView(_ uiView: ObserverView, context: Context) {
         context.coordinator.onMetrics = onMetrics
+        context.coordinator.prependScrollPositionController = prependScrollPositionController
         uiView.coordinator = context.coordinator
         context.coordinator.updateMetricContext(metricContext)
 
@@ -86,12 +102,23 @@ struct ChatScrollObserver: UIViewRepresentable {
         private var lastMetrics: ChatScrollMetrics?
         private var pendingMetrics: ChatScrollMetrics?
         private var hasScheduledMetricDelivery = false
+        var prependScrollPositionController: ChatPrependScrollPositionController? {
+            didSet {
+                guard oldValue !== prependScrollPositionController else { return }
+                oldValue?.detach()
+                if let scrollView {
+                    prependScrollPositionController?.attach(to: scrollView)
+                }
+            }
+        }
 
         init(
             metricContext: MetricContext,
+            prependScrollPositionController: ChatPrependScrollPositionController?,
             onMetrics: @escaping @MainActor (ChatScrollMetrics) -> Void
         ) {
             self.metricContext = metricContext
+            self.prependScrollPositionController = prependScrollPositionController
             self.onMetrics = onMetrics
         }
 
@@ -106,6 +133,7 @@ struct ChatScrollObserver: UIViewRepresentable {
             guard let scrollView = enclosingScrollView(for: view) else { return }
 
             guard scrollView !== self.scrollView else {
+                prependScrollPositionController?.attach(to: scrollView)
                 reportMetrics(delivery: delivery)
                 return
             }
@@ -113,6 +141,7 @@ struct ChatScrollObserver: UIViewRepresentable {
             observations.removeAll()
             lastMetrics = nil
             self.scrollView = scrollView
+            prependScrollPositionController?.attach(to: scrollView)
 
             observations = [
                 scrollView.observe(\.contentOffset, options: [.new]) { [weak self] _, _ in
@@ -128,6 +157,7 @@ struct ChatScrollObserver: UIViewRepresentable {
 
         func detach() {
             observations.removeAll()
+            prependScrollPositionController?.detach()
             lastMetrics = nil
             pendingMetrics = nil
             hasScheduledMetricDelivery = false
@@ -201,6 +231,175 @@ struct ChatScrollObserver: UIViewRepresentable {
 
             return nil
         }
+    }
+}
+
+/// Keeps the reader's exact vertical position while older transcript rows are
+/// inserted above it. `ScrollViewProxy.scrollTo(_:anchor:)` can only align a row
+/// to a coarse anchor; aligning the previous first row to `.top` loses the gap
+/// formerly occupied by the Load Older button and causes a visible hop.
+///
+/// This controller snapshots the UIKit scroll geometry before the request, then
+/// offsets by the net content-height growth during the following layout pass.
+/// The correction is deliberately non-animated: it preserves an existing
+/// position rather than navigating to a new one.
+@MainActor
+final class ChatPrependScrollPositionController {
+    private weak var scrollView: UIScrollView?
+    private var baselineContentHeight: CGFloat?
+    private var baselineOffsetY: CGFloat?
+    private var contentSizeObservation: NSKeyValueObservation?
+    private var contentOffsetObservation: NSKeyValueObservation?
+    private var completionTask: Task<Void, Never>?
+    private var isApplyingCompensation = false
+
+    func attach(to scrollView: UIScrollView) {
+        guard scrollView !== self.scrollView else { return }
+        cancelPreservation()
+        self.scrollView = scrollView
+    }
+
+    func detach() {
+        cancelPreservation()
+        scrollView = nil
+    }
+
+    @discardableResult
+    func capture() -> Bool {
+        cancelPreservation()
+        guard let scrollView else { return false }
+
+        baselineContentHeight = scrollView.contentSize.height
+        baselineOffsetY = scrollView.contentOffset.y
+        return true
+    }
+
+    /// Arms compensation before SwiftUI performs the prepend layout. Returns
+    /// false when the user moved the scroll view while the request was in flight,
+    /// leaving the caller free to use its coarse fallback instead of overriding
+    /// user-owned movement.
+    @discardableResult
+    func restoreAfterPrepend() -> Bool {
+        guard let scrollView,
+              let baselineOffsetY,
+              baselineContentHeight != nil,
+              !scrollView.isDragging,
+              !scrollView.isTracking,
+              !scrollView.isDecelerating,
+              abs(scrollView.contentOffset.y - baselineOffsetY) <= 1
+        else {
+            cancelPreservation()
+            return false
+        }
+
+        contentSizeObservation = scrollView.observe(\.contentSize, options: [.new]) { [weak self] _, _ in
+            Self.handleObservedContentSizeChange(for: self)
+        }
+        contentOffsetObservation = scrollView.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, _ in
+            Self.handleObservedUserMovement(for: self, scrollView: scrollView)
+        }
+
+        // Text and attachment layout can settle over several run-loop passes.
+        // Keep applying the same net-height correction for a short bounded
+        // window, then release ownership back to normal scrolling.
+        completionTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled, let self else { return }
+            self.applyCompensation()
+            self.cancelPreservation()
+        }
+        return true
+    }
+
+    func cancelPreservation() {
+        contentSizeObservation = nil
+        contentOffsetObservation = nil
+        completionTask?.cancel()
+        completionTask = nil
+        baselineContentHeight = nil
+        baselineOffsetY = nil
+        isApplyingCompensation = false
+    }
+
+    nonisolated private static func handleObservedContentSizeChange(
+        for controller: ChatPrependScrollPositionController?
+    ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak controller] in
+                MainActor.assumeIsolated {
+                    controller?.applyCompensation()
+                }
+            }
+            return
+        }
+
+        MainActor.assumeIsolated {
+            controller?.applyCompensation()
+        }
+    }
+
+    nonisolated private static func handleObservedUserMovement(
+        for controller: ChatPrependScrollPositionController?,
+        scrollView: UIScrollView
+    ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak controller, weak scrollView] in
+                MainActor.assumeIsolated {
+                    guard let scrollView else { return }
+                    controller?.cancelIfUserIsMoving(scrollView)
+                }
+            }
+            return
+        }
+
+        MainActor.assumeIsolated {
+            controller?.cancelIfUserIsMoving(scrollView)
+        }
+    }
+
+    private func cancelIfUserIsMoving(_ scrollView: UIScrollView) {
+        guard !isApplyingCompensation,
+              scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating
+        else { return }
+
+        cancelPreservation()
+    }
+
+    private func applyCompensation() {
+        guard let scrollView,
+              let baselineContentHeight,
+              let baselineOffsetY
+        else { return }
+
+        let targetY = Self.compensatedOffsetY(
+            baselineOffsetY: baselineOffsetY,
+            contentHeightDelta: scrollView.contentSize.height - baselineContentHeight,
+            adjustedInset: scrollView.adjustedContentInset,
+            contentSizeHeight: scrollView.contentSize.height,
+            boundsHeight: scrollView.bounds.height
+        )
+        guard abs(scrollView.contentOffset.y - targetY) > 0.5 else { return }
+
+        isApplyingCompensation = true
+        var offset = scrollView.contentOffset
+        offset.y = targetY
+        scrollView.setContentOffset(offset, animated: false)
+        isApplyingCompensation = false
+    }
+
+    nonisolated static func compensatedOffsetY(
+        baselineOffsetY: CGFloat,
+        contentHeightDelta: CGFloat,
+        adjustedInset: UIEdgeInsets,
+        contentSizeHeight: CGFloat,
+        boundsHeight: CGFloat
+    ) -> CGFloat {
+        let minimumY = -adjustedInset.top
+        let maximumY = max(
+            minimumY,
+            contentSizeHeight - boundsHeight + adjustedInset.bottom
+        )
+        return min(max(baselineOffsetY + contentHeightDelta, minimumY), maximumY)
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -4,6 +4,7 @@ import UIKit
 struct ChatTranscriptView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @State private var prependScrollPositionController = ChatPrependScrollPositionController()
 
     let isLoading: Bool
     let errorMessage: String?
@@ -285,7 +286,10 @@ struct ChatTranscriptView: View {
         .clipped()
         .background {
             ZStack {
-                ChatScrollObserver(isStreaming: activeStreamID != nil) { metrics in
+                ChatScrollObserver(
+                    isStreaming: activeStreamID != nil,
+                    prependScrollPositionController: prependScrollPositionController
+                ) { metrics in
                     onUpdateScrollMetrics(metrics)
                 }
 
@@ -317,18 +321,23 @@ struct ChatTranscriptView: View {
     }
 
     private func loadOlderMessagesPreservingPosition(proxy: ScrollViewProxy) async {
+        let capturedExactPosition = prependScrollPositionController.capture()
         let renderID = displayedTranscriptMessages.first?.renderID
         let didLoad = await onLoadOlderMessages()
-        guard didLoad, let renderID else { return }
+        guard didLoad else {
+            prependScrollPositionController.cancelPreservation()
+            return
+        }
+
+        if capturedExactPosition,
+           prependScrollPositionController.restoreAfterPrepend() {
+            return
+        }
+
+        guard let renderID else { return }
 
         await Task.yield()
-        if reduceMotion {
-            proxy.scrollTo(renderID, anchor: .top)
-        } else {
-            withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
-                proxy.scrollTo(renderID, anchor: .top)
-            }
-        }
+        proxy.scrollTo(renderID, anchor: .top)
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -1625,10 +1625,11 @@ final class ChatViewModel {
     /// and a reader who scrolled up is dumped at the top of the session.
     ///
     /// When the reloaded window still contains the first message we're already
-    /// showing, drop the reloaded rows *before* that overlap and keep the
-    /// current offset: rows on screen keep their renderIDs, and the tail is
-    /// replaced with the server-authoritative content. Returns nil when the
-    /// windows don't overlap (fall back to plain replacement).
+    /// showing at the absolute index implied by both offsets, drop the reloaded
+    /// rows *before* that overlap and keep the current offset: rows on screen
+    /// keep their renderIDs, and the tail is replaced with the
+    /// server-authoritative content. Returns nil when the windows don't align
+    /// (fall back to plain replacement).
     nonisolated private static func trimmingReloadedMessages(
         _ reloadedMessages: [ChatMessage],
         toPreserveCurrentMessages currentMessages: [ChatMessage],
@@ -1636,8 +1637,14 @@ final class ChatViewModel {
         reloadedMessagesOffset: Int
     ) -> [ChatMessage]? {
         guard reloadedMessagesOffset < currentMessagesOffset,
-              let firstCurrentMessage = currentMessages.first,
-              let overlapIndex = reloadedMessages.firstIndex(where: { $0.id == firstCurrentMessage.id })
+              let firstCurrentMessage = currentMessages.first
+        else {
+            return nil
+        }
+
+        let overlapIndex = currentMessagesOffset - reloadedMessagesOffset
+        guard reloadedMessages.indices.contains(overlapIndex),
+              reloadedMessages[overlapIndex].id == firstCurrentMessage.id
         else {
             return nil
         }

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -1583,6 +1583,18 @@ final class ChatViewModel {
             return
         }
 
+        if let trimmedMessages = Self.trimmingReloadedMessages(
+            reloadedMessages,
+            toPreserveCurrentMessages: previousMessages,
+            currentMessagesOffset: previousMessagesOffset,
+            reloadedMessagesOffset: reloadedMessagesOffset
+        ) {
+            messages = trimmedMessages
+            messagesOffset = previousMessagesOffset
+            hasOlderMessages = previousMessagesOffset > 0 || session?.messagesTruncated == true
+            return
+        }
+
         messages = reloadedMessages
         updateOlderMessagePagination(from: session, loadedMessageCount: messages.count)
     }
@@ -1602,6 +1614,35 @@ final class ChatViewModel {
         }
 
         return Array(currentMessages[..<overlapIndex]) + reloadedMessages
+    }
+
+    /// Mid-session reloads (turn-end `.done`, the completion refresh, or a
+    /// pull-to-refresh while reading) can come back with a *smaller*
+    /// `_messages_offset` than the window on screen — the server widened the
+    /// page, or `.done` omitted the offset entirely and it resolved to 0.
+    /// Adopting that shrunken offset renumbers every positional
+    /// `transcript:<absoluteIndex>` renderID, SwiftUI remounts the whole list,
+    /// and a reader who scrolled up is dumped at the top of the session.
+    ///
+    /// When the reloaded window still contains the first message we're already
+    /// showing, drop the reloaded rows *before* that overlap and keep the
+    /// current offset: rows on screen keep their renderIDs, and the tail is
+    /// replaced with the server-authoritative content. Returns nil when the
+    /// windows don't overlap (fall back to plain replacement).
+    nonisolated private static func trimmingReloadedMessages(
+        _ reloadedMessages: [ChatMessage],
+        toPreserveCurrentMessages currentMessages: [ChatMessage],
+        currentMessagesOffset: Int,
+        reloadedMessagesOffset: Int
+    ) -> [ChatMessage]? {
+        guard reloadedMessagesOffset < currentMessagesOffset,
+              let firstCurrentMessage = currentMessages.first,
+              let overlapIndex = reloadedMessages.firstIndex(where: { $0.id == firstCurrentMessage.id })
+        else {
+            return nil
+        }
+
+        return Array(reloadedMessages[overlapIndex...])
     }
 
     private func updateOlderMessagePagination(from session: SessionDetail?, loadedMessageCount: Int) {

--- a/HermesMobileTests/ChatVerticalScrollAxisGuardTests.swift
+++ b/HermesMobileTests/ChatVerticalScrollAxisGuardTests.swift
@@ -132,3 +132,80 @@ final class ChatVerticalScrollAxisGuardTests: XCTestCase {
         return guardView
     }
 }
+
+@MainActor
+final class ChatPrependScrollPositionControllerTests: XCTestCase {
+    func testPrependCompensatesByExactContentHeightGrowth() {
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 240)
+        let controller = ChatPrependScrollPositionController()
+        controller.attach(to: scrollView)
+
+        XCTAssertTrue(controller.capture())
+        XCTAssertTrue(controller.restoreAfterPrepend())
+
+        scrollView.contentSize.height += 640
+
+        XCTAssertEqual(scrollView.contentOffset.y, 880, accuracy: 0.001)
+    }
+
+    func testCancelledPrependDoesNotMoveScrollPosition() {
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 240)
+        let controller = ChatPrependScrollPositionController()
+        controller.attach(to: scrollView)
+
+        XCTAssertTrue(controller.capture())
+        controller.cancelPreservation()
+        scrollView.contentSize.height += 640
+
+        XCTAssertEqual(scrollView.contentOffset.y, 240, accuracy: 0.001)
+    }
+
+    func testPrependDoesNotOverrideMovementWhileRequestIsInFlight() {
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 240)
+        let controller = ChatPrependScrollPositionController()
+        controller.attach(to: scrollView)
+
+        XCTAssertTrue(controller.capture())
+        scrollView.contentOffset.y = 300
+
+        XCTAssertFalse(controller.restoreAfterPrepend())
+        scrollView.contentSize.height += 640
+        XCTAssertEqual(scrollView.contentOffset.y, 300, accuracy: 0.001)
+    }
+
+    func testCompensatedOffsetClampsToScrollableBounds() {
+        let inset = UIEdgeInsets(top: 12, left: 0, bottom: 20, right: 0)
+
+        XCTAssertEqual(
+            ChatPrependScrollPositionController.compensatedOffsetY(
+                baselineOffsetY: -12,
+                contentHeightDelta: -100,
+                adjustedInset: inset,
+                contentSizeHeight: 1_200,
+                boundsHeight: 480
+            ),
+            -12,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ChatPrependScrollPositionController.compensatedOffsetY(
+                baselineOffsetY: 700,
+                contentHeightDelta: 500,
+                adjustedInset: inset,
+                contentSizeHeight: 1_200,
+                boundsHeight: 480
+            ),
+            740,
+            accuracy: 0.001
+        )
+    }
+
+    private func makeScrollView() -> UIScrollView {
+        let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        scrollView.contentSize = CGSize(width: 320, height: 1_200)
+        return scrollView
+    }
+}

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -6502,6 +6502,187 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testCompletedStreamSessionKeepsCurrentOffsetWhenDoneReturnsWidenedWindow() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "messages": [
+                      {"role": "user", "content": "Recent question", "timestamp": 3, "message_id": "u-2"},
+                      {"role": "assistant", "content": "Recent answer", "timestamp": 4, "message_id": "a-3"}
+                    ],
+                    "_messages_truncated": true,
+                    "_messages_offset": 2
+                  }
+                }
+                """, for: request)
+            case "/api/chat/start":
+                return apiTestJSONResponse("""
+                {
+                  "session_id": "session-abc",
+                  "stream_id": "stream-123"
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        let didStart = await viewModel.sendMessage("Newest question")
+        // `.done` widens the window all the way back to the session start
+        // (offset 0). The rows already on screen must keep their positional
+        // renderIDs, so the current offset wins and the widened head is trimmed.
+        let completedSession = try makeSessionDetail("""
+        {
+          "session_id": "session-abc",
+          "messages": [
+            {"role": "user", "content": "Older question", "message_id": "u-0"},
+            {"role": "assistant", "content": "Older answer", "message_id": "a-1"},
+            {"role": "user", "content": "Recent question", "message_id": "u-2"},
+            {"role": "assistant", "content": "Recent answer", "message_id": "a-3"},
+            {"role": "user", "content": "Newest question", "message_id": "u-4"},
+            {"role": "assistant", "content": "Newest answer", "message_id": "a-5"}
+          ],
+          "_messages_truncated": false,
+          "_messages_offset": 0
+        }
+        """)
+
+        streamClient.emit(.done(DoneStreamEvent(session: completedSession)))
+
+        XCTAssertTrue(didStart)
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), [
+            "Recent question",
+            "Recent answer",
+            "Newest question",
+            "Newest answer"
+        ])
+        XCTAssertEqual(viewModel.messagesOffset, 2)
+        XCTAssertTrue(viewModel.hasOlderMessages)
+        XCTAssertFalse(viewModel.responseCompletionNeedsTranscriptRefresh)
+    }
+
+    @MainActor
+    func testCompletedStreamSessionKeepsCurrentOffsetWhenDoneOmitsOffset() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "messages": [
+                      {"role": "user", "content": "Recent question", "timestamp": 3, "message_id": "u-2"},
+                      {"role": "assistant", "content": "Recent answer", "timestamp": 4, "message_id": "a-3"}
+                    ],
+                    "_messages_truncated": true,
+                    "_messages_offset": 2
+                  }
+                }
+                """, for: request)
+            case "/api/chat/start":
+                return apiTestJSONResponse("""
+                {
+                  "session_id": "session-abc",
+                  "stream_id": "stream-123"
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        let didStart = await viewModel.sendMessage("Newest question")
+        // `.done` without `_messages_offset` used to resolve to offset 0 and
+        // renumber every on-screen row. The overlap trim must keep offset 2.
+        let completedSession = try makeSessionDetail("""
+        {
+          "session_id": "session-abc",
+          "messages": [
+            {"role": "user", "content": "Older question", "message_id": "u-0"},
+            {"role": "assistant", "content": "Older answer", "message_id": "a-1"},
+            {"role": "user", "content": "Recent question", "message_id": "u-2"},
+            {"role": "assistant", "content": "Recent answer", "message_id": "a-3"},
+            {"role": "user", "content": "Newest question", "message_id": "u-4"},
+            {"role": "assistant", "content": "Newest answer", "message_id": "a-5"}
+          ]
+        }
+        """)
+
+        streamClient.emit(.done(DoneStreamEvent(session: completedSession)))
+
+        XCTAssertTrue(didStart)
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), [
+            "Recent question",
+            "Recent answer",
+            "Newest question",
+            "Newest answer"
+        ])
+        XCTAssertEqual(viewModel.messagesOffset, 2)
+        XCTAssertTrue(viewModel.hasOlderMessages)
+        XCTAssertFalse(viewModel.responseCompletionNeedsTranscriptRefresh)
+    }
+
+    @MainActor
+    func testReloadWithoutOverlapStillReplacesTranscript() async throws {
+        var sessionRequestCount = 0
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/session")
+            sessionRequestCount += 1
+            if sessionRequestCount == 1 {
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "messages": [
+                      {"role": "user", "content": "Recent question", "timestamp": 3, "message_id": "u-2"},
+                      {"role": "assistant", "content": "Recent answer", "timestamp": 4, "message_id": "a-3"}
+                    ],
+                    "_messages_truncated": true,
+                    "_messages_offset": 2
+                  }
+                }
+                """, for: request)
+            }
+
+            // Truncation/compaction rewrote history: no overlap with the
+            // on-screen window, so the reload must fully replace it.
+            return apiTestJSONResponse("""
+            {
+              "session": {
+                "session_id": "session-abc",
+                "messages": [
+                  {"role": "user", "content": "Rewritten question", "timestamp": 5, "message_id": "u-9"},
+                  {"role": "assistant", "content": "Rewritten answer", "timestamp": 6, "message_id": "a-10"}
+                ],
+                "_messages_truncated": false,
+                "_messages_offset": 0
+              }
+            }
+            """, for: request)
+        }
+
+        await viewModel.loadMessages()
+        await viewModel.loadMessages()
+
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), [
+            "Rewritten question",
+            "Rewritten answer"
+        ])
+        XCTAssertEqual(viewModel.messagesOffset, 0)
+        XCTAssertFalse(viewModel.hasOlderMessages)
+    }
+
+    @MainActor
     func testLoadOlderMessagesKeepsAffordanceWhenAnotherOlderPageExists() async throws {
         let viewModel = try makeViewModel { request in
             XCTAssertEqual(request.url?.path, "/api/session")

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -6683,6 +6683,112 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testReloadWithMisalignedOverlapStillReplacesTranscript() async throws {
+        var sessionRequestCount = 0
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/session")
+            sessionRequestCount += 1
+            if sessionRequestCount == 1 {
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "messages": [
+                      {"role": "user", "content": "Recent question", "timestamp": 3, "message_id": "u-2"},
+                      {"role": "assistant", "content": "Recent answer", "timestamp": 4, "message_id": "a-3"}
+                    ],
+                    "_messages_truncated": true,
+                    "_messages_offset": 2
+                  }
+                }
+                """, for: request)
+            }
+
+            // A rewrite retained the first on-screen message but moved it to a
+            // different absolute index. Preserving offset 2 would make both row
+            // identity and destructive action keep-counts incorrect.
+            return apiTestJSONResponse("""
+            {
+              "session": {
+                "session_id": "session-abc",
+                "messages": [
+                  {"role": "assistant", "content": "Compacted context", "timestamp": 2, "message_id": "a-1"},
+                  {"role": "user", "content": "Recent question", "timestamp": 3, "message_id": "u-2"},
+                  {"role": "assistant", "content": "Recent answer", "timestamp": 4, "message_id": "a-3"}
+                ],
+                "_messages_truncated": false,
+                "_messages_offset": 0
+              }
+            }
+            """, for: request)
+        }
+
+        await viewModel.loadMessages()
+        await viewModel.loadMessages()
+
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), [
+            "Compacted context",
+            "Recent question",
+            "Recent answer"
+        ])
+        XCTAssertEqual(viewModel.messagesOffset, 0)
+        XCTAssertFalse(viewModel.hasOlderMessages)
+    }
+
+    @MainActor
+    func testReloadUsesExpectedOverlapWhenFallbackMessageIDsRepeat() async throws {
+        var sessionRequestCount = 0
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/session")
+            sessionRequestCount += 1
+            if sessionRequestCount == 1 {
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "messages": [
+                      {"role": "user", "content": "Repeated question"},
+                      {"role": "assistant", "content": "Recent answer", "message_id": "a-3"}
+                    ],
+                    "_messages_truncated": true,
+                    "_messages_offset": 2
+                  }
+                }
+                """, for: request)
+            }
+
+            // The first and third messages intentionally share ChatMessage's
+            // fallback ID. The offset delta identifies index 2 as the real
+            // overlap; firstIndex would incorrectly choose index 0.
+            return apiTestJSONResponse("""
+            {
+              "session": {
+                "session_id": "session-abc",
+                "messages": [
+                  {"role": "user", "content": "Repeated question"},
+                  {"role": "assistant", "content": "Older answer", "message_id": "a-1"},
+                  {"role": "user", "content": "Repeated question"},
+                  {"role": "assistant", "content": "Recent answer", "message_id": "a-3"}
+                ],
+                "_messages_truncated": false,
+                "_messages_offset": 0
+              }
+            }
+            """, for: request)
+        }
+
+        await viewModel.loadMessages()
+        await viewModel.loadMessages()
+
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), [
+            "Repeated question",
+            "Recent answer"
+        ])
+        XCTAssertEqual(viewModel.messagesOffset, 2)
+        XCTAssertTrue(viewModel.hasOlderMessages)
+    }
+
+    @MainActor
     func testLoadOlderMessagesKeepsAffordanceWhenAnotherOlderPageExists() async throws {
         let viewModel = try makeViewModel { request in
             XCTAssertEqual(request.url?.path, "/api/session")


### PR DESCRIPTION
## The bug

Wait for a response to finish while scrolled up in a long session and you get dumped at the very top of the transcript.

## Mechanism

Transcript row identity is positional on purpose — `transcript:<messagesOffset + loadedIndex>` — so **Load earlier** can prepend a page without moving already-visible rows.

The problem is mid-session reloads reusing that numbering with a *different* offset:

1. When a turn completes, the `.done` payload (or the fallback completion refresh via `loadMessages(expandRenderable: true)`) can return a **wider window** than the one on screen — a smaller `_messages_offset`, or no offset at all (which resolves to 0).
2. `applyReloadedMessages` only preserved the current offset when the reload offset **grew** (the load-earlier merge). A shrunken offset fell through to `updateOlderMessagePagination`, which adopted it.
3. Every renderID shifts → SwiftUI treats it as all-rows-deleted/all-rows-inserted and remounts the list → the reader's frozen pixel offset now shows the start of the session.

`ChatScrollPolicy` is not at fault — it correctly refuses to auto-follow once the reader scrolls up. The content underneath the viewport changed identity.

## The fix

Treat an on-screen transcript as a **reconcile, not a reopen**. When a reload comes back with a smaller offset but its window still contains the first on-screen message, trim the widened head, splice the server-authoritative tail, and keep the current offset — on-screen renderIDs never shift. Cold opens still widen normally, and non-overlapping reloads (truncation/compaction rewrote history) still fully replace the window.

One new helper (`trimmingReloadedMessages`) mirroring the existing `mergingReloadedMessages` growth path; both `.done` and the completion refresh funnel through `applyReloadedMessages`, so one change covers both triggers.

## Tests

- `testCompletedStreamSessionKeepsCurrentOffsetWhenDoneReturnsWidenedWindow` — `.done` widens to offset 0; on-screen rows keep offset 2 and their renderIDs.
- `testCompletedStreamSessionKeepsCurrentOffsetWhenDoneOmitsOffset` — `.done` without `_messages_offset`; same preservation.
- `testReloadWithoutOverlapStillReplacesTranscript` — rewritten history still replaces the window fully.
- Existing growth-merge test (`testCompletedStreamSessionPreservesExpandedTranscriptWhenDoneReturnsLatestWindow`) still passes — the load-earlier contract is untouched.

`HermesMobileTests/ChatViewModelSendTests`: 145 tests, 0 failures, TEST SUCCEEDED.

Possibly related to the reading experience behind #213, but this is a defect fix, not that preference.