### PR TITLE
fix(models): persist and match the default model with its provider

### DIFF
--- a/HermesMobile/Features/Settings/DefaultModelPickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultModelPickerView.swift
@@ -242,11 +242,13 @@ struct DefaultModelPickerView: View {
 
         // A stored `@provider:` spelling must not be pre-split with
         // `lastIndex(of: ":")` — that turns `@ollama:qwen3:32b` into provider
-        // `ollama:qwen3`. Passing nil lets `matchesSelection` use the row's
-        // own `providerID` as the prefix key. A bare stored id belongs to
-        // whichever provider is active.
+        // `ollama:qwen3`. Detect the prefix by whether one exists at all
+        // (`@cf/meta/...` model ids start with `@` but have no colon, so they
+        // stay bare and match against `activeProvider`). Passing nil then
+        // lets `matchesSelection` use the row's own `providerID` as the
+        // prefix key.
         let defaultProvider: String?
-        if let defaultModel, defaultModel.hasPrefix("@") {
+        if defaultModel?.modelIDProviderPrefix != nil {
             defaultProvider = nil
         } else {
             defaultProvider = activeProvider

--- a/HermesMobile/Features/Settings/DefaultModelPickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultModelPickerView.swift
@@ -231,7 +231,12 @@ struct DefaultModelPickerView: View {
     ) -> Bool {
         // An in-flight tap owns the projection: OR-ing the previous default
         // would leave two rows announcing "Selected" until the save finishes.
+        // A custom / providerless save names no catalog row — matching with
+        // `providerID: nil` would tick every bare same-id row after the live
+        // overlay. Leave the catalog unchecked; the custom button owns the
+        // spinner via `isSavingCustom`.
         if selectedModel != nil {
+            guard selectedProvider != nil else { return false }
             return model.matchesSelection(modelID: selectedModel, providerID: selectedProvider)
         }
 

--- a/HermesMobile/Features/Settings/DefaultModelPickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultModelPickerView.swift
@@ -229,11 +229,24 @@ struct DefaultModelPickerView: View {
         defaultModel: String?,
         activeProvider: String?
     ) -> Bool {
-        model.matchesSelection(modelID: selectedModel, providerID: selectedProvider)
-            || model.matchesSelection(
-                modelID: defaultModel,
-                providerID: defaultModel?.modelIDProviderPrefix ?? activeProvider
-            )
+        // An in-flight tap owns the projection: OR-ing the previous default
+        // would leave two rows announcing "Selected" until the save finishes.
+        if selectedModel != nil {
+            return model.matchesSelection(modelID: selectedModel, providerID: selectedProvider)
+        }
+
+        // A stored `@provider:` spelling must not be pre-split with
+        // `lastIndex(of: ":")` — that turns `@ollama:qwen3:32b` into provider
+        // `ollama:qwen3`. Passing nil lets `matchesSelection` use the row's
+        // own `providerID` as the prefix key. A bare stored id belongs to
+        // whichever provider is active.
+        let defaultProvider: String?
+        if let defaultModel, defaultModel.hasPrefix("@") {
+            defaultProvider = nil
+        } else {
+            defaultProvider = activeProvider
+        }
+        return model.matchesSelection(modelID: defaultModel, providerID: defaultProvider)
     }
 
     private func modelAccessibilityLabel(for model: ModelCatalogOption) -> String {

--- a/HermesMobile/Features/Settings/DefaultModelPickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultModelPickerView.swift
@@ -11,8 +11,10 @@ struct DefaultModelPickerView: View {
     @State private var isLoading = false
     @State private var groups: [ModelCatalogGroup] = []
     @State private var defaultModel: String?
+    @State private var activeProvider: String?
     @State private var customModel = ""
     @State private var selectedModel: String?
+    @State private var selectedProvider: String?
     @State private var searchText = ""
     @State private var errorMessage: String?
     @State private var isSaving = false
@@ -144,7 +146,7 @@ struct DefaultModelPickerView: View {
 
     private func modelRow(_ model: ModelCatalogOption) -> some View {
         Button {
-            Task { await save(model.id) }
+            Task { await save(model.id, providerID: model.providerID) }
         } label: {
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -163,7 +165,7 @@ struct DefaultModelPickerView: View {
 
                 Spacer(minLength: 12)
 
-                if isSaving && selectedModel == model.id {
+                if isSavingRow(model) {
                     ProgressView()
                 } else if isCurrentDefault(model) {
                     Image(systemName: "checkmark")
@@ -182,6 +184,16 @@ struct DefaultModelPickerView: View {
         .accessibilityValue(isCurrentDefault(model) ? "Selected" : "")
     }
 
+    /// Whether this row shows the spinner for an in-flight save.
+    ///
+    /// Both the id and the provider recorded at tap time must agree: after
+    /// the live overlay replaces the active provider's prefixed cached row
+    /// with a bare id, two providers can offer the same spelling, and ticking
+    /// by id alone would spin both rows.
+    private func isSavingRow(_ model: ModelCatalogOption) -> Bool {
+        isSaving && selectedModel == model.id && model.providerID == selectedProvider
+    }
+
     /// Whether this row is the current default.
     ///
     /// Compared through `matchesSelection`, which normalizes the `@provider:`
@@ -189,9 +201,39 @@ struct DefaultModelPickerView: View {
     /// left the checkmark off every row whose saved spelling differed from the
     /// catalog's current one, so the picker could not answer "which one am I on"
     /// at all.
+    ///
+    /// The in-flight branch matches against the provider captured at tap time,
+    /// so only the tapped row announces "Selected". The stored default is
+    /// matched against the provider its own spelling names — an embedded
+    /// `@provider:` prefix stays authoritative — falling back to
+    /// `activeProvider` for a bare id, which belongs to whichever provider is
+    /// active. Without that fallback, Core's catalog dedup can prefix the
+    /// active provider's own rows while an inactive provider keeps the bare
+    /// spelling, and the wrong row ticks.
     private func isCurrentDefault(_ model: ModelCatalogOption) -> Bool {
-        model.matchesSelection(modelID: selectedModel, providerID: nil)
-            || model.matchesSelection(modelID: defaultModel, providerID: nil)
+        Self.isChecked(
+            model,
+            selectedModel: selectedModel,
+            selectedProvider: selectedProvider,
+            defaultModel: defaultModel,
+            activeProvider: activeProvider
+        )
+    }
+
+    /// The checkmark rule, static and internal so tests can pin the
+    /// decoded-response-to-checked-row mapping without driving SwiftUI.
+    static func isChecked(
+        _ model: ModelCatalogOption,
+        selectedModel: String?,
+        selectedProvider: String?,
+        defaultModel: String?,
+        activeProvider: String?
+    ) -> Bool {
+        model.matchesSelection(modelID: selectedModel, providerID: selectedProvider)
+            || model.matchesSelection(
+                modelID: defaultModel,
+                providerID: defaultModel?.modelIDProviderPrefix ?? activeProvider
+            )
     }
 
     private func modelAccessibilityLabel(for model: ModelCatalogOption) -> String {
@@ -211,6 +253,7 @@ struct DefaultModelPickerView: View {
             let response = try await APIClient(baseURL: server).models()
             defaultModel = response.defaultModel ?? currentDefaultModel
             groups = response.catalogGroups
+            activeProvider = response.activeProvider
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -228,27 +271,29 @@ struct DefaultModelPickerView: View {
         groups = groups.mergingLiveModels(from: live)
     }
 
-    private func save(_ model: String, isCustom: Bool = false) async {
+    private func save(_ model: String, providerID: String? = nil, isCustom: Bool = false) async {
         let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-
         isSaving = true
         isSavingCustom = isCustom
         saveError = nil
         selectedModel = trimmed
+        selectedProvider = providerID
 
         do {
-            let response = try await APIClient(baseURL: server).saveDefaultModel(model: trimmed)
+            let response = try await APIClient(baseURL: server).saveDefaultModel(model: trimmed, provider: providerID)
             if response.ok == true {
                 onSave(trimmed)
                 dismiss()
             } else {
                 saveError = String(localized: "The server did not confirm the change.")
                 selectedModel = nil
+                selectedProvider = nil
             }
         } catch {
             saveError = error.localizedDescription
             selectedModel = nil
+            selectedProvider = nil
         }
 
         isSaving = false

--- a/HermesMobile/Networking/APIClient+ServerPanels.swift
+++ b/HermesMobile/Networking/APIClient+ServerPanels.swift
@@ -16,11 +16,16 @@ extension APIClient {
         try await send(endpoint: .commands, method: "GET")
     }
 
-    func saveDefaultModel(model: String) async throws -> DefaultModelResponse {
+    /// Saves the default model. Pass `provider` whenever the row names its
+    /// provider (`provider_id` from the catalog group): Core persists
+    /// `{model, provider}` atomically and resolves slash-qualified ids like
+    /// `anthropic/...` through the named provider's route. Without it such an
+    /// id can be persisted through the wrong provider.
+    func saveDefaultModel(model: String, provider: String? = nil) async throws -> DefaultModelResponse {
         try await send(
             endpoint: .defaultModel,
             method: "POST",
-            body: DefaultModelRequest(model: model)
+            body: DefaultModelRequest(model: model, provider: provider)
         )
     }
 
@@ -166,6 +171,15 @@ extension APIClient {
 
 private struct DefaultModelRequest: Encodable {
     let model: String
+    /// The catalog row's provider, so the server persists `{model, provider}`
+    /// atomically and resolves slash-qualified ids through the right route.
+    /// Surface split, verified in source: the compatibility pin
+    /// (`f1d399b4`, `routes.py:4475`) reads only `body.get("model")` and
+    /// silently ignores the extra key; `set_hermes_default_model` accepts
+    /// `provider` from upstream HEAD `a00b02f` (`api/config.py:4780`).
+    /// Optional so a providerless custom-model save still sends the bare
+    /// `{model}` body; synthesized Encodable omits nil keys.
+    let provider: String?
 }
 
 private struct ReasoningEffortRequest: Encodable {

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -109,6 +109,8 @@ final class APIClientConfigurationTests: APIClientTestCase {
             let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
             XCTAssertEqual(body?["model"] as? String, "claude-sonnet-4")
             XCTAssertNil(body?["modelId"])
+            // A providerless save keeps the bare {model} body.
+            XCTAssertNil(body?["provider"])
 
             return apiTestJSONResponse("""
             {
@@ -143,6 +145,36 @@ final class APIClientConfigurationTests: APIClientTestCase {
         let response = try await client.saveDefaultModel(model: "@openai:gpt-5.4")
 
         XCTAssertEqual(response.model, "@openai:gpt-5.4")
+    }
+
+    /// A catalog row that names its provider must send it: Core persists
+    /// `{model, provider}` atomically and resolves slash-qualified ids like
+    /// `anthropic/...` through the named provider's route.
+    func testSaveDefaultModelSendsTheRowProviderWhenKnown() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/default-model")
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let data = try XCTUnwrap(apiTestBodyData(from: request))
+            let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertEqual(body?["model"] as? String, "deepseek/deepseek-chat-v3:free")
+            XCTAssertEqual(body?["provider"] as? String, "openrouter")
+
+            return apiTestJSONResponse("""
+            {
+              "ok": true,
+              "model": "deepseek/deepseek-chat-v3:free"
+            }
+            """, for: request)
+        }
+
+        let response = try await client.saveDefaultModel(
+            model: "deepseek/deepseek-chat-v3:free",
+            provider: "openrouter"
+        )
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.model, "deepseek/deepseek-chat-v3:free")
     }
 
     func testCommandsBuildsExpectedPathAndDecodesTolerantMetadata() async throws {

--- a/HermesMobileTests/ModelCatalogTests.swift
+++ b/HermesMobileTests/ModelCatalogTests.swift
@@ -436,27 +436,54 @@ final class ModelCatalogTests: XCTestCase {
         )
     }
 
-    /// A tap records the row's provider, so after the live overlay leaves two
-    /// bare `mymodel` rows only the tapped one is Selected / spinning.
+    /// A tap records the row's provider. The previous stored default must not
+    /// stay checkmarked / Selected while the save is in flight.
     func testPickerInFlightSelectionTicksOnlyTheTappedProviderRow() {
         let tapped = ModelCatalogOption(id: "mymodel", displayName: "DeepSeek", providerID: "deepseek")
-        let other = ModelCatalogOption(id: "mymodel", displayName: "OpenAI", providerID: "openai")
+        let previousDefault = ModelCatalogOption(id: "gpt-5.6-luna", displayName: "Luna", providerID: "openai")
 
         XCTAssertTrue(
             DefaultModelPickerView.isChecked(
                 tapped,
                 selectedModel: "mymodel",
                 selectedProvider: "deepseek",
-                defaultModel: nil,
+                defaultModel: "gpt-5.6-luna",
+                activeProvider: "openai"
+            )
+        )
+        XCTAssertFalse(
+            DefaultModelPickerView.isChecked(
+                previousDefault,
+                selectedModel: "mymodel",
+                selectedProvider: "deepseek",
+                defaultModel: "gpt-5.6-luna",
+                activeProvider: "openai"
+            )
+        )
+    }
+
+    /// A stored `@ollama:qwen3:32b` default must tick the Ollama row. Pre-parsing
+    /// the stored spelling with `lastIndex(of: ":")` produces provider
+    /// `ollama:qwen3` and leaves the row unchecked.
+    func testPickerCheckmarkHandlesPrefixedColonBearingDefault() {
+        let ollama = ModelCatalogOption(id: "@ollama:qwen3:32b", displayName: "Qwen3 32B", providerID: "ollama")
+        let other = ModelCatalogOption(id: "qwen3:32b", displayName: "Look-alike", providerID: "openai")
+
+        XCTAssertTrue(
+            DefaultModelPickerView.isChecked(
+                ollama,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "@ollama:qwen3:32b",
                 activeProvider: "openai"
             )
         )
         XCTAssertFalse(
             DefaultModelPickerView.isChecked(
                 other,
-                selectedModel: "mymodel",
-                selectedProvider: "deepseek",
-                defaultModel: nil,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "@ollama:qwen3:32b",
                 activeProvider: "openai"
             )
         )

--- a/HermesMobileTests/ModelCatalogTests.swift
+++ b/HermesMobileTests/ModelCatalogTests.swift
@@ -298,17 +298,167 @@ final class ModelCatalogTests: XCTestCase {
     }
 
     /// An exact spelling wins over a normalized one so a same-named model from
-    /// another provider can never be picked in its place.
+    /// another provider can never be picked in its place. The bare row comes
+    /// first on purpose: with `[prefixed, exact]` ordering the prefixed row
+    /// rejects a bare selection, so deleting the exact-first branch still
+    /// returned "Bare" and proved nothing.
     func testFirstMatchingSelectionPrefersTheExactSpelling() {
         let options = [
-            ModelCatalogOption(id: "@gemini:flash", displayName: "Prefixed", providerID: "gemini"),
-            ModelCatalogOption(id: "flash", displayName: "Bare", providerID: "gemini")
+            ModelCatalogOption(id: "flash", displayName: "Bare", providerID: "gemini"),
+            ModelCatalogOption(id: "@gemini:flash", displayName: "Prefixed", providerID: "gemini")
         ]
 
         XCTAssertEqual(options.firstMatchingSelection(modelID: "flash", providerID: nil)?.displayName, "Bare")
         XCTAssertEqual(
             options.firstMatchingSelection(modelID: "@gemini:flash", providerID: nil)?.displayName,
             "Prefixed"
+        )
+    }
+
+    /// Ollama and OpenRouter model ids carry their own colons
+    /// (`qwen3:32b`, `...:free`). Prefix parsing splits on the FINAL
+    /// separator, so an id like `@ollama:qwen3:32b` is genuinely ambiguous —
+    /// the row's own `provider_id` anchors the match, and the provider named
+    /// on either side must still agree.
+    func testModelSelectionHandlesColonBearingModelIDs() {
+        // A bare id's trailing colons belong to the model: nothing to strip.
+        XCTAssertEqual("deepseek/deepseek-chat-v3:free".bareModelID, "deepseek/deepseek-chat-v3:free")
+        XCTAssertNil("deepseek/deepseek-chat-v3:free".modelIDProviderPrefix)
+
+        let ollama = ModelCatalogOption(id: "@ollama:qwen3:32b", displayName: "Qwen3 32B", providerID: "ollama")
+        XCTAssertTrue(ollama.matchesSelection(modelID: "@ollama:qwen3:32b", providerID: nil))
+
+        let openrouter = ModelCatalogOption(
+            id: "@openrouter:deepseek/deepseek-chat-v3:free",
+            displayName: "DeepSeek Chat v3",
+            providerID: "openrouter"
+        )
+        // The exact prefixed spelling matches itself...
+        XCTAssertTrue(openrouter.matchesSelection(
+            modelID: "@openrouter:deepseek/deepseek-chat-v3:free",
+            providerID: nil
+        ))
+        // ...and an active provider's bare row keeps matching its own bare
+        // spelling: both sides normalize through the same final-colon split,
+        // so a `:free` tail survives the symmetric comparison.
+        let bareOpenRouter = ModelCatalogOption(
+            id: "deepseek/deepseek-chat-v3:free",
+            displayName: "DeepSeek Chat v3",
+            providerID: "openrouter"
+        )
+        XCTAssertTrue(bareOpenRouter.matchesSelection(modelID: "deepseek/deepseek-chat-v3:free", providerID: "openrouter"))
+
+        // Cross-provider tails stay rejected even when both carry colons.
+        XCTAssertFalse(bareOpenRouter.matchesSelection(modelID: "deepseek/deepseek-chat-v3:free", providerID: "ollama"))
+        XCTAssertFalse(openrouter.matchesSelection(modelID: "deepseek/deepseek-chat-v3:free", providerID: "ollama"))
+        let ollamaLookAlike = ModelCatalogOption(id: "@ollama:deepseek/deepseek-chat-v3:free", displayName: "Look-alike", providerID: "ollama")
+        XCTAssertFalse(ollamaLookAlike.matchesSelection(modelID: "@openrouter:deepseek/deepseek-chat-v3:free", providerID: nil))
+
+        // `lastIndex(of: ":")` cannot tell `@provider:model:tag` apart from
+        // a named-custom-provider spelling at the string level, so the row's
+        // own provider_id anchors the comparison: anchored, both spellings
+        // still meet...
+        XCTAssertTrue(ollama.matchesSelection(modelID: "qwen3:32b", providerID: "ollama"))
+        // ...while a bare selection that names no provider stays the ACTIVE
+        // provider's spelling and must not tick a prefixed row.
+        XCTAssertFalse(ollama.matchesSelection(modelID: "qwen3:32b", providerID: nil))
+    }
+
+    /// Core's catalog dedup can prefix the ACTIVE provider's own rows when an
+    /// inactive provider lists the same bare id first, so a stored bare default
+    /// matched without naming the active provider ticks the inactive row and
+    /// leaves the real default unticked. Matching against `activeProvider`
+    /// (the picker now passes it) resolves both directions.
+    func testBareDefaultMatchedAgainstActiveProviderRejectsTheInactiveLookAlike() {
+        let activeRow = ModelCatalogOption(id: "@gemini:mymodel", displayName: "Prefixed", providerID: "gemini")
+        let inactiveRow = ModelCatalogOption(id: "mymodel", displayName: "Bare look-alike", providerID: "deepseek")
+
+        XCTAssertTrue(activeRow.matchesSelection(modelID: "mymodel", providerID: "gemini"))
+        XCTAssertFalse(inactiveRow.matchesSelection(modelID: "mymodel", providerID: "gemini"))
+        // An embedded @provider: spelling keeps naming its own provider even
+        // when another one is active.
+        XCTAssertTrue(activeRow.matchesSelection(modelID: "@gemini:mymodel", providerID: nil))
+        XCTAssertFalse(inactiveRow.matchesSelection(modelID: "@gemini:mymodel", providerID: nil))
+    }
+
+    /// Picker-boundary: decoded `(defaultModel, activeProvider)` must tick the
+    /// active provider's dedup-prefixed row and leave the inactive bare
+    /// look-alike unchecked. Passing `providerID: nil` (the pre-#284
+    /// `isCurrentDefault`) fails this case.
+    func testPickerCheckmarkResolvesTheActiveProvidersDedupPrefixedRow() {
+        let prefixedActive = ModelCatalogOption(id: "@gemini:mymodel", displayName: "Prefixed", providerID: "gemini")
+        let inactiveBare = ModelCatalogOption(id: "mymodel", displayName: "Bare look-alike", providerID: "deepseek")
+
+        XCTAssertTrue(
+            DefaultModelPickerView.isChecked(
+                prefixedActive,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "mymodel",
+                activeProvider: "gemini"
+            )
+        )
+        XCTAssertFalse(
+            DefaultModelPickerView.isChecked(
+                inactiveBare,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "mymodel",
+                activeProvider: "gemini"
+            )
+        )
+    }
+
+    /// An embedded `@provider:` spelling names its own provider and must win
+    /// over the currently active one. Passing `activeProvider` blindly
+    /// (without consulting the stored spelling) ticks the OpenAI look-alike.
+    func testPickerCheckmarkKeepsAnEmbeddedPrefixAuthoritative() {
+        let openAIRow = ModelCatalogOption(id: "mymodel", displayName: "OpenAI look-alike", providerID: "openai")
+        let geminiRow = ModelCatalogOption(id: "@gemini:mymodel", displayName: "Gemini", providerID: "gemini")
+
+        XCTAssertFalse(
+            DefaultModelPickerView.isChecked(
+                openAIRow,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "@gemini:mymodel",
+                activeProvider: "openai"
+            )
+        )
+        XCTAssertTrue(
+            DefaultModelPickerView.isChecked(
+                geminiRow,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "@gemini:mymodel",
+                activeProvider: "openai"
+            )
+        )
+    }
+
+    /// A tap records the row's provider, so after the live overlay leaves two
+    /// bare `mymodel` rows only the tapped one is Selected / spinning.
+    func testPickerInFlightSelectionTicksOnlyTheTappedProviderRow() {
+        let tapped = ModelCatalogOption(id: "mymodel", displayName: "DeepSeek", providerID: "deepseek")
+        let other = ModelCatalogOption(id: "mymodel", displayName: "OpenAI", providerID: "openai")
+
+        XCTAssertTrue(
+            DefaultModelPickerView.isChecked(
+                tapped,
+                selectedModel: "mymodel",
+                selectedProvider: "deepseek",
+                defaultModel: nil,
+                activeProvider: "openai"
+            )
+        )
+        XCTAssertFalse(
+            DefaultModelPickerView.isChecked(
+                other,
+                selectedModel: "mymodel",
+                selectedProvider: "deepseek",
+                defaultModel: nil,
+                activeProvider: "openai"
+            )
         )
     }
 

--- a/HermesMobileTests/ModelCatalogTests.swift
+++ b/HermesMobileTests/ModelCatalogTests.swift
@@ -462,6 +462,32 @@ final class ModelCatalogTests: XCTestCase {
         )
     }
 
+    /// A custom save records the typed id with no provider. That must not
+    /// tick every bare same-id catalog row while the request is in flight.
+    func testPickerCustomSaveDoesNotTickCatalogRows() {
+        let lookAlike = ModelCatalogOption(id: "mymodel", displayName: "DeepSeek", providerID: "deepseek")
+        let previousDefault = ModelCatalogOption(id: "gpt-5.6-luna", displayName: "Luna", providerID: "openai")
+
+        XCTAssertFalse(
+            DefaultModelPickerView.isChecked(
+                lookAlike,
+                selectedModel: "mymodel",
+                selectedProvider: nil,
+                defaultModel: "gpt-5.6-luna",
+                activeProvider: "openai"
+            )
+        )
+        XCTAssertFalse(
+            DefaultModelPickerView.isChecked(
+                previousDefault,
+                selectedModel: "mymodel",
+                selectedProvider: nil,
+                defaultModel: "gpt-5.6-luna",
+                activeProvider: "openai"
+            )
+        )
+    }
+
     /// A stored `@ollama:qwen3:32b` default must tick the Ollama row. Pre-parsing
     /// the stored spelling with `lastIndex(of: ":")` produces provider
     /// `ollama:qwen3` and leaves the row unchecked.

--- a/HermesMobileTests/ModelCatalogTests.swift
+++ b/HermesMobileTests/ModelCatalogTests.swift
@@ -409,6 +409,34 @@ final class ModelCatalogTests: XCTestCase {
         )
     }
 
+    /// A stored default can itself start with `@` without being a provider
+    /// prefix (`@cf/meta/...`). Those ids have no colon, so they stay a bare
+    /// active-provider spelling — passing `providerID: nil` would tick every
+    /// provider that lists the same id.
+    func testPickerCheckmarkTreatsAtPrefixedBareIDsAsActiveProviderSpellings() {
+        let active = ModelCatalogOption(id: "@cf/meta/llama", displayName: "Llama", providerID: "openai")
+        let other = ModelCatalogOption(id: "@cf/meta/llama", displayName: "Llama via OR", providerID: "openrouter")
+
+        XCTAssertTrue(
+            DefaultModelPickerView.isChecked(
+                active,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "@cf/meta/llama",
+                activeProvider: "openai"
+            )
+        )
+        XCTAssertFalse(
+            DefaultModelPickerView.isChecked(
+                other,
+                selectedModel: nil,
+                selectedProvider: nil,
+                defaultModel: "@cf/meta/llama",
+                activeProvider: "openai"
+            )
+        )
+    }
+
     /// An embedded `@provider:` spelling names its own provider and must win
     /// over the currently active one. Passing `activeProvider` blindly
     /// (without consulting the stored spelling) ticks the OpenAI look-alike.

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -484,7 +484,7 @@ Each phase ends in a working, committable state. Run on the simulator after ever
 
 #### 9.3 Settings default model picker ✅
 - **User-facing goal:** In Settings, select the default model from the server model picker.
-- **Upstream API/server contract to verify:** `GET /api/models` for grouped models and current `default_model`; `POST /api/default-model` with `{model}` to save.
+- **Upstream API/server contract to verify:** `GET /api/models` for grouped models, current `default_model`, and `active_provider`; `POST /api/default-model` with `{model}` to save. Verified in upstream source: the pin (`f1d399b4`, `api/routes.py:4475`) reads only `{model}`; `set_hermes_default_model` accepts `{model, provider, advanced}` from upstream HEAD `a00b02f` (`api/config.py:4780`). The client additionally sends the catalog row's `provider` when known — ignored by pinned servers, honored by current ones.
 - **iOS UI changes:** Add a Settings row/sheet for Default Model grouped by provider.
 - **Model/networking changes:** Preserve exact model IDs including provider-prefixed forms; do not normalize on the client.
 - **Persistence/cache impact:** No durable local cache beyond UI state. New sessions should use the updated server default.


### PR DESCRIPTION
Fixes #284

## Linked issue

Follow-up to merged #269. nesquena-hermes reviewed that head as **changes needed**; the two provider-identity gaps were still on `master` after the squash (`7f6b429`) and were filed as #284.

## What changed

- Catalog-row save now carries `model.providerID` through `save` → `saveDefaultModel` → `DefaultModelRequest`. A providerless custom-model save still sends the bare `{model}` body (synthesized `Encodable` omits nil).
- `loadModels()` retains `response.activeProvider`. The stored default is matched against it when the spelling is bare; a stored `@provider:` spelling stays authoritative via the row's own `providerID` (not a `lastIndex` pre-split, which turns `@ollama:qwen3:32b` into provider `ollama:qwen3`). `@cf/meta/...` ids start with `@` but have no colon, so they stay bare and match against `activeProvider`.
- An in-flight catalog tap owns the checkmark / VoiceOver "Selected" value. A custom save names no catalog row, so no catalog row ticks while that request is in flight.

## Root cause

`#269` taught the matcher to keep provider identity, but the picker still discarded it at both boundaries: the write sent only `{model}`, and the checkmark called `matchesSelection(..., providerID: nil)`. Core leaves slash-qualified ids unprefixed and its catalog dedup can prefix the *active* provider's own row, so model text alone is not a stable routing or selection identity.

## Contract evidence

Verified in upstream source, not docs:

- Compatibility pin `f1d399b4` (`api/routes.py:4475`) reads only `body.get("model")` and ignores an extra `provider` key.
- Upstream HEAD `a00b02f` (`set_hermes_default_model`, `api/config.py:4780`; route `api/routes.py:15474`) accepts `{model, provider, advanced}` and persists them atomically.

Sending `provider` when known is therefore inert on the pin and load-bearing on current servers. `PROJECT_SPEC.md` §9.3 records that split.

## How it was tested

- Focused: `ModelCatalogTests` + `APIClientConfigurationTests` (provider body present/absent, colon-bearing ids, exact-first option order, picker-boundary `isChecked` cases including dedup-prefixed active row, embedded-prefix authority, in-flight exclusivity, custom-save, `@ollama:qwen3:32b` stored default, `@cf/meta/llama` bare-`@` ids).
- Full XCTest, iPhone 17 Simulator, `-parallel-testing-enabled NO`: **1611 passed, 0 failed, 2 skipped**.
- `git diff --check origin/master..HEAD`: clean.
- Pushed SHA verified against `audichuang/hermex`: `1f01057df2445198d84396f89b444df6dd201782`.

## Need to verify

- **No live save of a slash-qualified default.** Selecting a Nous `anthropic/...` row writes the real server; the request-body test covers the wire, not a live persist-and-reload.
- **No signed-build UI walkthrough** of the picker after this change. Checkmark / VoiceOver exclusivity is covered by `DefaultModelPickerView.isChecked` unit tests, not by tapping the sheet on a device.
- **No UI test** that the row tap itself forwards `model.providerID` (the request-body test supplies the provider at the API client). The one-line glue `save(model.id, providerID: model.providerID)` is review-backed.

## Checklist

- [x] The full test suite passes locally
- [x] No new third-party dependencies
- [x] No invented API endpoints (provider field verified against pin + HEAD source above)

## AI assistance

Prepared with Claude Code; an independent Codex (gpt-5.6 Sol) review of `1f01057` returned GO with no new confirmed findings. Diff, contract reading, and test output were reviewed before publishing.