### PR TITLE
fix(share): make incoming shares transactional

### DIFF
--- a/HermesMobile/ContentView.swift
+++ b/HermesMobile/ContentView.swift
@@ -4,7 +4,7 @@ struct ContentView: View {
     @Bindable var authManager: AuthManager
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(ResponseCompletionNotifications.isEnabledKey) private var isResponseCompletionNotificationsEnabled = false
-    @State private var pendingSharedImport: SharedImport?
+    @State private var pendingSharedImport: SharedImportReservation?
     @State private var pendingDeepLinkedSessionID: String?
     @State private var pendingNewChatRequest: NewChatRequest?
     @State private var didCheckInitialPendingShare = false
@@ -62,6 +62,7 @@ struct ContentView: View {
                 authManager: authManager,
                 server: server,
                 pendingSharedImport: $pendingSharedImport,
+                didRoutePendingSharedImport: consumePendingSharedImport,
                 pendingDeepLinkedSessionID: $pendingDeepLinkedSessionID,
                 requestedNewChat: $pendingNewChatRequest
             )
@@ -119,16 +120,37 @@ struct ContentView: View {
     }
 
     private func importPendingSharedDraftIfAvailable() {
+        guard pendingSharedImport == nil else {
+            return
+        }
+
         guard let directory = HermesShareDraft.containerURL() else {
             return
         }
 
         do {
-            if let sharedImport = try HermesShareDraft.loadPendingImport(from: directory) {
-                pendingSharedImport = sharedImport
-            }
+            pendingSharedImport = try HermesShareDraft.reserveNextPendingImport(from: directory)
         } catch {
             pendingSharedImport = nil
+        }
+    }
+
+    private func consumePendingSharedImport(_ reservation: SharedImportReservation) {
+        defer {
+            if pendingSharedImport?.reservationID == reservation.reservationID {
+                pendingSharedImport = nil
+            }
+        }
+
+        guard let directory = HermesShareDraft.containerURL() else {
+            return
+        }
+
+        do {
+            try HermesShareDraft.consume(reservation, from: directory)
+        } catch {
+            // Keep the share recoverable if acknowledgement fails after routing.
+            try? HermesShareDraft.release(reservation, in: directory)
         }
     }
 }

