### PR TITLE
fix(chat): preserve unsent composer text

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -187,6 +187,8 @@
 		1A2B3C4D5E6F7000000000ED /* CachedMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000EF /* CachedMessage.swift */; };
 		1A2B3C4D5E6F7000000000F1 /* CacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F3 /* CacheStore.swift */; };
 		1A2B3C4D5E6F7000000000F2 /* CacheStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F4 /* CacheStoreTests.swift */; };
+		C28702000000000000000001 /* ChatDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28702000000000000000002 /* ChatDraftStore.swift */; };
+		C28702000000000000000003 /* ChatDraftStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28702000000000000000004 /* ChatDraftStoreTests.swift */; };
 		C04400000000000000000003 /* CacheFallbackPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04400000000000000000004 /* CacheFallbackPolicyTests.swift */; };
 		1A2B3C4D5E6F7000000000F5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F6 /* SettingsView.swift */; };
 		1A2B3C4D5E6F7000000000F8 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000F9 /* AppConfig.swift */; };
@@ -527,6 +529,8 @@
 		1A2B3C4D5E6F7000000000EF /* CachedMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedMessage.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F3 /* CacheStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStore.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F4 /* CacheStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStoreTests.swift; sourceTree = "<group>"; };
+		C28702000000000000000002 /* ChatDraftStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDraftStore.swift; sourceTree = "<group>"; };
+		C28702000000000000000004 /* ChatDraftStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDraftStoreTests.swift; sourceTree = "<group>"; };
 		C04400000000000000000004 /* CacheFallbackPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFallbackPolicyTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F6 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000F9 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -758,6 +762,7 @@
 		1A2B3C4D5E6F700000000034 /* HermesMobileTests */ = {
 			isa = PBXGroup;
 			children = (
+				C28702000000000000000004 /* ChatDraftStoreTests.swift */,
 				10CA110C0DE000000000C002 /* LocalizationCatalogTests.swift */,
 				1A2B3C4D5E6F7000000000BC /* APIClientTests.swift */,
 				B5A1000000000000000000A1 /* ServerRegistryTests.swift */,
@@ -1093,6 +1098,7 @@
 		1A2B3C4D5E6F7000000000F0 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				C28702000000000000000002 /* ChatDraftStore.swift */,
 				1A2B3C4D5E6F7000000000F3 /* CacheStore.swift */,
 				1A2B3C4D5E6F7000000000EE /* CachedSession.swift */,
 				1A2B3C4D5E6F7000000000EF /* CachedMessage.swift */,
@@ -1497,6 +1503,7 @@
 				1A2B3C4D5E6F7000000000EC /* CachedSession.swift in Sources */,
 				1A2B3C4D5E6F7000000000ED /* CachedMessage.swift in Sources */,
 				1A2B3C4D5E6F7000000000F1 /* CacheStore.swift in Sources */,
+				C28702000000000000000001 /* ChatDraftStore.swift in Sources */,
 				1A2B3C4D5E6F7000000000F5 /* SettingsView.swift in Sources */,
 				C012400000000000000004 /* AppIconSettingsSection.swift in Sources */,
 				1A2B3C4D5E6F70000000114 /* DefaultModelPickerView.swift in Sources */,
@@ -1706,6 +1713,7 @@
 				26AB000000000000000000B4 /* ProvidersViewModelTests.swift in Sources */,
 				22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */,
 				B5A100000000000000000005 /* SharedDraftStoreTests.swift in Sources */,
+				C28702000000000000000003 /* ChatDraftStoreTests.swift in Sources */,
 				B5A100000000000000000009 /* ShareInputReaderTests.swift in Sources */,
 				B5A100000000000000000060 /* AuthManagerStateTests.swift in Sources */,
 				B5A220000000000000000005 /* ChatMarkerMessageClassifierTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -284,6 +284,7 @@ struct ChatView: View {
     let draftStore: ChatDraftStore
 
     @State private var draftMessage = ""
+    @State private var draftRevision = 0
     @State private var isScrolledNearBottom = true
     @State private var isReadingOlderTranscript = false
     @State private var shouldFollowLatestMessage = true
@@ -1432,6 +1433,7 @@ struct ChatView: View {
 
     private func sendDraftMessage() async {
         let submittedDraft = draftMessage
+        let submittedDraftRevision = draftRevision
         let shouldRestoreFocusAfterSend = composerIsFocused
 
         if submittedDraft.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/") {
@@ -1440,7 +1442,8 @@ struct ChatView: View {
             handleSlashExecutionResult(
                 result,
                 parsedCommand: parsedCommand,
-                submittedDraft: submittedDraft
+                submittedDraft: submittedDraft,
+                submittedDraftRevision: submittedDraftRevision
             )
 
             if result != .sendAsMessage {
@@ -1462,11 +1465,15 @@ struct ChatView: View {
                 result,
                 parsedCommand: SlashCommandCatalog.command(named: streamingSendBehaviorCommandName),
                 submittedDraft: submittedDraft,
+                submittedDraftRevision: submittedDraftRevision,
                 consumesDraft: result.isSuccessfulSubmission
             )
             didStart = result.isSuccessfulSubmission
         } else {
-            didStart = await sendStandardMessage(submittedDraft)
+            didStart = await sendStandardMessage(
+                submittedDraft,
+                submittedDraftRevision: submittedDraftRevision
+            )
         }
 
         if didStart {
@@ -1501,7 +1508,10 @@ struct ChatView: View {
         }
     }
 
-    private func sendStandardMessage(_ submittedDraft: String) async -> Bool {
+    private func sendStandardMessage(
+        _ submittedDraft: String,
+        submittedDraftRevision: Int
+    ) async -> Bool {
         guard !submittedDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
@@ -1516,6 +1526,7 @@ struct ChatView: View {
             submittedText: submittedDraft,
             currentText: draftMessage,
             didStart: didStart,
+            draftWasEdited: draftRevision != submittedDraftRevision,
             for: draftKey
         )
 
@@ -1526,6 +1537,7 @@ struct ChatView: View {
         _ result: SlashCommandExecutionResult,
         parsedCommand: SlashCommand?,
         submittedDraft: String,
+        submittedDraftRevision: Int,
         consumesDraft: Bool = true
     ) {
         switch result {
@@ -1542,17 +1554,26 @@ struct ChatView: View {
                 }
             }
             if consumesDraft {
-                reconcileConsumedDraft(submittedDraft)
+                reconcileConsumedDraft(
+                    submittedDraft,
+                    submittedDraftRevision: submittedDraftRevision
+                )
             }
         case .openedSession(let session):
             forkedSession = session
             if consumesDraft {
-                reconcileConsumedDraft(submittedDraft)
+                reconcileConsumedDraft(
+                    submittedDraft,
+                    submittedDraftRevision: submittedDraftRevision
+                )
             }
         case .unsupported(let friendlyMessage):
             viewModel.setSendErrorMessage(friendlyMessage)
             if consumesDraft {
-                reconcileConsumedDraft(submittedDraft)
+                reconcileConsumedDraft(
+                    submittedDraft,
+                    submittedDraftRevision: submittedDraftRevision
+                )
             }
         case .needsSubArg:
             viewModel.setSendErrorMessage(String(localized: "Choose a slash command or continue typing."))
@@ -1594,6 +1615,7 @@ struct ChatView: View {
             get: { draftMessage },
             set: { newValue in
                 draftMessage = newValue
+                draftRevision &+= 1
                 draftStore.setDraft(newValue, for: draftKey)
             }
         )
@@ -1615,10 +1637,14 @@ struct ChatView: View {
         didHydrateDraft = true
     }
 
-    private func reconcileConsumedDraft(_ submittedDraft: String) {
+    private func reconcileConsumedDraft(
+        _ submittedDraft: String,
+        submittedDraftRevision: Int
+    ) {
         draftMessage = draftStore.resolveConsumedInput(
             submittedText: submittedDraft,
             currentText: draftMessage,
+            draftWasEdited: draftRevision != submittedDraftRevision,
             for: draftKey
         )
     }

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -281,6 +281,7 @@ struct ChatView: View {
     /// When true, the composer auto-starts voice dictation on appear — set by the
     /// "New Chat with Voice" App Intent (#338). Defaults to false for normal opens.
     let autoStartsVoiceInput: Bool
+    let draftStore: ChatDraftStore
 
     @State private var draftMessage = ""
     @State private var isScrolledNearBottom = true
@@ -314,6 +315,7 @@ struct ChatView: View {
     @State private var gitAlert: GitChatAlert?
     @State private var composerHeight: CGFloat = 52
     @State private var composerIsFocused = false
+    @State private var didHydrateDraft = false
     @State private var didCompleteInitialAppearance = false
     @State private var isInitialComposerFocusContentReady = false
     @State private var didApplyInitialComposerFocusPolicy = false
@@ -331,13 +333,15 @@ struct ChatView: View {
         initialDraft: String = "",
         initialAttachments: [SharedAttachmentImport] = [],
         loadsInitialMessages: Bool = true,
-        autoStartsVoiceInput: Bool = false
+        autoStartsVoiceInput: Bool = false,
+        draftStore: ChatDraftStore? = nil
     ) {
         self.session = session
         self.server = server
         self.onAPIError = onAPIError
         self.loadsInitialMessages = loadsInitialMessages
         self.autoStartsVoiceInput = autoStartsVoiceInput
+        self.draftStore = draftStore ?? .shared
         _draftMessage = State(initialValue: initialDraft)
         _initialAttachments = State(initialValue: initialAttachments)
         _viewModel = State(initialValue: ChatViewModel(
@@ -358,7 +362,7 @@ struct ChatView: View {
     // "unable to type-check in reasonable time" limit).
     private var messageComposer: some View {
         MessageComposerView(
-            draftMessage: $draftMessage,
+            draftMessage: persistedDraftBinding,
             isFocused: $composerIsFocused,
             isSending: viewModel.isStartingChat || viewModel.isSendingVoiceNote,
             isCompressingSession: viewModel.isCompressingSession,
@@ -602,6 +606,7 @@ struct ChatView: View {
                 viewModel.setShowsLiveActivityResponseExcerpts(showsLiveActivityResponseExcerpts)
             }
             .onDisappear {
+                flushDraftsBestEffort()
                 activeStreamStatusRefreshTask?.cancel()
                 activeStreamStatusRefreshTask = nil
                 viewModel.stopListening()
@@ -1311,6 +1316,7 @@ struct ChatView: View {
     }
 
     private func handleInitialAppearanceTask() async {
+        await hydrateDraftIfNeeded()
         prepareInitialAppearance()
 
         guard ChatInitialAppearancePolicy.shouldBeginAsyncWork(
@@ -1448,7 +1454,11 @@ struct ChatView: View {
                 submittedDraft,
                 behavior: StreamingSendBehavior.storedValue(streamingSendBehaviorRawValue)
             )
-            handleSlashExecutionResult(result, parsedCommand: SlashCommandCatalog.command(named: streamingSendBehaviorCommandName))
+            handleSlashExecutionResult(
+                result,
+                parsedCommand: SlashCommandCatalog.command(named: streamingSendBehaviorCommandName),
+                clearsDraft: result.isSuccessfulSubmission && draftMessage == submittedDraft
+            )
             didStart = result.isSuccessfulSubmission
         } else {
             didStart = await sendStandardMessage(submittedDraft)
@@ -1493,19 +1503,24 @@ struct ChatView: View {
 
         prepareTranscriptForExplicitSend()
 
+        draftStore.setDraft(submittedDraft, for: draftKey)
         draftMessage = ""
 
         let didStart = await viewModel.sendMessage(submittedDraft, modelContext: modelContext)
-        if !didStart, draftMessage.isEmpty {
-            draftMessage = submittedDraft
-        }
+        draftMessage = draftStore.resolveSubmission(
+            submittedText: submittedDraft,
+            currentText: draftMessage,
+            didStart: didStart,
+            for: draftKey
+        )
 
         return didStart
     }
 
     private func handleSlashExecutionResult(
         _ result: SlashCommandExecutionResult,
-        parsedCommand: SlashCommand?
+        parsedCommand: SlashCommand?,
+        clearsDraft: Bool = true
     ) {
         switch result {
         case .executed(let message):
@@ -1520,13 +1535,19 @@ struct ChatView: View {
                     viewModel.appendLocalAssistantMessage(message)
                 }
             }
-            draftMessage = ""
+            if clearsDraft {
+                clearCurrentDraft()
+            }
         case .openedSession(let session):
             forkedSession = session
-            draftMessage = ""
+            if clearsDraft {
+                clearCurrentDraft()
+            }
         case .unsupported(let friendlyMessage):
             viewModel.setSendErrorMessage(friendlyMessage)
-            draftMessage = ""
+            if clearsDraft {
+                clearCurrentDraft()
+            }
         case .needsSubArg:
             viewModel.setSendErrorMessage(String(localized: "Choose a slash command or continue typing."))
         case .sendAsMessage:
@@ -1550,6 +1571,52 @@ struct ChatView: View {
             "interrupt"
         case .queue:
             "queue"
+        }
+    }
+
+    private var draftKey: ChatDraftKey {
+        let normalizedSessionID = session.sessionId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sessionID = normalizedSessionID.flatMap { $0.isEmpty ? nil : $0 } ?? session.id
+        return .session(
+            server: server,
+            sessionID: sessionID
+        )
+    }
+
+    private var persistedDraftBinding: Binding<String> {
+        Binding(
+            get: { draftMessage },
+            set: { newValue in
+                draftMessage = newValue
+                draftStore.setDraft(newValue, for: draftKey)
+            }
+        )
+    }
+
+    private func hydrateDraftIfNeeded() async {
+        guard !didHydrateDraft else { return }
+        let textBeforeHydration = draftMessage
+        let persistedDraft = await draftStore.draft(for: draftKey)
+        guard !Task.isCancelled, draftMessage == textBeforeHydration else { return }
+
+        if textBeforeHydration.isEmpty {
+            if let persistedDraft {
+                draftMessage = persistedDraft
+            }
+        } else {
+            draftStore.setDraft(textBeforeHydration, for: draftKey)
+        }
+        didHydrateDraft = true
+    }
+
+    private func clearCurrentDraft() {
+        draftMessage = ""
+        draftStore.clearDraft(for: draftKey)
+    }
+
+    private func flushDraftsBestEffort() {
+        Task {
+            try? await draftStore.flush()
         }
     }
 
@@ -1846,6 +1913,10 @@ struct ChatView: View {
     }
 
     private func handleScenePhaseChange(_ phase: ScenePhase) {
+        if phase != .active {
+            flushDraftsBestEffort()
+        }
+
         switch phase {
         case .background:
             if viewModel.activeStreamID != nil {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -282,6 +282,7 @@ struct ChatView: View {
     /// "New Chat with Voice" App Intent (#338). Defaults to false for normal opens.
     let autoStartsVoiceInput: Bool
     let draftStore: ChatDraftStore
+    let onConversationStarted: () -> Void
 
     @State private var draftMessage = ""
     @State private var draftRevision = 0
@@ -335,7 +336,8 @@ struct ChatView: View {
         initialAttachments: [SharedAttachmentImport] = [],
         loadsInitialMessages: Bool = true,
         autoStartsVoiceInput: Bool = false,
-        draftStore: ChatDraftStore? = nil
+        draftStore: ChatDraftStore? = nil,
+        onConversationStarted: @escaping () -> Void = {}
     ) {
         self.session = session
         self.server = server
@@ -343,6 +345,7 @@ struct ChatView: View {
         self.loadsInitialMessages = loadsInitialMessages
         self.autoStartsVoiceInput = autoStartsVoiceInput
         self.draftStore = draftStore ?? .shared
+        self.onConversationStarted = onConversationStarted
         _draftMessage = State(initialValue: initialDraft)
         _initialAttachments = State(initialValue: initialAttachments)
         _viewModel = State(initialValue: ChatViewModel(
@@ -1500,6 +1503,7 @@ struct ChatView: View {
         )
 
         if didSend {
+            onConversationStarted()
             ChatHaptics.messageSent(isEnabled: isHapticsEnabled)
         }
 
@@ -1522,6 +1526,9 @@ struct ChatView: View {
         draftMessage = ""
 
         let didStart = await viewModel.sendMessage(submittedDraft, modelContext: modelContext)
+        if didStart {
+            onConversationStarted()
+        }
         draftMessage = draftStore.resolveSubmission(
             submittedText: submittedDraft,
             currentText: draftMessage,

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1437,7 +1437,11 @@ struct ChatView: View {
         if submittedDraft.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/") {
             let parsedCommand = SlashCommandExecutor.parse(submittedDraft)?.command
             let result = await SlashCommandExecutor.execute(text: submittedDraft, viewModel: viewModel)
-            handleSlashExecutionResult(result, parsedCommand: parsedCommand)
+            handleSlashExecutionResult(
+                result,
+                parsedCommand: parsedCommand,
+                submittedDraft: submittedDraft
+            )
 
             if result != .sendAsMessage {
                 if let lastError = viewModel.lastError {
@@ -1457,7 +1461,8 @@ struct ChatView: View {
             handleSlashExecutionResult(
                 result,
                 parsedCommand: SlashCommandCatalog.command(named: streamingSendBehaviorCommandName),
-                clearsDraft: result.isSuccessfulSubmission && draftMessage == submittedDraft
+                submittedDraft: submittedDraft,
+                consumesDraft: result.isSuccessfulSubmission
             )
             didStart = result.isSuccessfulSubmission
         } else {
@@ -1520,7 +1525,8 @@ struct ChatView: View {
     private func handleSlashExecutionResult(
         _ result: SlashCommandExecutionResult,
         parsedCommand: SlashCommand?,
-        clearsDraft: Bool = true
+        submittedDraft: String,
+        consumesDraft: Bool = true
     ) {
         switch result {
         case .executed(let message):
@@ -1535,18 +1541,18 @@ struct ChatView: View {
                     viewModel.appendLocalAssistantMessage(message)
                 }
             }
-            if clearsDraft {
-                clearCurrentDraft()
+            if consumesDraft {
+                reconcileConsumedDraft(submittedDraft)
             }
         case .openedSession(let session):
             forkedSession = session
-            if clearsDraft {
-                clearCurrentDraft()
+            if consumesDraft {
+                reconcileConsumedDraft(submittedDraft)
             }
         case .unsupported(let friendlyMessage):
             viewModel.setSendErrorMessage(friendlyMessage)
-            if clearsDraft {
-                clearCurrentDraft()
+            if consumesDraft {
+                reconcileConsumedDraft(submittedDraft)
             }
         case .needsSubArg:
             viewModel.setSendErrorMessage(String(localized: "Choose a slash command or continue typing."))
@@ -1609,9 +1615,12 @@ struct ChatView: View {
         didHydrateDraft = true
     }
 
-    private func clearCurrentDraft() {
-        draftMessage = ""
-        draftStore.clearDraft(for: draftKey)
+    private func reconcileConsumedDraft(_ submittedDraft: String) {
+        draftMessage = draftStore.resolveConsumedInput(
+            submittedText: submittedDraft,
+            currentText: draftMessage,
+            for: draftKey
+        )
     }
 
     private func flushDraftsBestEffort() {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -1436,6 +1436,7 @@ private struct PendingNewChatView: View {
     @State private var createdSession: SessionSummary?
     @State private var draftMessage = ""
     @State private var didStartCreation = false
+    @State private var didStartConversation = false
     @State private var didRequestComposerFocus = false
     @State private var creationErrorMessage: String?
     @FocusState private var composerIsFocused: Bool
@@ -1473,7 +1474,8 @@ private struct PendingNewChatView: View {
                     initialAttachments: initialAttachments,
                     loadsInitialMessages: false,
                     autoStartsVoiceInput: autoStartsVoiceInput,
-                    draftStore: draftStore
+                    draftStore: draftStore,
+                    onConversationStarted: markConversationStarted
                 )
             } else {
                 pendingContent
@@ -1493,6 +1495,7 @@ private struct PendingNewChatView: View {
             }
         }
         .onDisappear {
+            restoreAbandonedDraftIfNeeded()
             flushDraftsBestEffort()
         }
     }
@@ -1589,12 +1592,7 @@ private struct PendingNewChatView: View {
         }
 
         if let session {
-            let normalizedSessionID = session.sessionId?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let sessionID = normalizedSessionID.flatMap { $0.isEmpty ? nil : $0 } ?? session.id
-            let sessionKey = ChatDraftKey.session(
-                server: server,
-                sessionID: sessionID
-            )
+            let sessionKey = draftKey(for: session)
             draftStore.setDraft(draftMessage, for: draftKey)
             draftMessage = draftStore.moveDraft(from: draftKey, to: sessionKey)
             SessionHaptics.sessionCreated(isEnabled: isHapticsEnabled)
@@ -1618,6 +1616,12 @@ private struct PendingNewChatView: View {
 
     private var draftKey: ChatDraftKey {
         .newChat(server: server)
+    }
+
+    private func draftKey(for session: SessionSummary) -> ChatDraftKey {
+        let normalizedSessionID = session.sessionId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sessionID = normalizedSessionID.flatMap { $0.isEmpty ? nil : $0 } ?? session.id
+        return .session(server: server, sessionID: sessionID)
     }
 
     private var persistedDraftBinding: Binding<String> {
@@ -1654,6 +1658,19 @@ private struct PendingNewChatView: View {
         Task {
             try? await draftStore.flush()
         }
+    }
+
+    private func markConversationStarted() {
+        didStartConversation = true
+    }
+
+    private func restoreAbandonedDraftIfNeeded() {
+        guard let createdSession else { return }
+        draftMessage = draftStore.restoreAbandonedNewChatDraft(
+            from: draftKey(for: createdSession),
+            to: draftKey,
+            didStartConversation: didStartConversation
+        ) ?? draftMessage
     }
 
     private func requestPendingComposerFocus() {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -1421,6 +1421,7 @@ private struct ActiveSessionMonitorTaskID: Hashable {
 
 private struct PendingNewChatView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
 
     let server: URL
@@ -1430,6 +1431,7 @@ private struct PendingNewChatView: View {
     let initialAttachments: [SharedAttachmentImport]
     let autoStartsVoiceInput: Bool
     let profileName: String?
+    let draftStore: ChatDraftStore
 
     @State private var createdSession: SessionSummary?
     @State private var draftMessage = ""
@@ -1446,7 +1448,8 @@ private struct PendingNewChatView: View {
         server: URL,
         viewModel: SessionListViewModel,
         onAPIError: @escaping (Error) -> Void,
-        onSessionCreated: @escaping (SessionSummary) -> Void = { _ in }
+        onSessionCreated: @escaping (SessionSummary) -> Void = { _ in },
+        draftStore: ChatDraftStore? = nil
     ) {
         self.server = server
         self.viewModel = viewModel
@@ -1455,6 +1458,7 @@ private struct PendingNewChatView: View {
         self.initialAttachments = initialAttachments
         self.autoStartsVoiceInput = autoStartsVoiceInput
         self.profileName = profileName
+        self.draftStore = draftStore ?? .shared
         _draftMessage = State(initialValue: initialDraft)
     }
 
@@ -1468,7 +1472,8 @@ private struct PendingNewChatView: View {
                     initialDraft: draftMessage,
                     initialAttachments: initialAttachments,
                     loadsInitialMessages: false,
-                    autoStartsVoiceInput: autoStartsVoiceInput
+                    autoStartsVoiceInput: autoStartsVoiceInput,
+                    draftStore: draftStore
                 )
             } else {
                 pendingContent
@@ -1480,7 +1485,15 @@ private struct PendingNewChatView: View {
                 .accessibilityHidden(true)
         )
         .task {
-            await createSessionIfNeeded()
+            await prepareNewChat()
+        }
+        .onChange(of: scenePhase) {
+            if scenePhase != .active {
+                flushDraftsBestEffort()
+            }
+        }
+        .onDisappear {
+            flushDraftsBestEffort()
         }
     }
 
@@ -1515,7 +1528,7 @@ private struct PendingNewChatView: View {
 
     private var pendingComposer: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            TextField("Message Hermex", text: $draftMessage, axis: .vertical)
+            TextField("Message Hermex", text: persistedDraftBinding, axis: .vertical)
                 .textFieldStyle(.plain)
                 .lineLimit(1...5)
                 .focused($composerIsFocused)
@@ -1576,6 +1589,14 @@ private struct PendingNewChatView: View {
         }
 
         if let session {
+            let normalizedSessionID = session.sessionId?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let sessionID = normalizedSessionID.flatMap { $0.isEmpty ? nil : $0 } ?? session.id
+            let sessionKey = ChatDraftKey.session(
+                server: server,
+                sessionID: sessionID
+            )
+            draftStore.setDraft(draftMessage, for: draftKey)
+            draftMessage = draftStore.moveDraft(from: draftKey, to: sessionKey)
             SessionHaptics.sessionCreated(isEnabled: isHapticsEnabled)
             onSessionCreated(session)
             createdSession = session
@@ -1593,6 +1614,46 @@ private struct PendingNewChatView: View {
         creationErrorMessage = nil
         viewModel.clearActionError()
         await createSessionIfNeeded()
+    }
+
+    private var draftKey: ChatDraftKey {
+        .newChat(server: server)
+    }
+
+    private var persistedDraftBinding: Binding<String> {
+        Binding(
+            get: { draftMessage },
+            set: { newValue in
+                draftMessage = newValue
+                draftStore.setDraft(newValue, for: draftKey)
+            }
+        )
+    }
+
+    private func prepareNewChat() async {
+        await hydrateDraft()
+        guard !Task.isCancelled else { return }
+        await createSessionIfNeeded()
+    }
+
+    private func hydrateDraft() async {
+        let textBeforeHydration = draftMessage
+        let persistedDraft = await draftStore.draft(for: draftKey)
+        guard !Task.isCancelled, draftMessage == textBeforeHydration else { return }
+
+        if textBeforeHydration.isEmpty {
+            if let persistedDraft {
+                draftMessage = persistedDraft
+            }
+        } else {
+            draftStore.setDraft(textBeforeHydration, for: draftKey)
+        }
+    }
+
+    private func flushDraftsBestEffort() {
+        Task {
+            try? await draftStore.flush()
+        }
     }
 
     private func requestPendingComposerFocus() {

--- a/HermesMobile/Persistence/ChatDraftStore.swift
+++ b/HermesMobile/Persistence/ChatDraftStore.swift
@@ -246,6 +246,16 @@ final class ChatDraftStore {
         return currentText
     }
 
+    func resolveConsumedInput(
+        submittedText: String,
+        currentText: String,
+        for key: ChatDraftKey
+    ) -> String {
+        guard currentText == submittedText else { return currentText }
+        clearDraft(for: key)
+        return ""
+    }
+
     @discardableResult
     func moveDraft(from sourceKey: ChatDraftKey, to targetKey: ChatDraftKey) -> String {
         markChangedBeforeLoad(sourceKey)

--- a/HermesMobile/Persistence/ChatDraftStore.swift
+++ b/HermesMobile/Persistence/ChatDraftStore.swift
@@ -276,6 +276,16 @@ final class ChatDraftStore {
         return movedText
     }
 
+    @discardableResult
+    func restoreAbandonedNewChatDraft(
+        from sessionKey: ChatDraftKey,
+        to newChatKey: ChatDraftKey,
+        didStartConversation: Bool
+    ) -> String? {
+        guard !didStartConversation else { return nil }
+        return moveDraft(from: sessionKey, to: newChatKey)
+    }
+
     func flush() async throws {
         persistTask?.cancel()
         persistTask = nil

--- a/HermesMobile/Persistence/ChatDraftStore.swift
+++ b/HermesMobile/Persistence/ChatDraftStore.swift
@@ -1,0 +1,318 @@
+import Foundation
+import os
+
+struct ChatDraftKey: Hashable, Sendable {
+    enum Context: Hashable, Sendable {
+        case session(String)
+        case newChat
+    }
+
+    let serverID: String
+    let context: Context
+
+    static func session(server: URL, sessionID: String) -> Self {
+        Self(serverID: server.absoluteString, context: .session(sessionID))
+    }
+
+    static func newChat(server: URL) -> Self {
+        Self(serverID: server.absoluteString, context: .newChat)
+    }
+}
+
+protocol ChatDraftPersisting: Sendable {
+    func load() async -> [ChatDraftKey: String]
+    func write(_ drafts: [ChatDraftKey: String]) async throws
+}
+
+actor ChatDraftFilePersistence: ChatDraftPersisting {
+    #if os(iOS)
+    static let fileProtectionType = FileProtectionType.completeUntilFirstUserAuthentication
+    #endif
+
+    private struct Document: Codable {
+        let version: Int?
+        let drafts: [FailableRecord]?
+
+        init(version: Int, records: [Record]) {
+            self.version = version
+            drafts = records.map { FailableRecord(value: $0) }
+        }
+    }
+
+    private struct FailableRecord: Codable {
+        let value: Record?
+
+        init(value: Record?) {
+            self.value = value
+        }
+
+        init(from decoder: Decoder) throws {
+            value = try? Record(from: decoder)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            guard let value else {
+                var container = encoder.singleValueContainer()
+                try container.encodeNil()
+                return
+            }
+            try value.encode(to: encoder)
+        }
+    }
+
+    private struct Record: Codable {
+        let serverID: String?
+        let context: String?
+        let sessionID: String?
+        let text: String?
+
+        init(key: ChatDraftKey, text: String) {
+            serverID = key.serverID
+            switch key.context {
+            case .session(let sessionID):
+                context = "session"
+                self.sessionID = sessionID
+            case .newChat:
+                context = "newChat"
+                sessionID = nil
+            }
+            self.text = text
+        }
+
+        var draft: (key: ChatDraftKey, text: String)? {
+            guard
+                let serverID = serverID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                !serverID.isEmpty,
+                let context,
+                let text,
+                !text.isEmpty
+            else {
+                return nil
+            }
+
+            let key: ChatDraftKey
+            switch context {
+            case "session":
+                guard
+                    let sessionID = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                    !sessionID.isEmpty
+                else {
+                    return nil
+                }
+                key = ChatDraftKey(serverID: serverID, context: .session(sessionID))
+            case "newChat":
+                key = ChatDraftKey(serverID: serverID, context: .newChat)
+            default:
+                return nil
+            }
+
+            return (key, text)
+        }
+    }
+
+    private static let currentVersion = 1
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile",
+        category: "ChatDraftStore"
+    )
+
+    private let fileManager: FileManager
+    private let fileURL: URL
+
+    init(
+        fileManager: FileManager = .default,
+        directoryURL: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        let baseURL = directoryURL
+            ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        fileURL = baseURL
+            .appendingPathComponent("ChatDrafts", isDirectory: true)
+            .appendingPathComponent("drafts.json", isDirectory: false)
+    }
+
+    func load() async -> [ChatDraftKey: String] {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return [:] }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let document = try JSONDecoder().decode(Document.self, from: data)
+            guard document.version == Self.currentVersion else { return [:] }
+
+            return (document.drafts ?? []).reduce(into: [:]) { result, record in
+                guard let draft = record.value?.draft else { return }
+                result[draft.key] = draft.text
+            }
+        } catch {
+            Self.logger.warning("Ignoring unreadable persisted chat drafts: \(error.localizedDescription, privacy: .public)")
+            return [:]
+        }
+    }
+
+    func write(_ drafts: [ChatDraftKey: String]) async throws {
+        let nonEmptyDrafts = drafts.filter { !$0.value.isEmpty }
+        let records = nonEmptyDrafts
+            .map { Record(key: $0.key, text: $0.value) }
+            .sorted {
+                let lhs = ($0.serverID ?? "", $0.context ?? "", $0.sessionID ?? "")
+                let rhs = ($1.serverID ?? "", $1.context ?? "", $1.sessionID ?? "")
+                return lhs < rhs
+            }
+        let data = try JSONEncoder().encode(
+            Document(version: Self.currentVersion, records: records)
+        )
+        let directoryURL = fileURL.deletingLastPathComponent()
+
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        try setProtectedFileAttributes(at: directoryURL)
+        try data.write(to: fileURL, options: [.atomic])
+        try setProtectedFileAttributes(at: fileURL)
+    }
+
+    private func setProtectedFileAttributes(at url: URL) throws {
+        #if os(iOS)
+        try fileManager.setAttributes(
+            [.protectionKey: Self.fileProtectionType],
+            ofItemAtPath: url.path
+        )
+        #endif
+    }
+}
+
+@MainActor
+final class ChatDraftStore {
+    static let shared = ChatDraftStore()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile",
+        category: "ChatDraftStore"
+    )
+
+    private let persistence: any ChatDraftPersisting
+    private let debounceDuration: Duration
+    private var drafts: [ChatDraftKey: String] = [:]
+    private var keysChangedBeforeLoad: Set<ChatDraftKey> = []
+    private var loadTask: Task<[ChatDraftKey: String], Never>?
+    private var persistTask: Task<Void, Never>?
+    private var isLoaded = false
+
+    init(
+        persistence: any ChatDraftPersisting = ChatDraftFilePersistence(),
+        debounceDuration: Duration = .milliseconds(200)
+    ) {
+        self.persistence = persistence
+        self.debounceDuration = debounceDuration
+    }
+
+    func draft(for key: ChatDraftKey) async -> String? {
+        await loadIfNeeded()
+        return drafts[key]
+    }
+
+    func setDraft(_ text: String, for key: ChatDraftKey) {
+        markChangedBeforeLoad(key)
+        if text.isEmpty {
+            drafts.removeValue(forKey: key)
+        } else {
+            drafts[key] = text
+        }
+        schedulePersist()
+    }
+
+    func clearDraft(for key: ChatDraftKey) {
+        setDraft("", for: key)
+    }
+
+    func resolveSubmission(
+        submittedText: String,
+        currentText: String,
+        didStart: Bool,
+        for key: ChatDraftKey
+    ) -> String {
+        if didStart {
+            if currentText.isEmpty {
+                clearDraft(for: key)
+            }
+            return currentText
+        }
+
+        if currentText.isEmpty {
+            setDraft(submittedText, for: key)
+            return submittedText
+        }
+        return currentText
+    }
+
+    @discardableResult
+    func moveDraft(from sourceKey: ChatDraftKey, to targetKey: ChatDraftKey) -> String {
+        markChangedBeforeLoad(sourceKey)
+        markChangedBeforeLoad(targetKey)
+
+        let movedText = drafts[sourceKey] ?? drafts[targetKey] ?? ""
+        drafts.removeValue(forKey: sourceKey)
+        if movedText.isEmpty {
+            drafts.removeValue(forKey: targetKey)
+        } else {
+            drafts[targetKey] = movedText
+        }
+        schedulePersist()
+        return movedText
+    }
+
+    func flush() async throws {
+        persistTask?.cancel()
+        persistTask = nil
+        try await persistNow()
+    }
+
+    private func persistNow() async throws {
+        await loadIfNeeded()
+        try await persistence.write(drafts)
+    }
+
+    private func markChangedBeforeLoad(_ key: ChatDraftKey) {
+        if !isLoaded {
+            keysChangedBeforeLoad.insert(key)
+        }
+    }
+
+    private func loadIfNeeded() async {
+        guard !isLoaded else { return }
+
+        if loadTask == nil {
+            let persistence = persistence
+            loadTask = Task {
+                await persistence.load()
+            }
+        }
+
+        guard let loadTask else { return }
+        let persistedDrafts = await loadTask.value
+        guard !isLoaded else { return }
+
+        for (key, text) in persistedDrafts where !keysChangedBeforeLoad.contains(key) {
+            drafts[key] = text
+        }
+        isLoaded = true
+        self.loadTask = nil
+    }
+
+    private func schedulePersist() {
+        persistTask?.cancel()
+        persistTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: debounceDuration)
+                try Task.checkCancellation()
+                try await persistNow()
+            } catch is CancellationError {
+                return
+            } catch {
+                Self.logger.warning("Could not persist chat drafts: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+}

--- a/HermesMobile/Persistence/ChatDraftStore.swift
+++ b/HermesMobile/Persistence/ChatDraftStore.swift
@@ -230,8 +230,11 @@ final class ChatDraftStore {
         submittedText: String,
         currentText: String,
         didStart: Bool,
+        draftWasEdited: Bool,
         for key: ChatDraftKey
     ) -> String {
+        guard !draftWasEdited else { return currentText }
+
         if didStart {
             if currentText.isEmpty {
                 clearDraft(for: key)
@@ -249,9 +252,10 @@ final class ChatDraftStore {
     func resolveConsumedInput(
         submittedText: String,
         currentText: String,
+        draftWasEdited: Bool,
         for key: ChatDraftKey
     ) -> String {
-        guard currentText == submittedText else { return currentText }
+        guard !draftWasEdited, currentText == submittedText else { return currentText }
         clearDraft(for: key)
         return ""
     }

--- a/HermesMobileTests/ChatDraftStoreTests.swift
+++ b/HermesMobileTests/ChatDraftStoreTests.swift
@@ -124,6 +124,7 @@ final class ChatDraftStoreTests: XCTestCase {
             submittedText: submitted,
             currentText: "",
             didStart: false,
+            draftWasEdited: false,
             for: key
         )
         XCTAssertEqual(restored, submitted)
@@ -134,6 +135,7 @@ final class ChatDraftStoreTests: XCTestCase {
             submittedText: submitted,
             currentText: "",
             didStart: true,
+            draftWasEdited: false,
             for: key
         )
         XCTAssertEqual(cleared, "")
@@ -155,6 +157,7 @@ final class ChatDraftStoreTests: XCTestCase {
                 submittedText: "Submitted text",
                 currentText: "New text",
                 didStart: true,
+                draftWasEdited: true,
                 for: key
             ),
             "New text"
@@ -164,15 +167,28 @@ final class ChatDraftStoreTests: XCTestCase {
                 submittedText: "Submitted text",
                 currentText: "New text",
                 didStart: false,
+                draftWasEdited: true,
                 for: key
             ),
             "New text"
         )
         let currentDraft = await store.draft(for: key)
         XCTAssertEqual(currentDraft, "New text")
+
+        store.clearDraft(for: key)
+        let editedBackToEmpty = store.resolveSubmission(
+            submittedText: "Submitted text",
+            currentText: "",
+            didStart: false,
+            draftWasEdited: true,
+            for: key
+        )
+        XCTAssertEqual(editedBackToEmpty, "")
+        let emptyDraft = await store.draft(for: key)
+        XCTAssertNil(emptyDraft)
     }
 
-    func testTextEnteredWhileConsumedInputRunsIsNotCleared() async {
+    func testNewComposerRevisionIsNotClearedEvenWhenTextMatchesConsumedInput() async {
         let persistence = RecordingChatDraftPersistence()
         let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
         let key = ChatDraftKey(
@@ -180,20 +196,22 @@ final class ChatDraftStoreTests: XCTestCase {
             context: .session("chat-1")
         )
 
-        store.setDraft("New text", for: key)
+        store.setDraft("/status", for: key)
         let retained = store.resolveConsumedInput(
             submittedText: "/status",
-            currentText: "New text",
+            currentText: "/status",
+            draftWasEdited: true,
             for: key
         )
-        XCTAssertEqual(retained, "New text")
+        XCTAssertEqual(retained, "/status")
         let retainedDraft = await store.draft(for: key)
-        XCTAssertEqual(retainedDraft, "New text")
+        XCTAssertEqual(retainedDraft, "/status")
 
         store.setDraft("/status", for: key)
         let cleared = store.resolveConsumedInput(
             submittedText: "/status",
             currentText: "/status",
+            draftWasEdited: false,
             for: key
         )
         XCTAssertEqual(cleared, "")

--- a/HermesMobileTests/ChatDraftStoreTests.swift
+++ b/HermesMobileTests/ChatDraftStoreTests.swift
@@ -172,6 +172,35 @@ final class ChatDraftStoreTests: XCTestCase {
         XCTAssertEqual(currentDraft, "New text")
     }
 
+    func testTextEnteredWhileConsumedInputRunsIsNotCleared() async {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let key = ChatDraftKey(
+            serverID: "https://example.com",
+            context: .session("chat-1")
+        )
+
+        store.setDraft("New text", for: key)
+        let retained = store.resolveConsumedInput(
+            submittedText: "/status",
+            currentText: "New text",
+            for: key
+        )
+        XCTAssertEqual(retained, "New text")
+        let retainedDraft = await store.draft(for: key)
+        XCTAssertEqual(retainedDraft, "New text")
+
+        store.setDraft("/status", for: key)
+        let cleared = store.resolveConsumedInput(
+            submittedText: "/status",
+            currentText: "/status",
+            for: key
+        )
+        XCTAssertEqual(cleared, "")
+        let clearedDraft = await store.draft(for: key)
+        XCTAssertNil(clearedDraft)
+    }
+
     func testFilePersistenceUsesVersionedLossyDecoding() async throws {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/HermesMobileTests/ChatDraftStoreTests.swift
+++ b/HermesMobileTests/ChatDraftStoreTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+import XCTest
+@testable import HermesMobile
+
+@MainActor
+final class ChatDraftStoreTests: XCTestCase {
+    func testDraftsAreIsolatedByServerAndContext() async throws {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let serverA = URL(string: "https://one.example.com")!
+        let serverB = URL(string: "https://two.example.com")!
+        let firstChat = ChatDraftKey.session(server: serverA, sessionID: "chat-1")
+        let secondChat = ChatDraftKey.session(server: serverA, sessionID: "chat-2")
+        let otherServerChat = ChatDraftKey.session(server: serverB, sessionID: "chat-1")
+        let newChat = ChatDraftKey.newChat(server: serverA)
+
+        store.setDraft("First", for: firstChat)
+        store.setDraft("Second", for: secondChat)
+        store.setDraft("Other server", for: otherServerChat)
+        store.setDraft("New chat", for: newChat)
+        try await store.flush()
+
+        let restoredStore = ChatDraftStore(
+            persistence: persistence,
+            debounceDuration: .seconds(10)
+        )
+        let restoredFirstChat = await restoredStore.draft(for: firstChat)
+        let restoredSecondChat = await restoredStore.draft(for: secondChat)
+        let restoredOtherServerChat = await restoredStore.draft(for: otherServerChat)
+        let restoredNewChat = await restoredStore.draft(for: newChat)
+        XCTAssertEqual(restoredFirstChat, "First")
+        XCTAssertEqual(restoredSecondChat, "Second")
+        XCTAssertEqual(restoredOtherServerChat, "Other server")
+        XCTAssertEqual(restoredNewChat, "New chat")
+    }
+
+    func testTypingDuringHydrationWinsOverPersistedText() async throws {
+        let key = ChatDraftKey(
+            serverID: "https://example.com",
+            context: .session("chat-1")
+        )
+        let persistence = BlockingChatDraftPersistence(initialDrafts: [key: "Persisted"])
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+
+        let hydration = Task { await store.draft(for: key) }
+        await persistence.waitUntilLoadStarts()
+        store.setDraft("Typed while loading", for: key)
+        await persistence.releaseLoad()
+
+        let hydratedDraft = await hydration.value
+        XCTAssertEqual(hydratedDraft, "Typed while loading")
+        try await store.flush()
+        let persistedDrafts = await persistence.latestDrafts()
+        XCTAssertEqual(persistedDrafts[key], "Typed while loading")
+    }
+
+    func testDebouncedEditsFlushAsOneLatestWrite() async throws {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let key = ChatDraftKey(
+            serverID: "https://example.com",
+            context: .session("chat-1")
+        )
+
+        store.setDraft("a", for: key)
+        store.setDraft("ab", for: key)
+        store.setDraft("abc", for: key)
+        try await store.flush()
+
+        let writeCount = await persistence.writeCount()
+        let persistedDrafts = await persistence.latestDrafts()
+        XCTAssertEqual(writeCount, 1)
+        XCTAssertEqual(persistedDrafts[key], "abc")
+    }
+
+    func testFlushLandsAStillDebouncedWrite() async throws {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let key = ChatDraftKey(
+            serverID: "https://example.com",
+            context: .session("chat-1")
+        )
+
+        store.setDraft("Typed before backgrounding", for: key)
+        try await store.flush()
+
+        let writeCount = await persistence.writeCount()
+        let persistedDrafts = await persistence.latestDrafts()
+        XCTAssertEqual(writeCount, 1)
+        XCTAssertEqual(persistedDrafts[key], "Typed before backgrounding")
+    }
+
+    func testNewChatDraftMovesToCreatedSession() async throws {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let server = URL(string: "https://example.com")!
+        let newChat = ChatDraftKey.newChat(server: server)
+        let createdChat = ChatDraftKey.session(server: server, sessionID: "created-chat")
+
+        store.setDraft("Carry this forward", for: newChat)
+        XCTAssertEqual(
+            store.moveDraft(from: newChat, to: createdChat),
+            "Carry this forward"
+        )
+        try await store.flush()
+
+        let restoredNewChat = await store.draft(for: newChat)
+        let restoredCreatedChat = await store.draft(for: createdChat)
+        XCTAssertNil(restoredNewChat)
+        XCTAssertEqual(restoredCreatedChat, "Carry this forward")
+    }
+
+    func testSubmissionFailureRestoresExactSnapshotAndSuccessClearsIt() async throws {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let key = ChatDraftKey(
+            serverID: "https://example.com",
+            context: .session("chat-1")
+        )
+        let submitted = "  Preserve spacing\nexactly  "
+
+        store.setDraft(submitted, for: key)
+        let restored = store.resolveSubmission(
+            submittedText: submitted,
+            currentText: "",
+            didStart: false,
+            for: key
+        )
+        XCTAssertEqual(restored, submitted)
+        let restoredDraft = await store.draft(for: key)
+        XCTAssertEqual(restoredDraft, submitted)
+
+        let cleared = store.resolveSubmission(
+            submittedText: submitted,
+            currentText: "",
+            didStart: true,
+            for: key
+        )
+        XCTAssertEqual(cleared, "")
+        let clearedDraft = await store.draft(for: key)
+        XCTAssertNil(clearedDraft)
+    }
+
+    func testTextEnteredDuringSendIsNeverClearedOrReplaced() async {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let key = ChatDraftKey(
+            serverID: "https://example.com",
+            context: .session("chat-1")
+        )
+
+        store.setDraft("New text", for: key)
+        XCTAssertEqual(
+            store.resolveSubmission(
+                submittedText: "Submitted text",
+                currentText: "New text",
+                didStart: true,
+                for: key
+            ),
+            "New text"
+        )
+        XCTAssertEqual(
+            store.resolveSubmission(
+                submittedText: "Submitted text",
+                currentText: "New text",
+                didStart: false,
+                for: key
+            ),
+            "New text"
+        )
+        let currentDraft = await store.draft(for: key)
+        XCTAssertEqual(currentDraft, "New text")
+    }
+
+    func testFilePersistenceUsesVersionedLossyDecoding() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let persistence = ChatDraftFilePersistence(directoryURL: directory)
+        let fileURL = directory
+            .appendingPathComponent("ChatDrafts", isDirectory: true)
+            .appendingPathComponent("drafts.json")
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let document = """
+        {
+          "version": 1,
+          "drafts": [
+            {
+              "serverID": "https://example.com",
+              "context": "session",
+              "sessionID": "valid-chat",
+              "text": "Keep this",
+              "futureField": true
+            },
+            {
+              "serverID": 42,
+              "context": "session",
+              "sessionID": "invalid-chat",
+              "text": "Ignore this"
+            },
+            {
+              "serverID": "https://example.com",
+              "context": "future-context",
+              "text": "Ignore this too"
+            }
+          ],
+          "futureDocumentField": "ignored"
+        }
+        """
+        try Data(document.utf8).write(to: fileURL, options: [.atomic])
+
+        let drafts = await persistence.load()
+
+        XCTAssertEqual(
+            drafts[
+                ChatDraftKey(
+                    serverID: "https://example.com",
+                    context: .session("valid-chat")
+                )
+            ],
+            "Keep this"
+        )
+        XCTAssertEqual(drafts.count, 1)
+    }
+
+    func testFilePersistenceWritesAtomicallyWithFileProtection() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let persistence = ChatDraftFilePersistence(directoryURL: directory)
+        let key = ChatDraftKey(
+            serverID: "https://example.com",
+            context: .newChat
+        )
+
+        try await persistence.write([key: "Protected prompt"])
+
+        let restoredDrafts = await persistence.load()
+        XCTAssertEqual(restoredDrafts[key], "Protected prompt")
+        #if os(iOS)
+        XCTAssertEqual(
+            ChatDraftFilePersistence.fileProtectionType,
+            .completeUntilFirstUserAuthentication
+        )
+        #endif
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChatDraftStoreTests-\(UUID().uuidString)", isDirectory: true)
+    }
+}
+
+private actor RecordingChatDraftPersistence: ChatDraftPersisting {
+    private var drafts: [ChatDraftKey: String]
+    private var writes = 0
+
+    init(initialDrafts: [ChatDraftKey: String] = [:]) {
+        drafts = initialDrafts
+    }
+
+    func load() async -> [ChatDraftKey: String] {
+        drafts
+    }
+
+    func write(_ drafts: [ChatDraftKey: String]) async throws {
+        self.drafts = drafts
+        writes += 1
+    }
+
+    func latestDrafts() -> [ChatDraftKey: String] {
+        drafts
+    }
+
+    func writeCount() -> Int {
+        writes
+    }
+}
+
+private actor BlockingChatDraftPersistence: ChatDraftPersisting {
+    private let initialDrafts: [ChatDraftKey: String]
+    private var latest: [ChatDraftKey: String]
+    private var loadStarted = false
+    private var loadStartContinuation: CheckedContinuation<Void, Never>?
+    private var loadReleaseContinuation: CheckedContinuation<Void, Never>?
+
+    init(initialDrafts: [ChatDraftKey: String]) {
+        self.initialDrafts = initialDrafts
+        latest = initialDrafts
+    }
+
+    func load() async -> [ChatDraftKey: String] {
+        loadStarted = true
+        loadStartContinuation?.resume()
+        loadStartContinuation = nil
+        await withCheckedContinuation { continuation in
+            loadReleaseContinuation = continuation
+        }
+        return initialDrafts
+    }
+
+    func write(_ drafts: [ChatDraftKey: String]) async throws {
+        latest = drafts
+    }
+
+    func waitUntilLoadStarts() async {
+        guard !loadStarted else { return }
+        await withCheckedContinuation { continuation in
+            loadStartContinuation = continuation
+        }
+    }
+
+    func releaseLoad() {
+        loadReleaseContinuation?.resume()
+        loadReleaseContinuation = nil
+    }
+
+    func latestDrafts() -> [ChatDraftKey: String] {
+        latest
+    }
+}

--- a/HermesMobileTests/ChatDraftStoreTests.swift
+++ b/HermesMobileTests/ChatDraftStoreTests.swift
@@ -110,6 +110,46 @@ final class ChatDraftStoreTests: XCTestCase {
         XCTAssertEqual(restoredCreatedChat, "Carry this forward")
     }
 
+    func testAbandonedCreatedChatDraftReturnsToNewChat() async throws {
+        let persistence = RecordingChatDraftPersistence()
+        let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))
+        let server = URL(string: "https://example.com")!
+        let newChat = ChatDraftKey.newChat(server: server)
+        let createdChat = ChatDraftKey.session(server: server, sessionID: "created-chat")
+
+        store.setDraft("Started before creation", for: newChat)
+        _ = store.moveDraft(from: newChat, to: createdChat)
+        store.setDraft("Typed after creation", for: createdChat)
+
+        XCTAssertEqual(
+            store.restoreAbandonedNewChatDraft(
+                from: createdChat,
+                to: newChat,
+                didStartConversation: false
+            ),
+            "Typed after creation"
+        )
+        let abandonedSessionDraft = await store.draft(for: createdChat)
+        let restoredNewChatDraft = await store.draft(for: newChat)
+        XCTAssertNil(abandonedSessionDraft)
+        XCTAssertEqual(restoredNewChatDraft, "Typed after creation")
+
+        _ = store.moveDraft(from: newChat, to: createdChat)
+        store.setDraft("Follow-up for the started chat", for: createdChat)
+
+        XCTAssertNil(
+            store.restoreAbandonedNewChatDraft(
+                from: createdChat,
+                to: newChat,
+                didStartConversation: true
+            )
+        )
+        let startedSessionDraft = await store.draft(for: createdChat)
+        let startedNewChatDraft = await store.draft(for: newChat)
+        XCTAssertEqual(startedSessionDraft, "Follow-up for the started chat")
+        XCTAssertNil(startedNewChatDraft)
+    }
+
     func testSubmissionFailureRestoresExactSnapshotAndSuccessClearsIt() async throws {
         let persistence = RecordingChatDraftPersistence()
         let store = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(10))


### PR DESCRIPTION
## Summary

- Save unsent composer text independently for each server and chat, including the new-chat composer.
- Restore drafts after navigation or relaunch without replacing text entered while storage is loading.
- Return text from an abandoned, unsent New Chat to the next New Chat composer. After the first successful send, later drafts remain with that conversation.
- Keep submitted text durable until the server accepts it, restore the exact text after an immediate failure, and preserve every newer composer edit during asynchronous sends and commands.
- Store drafts in a versioned, tolerant document with debounced atomic writes and iOS file protection.

## Validation

- `git diff --check`
- `plutil -lint HermesMobile.xcodeproj/project.pbxproj`
- Focused `ChatDraftStoreTests`: 11 passed, 0 failed
- Full XCTest suite on iPhone 17 Pro, iOS 26.5: 1,621 passed, 0 failed, 2 skipped
- Automated simulator check confirmed that Back followed by New Session restores the exact unsent text
- Signed Debug build, install, and launch on iPhone 17 Pro

## Owner manual checks

1. Type different unsent text in two chats, navigate between them, and confirm each draft returns unchanged.
2. Switch servers and confirm chats with matching session IDs do not share drafts.
3. Force-quit and relaunch Hermex, then confirm the selected chat restores its draft.
4. Start a new chat, type while session creation is pending, and confirm the text carries into the created chat.
5. Trigger an immediate send failure and confirm the exact submitted text returns. Retry successfully and confirm the sent text no longer restores.
6. Type in New Session, go Back without sending, open New Session again, and confirm the text returns. After a successful first send, confirm a later follow-up draft stays with that conversation.