### PR TITLE
feat(sessions): add session status filters

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -33,6 +33,7 @@ struct SessionListView: View {
     @State private var isSearchFocused = false
     @State private var searchChromeIsExpanded = false
     @State private var selectedProjectID: String?
+    @State private var selectedStatusFilter: SessionListStatusFilter = .all
     @State private var sidebarScrollPosition: String?
     @State private var didCompleteInitialLoad = false
     @State private var returnRefreshID: UUID?
@@ -402,6 +403,16 @@ struct SessionListView: View {
             header
                 .sessionsTopChromeListRow()
 
+            Picker("Session status", selection: $selectedStatusFilter) {
+                ForEach(SessionListStatusFilter.allCases) { filter in
+                    Text(filter.title).tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .sessionsScreenListRow()
+
             if viewModel.isViewingCachedData {
                 OfflineCacheBanner()
                     .padding(.top, 16)
@@ -678,6 +689,7 @@ struct SessionListView: View {
         viewModel.visibleSessions(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: selectedStatusFilter,
             automatedVisibility: automatedSessionVisibility
         )
     }
@@ -686,6 +698,7 @@ struct SessionListView: View {
         viewModel.scheduledSessionGroups(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: selectedStatusFilter,
             automatedVisibility: automatedSessionVisibility
         )
     }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -403,7 +403,7 @@ struct SessionListView: View {
             header
                 .sessionsTopChromeListRow()
 
-            Picker("Session status", selection: $selectedStatusFilter) {
+            Picker("Session status", selection: $selectedStatusFilter.animation()) {
                 ForEach(SessionListStatusFilter.allCases) { filter in
                     Text(filter.title).tag(filter)
                 }
@@ -791,7 +791,7 @@ struct SessionListView: View {
     }
 
     private var hasActiveSessionFilter: Bool {
-        selectedProjectID != nil || !normalizedSearchText.isEmpty
+        selectedProjectID != nil || !normalizedSearchText.isEmpty || selectedStatusFilter != .all
     }
 
     private var showsSearchClearButton: Bool {

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -21,11 +21,14 @@ enum SessionListStatusFilter: String, CaseIterable, Identifiable {
     }
 
     func includes(_ session: SessionSummary) -> Bool {
+        let hasActiveStream = session.activeStreamId?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
         switch self {
         case .all: return true
-        case .active: return session.isStreaming == true || session.activeStreamId != nil
+        case .active: return session.isStreaming == true || hasActiveStream
         case .waiting: return session.hasPendingUserMessage == true
-        case .idle: return session.isStreaming != true && session.activeStreamId == nil && session.hasPendingUserMessage != true
+        case .idle: return session.isStreaming != true && !hasActiveStream && session.hasPendingUserMessage != true
         }
     }
 }
@@ -232,7 +235,9 @@ final class SessionListViewModel {
             ordinary: ordinaryCandidates.filter { !$0.isCronSession },
             scheduled: scheduledCandidates.filter { $0.isCronSession && $0.archived != true },
             totalScheduledCount: automatedVisibility.showsCron
-                ? sessions.filter { $0.isCronSession && $0.archived != true }.count
+                ? sessions.filter {
+                    $0.isCronSession && $0.archived != true && statusFilter.includes($0)
+                }.count
                 : 0
         )
     }

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -3,6 +3,33 @@ import Observation
 import SwiftData
 import SwiftUI
 
+enum SessionListStatusFilter: String, CaseIterable, Identifiable {
+    case all
+    case active
+    case waiting
+    case idle
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: return String(localized: "All")
+        case .active: return String(localized: "Active")
+        case .waiting: return String(localized: "Waiting")
+        case .idle: return String(localized: "Idle")
+        }
+    }
+
+    func includes(_ session: SessionSummary) -> Bool {
+        switch self {
+        case .all: return true
+        case .active: return session.isStreaming == true || session.activeStreamId != nil
+        case .waiting: return session.hasPendingUserMessage == true
+        case .idle: return session.isStreaming != true && session.activeStreamId == nil && session.hasPendingUserMessage != true
+        }
+    }
+}
+
 struct SessionListSection: Identifiable {
     enum Kind: String {
         case pinned
@@ -147,10 +174,11 @@ final class SessionListViewModel {
     func visibleSessions(
         searchText rawSearchText: String,
         selectedProjectID: String?,
+        statusFilter: SessionListStatusFilter = .all,
         automatedVisibility: AutomatedSessionVisibility = .showAll
     ) -> [SessionSummary] {
         let query = Self.normalizedSearchQuery(rawSearchText)
-        let baseSessions = sessions.filter { automatedVisibility.shows($0) }
+        let baseSessions = sessions.filter { automatedVisibility.shows($0) && statusFilter.includes($0) }
         let projectFilteredSessions = baseSessions.filter { session in
             guard let selectedProjectID else { return true }
             return session.projectId == selectedProjectID
@@ -184,16 +212,19 @@ final class SessionListViewModel {
     func scheduledSessionGroups(
         searchText: String,
         selectedProjectID: String?,
+        statusFilter: SessionListStatusFilter = .all,
         automatedVisibility: AutomatedSessionVisibility = .showAll
     ) -> ScheduledSessionGroups {
         let ordinaryCandidates = visibleSessions(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: statusFilter,
             automatedVisibility: automatedVisibility
         )
         let scheduledCandidates = visibleSessions(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: statusFilter,
             automatedVisibility: automatedVisibility
         )
 

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -7,6 +7,19 @@ import UniformTypeIdentifiers
 @testable import HermesMobile
 
 final class SessionListMutationTests: XCTestCase {
+    func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {
+        let active = SessionSummary(sessionId: "active", isStreaming: true)
+        let waiting = SessionSummary(sessionId: "waiting", hasPendingUserMessage: true)
+        let idle = SessionSummary(sessionId: "idle")
+
+        XCTAssertTrue(SessionListStatusFilter.active.includes(active))
+        XCTAssertFalse(SessionListStatusFilter.active.includes(idle))
+        XCTAssertTrue(SessionListStatusFilter.waiting.includes(waiting))
+        XCTAssertFalse(SessionListStatusFilter.waiting.includes(active))
+        XCTAssertTrue(SessionListStatusFilter.idle.includes(idle))
+        XCTAssertFalse(SessionListStatusFilter.idle.includes(waiting))
+    }
+
     override func tearDown() {
         MockURLProtocol.requestHandler = nil
         super.tearDown()

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -9,15 +9,23 @@ import UniformTypeIdentifiers
 final class SessionListMutationTests: XCTestCase {
     func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {
         let active = SessionSummary(sessionId: "active", isStreaming: true)
+        let streamIDOnly = SessionSummary(sessionId: "stream-id-only", activeStreamId: "stream-1")
+        let emptyStreamID = SessionSummary(sessionId: "empty-stream-id", activeStreamId: "   ")
         let waiting = SessionSummary(sessionId: "waiting", hasPendingUserMessage: true)
         let idle = SessionSummary(sessionId: "idle")
 
         XCTAssertTrue(SessionListStatusFilter.active.includes(active))
+        XCTAssertTrue(SessionListStatusFilter.active.includes(streamIDOnly))
+        XCTAssertFalse(SessionListStatusFilter.active.includes(emptyStreamID))
         XCTAssertFalse(SessionListStatusFilter.active.includes(idle))
         XCTAssertTrue(SessionListStatusFilter.waiting.includes(waiting))
         XCTAssertFalse(SessionListStatusFilter.waiting.includes(active))
         XCTAssertTrue(SessionListStatusFilter.idle.includes(idle))
+        XCTAssertTrue(SessionListStatusFilter.idle.includes(emptyStreamID))
         XCTAssertFalse(SessionListStatusFilter.idle.includes(waiting))
+        XCTAssertTrue(SessionListStatusFilter.all.includes(active))
+        XCTAssertTrue(SessionListStatusFilter.all.includes(waiting))
+        XCTAssertTrue(SessionListStatusFilter.all.includes(idle))
     }
 
     override func tearDown() {


### PR DESCRIPTION
## Summary
- Add an explicit session status filter to the Hermex session list.
- Support `All`, `Active`, `Waiting`, and `Idle` filters using fields already present in `SessionSummary`.
- Apply the filter consistently with search, project filtering, automated-session visibility, and scheduled-session grouping.
- Add unit coverage for the status classification behavior.

## Scope
This PR is limited to the Hermex iOS client. It does not add or change server endpoints and does not alter the `hermes-webui` contract.

## Compatibility
Sessions with missing status fields remain visible under `All` and `Idle`; the client does not invent a server-side state.

## Validation
- `git diff --check` passed.
- XCTest execution was not available on this Linux host because `xcodebuild` is not installed.
- The added test is included in `HermesMobileTests/SessionListMutationTests.swift` for the repository's macOS/Xcode CI.

## Review notes
Please verify the product vocabulary for `Active`, `Waiting`, and `Idle` against the server's lifecycle semantics during review.