--- a/HermesMobile/ContentView.swift
+++ b/HermesMobile/ContentView.swift
@@ -6,6 +6,7 @@ struct ContentView: View {
     @AppStorage(ResponseCompletionNotifications.isEnabledKey) private var isResponseCompletionNotificationsEnabled = false
     @State private var pendingSharedImport: SharedImportReservation?
     @State private var hasWaitingSharedImport = false
+    @State private var hasRoutedSharedImport = false
     @State private var pendingDeepLinkedSessionID: String?
     @State private var pendingNewChatRequest: NewChatRequest?
     @State private var didCheckInitialPendingShare = false
@@ -131,6 +132,11 @@ struct ContentView: View {
             return
         }
 
+        guard !hasRoutedSharedImport else {
+            refreshWaitingSharedImport(in: directory)
+            return
+        }
+
         do {
             pendingSharedImport = try HermesShareDraft.reserveNextPendingImport(from: directory)
             refreshWaitingSharedImport(in: directory)
@@ -141,6 +147,8 @@ struct ContentView: View {
     }
 
     private func consumePendingSharedImport(_ reservation: SharedImportReservation) {
+        hasRoutedSharedImport = true
+
         defer {
             if pendingSharedImport?.reservationID == reservation.reservationID {
                 pendingSharedImport = nil
@@ -162,6 +170,7 @@ struct ContentView: View {
 
     private func openNextSharedImport() {
         hasWaitingSharedImport = false
+        hasRoutedSharedImport = false
         importPendingSharedDraftIfAvailable()
     }
 

--- a/HermesMobile/ContentView.swift
+++ b/HermesMobile/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(ResponseCompletionNotifications.isEnabledKey) private var isResponseCompletionNotificationsEnabled = false
     @State private var pendingSharedImport: SharedImportReservation?
+    @State private var hasWaitingSharedImport = false
     @State private var pendingDeepLinkedSessionID: String?
     @State private var pendingNewChatRequest: NewChatRequest?
     @State private var didCheckInitialPendingShare = false
@@ -63,6 +64,8 @@ struct ContentView: View {
                 server: server,
                 pendingSharedImport: $pendingSharedImport,
                 didRoutePendingSharedImport: consumePendingSharedImport,
+                hasWaitingSharedImport: hasWaitingSharedImport,
+                openNextSharedImport: openNextSharedImport,
                 pendingDeepLinkedSessionID: $pendingDeepLinkedSessionID,
                 requestedNewChat: $pendingNewChatRequest
             )
@@ -130,8 +133,10 @@ struct ContentView: View {
 
         do {
             pendingSharedImport = try HermesShareDraft.reserveNextPendingImport(from: directory)
+            refreshWaitingSharedImport(in: directory)
         } catch {
             pendingSharedImport = nil
+            hasWaitingSharedImport = false
         }
     }
 
@@ -152,6 +157,16 @@ struct ContentView: View {
             // Keep the share recoverable if acknowledgement fails after routing.
             try? HermesShareDraft.release(reservation, in: directory)
         }
+        refreshWaitingSharedImport(in: directory)
+    }
+
+    private func openNextSharedImport() {
+        hasWaitingSharedImport = false
+        importPendingSharedDraftIfAvailable()
+    }
+
+    private func refreshWaitingSharedImport(in directory: URL) {
+        hasWaitingSharedImport = (try? HermesShareDraft.hasPendingImport(in: directory)) ?? false
     }
 }
 

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -9,7 +9,8 @@ struct SessionListView: View {
 
     @Bindable var authManager: AuthManager
     let server: URL
-    @Binding private var pendingSharedImport: SharedImport?
+    @Binding private var pendingSharedImport: SharedImportReservation?
+    private let didRoutePendingSharedImport: (SharedImportReservation) -> Void
     @Binding private var pendingDeepLinkedSessionID: String?
     @Binding private var requestedNewChat: NewChatRequest?
 
@@ -70,13 +71,15 @@ struct SessionListView: View {
     init(
         authManager: AuthManager,
         server: URL,
-        pendingSharedImport: Binding<SharedImport?> = .constant(nil),
+        pendingSharedImport: Binding<SharedImportReservation?> = .constant(nil),
+        didRoutePendingSharedImport: @escaping (SharedImportReservation) -> Void = { _ in },
         pendingDeepLinkedSessionID: Binding<String?> = .constant(nil),
         requestedNewChat: Binding<NewChatRequest?> = .constant(nil)
     ) {
         self.authManager = authManager
         self.server = server
         _pendingSharedImport = pendingSharedImport
+        self.didRoutePendingSharedImport = didRoutePendingSharedImport
         _pendingDeepLinkedSessionID = pendingDeepLinkedSessionID
         _requestedNewChat = requestedNewChat
         _viewModel = State(initialValue: SessionListViewModel(server: server))
@@ -1134,13 +1137,14 @@ struct SessionListView: View {
     }
 
     private func openPendingSharedImportIfNeeded() {
-        guard let sharedImport = pendingSharedImport else {
+        guard let reservation = pendingSharedImport else {
             return
         }
 
-        pendingSharedImport = nil
+        let sharedImport = reservation.sharedImport
         let draft = HermesShareDraft.composerDraft(from: sharedImport.draft)
         guard !draft.isEmpty || !sharedImport.attachments.isEmpty else {
+            didRoutePendingSharedImport(reservation)
             return
         }
 
@@ -1150,6 +1154,7 @@ struct SessionListView: View {
                 initialAttachments: sharedImport.attachments
             )
         )
+        didRoutePendingSharedImport(reservation)
     }
 
     /// Awaited (not fire-and-forget) so the cold-start `.task` can resolve it before

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -11,6 +11,8 @@ struct SessionListView: View {
     let server: URL
     @Binding private var pendingSharedImport: SharedImportReservation?
     private let didRoutePendingSharedImport: (SharedImportReservation) -> Void
+    private let hasWaitingSharedImport: Bool
+    private let openNextSharedImport: () -> Void
     @Binding private var pendingDeepLinkedSessionID: String?
     @Binding private var requestedNewChat: NewChatRequest?
 
@@ -73,6 +75,8 @@ struct SessionListView: View {
         server: URL,
         pendingSharedImport: Binding<SharedImportReservation?> = .constant(nil),
         didRoutePendingSharedImport: @escaping (SharedImportReservation) -> Void = { _ in },
+        hasWaitingSharedImport: Bool = false,
+        openNextSharedImport: @escaping () -> Void = {},
         pendingDeepLinkedSessionID: Binding<String?> = .constant(nil),
         requestedNewChat: Binding<NewChatRequest?> = .constant(nil)
     ) {
@@ -80,6 +84,8 @@ struct SessionListView: View {
         self.server = server
         _pendingSharedImport = pendingSharedImport
         self.didRoutePendingSharedImport = didRoutePendingSharedImport
+        self.hasWaitingSharedImport = hasWaitingSharedImport
+        self.openNextSharedImport = openNextSharedImport
         _pendingDeepLinkedSessionID = pendingDeepLinkedSessionID
         _requestedNewChat = requestedNewChat
         _viewModel = State(initialValue: SessionListViewModel(server: server))
@@ -100,6 +106,11 @@ struct SessionListView: View {
 
     var body: some View {
         navigationContainer
+            .safeAreaInset(edge: .top, spacing: 0) {
+                if hasWaitingSharedImport {
+                    waitingSharedImportBanner
+                }
+            }
             .sheet(item: $sessionExportShareItem) { item in
                 SessionExportShareSheet(fileURL: item.fileURL)
                     .presentationDetents([.medium, .large])
@@ -276,6 +287,34 @@ struct SessionListView: View {
                 )
             )
             .focusedSceneValue(\.hermexSceneActions, sceneActions)
+    }
+
+    private var waitingSharedImportBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "square.and.arrow.down")
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Another shared item is waiting")
+                    .font(.subheadline.weight(.semibold))
+                Text("Open it when you are done with this draft.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+
+            Button("Open Next", action: openNextSharedImport)
+                .font(.subheadline.weight(.semibold))
+                .buttonStyle(.bordered)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(Color(.secondarySystemBackground))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityElement(children: .contain)
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Share/SharedDraftStore.swift
+++ b/HermesMobile/Features/Share/SharedDraftStore.swift
@@ -234,6 +234,24 @@ enum HermesShareDraft {
         return nil
     }
 
+    static func hasPendingImport(
+        in directory: URL,
+        fileManager: FileManager = .default,
+        now: Date = Date(),
+        reservationTimeout: TimeInterval = reservationLifetime
+    ) throws -> Bool {
+        try prepareInbox(in: directory, fileManager: fileManager)
+        try migrateLegacyPendingImportIfNeeded(in: directory, fileManager: fileManager, now: now)
+        try recoverExpiredReservations(
+            in: directory,
+            fileManager: fileManager,
+            now: now,
+            reservationTimeout: reservationTimeout
+        )
+        try cleanTemporaryItems(in: directory, fileManager: fileManager, now: now)
+        return try !sortedPendingItemURLs(in: directory, fileManager: fileManager).isEmpty
+    }
+
     static func consume(
         _ reservation: SharedImportReservation,
         from directory: URL,
@@ -421,10 +439,17 @@ enum HermesShareDraft {
             return
         }
 
-        let payload = try JSONDecoder().decode(
-            SharedDraftPayload.self,
-            from: Data(contentsOf: legacyPayloadURL)
-        )
+        let legacyData = try Data(contentsOf: legacyPayloadURL)
+        let payload: SharedDraftPayload
+        do {
+            payload = try JSONDecoder().decode(SharedDraftPayload.self, from: legacyData)
+        } catch {
+            // The legacy format has no partial recovery path. Drop malformed data so
+            // it cannot permanently block valid records in the transactional inbox.
+            try? fileManager.removeItem(at: legacyPayloadURL)
+            try? fileManager.removeItem(at: pendingAttachmentsDirectoryURL(in: directory))
+            return
+        }
         let draft = (payload.draft ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let attachments = loadLegacyAttachments(from: payload, in: directory)
         let sharedImport = normalizedImport(draft: draft, attachments: attachments)

--- a/HermesMobile/Features/Share/SharedDraftStore.swift
+++ b/HermesMobile/Features/Share/SharedDraftStore.swift
@@ -1,15 +1,22 @@
+import CryptoKit
 import Foundation
 
 struct SharedDraftPayload: Codable, Equatable {
-    let draft: String
-    let createdAt: Date
+    let version: Int?
+    let id: String?
+    let draft: String?
+    let createdAt: Date?
     let attachments: [SharedAttachmentPayload]?
 
     init(
+        version: Int? = nil,
+        id: String? = nil,
         draft: String,
         createdAt: Date,
         attachments: [SharedAttachmentPayload] = []
     ) {
+        self.version = version
+        self.id = id
         self.draft = draft
         self.createdAt = createdAt
         self.attachments = attachments.isEmpty ? nil : attachments
@@ -17,10 +24,17 @@ struct SharedDraftPayload: Codable, Equatable {
 }
 
 struct SharedAttachmentPayload: Codable, Equatable {
-    let filename: String
-    let storedFileName: String
+    let filename: String?
+    let storedFileName: String?
     let typeIdentifier: String?
     let size: Int?
+
+    init(filename: String, storedFileName: String, typeIdentifier: String?, size: Int?) {
+        self.filename = filename
+        self.storedFileName = storedFileName
+        self.typeIdentifier = typeIdentifier
+        self.size = size
+    }
 }
 
 struct SharedAttachmentImport: Equatable {
@@ -38,14 +52,37 @@ struct SharedImport: Equatable {
     }
 }
 
+struct SharedImportReservation: Equatable, Identifiable {
+    let itemID: String
+    let reservationID: String
+    let createdAt: Date
+    let sharedImport: SharedImport
+
+    var id: String { reservationID }
+}
+
 enum HermesShareDraft {
     static var appGroupIdentifier: String {
         Bundle.main.object(forInfoDictionaryKey: "HermesAppGroupIdentifier") as? String
             ?? "group.com.uzairansar.hermesmobile"
     }
 
+    // Legacy single-slot names. Existing installs may still have one of these records.
     static let pendingDraftFileName = "pending-share-draft.json"
     static let pendingAttachmentsDirectoryName = "pending-share-attachments"
+
+    static let inboxDirectoryName = "share-inbox-v1"
+    static let pendingItemsDirectoryName = "pending"
+    static let reservedItemsDirectoryName = "reserved"
+    static let temporaryItemsDirectoryName = "temporary"
+    static let reservationLifetime: TimeInterval = 15 * 60
+    static let temporaryItemLifetime: TimeInterval = 24 * 60 * 60
+
+    private static let currentPayloadVersion = 1
+    private static let payloadFileName = "payload.json"
+    private static let reservationFileName = "reservation.json"
+    private static let attachmentsDirectoryName = "attachments"
+
     static var urlScheme: String {
         Bundle.main.object(forInfoDictionaryKey: "HermesURLScheme") as? String
             ?? "hermes-agent"
@@ -119,42 +156,109 @@ enum HermesShareDraft {
         fileManager: FileManager = .default,
         now: Date = Date()
     ) throws {
-        let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let uploadableAttachments = attachments
-            .filter { !$0.data.isEmpty && $0.data.count <= maximumSharedAttachmentBytes }
-            .prefix(maximumSharedAttachmentCount)
-
-        guard !trimmedDraft.isEmpty || !uploadableAttachments.isEmpty else {
+        let normalizedImport = normalizedImport(draft: draft, attachments: attachments)
+        guard !normalizedImport.isEmpty else {
             return
         }
 
-        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        let attachmentsDirectory = pendingAttachmentsDirectoryURL(in: directory)
-        try? fileManager.removeItem(at: attachmentsDirectory)
+        try prepareInbox(in: directory, fileManager: fileManager)
+        try cleanTemporaryItems(in: directory, fileManager: fileManager, now: now)
+        try enqueue(
+            normalizedImport,
+            createdAt: now,
+            in: directory,
+            fileManager: fileManager
+        )
+    }
 
-        var attachmentPayloads: [SharedAttachmentPayload] = []
-        if !uploadableAttachments.isEmpty {
-            try fileManager.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
+    static func reserveNextPendingImport(
+        from directory: URL,
+        fileManager: FileManager = .default,
+        now: Date = Date(),
+        reservationTimeout: TimeInterval = reservationLifetime
+    ) throws -> SharedImportReservation? {
+        try prepareInbox(in: directory, fileManager: fileManager)
+        try migrateLegacyPendingImportIfNeeded(in: directory, fileManager: fileManager, now: now)
+        try recoverExpiredReservations(
+            in: directory,
+            fileManager: fileManager,
+            now: now,
+            reservationTimeout: reservationTimeout
+        )
+        try cleanTemporaryItems(in: directory, fileManager: fileManager, now: now)
 
-            for attachment in uploadableAttachments {
-                let filename = sanitizedFilename(attachment.filename)
-                let storedFileName = storedFileName(for: filename)
-                let destinationURL = attachmentsDirectory.appendingPathComponent(storedFileName, isDirectory: false)
-                try attachment.data.write(to: destinationURL, options: [.atomic])
-                attachmentPayloads.append(
-                    SharedAttachmentPayload(
-                        filename: filename,
-                        storedFileName: storedFileName,
-                        typeIdentifier: attachment.typeIdentifier,
-                        size: attachment.data.count
-                    )
-                )
+        for pendingURL in try sortedPendingItemURLs(in: directory, fileManager: fileManager) {
+            let itemID = pendingURL.lastPathComponent
+            let reservedURL = reservedItemURL(for: itemID, in: directory)
+
+            do {
+                try fileManager.moveItem(at: pendingURL, to: reservedURL)
+            } catch {
+                // Another process may have reserved or consumed this item after enumeration.
+                if !fileManager.fileExists(atPath: pendingURL.path) {
+                    continue
+                }
+                throw error
             }
+
+            let reservationID = UUID().uuidString
+            let metadata = SharedReservationMetadata(
+                reservationID: reservationID,
+                reservedAt: now
+            )
+
+            do {
+                let metadataURL = reservationURL(in: reservedURL)
+                try writeJSON(metadata, to: metadataURL)
+                try setProtectedFileAttributes(at: metadataURL, fileManager: fileManager)
+            } catch {
+                try? fileManager.removeItem(at: reservationURL(in: reservedURL))
+                try? fileManager.moveItem(at: reservedURL, to: pendingURL)
+                throw error
+            }
+
+            guard let loaded = try? loadImport(from: reservedURL), !loaded.sharedImport.isEmpty else {
+                // A malformed or incomplete record must not block later valid shares.
+                try? fileManager.removeItem(at: reservedURL)
+                continue
+            }
+
+            return SharedImportReservation(
+                itemID: itemID,
+                reservationID: reservationID,
+                createdAt: loaded.createdAt,
+                sharedImport: loaded.sharedImport
+            )
         }
 
-        let payload = SharedDraftPayload(draft: trimmedDraft, createdAt: now, attachments: attachmentPayloads)
-        let data = try JSONEncoder().encode(payload)
-        try data.write(to: pendingDraftURL(in: directory), options: [.atomic])
+        return nil
+    }
+
+    static func consume(
+        _ reservation: SharedImportReservation,
+        from directory: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        let reservedURL = reservedItemURL(for: reservation.itemID, in: directory)
+        try validateReservation(reservation, at: reservedURL)
+        try fileManager.removeItem(at: reservedURL)
+    }
+
+    static func release(
+        _ reservation: SharedImportReservation,
+        in directory: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        let reservedURL = reservedItemURL(for: reservation.itemID, in: directory)
+        try validateReservation(reservation, at: reservedURL)
+
+        let pendingURL = pendingItemURL(for: reservation.itemID, in: directory)
+        try? fileManager.removeItem(at: reservationURL(in: reservedURL))
+        if fileManager.fileExists(atPath: pendingURL.path) {
+            try fileManager.removeItem(at: reservedURL)
+        } else {
+            try fileManager.moveItem(at: reservedURL, to: pendingURL)
+        }
     }
 
     static func loadPendingDraft(
@@ -174,51 +278,363 @@ enum HermesShareDraft {
         fileManager: FileManager = .default,
         removeAfterLoad: Bool = true
     ) throws -> SharedImport? {
-        let url = pendingDraftURL(in: directory)
-        guard fileManager.fileExists(atPath: url.path) else {
+        guard let reservation = try reserveNextPendingImport(
+            from: directory,
+            fileManager: fileManager
+        ) else {
             return nil
         }
 
-        defer {
-            if removeAfterLoad {
-                try? fileManager.removeItem(at: url)
-                try? fileManager.removeItem(at: pendingAttachmentsDirectoryURL(in: directory))
+        if removeAfterLoad {
+            try consume(reservation, from: directory, fileManager: fileManager)
+        } else {
+            try release(reservation, in: directory, fileManager: fileManager)
+        }
+        return reservation.sharedImport
+    }
+
+    private struct LoadedSharedImport {
+        let createdAt: Date
+        let sharedImport: SharedImport
+    }
+
+    private struct SharedReservationMetadata: Codable {
+        let reservationID: String?
+        let reservedAt: Date?
+
+        init(reservationID: String, reservedAt: Date) {
+            self.reservationID = reservationID
+            self.reservedAt = reservedAt
+        }
+    }
+
+    private enum SharedInboxError: Error {
+        case reservationNoLongerOwned
+    }
+
+    private static func normalizedImport(
+        draft: String,
+        attachments: [SharedAttachmentImport]
+    ) -> SharedImport {
+        let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let uploadableAttachments = attachments
+            .filter { !$0.data.isEmpty && $0.data.count <= maximumSharedAttachmentBytes }
+            .prefix(maximumSharedAttachmentCount)
+            .map {
+                SharedAttachmentImport(
+                    filename: sanitizedFilename($0.filename),
+                    typeIdentifier: $0.typeIdentifier,
+                    data: $0.data
+                )
+            }
+
+        return SharedImport(draft: trimmedDraft, attachments: uploadableAttachments)
+    }
+
+    private static func prepareInbox(in directory: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        for inboxURL in [
+            inboxRootURL(in: directory),
+            pendingItemsURL(in: directory),
+            reservedItemsURL(in: directory),
+            temporaryItemsURL(in: directory)
+        ] {
+            try fileManager.createDirectory(at: inboxURL, withIntermediateDirectories: true)
+            try setProtectedFileAttributes(at: inboxURL, fileManager: fileManager)
+        }
+    }
+
+    private static func enqueue(
+        _ sharedImport: SharedImport,
+        createdAt: Date,
+        in directory: URL,
+        fileManager: FileManager
+    ) throws {
+        let itemID = contentID(for: sharedImport)
+        let pendingURL = pendingItemURL(for: itemID, in: directory)
+        let reservedURL = reservedItemURL(for: itemID, in: directory)
+
+        guard
+            !fileManager.fileExists(atPath: pendingURL.path),
+            !fileManager.fileExists(atPath: reservedURL.path)
+        else {
+            return
+        }
+
+        let temporaryURL = temporaryItemsURL(in: directory)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: temporaryURL, withIntermediateDirectories: false)
+        defer { try? fileManager.removeItem(at: temporaryURL) }
+
+        let attachmentsURL = attachmentsURL(in: temporaryURL)
+        var attachmentPayloads: [SharedAttachmentPayload] = []
+        if !sharedImport.attachments.isEmpty {
+            try fileManager.createDirectory(at: attachmentsURL, withIntermediateDirectories: false)
+
+            for attachment in sharedImport.attachments {
+                let storedFileName = storedFileName(for: attachment.filename)
+                let destinationURL = attachmentsURL.appendingPathComponent(storedFileName, isDirectory: false)
+                try attachment.data.write(to: destinationURL, options: [.atomic])
+                try setProtectedFileAttributes(at: destinationURL, fileManager: fileManager)
+                attachmentPayloads.append(
+                    SharedAttachmentPayload(
+                        filename: attachment.filename,
+                        storedFileName: storedFileName,
+                        typeIdentifier: attachment.typeIdentifier,
+                        size: attachment.data.count
+                    )
+                )
             }
         }
 
-        let payload = try JSONDecoder().decode(SharedDraftPayload.self, from: Data(contentsOf: url))
-        let draft = payload.draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let attachments = loadAttachments(from: payload, in: directory)
-        let sharedImport = SharedImport(draft: draft, attachments: attachments)
-        return sharedImport.isEmpty ? nil : sharedImport
+        let payload = SharedDraftPayload(
+            version: currentPayloadVersion,
+            id: itemID,
+            draft: sharedImport.draft,
+            createdAt: createdAt,
+            attachments: attachmentPayloads
+        )
+        let payloadURL = payloadURL(in: temporaryURL)
+        try writeJSON(payload, to: payloadURL)
+        try setProtectedFileAttributes(at: payloadURL, fileManager: fileManager)
+        try setProtectedFileAttributes(at: temporaryURL, fileManager: fileManager)
+
+        do {
+            try fileManager.moveItem(at: temporaryURL, to: pendingURL)
+        } catch {
+            // A concurrent extension save of the same content is a successful deduplication.
+            if fileManager.fileExists(atPath: pendingURL.path)
+                || fileManager.fileExists(atPath: reservedURL.path) {
+                return
+            }
+            throw error
+        }
     }
 
-    private static func pendingDraftURL(in directory: URL) -> URL {
-        directory.appendingPathComponent(pendingDraftFileName, isDirectory: false)
+    private static func migrateLegacyPendingImportIfNeeded(
+        in directory: URL,
+        fileManager: FileManager,
+        now: Date
+    ) throws {
+        let legacyPayloadURL = pendingDraftURL(in: directory)
+        guard fileManager.fileExists(atPath: legacyPayloadURL.path) else {
+            return
+        }
+
+        let payload = try JSONDecoder().decode(
+            SharedDraftPayload.self,
+            from: Data(contentsOf: legacyPayloadURL)
+        )
+        let draft = (payload.draft ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let attachments = loadLegacyAttachments(from: payload, in: directory)
+        let sharedImport = normalizedImport(draft: draft, attachments: attachments)
+
+        if !sharedImport.isEmpty {
+            try enqueue(
+                sharedImport,
+                createdAt: payload.createdAt ?? now,
+                in: directory,
+                fileManager: fileManager
+            )
+        }
+
+        try fileManager.removeItem(at: legacyPayloadURL)
+        try? fileManager.removeItem(at: pendingAttachmentsDirectoryURL(in: directory))
     }
 
-    private static func pendingAttachmentsDirectoryURL(in directory: URL) -> URL {
-        directory.appendingPathComponent(pendingAttachmentsDirectoryName, isDirectory: true)
+    private static func recoverExpiredReservations(
+        in directory: URL,
+        fileManager: FileManager,
+        now: Date,
+        reservationTimeout: TimeInterval
+    ) throws {
+        for reservedURL in try itemDirectoryURLs(at: reservedItemsURL(in: directory), fileManager: fileManager) {
+            let metadata = try? JSONDecoder().decode(
+                SharedReservationMetadata.self,
+                from: Data(contentsOf: reservationURL(in: reservedURL))
+            )
+            let fallbackDate = try? reservedURL.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate
+            let reservedAt = metadata?.reservedAt ?? fallbackDate ?? .distantPast
+            guard now.timeIntervalSince(reservedAt) >= reservationTimeout else {
+                continue
+            }
+
+            let pendingURL = pendingItemURL(for: reservedURL.lastPathComponent, in: directory)
+            try? fileManager.removeItem(at: reservationURL(in: reservedURL))
+            if fileManager.fileExists(atPath: pendingURL.path) {
+                try fileManager.removeItem(at: reservedURL)
+            } else {
+                try fileManager.moveItem(at: reservedURL, to: pendingURL)
+            }
+        }
+    }
+
+    private static func cleanTemporaryItems(
+        in directory: URL,
+        fileManager: FileManager,
+        now: Date
+    ) throws {
+        for temporaryURL in try itemDirectoryURLs(at: temporaryItemsURL(in: directory), fileManager: fileManager) {
+            let values = try? temporaryURL.resourceValues(forKeys: [.contentModificationDateKey])
+            let modifiedAt = values?.contentModificationDate ?? .distantPast
+            if now.timeIntervalSince(modifiedAt) >= temporaryItemLifetime {
+                try? fileManager.removeItem(at: temporaryURL)
+            }
+        }
+    }
+
+    private static func sortedPendingItemURLs(
+        in directory: URL,
+        fileManager: FileManager
+    ) throws -> [URL] {
+        try itemDirectoryURLs(at: pendingItemsURL(in: directory), fileManager: fileManager)
+            .sorted { lhs, rhs in
+                let lhsDate = payloadCreatedAt(in: lhs) ?? .distantPast
+                let rhsDate = payloadCreatedAt(in: rhs) ?? .distantPast
+                if lhsDate == rhsDate {
+                    return lhs.lastPathComponent < rhs.lastPathComponent
+                }
+                return lhsDate < rhsDate
+            }
+    }
+
+    private static func itemDirectoryURLs(at directory: URL, fileManager: FileManager) throws -> [URL] {
+        try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ).filter { url in
+            (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        }
+    }
+
+    private static func loadImport(from itemURL: URL) throws -> LoadedSharedImport {
+        let payload = try JSONDecoder().decode(
+            SharedDraftPayload.self,
+            from: Data(contentsOf: payloadURL(in: itemURL))
+        )
+        let draft = (payload.draft ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let attachments = loadAttachments(from: payload, in: itemURL)
+        return LoadedSharedImport(
+            createdAt: payload.createdAt ?? .distantPast,
+            sharedImport: SharedImport(draft: draft, attachments: attachments)
+        )
     }
 
     private static func loadAttachments(
+        from payload: SharedDraftPayload,
+        in itemURL: URL
+    ) -> [SharedAttachmentImport] {
+        let directory = attachmentsURL(in: itemURL)
+
+        return (payload.attachments ?? []).compactMap { attachment in
+            guard
+                let storedFileName = attachment.storedFileName,
+                isSafeStoredFileName(storedFileName),
+                let data = try? Data(
+                    contentsOf: directory.appendingPathComponent(storedFileName, isDirectory: false)
+                ),
+                !data.isEmpty
+            else {
+                return nil
+            }
+
+            return SharedAttachmentImport(
+                filename: sanitizedFilename(attachment.filename ?? "shared-file"),
+                typeIdentifier: attachment.typeIdentifier,
+                data: data
+            )
+        }
+    }
+
+    private static func loadLegacyAttachments(
         from payload: SharedDraftPayload,
         in directory: URL
     ) -> [SharedAttachmentImport] {
         let attachmentsDirectory = pendingAttachmentsDirectoryURL(in: directory)
 
         return (payload.attachments ?? []).compactMap { attachment in
-            let fileURL = attachmentsDirectory.appendingPathComponent(attachment.storedFileName, isDirectory: false)
-            guard let data = try? Data(contentsOf: fileURL), !data.isEmpty else {
+            guard
+                let storedFileName = attachment.storedFileName,
+                isSafeStoredFileName(storedFileName),
+                let data = try? Data(
+                    contentsOf: attachmentsDirectory.appendingPathComponent(
+                        storedFileName,
+                        isDirectory: false
+                    )
+                ),
+                !data.isEmpty
+            else {
                 return nil
             }
 
             return SharedAttachmentImport(
-                filename: sanitizedFilename(attachment.filename),
+                filename: sanitizedFilename(attachment.filename ?? "shared-file"),
                 typeIdentifier: attachment.typeIdentifier,
                 data: data
             )
         }
+    }
+
+    private static func validateReservation(
+        _ reservation: SharedImportReservation,
+        at reservedURL: URL
+    ) throws {
+        guard
+            let metadata = try? JSONDecoder().decode(
+                SharedReservationMetadata.self,
+                from: Data(contentsOf: reservationURL(in: reservedURL))
+            ),
+            metadata.reservationID == reservation.reservationID
+        else {
+            throw SharedInboxError.reservationNoLongerOwned
+        }
+    }
+
+    private static func contentID(for sharedImport: SharedImport) -> String {
+        var hasher = SHA256()
+        update(&hasher, with: Data("hermex-share-inbox-v1".utf8))
+        update(&hasher, with: Data(sharedImport.draft.utf8))
+        for attachment in sharedImport.attachments {
+            update(&hasher, with: Data(attachment.filename.utf8))
+            update(&hasher, with: Data((attachment.typeIdentifier ?? "").utf8))
+            update(&hasher, with: attachment.data)
+        }
+
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func update(_ hasher: inout SHA256, with data: Data) {
+        var length = UInt64(data.count).bigEndian
+        withUnsafeBytes(of: &length) { bytes in
+            hasher.update(data: Data(bytes))
+        }
+        hasher.update(data: data)
+    }
+
+    private static func writeJSON<T: Encodable>(_ value: T, to url: URL) throws {
+        let data = try JSONEncoder().encode(value)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    private static func payloadCreatedAt(in itemURL: URL) -> Date? {
+        guard
+            let data = try? Data(contentsOf: payloadURL(in: itemURL)),
+            let payload = try? JSONDecoder().decode(SharedDraftPayload.self, from: data)
+        else {
+            return nil
+        }
+        return payload.createdAt
+    }
+
+    private static func setProtectedFileAttributes(at url: URL, fileManager: FileManager) throws {
+        #if os(iOS)
+        try fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: url.path
+        )
+        #endif
     }
 
     private static func sanitizedFilename(_ filename: String) -> String {
@@ -234,6 +650,54 @@ enum HermesShareDraft {
         }
 
         return "\(UUID().uuidString).\(fileExtension)"
+    }
+
+    private static func isSafeStoredFileName(_ filename: String) -> Bool {
+        !filename.isEmpty && URL(fileURLWithPath: filename).lastPathComponent == filename
+    }
+
+    private static func inboxRootURL(in directory: URL) -> URL {
+        directory.appendingPathComponent(inboxDirectoryName, isDirectory: true)
+    }
+
+    private static func pendingItemsURL(in directory: URL) -> URL {
+        inboxRootURL(in: directory).appendingPathComponent(pendingItemsDirectoryName, isDirectory: true)
+    }
+
+    private static func reservedItemsURL(in directory: URL) -> URL {
+        inboxRootURL(in: directory).appendingPathComponent(reservedItemsDirectoryName, isDirectory: true)
+    }
+
+    private static func temporaryItemsURL(in directory: URL) -> URL {
+        inboxRootURL(in: directory).appendingPathComponent(temporaryItemsDirectoryName, isDirectory: true)
+    }
+
+    private static func pendingItemURL(for itemID: String, in directory: URL) -> URL {
+        pendingItemsURL(in: directory).appendingPathComponent(itemID, isDirectory: true)
+    }
+
+    private static func reservedItemURL(for itemID: String, in directory: URL) -> URL {
+        reservedItemsURL(in: directory).appendingPathComponent(itemID, isDirectory: true)
+    }
+
+    private static func payloadURL(in itemURL: URL) -> URL {
+        itemURL.appendingPathComponent(payloadFileName, isDirectory: false)
+    }
+
+    private static func reservationURL(in itemURL: URL) -> URL {
+        itemURL.appendingPathComponent(reservationFileName, isDirectory: false)
+    }
+
+    private static func attachmentsURL(in itemURL: URL) -> URL {
+        itemURL.appendingPathComponent(attachmentsDirectoryName, isDirectory: true)
+    }
+
+    private static func pendingDraftURL(in directory: URL) -> URL {
+        directory.appendingPathComponent(pendingDraftFileName, isDirectory: false)
+    }
+
+    private static func pendingAttachmentsDirectoryURL(in directory: URL) -> URL {
+        directory.appendingPathComponent(pendingAttachmentsDirectoryName, isDirectory: true)
     }
 
     private static func uniqueNonEmptyStrings(_ values: [String]) -> [String] {

--- a/HermesMobileTests/SharedDraftStoreTests.swift
+++ b/HermesMobileTests/SharedDraftStoreTests.swift
@@ -170,6 +170,172 @@ final class SharedDraftStoreTests: XCTestCase {
         XCTAssertEqual(sharedImport.attachments.last?.filename, "file-9.txt")
     }
 
+    func testInboxKeepsTwoSharesAndReservesThemOldestFirst() throws {
+        let directory = try temporaryDirectory()
+        let firstDate = Date(timeIntervalSince1970: 1_800_000_010)
+        let secondDate = Date(timeIntervalSince1970: 1_800_000_020)
+
+        try HermesShareDraft.savePendingDraft("First share", in: directory, now: firstDate)
+        try HermesShareDraft.savePendingDraft("Second share", in: directory, now: secondDate)
+
+        let first = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory, now: secondDate)
+        )
+        XCTAssertEqual(first.sharedImport.draft, "First share")
+        XCTAssertEqual(first.createdAt, firstDate)
+        try HermesShareDraft.consume(first, from: directory)
+
+        let second = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory, now: secondDate)
+        )
+        XCTAssertEqual(second.sharedImport.draft, "Second share")
+        XCTAssertEqual(second.createdAt, secondDate)
+        try HermesShareDraft.consume(second, from: directory)
+
+        XCTAssertNil(try HermesShareDraft.reserveNextPendingImport(from: directory, now: secondDate))
+    }
+
+    func testInboxDeduplicatesRepeatedPendingContent() throws {
+        let directory = try temporaryDirectory()
+
+        try HermesShareDraft.savePendingDraft(
+            "Repeated share",
+            in: directory,
+            now: Date(timeIntervalSince1970: 1_800_000_030)
+        )
+        try HermesShareDraft.savePendingDraft(
+            "Repeated share",
+            in: directory,
+            now: Date(timeIntervalSince1970: 1_800_000_040)
+        )
+
+        let reservation = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory)
+        )
+        try HermesShareDraft.savePendingDraft(
+            "Repeated share",
+            in: directory,
+            now: Date(timeIntervalSince1970: 1_800_000_050)
+        )
+        try HermesShareDraft.consume(reservation, from: directory)
+
+        XCTAssertNil(try HermesShareDraft.reserveNextPendingImport(from: directory))
+    }
+
+    func testReleasedReservationCanBeReservedAgain() throws {
+        let directory = try temporaryDirectory()
+        try HermesShareDraft.savePendingDraft("Route me later", in: directory)
+
+        let first = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory)
+        )
+        try HermesShareDraft.release(first, in: directory)
+
+        let second = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory)
+        )
+        XCTAssertEqual(second.itemID, first.itemID)
+        XCTAssertNotEqual(second.reservationID, first.reservationID)
+        XCTAssertEqual(second.sharedImport, first.sharedImport)
+    }
+
+    func testExpiredReservationReturnsToInboxWithNewOwnership() throws {
+        let directory = try temporaryDirectory()
+        let reservationDate = Date(timeIntervalSince1970: 1_800_000_050)
+        try HermesShareDraft.savePendingDraft("Recover me", in: directory, now: reservationDate)
+
+        let expired = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory, now: reservationDate)
+        )
+        let recovered = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(
+                from: directory,
+                now: reservationDate.addingTimeInterval(HermesShareDraft.reservationLifetime + 1)
+            )
+        )
+
+        XCTAssertEqual(recovered.itemID, expired.itemID)
+        XCTAssertNotEqual(recovered.reservationID, expired.reservationID)
+        XCTAssertThrowsError(try HermesShareDraft.consume(expired, from: directory))
+        try HermesShareDraft.consume(recovered, from: directory)
+    }
+
+    func testMissingAttachmentOnlyItemDoesNotBlockLaterShare() throws {
+        let directory = try temporaryDirectory()
+        let attachmentDate = Date(timeIntervalSince1970: 1_800_000_060)
+        try HermesShareDraft.savePendingImport(
+            draft: "",
+            attachments: [
+                SharedAttachmentImport(
+                    filename: "missing.txt",
+                    typeIdentifier: "public.plain-text",
+                    data: Data("gone".utf8)
+                )
+            ],
+            in: directory,
+            now: attachmentDate
+        )
+        try HermesShareDraft.savePendingDraft(
+            "Still valid",
+            in: directory,
+            now: attachmentDate.addingTimeInterval(1)
+        )
+
+        for fileURL in try attachmentFileURLs(in: directory) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+
+        let reservation = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory)
+        )
+        XCTAssertEqual(reservation.sharedImport.draft, "Still valid")
+        try HermesShareDraft.consume(reservation, from: directory)
+        XCTAssertNil(try HermesShareDraft.reserveNextPendingImport(from: directory))
+    }
+
+    func testMissingAttachmentDoesNotDiscardRemainingSharedContent() throws {
+        let directory = try temporaryDirectory()
+        try HermesShareDraft.savePendingImport(
+            draft: "Review what remains",
+            attachments: [
+                SharedAttachmentImport(
+                    filename: "first.txt",
+                    typeIdentifier: "public.plain-text",
+                    data: Data("first".utf8)
+                ),
+                SharedAttachmentImport(
+                    filename: "second.txt",
+                    typeIdentifier: "public.plain-text",
+                    data: Data("second".utf8)
+                )
+            ],
+            in: directory
+        )
+
+        let attachmentFiles = try attachmentFileURLs(in: directory)
+        XCTAssertEqual(attachmentFiles.count, 2)
+        try FileManager.default.removeItem(at: attachmentFiles[0])
+
+        let reservation = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory)
+        )
+        XCTAssertEqual(reservation.sharedImport.draft, "Review what remains")
+        XCTAssertEqual(reservation.sharedImport.attachments.count, 1)
+        try HermesShareDraft.consume(reservation, from: directory)
+    }
+
+    func testFailedInboxPreparationDoesNotOverwriteExistingFile() throws {
+        let parent = try temporaryDirectory()
+        let fileURL = parent.appendingPathComponent("not-a-directory")
+        let originalData = Data("keep me".utf8)
+        try originalData.write(to: fileURL)
+
+        XCTAssertThrowsError(
+            try HermesShareDraft.savePendingDraft("Unsaved share", in: fileURL)
+        )
+        XCTAssertEqual(try Data(contentsOf: fileURL), originalData)
+    }
+
     func testPendingImportDecodesLegacyDraftOnlyPayload() throws {
         let directory = try temporaryDirectory()
         let payloadURL = directory.appendingPathComponent(HermesShareDraft.pendingDraftFileName)
@@ -200,5 +366,25 @@ final class SharedDraftStoreTests: XCTestCase {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+
+    private func attachmentFileURLs(in directory: URL) throws -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            return []
+        }
+
+        return enumerator.compactMap { element in
+            guard
+                let url = element as? URL,
+                url.pathExtension != "json",
+                (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+            else {
+                return nil
+            }
+            return url
+        }
     }
 }

--- a/HermesMobileTests/SharedDraftStoreTests.swift
+++ b/HermesMobileTests/SharedDraftStoreTests.swift
@@ -177,12 +177,14 @@ final class SharedDraftStoreTests: XCTestCase {
 
         try HermesShareDraft.savePendingDraft("First share", in: directory, now: firstDate)
         try HermesShareDraft.savePendingDraft("Second share", in: directory, now: secondDate)
+        XCTAssertTrue(try HermesShareDraft.hasPendingImport(in: directory, now: secondDate))
 
         let first = try XCTUnwrap(
             try HermesShareDraft.reserveNextPendingImport(from: directory, now: secondDate)
         )
         XCTAssertEqual(first.sharedImport.draft, "First share")
         XCTAssertEqual(first.createdAt, firstDate)
+        XCTAssertTrue(try HermesShareDraft.hasPendingImport(in: directory, now: secondDate))
         try HermesShareDraft.consume(first, from: directory)
 
         let second = try XCTUnwrap(
@@ -192,6 +194,7 @@ final class SharedDraftStoreTests: XCTestCase {
         XCTAssertEqual(second.createdAt, secondDate)
         try HermesShareDraft.consume(second, from: directory)
 
+        XCTAssertFalse(try HermesShareDraft.hasPendingImport(in: directory, now: secondDate))
         XCTAssertNil(try HermesShareDraft.reserveNextPendingImport(from: directory, now: secondDate))
     }
 
@@ -351,6 +354,28 @@ final class SharedDraftStoreTests: XCTestCase {
 
         XCTAssertEqual(sharedImport.draft, "Legacy note")
         XCTAssertTrue(sharedImport.attachments.isEmpty)
+    }
+
+    func testMalformedLegacyPayloadDoesNotBlockTransactionalInbox() throws {
+        let directory = try temporaryDirectory()
+        try HermesShareDraft.savePendingDraft("Valid new share", in: directory)
+
+        let legacyPayloadURL = directory.appendingPathComponent(HermesShareDraft.pendingDraftFileName)
+        try Data("not json".utf8).write(to: legacyPayloadURL)
+        let legacyAttachmentsURL = directory.appendingPathComponent(
+            HermesShareDraft.pendingAttachmentsDirectoryName,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: legacyAttachmentsURL, withIntermediateDirectories: true)
+        try Data("orphan".utf8).write(to: legacyAttachmentsURL.appendingPathComponent("orphan.txt"))
+
+        let reservation = try XCTUnwrap(
+            try HermesShareDraft.reserveNextPendingImport(from: directory)
+        )
+
+        XCTAssertEqual(reservation.sharedImport.draft, "Valid new share")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyPayloadURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyAttachmentsURL.path))
     }
 
     func testEmptyPendingDraftIsNotWritten() throws {


### PR DESCRIPTION
## Summary

- replace the single pending-share slot with a versioned multi-item inbox
- reserve each item until the app installs its new-chat route, then consume it
- recover expired reservations, deduplicate repeated payloads, clean incomplete data, and migrate the legacy slot
- add regression coverage for multiple shares and recovery paths

## Validation

- `git diff --check`
- focused `SharedDraftStoreTests`
- full XCTest suite: 1,609 passed, 0 failed, 2 skipped
- signed Debug build, install, and launch on iPhone 17 Pro, iOS 26.5

## Owner manual checks

- shared text and two image attachments routed correctly
- resulting chat completed successfully

Local ticket: T3-01. No GitHub issue is linked by design.
