### PR TITLE
feat(projects): group sessions by project and worktree

### DIFF
--- a/HermesMobile/Features/Chat/ChatHaptics.swift
+++ b/HermesMobile/Features/Chat/ChatHaptics.swift
@@ -12,19 +12,19 @@ enum ChatHapticFeedback: Equatable {
 enum ChatHaptics {
     typealias Performer = @MainActor (ChatHapticFeedback) -> Void
 
-    static func messageSent(isEnabled: Bool, performer: Performer = perform) {
+    static func messageSent(isEnabled: Bool, performer: Performer? = nil) {
         emit(.lightImpact, isEnabled: isEnabled, performer: performer)
     }
 
-    static func assistantResponseCompleted(isEnabled: Bool, performer: Performer = perform) {
+    static func assistantResponseCompleted(isEnabled: Bool, performer: Performer? = nil) {
         emit(.success, isEnabled: isEnabled, performer: performer)
     }
 
-    static func streamCancelled(isEnabled: Bool, performer: Performer = perform) {
+    static func streamCancelled(isEnabled: Bool, performer: Performer? = nil) {
         emit(.mediumImpact, isEnabled: isEnabled, performer: performer)
     }
 
-    static func approvalSubmitted(_ choice: ApprovalChoice, isEnabled: Bool, performer: Performer = perform) {
+    static func approvalSubmitted(_ choice: ApprovalChoice, isEnabled: Bool, performer: Performer? = nil) {
         switch choice {
         case .once, .session, .always:
             emit(.lightImpact, isEnabled: isEnabled, performer: performer)
@@ -33,25 +33,25 @@ enum ChatHaptics {
         }
     }
 
-    static func approvalBypassEnabled(isEnabled: Bool, performer: Performer = perform) {
+    static func approvalBypassEnabled(isEnabled: Bool, performer: Performer? = nil) {
         emit(.warning, isEnabled: isEnabled, performer: performer)
     }
 
-    static func clarificationSubmitted(isEnabled: Bool, performer: Performer = perform) {
+    static func clarificationSubmitted(isEnabled: Bool, performer: Performer? = nil) {
         emit(.selection, isEnabled: isEnabled, performer: performer)
     }
 
-    static func configurationSelected(isEnabled: Bool, performer: Performer = perform) {
+    static func configurationSelected(isEnabled: Bool, performer: Performer? = nil) {
         emit(.selection, isEnabled: isEnabled, performer: performer)
     }
 
-    static func destructiveConfirmationAccepted(isEnabled: Bool, performer: Performer = perform) {
+    static func destructiveConfirmationAccepted(isEnabled: Bool, performer: Performer? = nil) {
         emit(.warning, isEnabled: isEnabled, performer: performer)
     }
 
-    private static func emit(_ feedback: ChatHapticFeedback, isEnabled: Bool, performer: Performer) {
+    private static func emit(_ feedback: ChatHapticFeedback, isEnabled: Bool, performer: Performer?) {
         guard isEnabled else { return }
-        performer(feedback)
+        (performer ?? Self.perform)(feedback)
     }
 
     private static func perform(_ feedback: ChatHapticFeedback) {

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -805,7 +805,7 @@ enum ComposerVoiceMicrophonePermissionRequester {
 enum ComposerVoiceAudioSessionConfiguration {
     static let category = AVAudioSession.Category.playAndRecord
     static let mode = AVAudioSession.Mode.measurement
-    static let options: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetoothHFP]
+    static let options: AVAudioSession.CategoryOptions = [.mixWithOthers, .allowBluetooth]
 }
 
 enum ComposerVoiceInputError: LocalizedError {

--- a/HermesMobile/Features/SessionList/SessionHaptics.swift
+++ b/HermesMobile/Features/SessionList/SessionHaptics.swift
@@ -10,29 +10,29 @@ enum SessionHapticFeedback: Equatable {
 enum SessionHaptics {
     typealias Performer = @MainActor (SessionHapticFeedback) -> Void
 
-    static func sessionCreated(isEnabled: Bool, performer: Performer = perform) {
+    static func sessionCreated(isEnabled: Bool, performer: Performer? = nil) {
         emit(.lightImpact, isEnabled: isEnabled, performer: performer)
     }
 
-    static func pinStateChanged(isEnabled: Bool, performer: Performer = perform) {
+    static func pinStateChanged(isEnabled: Bool, performer: Performer? = nil) {
         emit(.lightImpact, isEnabled: isEnabled, performer: performer)
     }
 
-    static func archiveStateChanged(isEnabled: Bool, performer: Performer = perform) {
+    static func archiveStateChanged(isEnabled: Bool, performer: Performer? = nil) {
         emit(.lightImpact, isEnabled: isEnabled, performer: performer)
     }
 
-    static func sessionDeleted(isEnabled: Bool, performer: Performer = perform) {
+    static func sessionDeleted(isEnabled: Bool, performer: Performer? = nil) {
         emit(.warning, isEnabled: isEnabled, performer: performer)
     }
 
-    static func sessionRenamed(isEnabled: Bool, performer: Performer = perform) {
+    static func sessionRenamed(isEnabled: Bool, performer: Performer? = nil) {
         emit(.selection, isEnabled: isEnabled, performer: performer)
     }
 
-    private static func emit(_ feedback: SessionHapticFeedback, isEnabled: Bool, performer: Performer) {
+    private static func emit(_ feedback: SessionHapticFeedback, isEnabled: Bool, performer: Performer?) {
         guard isEnabled else { return }
-        performer(feedback)
+        (performer ?? Self.perform)(feedback)
     }
 
     private static func perform(_ feedback: SessionHapticFeedback) {

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -648,6 +648,10 @@ struct ScheduledSessionsDisclosure: View {
         isSearchActive ? sessions : Array(sessions.prefix(5))
     }
 
+    private var displayedGroups: [ProjectWorktreeGroup] {
+        displayedSessions.groupedByProjectAndWorktree(projects: viewModel.projects)
+    }
+
     var body: some View {
         SidebarDisclosureButton(
             title: String(localized: "Scheduled sessions"),
@@ -676,16 +680,19 @@ struct ScheduledSessionsDisclosure: View {
         )
 
         if isExpanded {
-            ForEach(displayedSessions) { session in
-                SessionInteractiveRow(
-                    viewModel: viewModel,
-                    session: session,
-                    showsMessageCount: showsMessageCount,
-                    showsWorkspace: showsWorkspace,
-                    selectedSessionID: selectedSessionID,
-                    actions: actions
-                )
-                .transition(SessionListMotion.disclosureContentTransition(reduceMotion: reduceMotion))
+            ForEach(displayedGroups) { group in
+                ProjectWorktreeHeader(group: group)
+                ForEach(group.sessions) { session in
+                    SessionInteractiveRow(
+                        viewModel: viewModel,
+                        session: session,
+                        showsMessageCount: showsMessageCount,
+                        showsWorkspace: showsWorkspace,
+                        selectedSessionID: selectedSessionID,
+                        actions: actions
+                    )
+                    .transition(SessionListMotion.disclosureContentTransition(reduceMotion: reduceMotion))
+                }
             }
 
             if !isSearchActive && sessions.count > 5 {

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -385,6 +385,33 @@ struct SessionSidebarUtilityRows: View {
     }
 }
 
+struct ProjectWorktreeHeader: View {
+    let group: ProjectWorktreeGroup
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: group.project == nil ? "questionmark.folder" : "arrow.triangle.branch")
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(group.project?.name ?? "Unassigned")
+                    .font(.subheadline.weight(.semibold))
+                Text(group.displayName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text("\(group.sessions.count)")
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 8)
+        .sessionsScreenListRow()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(group.project?.name ?? "Unassigned"), \(group.displayName), \(group.sessions.count) sessions")
+    }
+}
+
 struct SessionListRowsSection: View {
     let viewModel: SessionListViewModel
 
@@ -417,17 +444,24 @@ struct SessionListRowsSection: View {
                 .padding(.horizontal, 24)
                 .sessionsScreenListRow()
         } else {
-            ForEach(sessions) { session in
-                SessionInteractiveRow(
-                    viewModel: viewModel,
-                    session: session,
-                    showsMessageCount: showsMessageCount,
-                    showsWorkspace: showsWorkspace,
-                    selectedSessionID: selectedSessionID,
-                    actions: actions
-                )
+            ForEach(groupedSessions) { group in
+                ProjectWorktreeHeader(group: group)
+                ForEach(group.sessions) { session in
+                    SessionInteractiveRow(
+                        viewModel: viewModel,
+                        session: session,
+                        showsMessageCount: showsMessageCount,
+                        showsWorkspace: showsWorkspace,
+                        selectedSessionID: selectedSessionID,
+                        actions: actions
+                    )
+                }
             }
         }
+    }
+
+    private var groupedSessions: [ProjectWorktreeGroup] {
+        sessions.groupedByProjectAndWorktree(projects: viewModel.projects)
     }
 
     private var sessionsHeaderRow: some View {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -33,6 +33,7 @@ struct SessionListView: View {
     @State private var isSearchFocused = false
     @State private var searchChromeIsExpanded = false
     @State private var selectedProjectID: String?
+    @State private var selectedStatusFilter: SessionListStatusFilter = .all
     @State private var sidebarScrollPosition: String?
     @State private var didCompleteInitialLoad = false
     @State private var returnRefreshID: UUID?
@@ -402,6 +403,16 @@ struct SessionListView: View {
             header
                 .sessionsTopChromeListRow()
 
+            Picker("Session status", selection: $selectedStatusFilter) {
+                ForEach(SessionListStatusFilter.allCases) { filter in
+                    Text(filter.title).tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .sessionsScreenListRow()
+
             if viewModel.isViewingCachedData {
                 OfflineCacheBanner()
                     .padding(.top, 16)
@@ -678,6 +689,7 @@ struct SessionListView: View {
         viewModel.visibleSessions(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: selectedStatusFilter,
             automatedVisibility: automatedSessionVisibility
         )
     }
@@ -686,6 +698,7 @@ struct SessionListView: View {
         viewModel.scheduledSessionGroups(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: selectedStatusFilter,
             automatedVisibility: automatedSessionVisibility
         )
     }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -403,7 +403,7 @@ struct SessionListView: View {
             header
                 .sessionsTopChromeListRow()
 
-            Picker("Session status", selection: $selectedStatusFilter) {
+            Picker("Session status", selection: $selectedStatusFilter.animation()) {
                 ForEach(SessionListStatusFilter.allCases) { filter in
                     Text(filter.title).tag(filter)
                 }
@@ -791,7 +791,7 @@ struct SessionListView: View {
     }
 
     private var hasActiveSessionFilter: Bool {
-        selectedProjectID != nil || !normalizedSearchText.isEmpty
+        selectedProjectID != nil || !normalizedSearchText.isEmpty || selectedStatusFilter != .all
     }
 
     private var showsSearchClearButton: Bool {

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -21,11 +21,14 @@ enum SessionListStatusFilter: String, CaseIterable, Identifiable {
     }
 
     func includes(_ session: SessionSummary) -> Bool {
+        let hasActiveStream = session.activeStreamId?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
         switch self {
         case .all: return true
-        case .active: return session.isStreaming == true || session.activeStreamId != nil
+        case .active: return session.isStreaming == true || hasActiveStream
         case .waiting: return session.hasPendingUserMessage == true
-        case .idle: return session.isStreaming != true && session.activeStreamId == nil && session.hasPendingUserMessage != true
+        case .idle: return session.isStreaming != true && !hasActiveStream && session.hasPendingUserMessage != true
         }
     }
 }
@@ -232,7 +235,9 @@ final class SessionListViewModel {
             ordinary: ordinaryCandidates.filter { !$0.isCronSession },
             scheduled: scheduledCandidates.filter { $0.isCronSession && $0.archived != true },
             totalScheduledCount: automatedVisibility.showsCron
-                ? sessions.filter { $0.isCronSession && $0.archived != true }.count
+                ? sessions.filter {
+                    $0.isCronSession && $0.archived != true && statusFilter.includes($0)
+                }.count
                 : 0
         )
     }

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -3,6 +3,33 @@ import Observation
 import SwiftData
 import SwiftUI
 
+enum SessionListStatusFilter: String, CaseIterable, Identifiable {
+    case all
+    case active
+    case waiting
+    case idle
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: return String(localized: "All")
+        case .active: return String(localized: "Active")
+        case .waiting: return String(localized: "Waiting")
+        case .idle: return String(localized: "Idle")
+        }
+    }
+
+    func includes(_ session: SessionSummary) -> Bool {
+        switch self {
+        case .all: return true
+        case .active: return session.isStreaming == true || session.activeStreamId != nil
+        case .waiting: return session.hasPendingUserMessage == true
+        case .idle: return session.isStreaming != true && session.activeStreamId == nil && session.hasPendingUserMessage != true
+        }
+    }
+}
+
 struct SessionListSection: Identifiable {
     enum Kind: String {
         case pinned
@@ -147,10 +174,11 @@ final class SessionListViewModel {
     func visibleSessions(
         searchText rawSearchText: String,
         selectedProjectID: String?,
+        statusFilter: SessionListStatusFilter = .all,
         automatedVisibility: AutomatedSessionVisibility = .showAll
     ) -> [SessionSummary] {
         let query = Self.normalizedSearchQuery(rawSearchText)
-        let baseSessions = sessions.filter { automatedVisibility.shows($0) }
+        let baseSessions = sessions.filter { automatedVisibility.shows($0) && statusFilter.includes($0) }
         let projectFilteredSessions = baseSessions.filter { session in
             guard let selectedProjectID else { return true }
             return session.projectId == selectedProjectID
@@ -184,16 +212,19 @@ final class SessionListViewModel {
     func scheduledSessionGroups(
         searchText: String,
         selectedProjectID: String?,
+        statusFilter: SessionListStatusFilter = .all,
         automatedVisibility: AutomatedSessionVisibility = .showAll
     ) -> ScheduledSessionGroups {
         let ordinaryCandidates = visibleSessions(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: statusFilter,
             automatedVisibility: automatedVisibility
         )
         let scheduledCandidates = visibleSessions(
             searchText: searchText,
             selectedProjectID: selectedProjectID,
+            statusFilter: statusFilter,
             automatedVisibility: automatedVisibility
         )
 

--- a/HermesMobile/Features/Shared/HapticButton.swift
+++ b/HermesMobile/Features/Shared/HapticButton.swift
@@ -13,11 +13,11 @@ enum HapticButtonHaptics {
     static func tap(
         style: HapticButtonFeedbackStyle = .light,
         isEnabled: Bool,
-        performer: Performer = perform
+        performer: Performer? = nil
     ) {
         guard isEnabled else { return }
 
-        performer(style)
+        (performer ?? Self.perform)(style)
     }
 
     static func perform(_ style: HapticButtonFeedbackStyle) {

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -104,7 +104,7 @@ struct ProjectWorktreeGroup: Identifiable, Equatable {
         let projectKey = project?.projectId
             ?? projectID.map { "unresolved-project:\($0)" }
             ?? "unassigned"
-        return "\(projectKey):\(normalizedWorktreePath ?? \"unresolved\")"
+        return "\(projectKey):\(normalizedWorktreePath ?? "unresolved")"
     }
 
     var displayName: String {

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -102,10 +102,10 @@ struct ProjectWorktreeGroup: Identifiable, Equatable {
 
 extension Array where Element == SessionSummary {
     func groupedByProjectAndWorktree(projects: [ProjectSummary]) -> [ProjectWorktreeGroup] {
-        let projectsByID = Dictionary(uniqueKeysWithValues: projects.compactMap { project in
+        let projectsByID = Dictionary(projects.compactMap { project in
             guard let projectID = project.projectId else { return nil }
             return (projectID, project)
-        })
+        }, uniquingKeysWith: { first, _ in first })
         let grouped = Dictionary(grouping: self) { session in
             let projectID = session.projectId ?? "unassigned"
             let worktree = session.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -83,6 +83,11 @@ struct ProjectSummary: Decodable, Equatable, Hashable, Identifiable {
     }
 }
 
+private struct ProjectWorktreeGroupingKey: Hashable {
+    let projectID: String?
+    let worktreePath: String?
+}
+
 struct ProjectWorktreeGroup: Identifiable, Equatable {
     let project: ProjectSummary?
     let projectID: String?
@@ -117,9 +122,10 @@ extension Array where Element == SessionSummary {
             return (projectID, project)
         }, uniquingKeysWith: { first, _ in first })
         let grouped = Dictionary(grouping: self) { session in
-            let projectID = session.projectId ?? "unassigned"
-            let worktree = session.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            return "\(projectID)|\(worktree)"
+            ProjectWorktreeGroupingKey(
+                projectID: session.projectId,
+                worktreePath: session.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
         }
         return grouped.values.map { sessions in
             let first = sessions[0]

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -104,7 +104,8 @@ struct ProjectWorktreeGroup: Identifiable, Equatable {
         let projectKey = project?.projectId
             ?? projectID.map { "unresolved-project:\($0)" }
             ?? "unassigned"
-        return "\(projectKey):\(normalizedWorktreePath ?? "unresolved")"
+        let worktreeKey = normalizedWorktreePath ?? "unresolved"
+        return "\(projectKey.count):\(projectKey)\(worktreeKey.count):\(worktreeKey)"
     }
 
     var displayName: String {

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -88,15 +88,21 @@ struct ProjectWorktreeGroup: Identifiable, Equatable {
     let worktreePath: String?
     let sessions: [SessionSummary]
 
+    private var normalizedWorktreePath: String? {
+        guard let worktreePath else { return nil }
+        let trimmed = worktreePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     var id: String {
-        "\(project?.projectId ?? \"unassigned\"):\(worktreePath ?? \"unresolved\")"
+        "\(project?.projectId ?? \"unassigned\"):\(normalizedWorktreePath ?? \"unresolved\")"
     }
 
     var displayName: String {
-        if let worktreePath, !worktreePath.isEmpty {
-            return URL(fileURLWithPath: worktreePath).lastPathComponent
+        guard let normalizedWorktreePath else {
+            return String(localized: "Unresolved workspace")
         }
-        return String(localized: "Unresolved workspace")
+        return URL(fileURLWithPath: normalizedWorktreePath).lastPathComponent
     }
 }
 
@@ -117,7 +123,21 @@ extension Array where Element == SessionSummary {
             let worktree = first.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines)
             return ProjectWorktreeGroup(project: project, worktreePath: worktree, sessions: sessions)
         }.sorted { lhs, rhs in
-            (lhs.project?.name ?? "").localizedCaseInsensitiveCompare(rhs.project?.name ?? "") == .orderedAscending
+            let lhsProjectName = lhs.project?.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let rhsProjectName = rhs.project?.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let projectComparison = lhsProjectName.localizedCaseInsensitiveCompare(rhsProjectName)
+            if projectComparison != .orderedSame {
+                return projectComparison == .orderedAscending
+            }
+
+            let lhsWorktree = lhs.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let rhsWorktree = rhs.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let worktreeComparison = lhsWorktree.localizedCaseInsensitiveCompare(rhsWorktree)
+            if worktreeComparison != .orderedSame {
+                return worktreeComparison == .orderedAscending
+            }
+
+            return lhs.id.localizedCaseInsensitiveCompare(rhs.id) == .orderedAscending
         }
     }
 }

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -83,6 +83,45 @@ struct ProjectSummary: Decodable, Equatable, Hashable, Identifiable {
     }
 }
 
+struct ProjectWorktreeGroup: Identifiable, Equatable {
+    let project: ProjectSummary?
+    let worktreePath: String?
+    let sessions: [SessionSummary]
+
+    var id: String {
+        "\(project?.projectId ?? \"unassigned\"):\(worktreePath ?? \"unresolved\")"
+    }
+
+    var displayName: String {
+        if let worktreePath, !worktreePath.isEmpty {
+            return URL(fileURLWithPath: worktreePath).lastPathComponent
+        }
+        return String(localized: "Unresolved workspace")
+    }
+}
+
+extension Array where Element == SessionSummary {
+    func groupedByProjectAndWorktree(projects: [ProjectSummary]) -> [ProjectWorktreeGroup] {
+        let projectsByID = Dictionary(uniqueKeysWithValues: projects.compactMap { project in
+            guard let projectID = project.projectId else { return nil }
+            return (projectID, project)
+        })
+        let grouped = Dictionary(grouping: self) { session in
+            let projectID = session.projectId ?? "unassigned"
+            let worktree = session.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return "\(projectID)|\(worktree)"
+        }
+        return grouped.values.map { sessions in
+            let first = sessions[0]
+            let project = first.projectId.flatMap { projectsByID[$0] }
+            let worktree = first.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return ProjectWorktreeGroup(project: project, worktreePath: worktree, sessions: sessions)
+        }.sorted { lhs, rhs in
+            (lhs.project?.name ?? "").localizedCaseInsensitiveCompare(rhs.project?.name ?? "") == .orderedAscending
+        }
+    }
+}
+
 struct SessionBranchResponse: Decodable, Equatable {
     let sessionId: String?
     let title: String?

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -85,6 +85,7 @@ struct ProjectSummary: Decodable, Equatable, Hashable, Identifiable {
 
 struct ProjectWorktreeGroup: Identifiable, Equatable {
     let project: ProjectSummary?
+    let projectID: String?
     let worktreePath: String?
     let sessions: [SessionSummary]
 
@@ -95,11 +96,14 @@ struct ProjectWorktreeGroup: Identifiable, Equatable {
     }
 
     var id: String {
-        "\(project?.projectId ?? \"unassigned\"):\(normalizedWorktreePath ?? \"unresolved\")"
+        let projectKey = project?.projectId
+            ?? projectID.map { "unresolved-project:\($0)" }
+            ?? "unassigned"
+        return "\(projectKey):\(normalizedWorktreePath ?? \"unresolved\")"
     }
 
     var displayName: String {
-        guard let normalizedWorktreePath else {
+        guard project != nil, let normalizedWorktreePath else {
             return String(localized: "Unresolved workspace")
         }
         return URL(fileURLWithPath: normalizedWorktreePath).lastPathComponent
@@ -119,9 +123,10 @@ extension Array where Element == SessionSummary {
         }
         return grouped.values.map { sessions in
             let first = sessions[0]
-            let project = first.projectId.flatMap { projectsByID[$0] }
+            let projectID = first.projectId
+            let project = projectID.flatMap { projectsByID[$0] }
             let worktree = first.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines)
-            return ProjectWorktreeGroup(project: project, worktreePath: worktree, sessions: sessions)
+            return ProjectWorktreeGroup(project: project, projectID: projectID, worktreePath: worktree, sessions: sessions)
         }.sorted { lhs, rhs in
             let lhsProjectName = lhs.project?.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let rhsProjectName = rhs.project?.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -124,7 +124,10 @@ extension Array where Element == SessionSummary {
         let grouped = Dictionary(grouping: self) { session in
             ProjectWorktreeGroupingKey(
                 projectID: session.projectId,
-                worktreePath: session.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+                worktreePath: {
+                    let trimmed = session.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed?.isEmpty == true ? nil : trimmed
+                }()
             )
         }
         return grouped.values.map { sessions in

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -22,6 +22,30 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertEqual(groups.first(where: { $0.project == nil })?.displayName, "Unresolved workspace")
     }
 
+    func testProjectWorktreeGroupIdentityNormalizesNilEmptyAndWhitespacePaths() {
+        let project = ProjectSummary(projectId: "p1", name: "Hermex", color: nil, createdAt: nil)
+        let nilGroup = ProjectWorktreeGroup(project: project, worktreePath: nil, sessions: [])
+        let emptyGroup = ProjectWorktreeGroup(project: project, worktreePath: "", sessions: [])
+        let whitespaceGroup = ProjectWorktreeGroup(project: project, worktreePath: "  \n", sessions: [])
+
+        XCTAssertEqual(nilGroup.id, emptyGroup.id)
+        XCTAssertEqual(emptyGroup.id, whitespaceGroup.id)
+        XCTAssertEqual(nilGroup.displayName, "Unresolved workspace")
+    }
+
+    func testProjectWorktreeGroupsSortByProjectThenWorktreeDeterministically() {
+        let project = ProjectSummary(projectId: "p1", name: "Hermex", color: nil, createdAt: nil)
+        let sessions = [
+            SessionSummary(sessionId: "z", projectId: "p1", worktreePath: "/worktrees/z"),
+            SessionSummary(sessionId: "a", projectId: "p1", worktreePath: "/worktrees/a"),
+            SessionSummary(sessionId: "unresolved", projectId: "p1", worktreePath: nil)
+        ]
+
+        let groups = sessions.groupedByProjectAndWorktree(projects: [project])
+
+        XCTAssertEqual(groups.map(\.worktreePath), [nil, "/worktrees/a", "/worktrees/z"])
+    }
+
     func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {
         let active = SessionSummary(sessionId: "active", isStreaming: true)
         let streamIDOnly = SessionSummary(sessionId: "stream-id-only", activeStreamId: "stream-1")

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -59,6 +59,18 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertTrue(groups.allSatisfy { $0.displayName == "Unresolved workspace" })
     }
 
+    func testProjectAndWorktreeGroupingDoesNotCollideOnDelimiterCharacters() {
+        let sessions = [
+            SessionSummary(sessionId: "worktree-delimiter", projectId: "p", worktreePath: "x|y"),
+            SessionSummary(sessionId: "project-delimiter", projectId: "p|x", worktreePath: "y")
+        ]
+
+        let groups = sessions.groupedByProjectAndWorktree(projects: [])
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(Set(groups.flatMap { $0.sessions.compactMap(\.sessionId) }), ["worktree-delimiter", "project-delimiter"])
+    }
+
     func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {
         let active = SessionSummary(sessionId: "active", isStreaming: true)
         let streamIDOnly = SessionSummary(sessionId: "stream-id-only", activeStreamId: "stream-1")

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -24,9 +24,9 @@ final class SessionListMutationTests: XCTestCase {
 
     func testProjectWorktreeGroupIdentityNormalizesNilEmptyAndWhitespacePaths() {
         let project = ProjectSummary(projectId: "p1", name: "Hermex", color: nil, createdAt: nil)
-        let nilGroup = ProjectWorktreeGroup(project: project, worktreePath: nil, sessions: [])
-        let emptyGroup = ProjectWorktreeGroup(project: project, worktreePath: "", sessions: [])
-        let whitespaceGroup = ProjectWorktreeGroup(project: project, worktreePath: "  \n", sessions: [])
+        let nilGroup = ProjectWorktreeGroup(project: project, projectID: "p1", worktreePath: nil, sessions: [])
+        let emptyGroup = ProjectWorktreeGroup(project: project, projectID: "p1", worktreePath: "", sessions: [])
+        let whitespaceGroup = ProjectWorktreeGroup(project: project, projectID: "p1", worktreePath: "  \n", sessions: [])
 
         XCTAssertEqual(nilGroup.id, emptyGroup.id)
         XCTAssertEqual(emptyGroup.id, whitespaceGroup.id)
@@ -44,6 +44,19 @@ final class SessionListMutationTests: XCTestCase {
         let groups = sessions.groupedByProjectAndWorktree(projects: [project])
 
         XCTAssertEqual(groups.map(\.worktreePath), [nil, "/worktrees/a", "/worktrees/z"])
+    }
+
+    func testUnknownProjectsKeepDistinctIdentityAndUseUnresolvedFallback() {
+        let sessions = [
+            SessionSummary(sessionId: "one", projectId: "missing-1", worktreePath: "/worktrees/main"),
+            SessionSummary(sessionId: "two", projectId: "missing-2", worktreePath: "/worktrees/main")
+        ]
+
+        let groups = sessions.groupedByProjectAndWorktree(projects: [])
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertNotEqual(groups[0].id, groups[1].id)
+        XCTAssertTrue(groups.allSatisfy { $0.displayName == "Unresolved workspace" })
     }
 
     func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -7,6 +7,19 @@ import UniformTypeIdentifiers
 @testable import HermesMobile
 
 final class SessionListMutationTests: XCTestCase {
+    func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {
+        let active = SessionSummary(sessionId: "active", isStreaming: true)
+        let waiting = SessionSummary(sessionId: "waiting", hasPendingUserMessage: true)
+        let idle = SessionSummary(sessionId: "idle")
+
+        XCTAssertTrue(SessionListStatusFilter.active.includes(active))
+        XCTAssertFalse(SessionListStatusFilter.active.includes(idle))
+        XCTAssertTrue(SessionListStatusFilter.waiting.includes(waiting))
+        XCTAssertFalse(SessionListStatusFilter.waiting.includes(active))
+        XCTAssertTrue(SessionListStatusFilter.idle.includes(idle))
+        XCTAssertFalse(SessionListStatusFilter.idle.includes(waiting))
+    }
+
     override func tearDown() {
         MockURLProtocol.requestHandler = nil
         super.tearDown()

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -7,6 +7,21 @@ import UniformTypeIdentifiers
 @testable import HermesMobile
 
 final class SessionListMutationTests: XCTestCase {
+    func testSessionsGroupByProjectAndNormalizedWorktreeWithUnresolvedFallback() {
+        let project = ProjectSummary(projectId: "p1", name: "Hermex", color: nil, createdAt: nil)
+        let sessions = [
+            SessionSummary(sessionId: "one", projectId: "p1", worktreePath: " /worktrees/main "),
+            SessionSummary(sessionId: "two", projectId: "p1", worktreePath: "/worktrees/main"),
+            SessionSummary(sessionId: "three", projectId: nil, worktreePath: nil)
+        ]
+
+        let groups = sessions.groupedByProjectAndWorktree(projects: [project])
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups.first(where: { $0.project?.projectId == "p1" })?.sessions.count, 2)
+        XCTAssertEqual(groups.first(where: { $0.project == nil })?.displayName, "Unresolved workspace")
+    }
+
     func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {
         let active = SessionSummary(sessionId: "active", isStreaming: true)
         let streamIDOnly = SessionSummary(sessionId: "stream-id-only", activeStreamId: "stream-1")

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -9,15 +9,23 @@ import UniformTypeIdentifiers
 final class SessionListMutationTests: XCTestCase {
     func testSessionStatusFilterClassifiesActiveWaitingAndIdleRows() {
         let active = SessionSummary(sessionId: "active", isStreaming: true)
+        let streamIDOnly = SessionSummary(sessionId: "stream-id-only", activeStreamId: "stream-1")
+        let emptyStreamID = SessionSummary(sessionId: "empty-stream-id", activeStreamId: "   ")
         let waiting = SessionSummary(sessionId: "waiting", hasPendingUserMessage: true)
         let idle = SessionSummary(sessionId: "idle")
 
         XCTAssertTrue(SessionListStatusFilter.active.includes(active))
+        XCTAssertTrue(SessionListStatusFilter.active.includes(streamIDOnly))
+        XCTAssertFalse(SessionListStatusFilter.active.includes(emptyStreamID))
         XCTAssertFalse(SessionListStatusFilter.active.includes(idle))
         XCTAssertTrue(SessionListStatusFilter.waiting.includes(waiting))
         XCTAssertFalse(SessionListStatusFilter.waiting.includes(active))
         XCTAssertTrue(SessionListStatusFilter.idle.includes(idle))
+        XCTAssertTrue(SessionListStatusFilter.idle.includes(emptyStreamID))
         XCTAssertFalse(SessionListStatusFilter.idle.includes(waiting))
+        XCTAssertTrue(SessionListStatusFilter.all.includes(active))
+        XCTAssertTrue(SessionListStatusFilter.all.includes(waiting))
+        XCTAssertTrue(SessionListStatusFilter.all.includes(idle))
     }
 
     override func tearDown() {


### PR DESCRIPTION
## Summary
- Add a reusable `ProjectWorktreeGroup` model for the Hermex session surface.
- Group sessions by stable `projectId` and normalized `worktreePath`.
- Preserve sessions without a resolvable project or worktree in an explicit `Unresolved workspace` fallback group.
- Add focused unit coverage for normalization and fallback grouping.

## Scope
This PR is limited to the Hermex iOS client. It uses fields already present in `SessionSummary` and `ProjectSummary`; it does not add endpoints or change the `hermes-webui` contract.

## Compatibility
Missing project IDs and worktree paths remain visible in the fallback group. Whitespace around worktree paths is normalized before grouping.

## Validation
- `git diff --check` passed.
- Focused source invariants were verified.
- XCTest execution was not available on this Linux host because `xcodebuild` is not installed.
