### PR TITLE
fix(ui): resolve haptic helper actor isolation

### DIFF
--- a/HermesMobile/Features/Chat/ChatHaptics.swift
+++ b/HermesMobile/Features/Chat/ChatHaptics.swift
@@ -12,41 +12,41 @@ enum ChatHapticFeedback: Equatable {
 enum ChatHaptics {
     typealias Performer = @MainActor (ChatHapticFeedback) -> Void
 
-    static func messageSent(isEnabled: Bool, performer: Performer = perform) {
-        emit(.lightImpact, isEnabled: isEnabled, performer: performer)
+    static func messageSent(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.lightImpact, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func assistantResponseCompleted(isEnabled: Bool, performer: Performer = perform) {
-        emit(.success, isEnabled: isEnabled, performer: performer)
+    static func assistantResponseCompleted(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.success, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func streamCancelled(isEnabled: Bool, performer: Performer = perform) {
-        emit(.mediumImpact, isEnabled: isEnabled, performer: performer)
+    static func streamCancelled(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.mediumImpact, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func approvalSubmitted(_ choice: ApprovalChoice, isEnabled: Bool, performer: Performer = perform) {
+    static func approvalSubmitted(_ choice: ApprovalChoice, isEnabled: Bool, performer: Performer? = nil) {
         switch choice {
         case .once, .session, .always:
-            emit(.lightImpact, isEnabled: isEnabled, performer: performer)
+            emit(.lightImpact, isEnabled: isEnabled, performer: performer ?? Self.perform)
         case .deny:
-            emit(.warning, isEnabled: isEnabled, performer: performer)
+            emit(.warning, isEnabled: isEnabled, performer: performer ?? Self.perform)
         }
     }
 
-    static func approvalBypassEnabled(isEnabled: Bool, performer: Performer = perform) {
-        emit(.warning, isEnabled: isEnabled, performer: performer)
+    static func approvalBypassEnabled(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.warning, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func clarificationSubmitted(isEnabled: Bool, performer: Performer = perform) {
-        emit(.selection, isEnabled: isEnabled, performer: performer)
+    static func clarificationSubmitted(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.selection, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func configurationSelected(isEnabled: Bool, performer: Performer = perform) {
-        emit(.selection, isEnabled: isEnabled, performer: performer)
+    static func configurationSelected(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.selection, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func destructiveConfirmationAccepted(isEnabled: Bool, performer: Performer = perform) {
-        emit(.warning, isEnabled: isEnabled, performer: performer)
+    static func destructiveConfirmationAccepted(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.warning, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
     private static func emit(_ feedback: ChatHapticFeedback, isEnabled: Bool, performer: Performer) {

--- a/HermesMobile/Features/SessionList/SessionHaptics.swift
+++ b/HermesMobile/Features/SessionList/SessionHaptics.swift
@@ -10,24 +10,24 @@ enum SessionHapticFeedback: Equatable {
 enum SessionHaptics {
     typealias Performer = @MainActor (SessionHapticFeedback) -> Void
 
-    static func sessionCreated(isEnabled: Bool, performer: Performer = perform) {
-        emit(.lightImpact, isEnabled: isEnabled, performer: performer)
+    static func sessionCreated(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.lightImpact, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func pinStateChanged(isEnabled: Bool, performer: Performer = perform) {
-        emit(.lightImpact, isEnabled: isEnabled, performer: performer)
+    static func pinStateChanged(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.lightImpact, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func archiveStateChanged(isEnabled: Bool, performer: Performer = perform) {
-        emit(.lightImpact, isEnabled: isEnabled, performer: performer)
+    static func archiveStateChanged(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.lightImpact, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func sessionDeleted(isEnabled: Bool, performer: Performer = perform) {
-        emit(.warning, isEnabled: isEnabled, performer: performer)
+    static func sessionDeleted(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.warning, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
-    static func sessionRenamed(isEnabled: Bool, performer: Performer = perform) {
-        emit(.selection, isEnabled: isEnabled, performer: performer)
+    static func sessionRenamed(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.selection, isEnabled: isEnabled, performer: performer ?? Self.perform)
     }
 
     private static func emit(_ feedback: SessionHapticFeedback, isEnabled: Bool, performer: Performer) {

--- a/HermesMobile/Features/Shared/HapticButton.swift
+++ b/HermesMobile/Features/Shared/HapticButton.swift
@@ -13,11 +13,11 @@ enum HapticButtonHaptics {
     static func tap(
         style: HapticButtonFeedbackStyle = .light,
         isEnabled: Bool,
-        performer: Performer = perform
+        performer: Performer? = nil
     ) {
         guard isEnabled else { return }
 
-        performer(style)
+        (performer ?? Self.perform)(style)
     }
 
     static func perform(_ style: HapticButtonFeedbackStyle) {


### PR DESCRIPTION
## Summary
- avoid evaluating MainActor-isolated haptic defaults at nonisolated call sites
- apply the same safe optional performer pattern to chat and session haptic helpers

## Validation
- `git diff --check` passes
- Xcode build/tests not runnable in this Linux environment (`xcodebuild` unavailable); requires MBP validation

## Scope
Focused haptics compilation fix only.