### PR TITLE
fix(onboarding): invalidate stale auth status when URL or headers change

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */; };
 		105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */; };
 		105050000000000000000003 /* ComposerModelPickerSectionExpansionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */; };
+		1050500000000000000000B1 /* OnboardingViewModelIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -663,6 +664,7 @@
 		FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandAutocompleteView.swift; sourceTree = "<group>"; };
 		105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelPickerSectionExpansionState.swift; sourceTree = "<group>"; };
 		105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelPickerSectionExpansionStateTests.swift; sourceTree = "<group>"; };
+		1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModelIdentityTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -836,6 +838,7 @@
 				1A2B3C4D5E6F70000000122 /* ContextWindowIndicatorTests.swift */,
 				1A2B3C4D5E6F70000000143 /* ModelFavoritesStoreTests.swift */,
 				105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */,
+				1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */,
 				0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */,
 				6809B8F1391248A4AA77C453 /* SlashCommandExecutorTests.swift */,
 				A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */,
@@ -1704,6 +1707,7 @@
 					1A2B3C4D5E6F70000000132 /* ContextWindowIndicatorTests.swift in Sources */,
 					1A2B3C4D5E6F70000000141 /* ModelFavoritesStoreTests.swift in Sources */,
 					105050000000000000000003 /* ComposerModelPickerSectionExpansionStateTests.swift in Sources */,
+					1050500000000000000000B1 /* OnboardingViewModelIdentityTests.swift in Sources */,
 					8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */,
 				0D82B28493C6401D98DA9C0E /* SlashCommandExecutorTests.swift in Sources */,
 				A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */,

--- a/HermesMobile/Features/Onboarding/OnboardingConnectPage.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingConnectPage.swift
@@ -53,7 +53,8 @@ struct OnboardingConnectPage: View {
                                 .submitLabel(.go)
                                 .tint(Color(red: 1.0, green: 0.74, blue: 0.10))
                                 .focused($focusedField, equals: .serverURL)
-                                .onSubmit(submitConnection)
+                                .disabled(viewModel.isConnectionLocked)
+                                .onSubmit { guard !viewModel.isConnectionLocked else { return }; submitConnection() }
                         }
                     }
 
@@ -68,13 +69,15 @@ struct OnboardingConnectPage: View {
                             .textContentType(.password)
                             .submitLabel(.go)
                             .focused($focusedField, equals: .password)
-                            .onSubmit(submitConnection)
+                            .disabled(viewModel.isConnectionLocked)
+                            .onSubmit { guard !viewModel.isConnectionLocked else { return }; submitConnection() }
                         }
                     }
                 }
 
                 DisclosureGroup(isExpanded: $isShowingAdvanced) {
                     CustomHeadersEditor(headers: $viewModel.customHeaders, style: .onboarding)
+                        .disabled(viewModel.isConnectionLocked)
                         .padding(.top, 10)
                 } label: {
                     Label("Advanced", systemImage: "slider.horizontal.3")

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -53,11 +53,27 @@ final class OnboardingViewModel {
         } catch {
             urlPart = serverURLString.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         }
+        // Encode header names/values so delimiters (":" and "|") inside a
+        // header value cannot collide with the identity serialization (e.g.
+        // "X: 1|y:2" as one header vs "X: 1" + "Y: 2" as two). Values are not
+        // lowercased — header values are case-sensitive.
         let headerPart = customHeaders.sanitizedForStorage()
-            .map { "\($0.sanitizedName.lowercased()):\($0.sanitizedValue)" }
+            .map { header -> String in
+                let name = Self.escapeForIdentity(header.sanitizedName.lowercased())
+                let value = Self.escapeForIdentity(header.sanitizedValue)
+                return "\(name):\(value)"
+            }
             .sorted()
             .joined(separator: "|")
         return "\(urlPart)|\(headerPart)"
+    }
+
+    nonisolated private static func escapeForIdentity(_ raw: String) -> String {
+        // Must escape "%" first so ":"/"|" escapes don't double-escape.
+        var out = raw.replacingOccurrences(of: "%", with: "%25")
+        out = out.replacingOccurrences(of: ":", with: "%3A")
+        out = out.replacingOccurrences(of: "|", with: "%7C")
+        return out
     }
 
     private func invalidateProbedAuthStatusIfNeeded() {

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -173,6 +173,9 @@ final class OnboardingViewModel {
 
         isWorking = true
         let token = beginOperation()
+        defer {
+            if token == operationGeneration { isWorking = false }
+        }
 
         if authStatus == nil {
             let identityAtStart = currentConnectionIdentity()

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -135,9 +135,10 @@ final class OnboardingViewModel {
         let token = beginOperation()
         let identityAtStart = currentConnectionIdentity()
         defer {
-            guard token == operationGeneration else { return }
-            isWorking = false
-            isConnectionLocked = false
+            if token == operationGeneration {
+                isWorking = false
+                isConnectionLocked = false
+            }
         }
 
         do {
@@ -187,9 +188,10 @@ final class OnboardingViewModel {
         isConnectionLocked = true
         let token = beginOperation()
         defer {
-            guard token == operationGeneration else { return }
-            isWorking = false
-            isConnectionLocked = false
+            if token == operationGeneration {
+                isWorking = false
+                isConnectionLocked = false
+            }
         }
 
         if authStatus == nil {

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -18,8 +18,11 @@ final class OnboardingViewModel {
     var errorMessage: String?
     var isWorking = false
 
+    // Identity + generation of the probe that produced `authStatus`.
     @ObservationIgnored private var probedConnectionIdentity: String?
-    @ObservationIgnored private var probeGeneration = 0
+    @ObservationIgnored private var operationGeneration = 0
+    /// Set while a configure is in flight; edits during it are fenced out.
+    @ObservationIgnored private var configureGeneration: Int?
 
     init(
         savedServer: URL? = nil,
@@ -31,6 +34,10 @@ final class OnboardingViewModel {
         }
         customHeaders = savedHeaders
         errorMessage = initialErrorMessage
+        if initialErrorMessage != nil {
+            // The banner belongs to the restored identity so later edits clear it.
+            probedConnectionIdentity = nil
+        }
     }
 
     var isPasswordRequired: Bool {
@@ -45,6 +52,25 @@ final class OnboardingViewModel {
 
     // MARK: - Connection identity (issue #285)
 
+    /// Effective headers exactly as the request path would apply them:
+    /// applicable rows only, case-insensitive names, array order preserved with
+    /// last-write-wins for duplicate names (matches
+    /// `Array<CustomHeader>.apply(to:)` via `URLRequest.setValue`). This is the
+    /// credential set that actually reaches the server, so reordering duplicate
+    /// names or adding/removing a newline-broken row must change it.
+    private func effectiveHeaderMap() -> [(name: String, value: String)] {
+        var map: [(name: String, value: String)] = []
+        for header in customHeaders where header.isApplicable {
+            let lowered = header.sanitizedName.lowercased()
+            if let index = map.firstIndex(where: { $0.name == lowered }) {
+                map[index].value = header.sanitizedValue
+            } else {
+                map.append((name: lowered, value: header.sanitizedValue))
+            }
+        }
+        return map
+    }
+
     private func currentConnectionIdentity() -> String {
         let urlPart: String
         do {
@@ -53,15 +79,11 @@ final class OnboardingViewModel {
         } catch {
             urlPart = serverURLString.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         }
-        // Encode header names/values so delimiters (":" and "|") inside a
-        // header value cannot collide with the identity serialization (e.g.
-        // "X: 1|y:2" as one header vs "X: 1" + "Y: 2" as two). Values are not
-        // lowercased — header values are case-sensitive.
-        let headerPart = customHeaders.sanitizedForStorage()
-            .map { header -> String in
-                let name = Self.escapeForIdentity(header.sanitizedName.lowercased())
-                let value = Self.escapeForIdentity(header.sanitizedValue)
-                return "\(name):\(value)"
+        // Escape delimiters so distinct header sets cannot collide, then sort
+        // canonical keys for stable serialization.
+        let headerPart = effectiveHeaderMap()
+            .map { name, value -> String in
+                "\(Self.escapeForIdentity(name)):\(Self.escapeForIdentity(value))"
             }
             .sorted()
             .joined(separator: "|")
@@ -69,7 +91,6 @@ final class OnboardingViewModel {
     }
 
     nonisolated private static func escapeForIdentity(_ raw: String) -> String {
-        // Must escape "%" first so ":"/"|" escapes don't double-escape.
         var out = raw.replacingOccurrences(of: "%", with: "%25")
         out = out.replacingOccurrences(of: ":", with: "%3A")
         out = out.replacingOccurrences(of: "|", with: "%7C")
@@ -77,7 +98,15 @@ final class OnboardingViewModel {
     }
 
     private func invalidateProbedAuthStatusIfNeeded() {
-        guard let probed = probedConnectionIdentity else { return }
+        guard let probed = probedConnectionIdentity else {
+            // No probe yet, but an inherited banner (re-login error) still has no
+            // owner — clear it on any edit so stale copy can't survive.
+            if errorMessage != nil || connectionMessage != nil {
+                errorMessage = nil
+                connectionMessage = nil
+            }
+            return
+        }
         let current = currentConnectionIdentity()
         if current != probed {
             authStatus = nil
@@ -87,22 +116,29 @@ final class OnboardingViewModel {
         }
     }
 
+    /// Begins a tracked async operation and returns its generation token used
+    /// to fence settlement against newer overlapping operations.
+    private func beginOperation() -> Int {
+        operationGeneration += 1
+        return operationGeneration
+    }
+
     func testConnection(authManager: AuthManager) async {
         errorMessage = nil
         connectionMessage = nil
         isWorking = true
-        defer { isWorking = false }
-
-        probeGeneration += 1
-        let generation = probeGeneration
+        let token = beginOperation()
         let identityAtStart = currentConnectionIdentity()
+        defer {
+            if token == operationGeneration { isWorking = false }
+        }
 
         do {
             let status = try await authManager.testConnection(
                 serverURLString: serverURLString,
                 customHeaders: customHeaders
             )
-            guard generation == probeGeneration else { return }
+            guard token == operationGeneration else { return }
             guard identityAtStart == currentConnectionIdentity() else { return }
             probedConnectionIdentity = identityAtStart
             authStatus = status
@@ -116,9 +152,12 @@ final class OnboardingViewModel {
                     : String(localized: "Connection ok. Password not required.")
             }
         } catch {
-            guard generation == probeGeneration else { return }
+            guard token == operationGeneration else { return }
             guard identityAtStart == currentConnectionIdentity() else { return }
-            probedConnectionIdentity = identityAtStart
+            // A failed re-probe invalidates the prior successful status: the old
+            // capability result no longer describes this identity.
+            authStatus = nil
+            probedConnectionIdentity = nil
             errorMessage = error.localizedDescription
         }
     }
@@ -133,25 +172,24 @@ final class OnboardingViewModel {
         }
 
         isWorking = true
-        defer { isWorking = false }
+        let token = beginOperation()
 
         if authStatus == nil {
-            probeGeneration += 1
-            let generation = probeGeneration
             let identityAtStart = currentConnectionIdentity()
             do {
                 let status = try await authManager.testConnection(
                     serverURLString: serverURLString,
                     customHeaders: customHeaders
                 )
-                guard generation == probeGeneration else { return }
+                guard token == operationGeneration else { return }
                 guard identityAtStart == currentConnectionIdentity() else { return }
                 probedConnectionIdentity = identityAtStart
                 authStatus = status
             } catch {
-                guard generation == probeGeneration else { return }
+                guard token == operationGeneration else { return }
                 guard identityAtStart == currentConnectionIdentity() else { return }
-                probedConnectionIdentity = identityAtStart
+                authStatus = nil
+                probedConnectionIdentity = nil
                 errorMessage = error.localizedDescription
                 return
             }
@@ -161,16 +199,19 @@ final class OnboardingViewModel {
                 return
             }
         } else if probedConnectionIdentity == nil {
-            // Auth status exists but probe identity was never recorded (e.g. restored
-            // from a previous session). Seed it so future edits can invalidate.
             probedConnectionIdentity = currentConnectionIdentity()
         }
 
+        // Fence the side effect: capture the identity configure was launched for
+        // and refuse to publish its outcome under different inputs.
+        let configureIdentity = currentConnectionIdentity()
         await authManager.configure(
             serverURLString: serverURLString,
             password: password,
             customHeaders: customHeaders
         )
+        guard token == operationGeneration else { return }
+        guard configureIdentity == currentConnectionIdentity() else { return }
         errorMessage = authManager.lastErrorMessage
     }
 

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -17,12 +17,15 @@ final class OnboardingViewModel {
     var connectionMessage: String?
     var errorMessage: String?
     var isWorking = false
+    /// True while an operation owns the form: views disable the URL/password
+    /// fields, header editor, and Return-key submission so a side effect that
+    /// has already run (AuthManager.configure persists and activates server
+    /// state) cannot be superseded by mid-flight edits (PR #294 re-gate).
+    var isConnectionLocked = false
 
     // Identity + generation of the probe that produced `authStatus`.
     @ObservationIgnored private var probedConnectionIdentity: String?
     @ObservationIgnored private var operationGeneration = 0
-    /// Set while a configure is in flight; edits during it are fenced out.
-    @ObservationIgnored private var configureGeneration: Int?
 
     init(
         savedServer: URL? = nil,
@@ -124,13 +127,17 @@ final class OnboardingViewModel {
     }
 
     func testConnection(authManager: AuthManager) async {
+        guard !isConnectionLocked else { return }
         errorMessage = nil
         connectionMessage = nil
         isWorking = true
+        isConnectionLocked = true
         let token = beginOperation()
         let identityAtStart = currentConnectionIdentity()
         defer {
-            if token == operationGeneration { isWorking = false }
+            guard token == operationGeneration else { return }
+            isWorking = false
+            isConnectionLocked = false
         }
 
         do {
@@ -163,6 +170,7 @@ final class OnboardingViewModel {
     }
 
     func connect(authManager: AuthManager) async {
+        guard !isConnectionLocked else { return }
         errorMessage = nil
         connectionMessage = nil
 
@@ -172,9 +180,16 @@ final class OnboardingViewModel {
         }
 
         isWorking = true
+        // Inputs stay frozen across probe AND configure: AuthManager.configure
+        // persists credentials and activates the captured URL/headers as a side
+        // effect, so accepting edits mid-operation would let the old server be
+        // configured under a form now showing a different one (PR #294 re-gate).
+        isConnectionLocked = true
         let token = beginOperation()
         defer {
-            if token == operationGeneration { isWorking = false }
+            guard token == operationGeneration else { return }
+            isWorking = false
+            isConnectionLocked = false
         }
 
         if authStatus == nil {

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -6,13 +6,20 @@ import Observation
 final class OnboardingViewModel {
     nonisolated static let emptyPasswordMessage = String(localized: "Enter the server password.")
 
-    var serverURLString = ""
+    var serverURLString = "" {
+        didSet { invalidateProbedAuthStatusIfNeeded() }
+    }
     var password = ""
-    var customHeaders: [CustomHeader] = []
+    var customHeaders: [CustomHeader] = [] {
+        didSet { invalidateProbedAuthStatusIfNeeded() }
+    }
     var authStatus: AuthStatusResponse?
     var connectionMessage: String?
     var errorMessage: String?
     var isWorking = false
+
+    @ObservationIgnored private var probedConnectionIdentity: String?
+    @ObservationIgnored private var probeGeneration = 0
 
     init(
         savedServer: URL? = nil,
@@ -36,17 +43,52 @@ final class OnboardingViewModel {
         return authStatus?.passwordAuthEnabled != false
     }
 
+    // MARK: - Connection identity (issue #285)
+
+    private func currentConnectionIdentity() -> String {
+        let urlPart: String
+        do {
+            let url = try AuthManager.normalizedServerURL(from: serverURLString)
+            urlPart = url.absoluteString.lowercased()
+        } catch {
+            urlPart = serverURLString.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+        let headerPart = customHeaders.sanitizedForStorage()
+            .map { "\($0.sanitizedName.lowercased()):\($0.sanitizedValue)" }
+            .sorted()
+            .joined(separator: "|")
+        return "\(urlPart)|\(headerPart)"
+    }
+
+    private func invalidateProbedAuthStatusIfNeeded() {
+        guard let probed = probedConnectionIdentity else { return }
+        let current = currentConnectionIdentity()
+        if current != probed {
+            authStatus = nil
+            connectionMessage = nil
+            errorMessage = nil
+            probedConnectionIdentity = nil
+        }
+    }
+
     func testConnection(authManager: AuthManager) async {
         errorMessage = nil
         connectionMessage = nil
         isWorking = true
         defer { isWorking = false }
 
+        probeGeneration += 1
+        let generation = probeGeneration
+        let identityAtStart = currentConnectionIdentity()
+
         do {
             let status = try await authManager.testConnection(
                 serverURLString: serverURLString,
                 customHeaders: customHeaders
             )
+            guard generation == probeGeneration else { return }
+            guard identityAtStart == currentConnectionIdentity() else { return }
+            probedConnectionIdentity = identityAtStart
             authStatus = status
             if let message = AuthManager.unsupportedSignInMessage(for: status) {
                 errorMessage = message
@@ -58,6 +100,9 @@ final class OnboardingViewModel {
                     : String(localized: "Connection ok. Password not required.")
             }
         } catch {
+            guard generation == probeGeneration else { return }
+            guard identityAtStart == currentConnectionIdentity() else { return }
+            probedConnectionIdentity = identityAtStart
             errorMessage = error.localizedDescription
         }
     }
@@ -75,12 +120,22 @@ final class OnboardingViewModel {
         defer { isWorking = false }
 
         if authStatus == nil {
+            probeGeneration += 1
+            let generation = probeGeneration
+            let identityAtStart = currentConnectionIdentity()
             do {
-                authStatus = try await authManager.testConnection(
+                let status = try await authManager.testConnection(
                     serverURLString: serverURLString,
                     customHeaders: customHeaders
                 )
+                guard generation == probeGeneration else { return }
+                guard identityAtStart == currentConnectionIdentity() else { return }
+                probedConnectionIdentity = identityAtStart
+                authStatus = status
             } catch {
+                guard generation == probeGeneration else { return }
+                guard identityAtStart == currentConnectionIdentity() else { return }
+                probedConnectionIdentity = identityAtStart
                 errorMessage = error.localizedDescription
                 return
             }
@@ -89,6 +144,10 @@ final class OnboardingViewModel {
                 errorMessage = validationMessage
                 return
             }
+        } else if probedConnectionIdentity == nil {
+            // Auth status exists but probe identity was never recorded (e.g. restored
+            // from a previous session). Seed it so future edits can invalidate.
+            probedConnectionIdentity = currentConnectionIdentity()
         }
 
         await authManager.configure(

--- a/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingViewModel.swift
@@ -215,6 +215,16 @@ final class OnboardingViewModel {
         errorMessage = authManager.lastErrorMessage
     }
 
+    // MARK: - Testing hooks (issue #285 regression matrix)
+
+    func probeConnectionIdentityForTesting() -> String {
+        currentConnectionIdentity()
+    }
+
+    func seedProbedIdentityForTesting() {
+        probedConnectionIdentity = currentConnectionIdentity()
+    }
+
     nonisolated static func passwordValidationMessage(authStatus: AuthStatusResponse?, password: String) -> String? {
         guard authStatus?.authEnabled == true else { return nil }
         // A server that already signed this client in (trusted-header proxy)

--- a/HermesMobileTests/OnboardingViewModelIdentityTests.swift
+++ b/HermesMobileTests/OnboardingViewModelIdentityTests.swift
@@ -88,10 +88,9 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
         XCTAssertNil(viewModel.connectionMessage)
     }
 
-// MARK: - Blocking client double
+// MARK: - Gated client double (drives real async schedules)
 
-/// Gates `health()` until the test releases it, so a probe can be held in
-/// flight while inputs change.
+/// Gates `health()` so a probe can be held in flight while inputs change.
 @MainActor
 final class OnboardingGateKeeper: @unchecked Sendable {
     private var continuations: [CheckedContinuation<Void, Never>] = []
@@ -123,9 +122,22 @@ final class OnboardingGateKeeper: @unchecked Sendable {
     }
 }
 
+enum GatedProbeOutcome {
+    case succeed(AuthStatusResponse)
+    case fail(String)
+}
+
 final class GatedAuthAPIClient: AuthAPIClient, @unchecked Sendable {
     let gatekeeper: OnboardingGateKeeper
-    init(gatekeeper: OnboardingGateKeeper) { self.gatekeeper = gatekeeper }
+    var outcome: GatedProbeOutcome
+    /// Records configure side effects so tests can assert what ACTUALLY ran.
+    private(set) var configuredServers: [String] = []
+    private(set) var configuredPasswords: [String] = []
+
+    init(gatekeeper: OnboardingGateKeeper, outcome: GatedProbeOutcome) {
+        self.gatekeeper = gatekeeper
+        self.outcome = outcome
+    }
 
     func health() async throws -> HealthResponse {
         await gatekeeper.gate()
@@ -133,17 +145,162 @@ final class GatedAuthAPIClient: AuthAPIClient, @unchecked Sendable {
     }
 
     func authStatus() async throws -> AuthStatusResponse {
-        AuthStatusResponse(authEnabled: true, loggedIn: false, passwordAuthEnabled: true)
+        await gatekeeper.gate()
+        switch outcome {
+        case .succeed(let status):
+            return status
+        case .fail(let message):
+            throw URLError(.badServerResponse, userInfo: [NSLocalizedDescriptionKey: message])
+        }
     }
 
     func login(password: String) async throws -> LoginResponse {
-        LoginResponse(ok: true, message: nil, error: nil)
+        configuredPasswords.append(password)
+        return LoginResponse(ok: true, message: nil, error: nil)
     }
 
     func logout() async throws -> LoginResponse {
         LoginResponse(ok: true, message: nil, error: nil)
     }
 }
+
+extension OnboardingViewModelIdentityTests {
+    @MainActor
+    func makeGatedManager(_ client: GatedAuthAPIClient) -> AuthManager {
+        AuthManager(
+            clientFactory: { _ in client },
+            serverRegistry: ServerRegistry.inMemory()
+        )
+    }
+
+    // Stale A success cannot publish over B: A is held, the user retargets to
+    // B, then A completes — its result must be discarded and B must still be
+    // free to probe.
+    @MainActor
+    func testStaleProbeSuccessForChangedIdentityIsDiscarded() async {
+        let gatekeeper = OnboardingGateKeeper()
+        let manager = makeGatedManager(GatedAuthAPIClient(
+            gatekeeper: gatekeeper,
+            outcome: .succeed(AuthStatusResponse(authEnabled: false, loggedIn: true))
+        ))
+        let viewModel = OnboardingViewModel()
+        viewModel.serverURLString = "https://first.example.com"
+
+        let probeTask = Task { await viewModel.testConnection(authManager: manager) }
+        await gatekeeper.waitUntilProbeStarted(count: 1)
+
+        viewModel.serverURLString = "https://second.example.com"
+        gatekeeper.releaseAll()
+        await probeTask.value
+
+        XCTAssertNil(viewModel.authStatus, "stale success for old identity must be discarded")
+        XCTAssertFalse(viewModel.isWorking)
+        XCTAssertFalse(viewModel.isConnectionLocked)
+    }
+
+    // Stale A rejection cannot publish its error over B.
+    @MainActor
+    func testStaleProbeFailureForChangedIdentityIsDiscarded() async {
+        let gatekeeper = OnboardingGateKeeper()
+        let manager = makeGatedManager(GatedAuthAPIClient(
+            gatekeeper: gatekeeper,
+            outcome: .fail("old server unreachable")
+        ))
+        let viewModel = OnboardingViewModel()
+        viewModel.serverURLString = "https://first.example.com"
+
+        let probeTask = Task { await viewModel.testConnection(authManager: manager) }
+        await gatekeeper.waitUntilProbeStarted(count: 1)
+
+        viewModel.serverURLString = "https://second.example.com"
+        gatekeeper.releaseAll()
+        await probeTask.value
+
+        XCTAssertNil(viewModel.errorMessage, "stale rejection must not surface under new identity")
+        XCTAssertNil(viewModel.authStatus)
+    }
+
+    // Overlapping generations: only the newest operation owns isWorking.
+    @MainActor
+    func testOverlappingProbesOnlyLatestOwnsIsWorking() async {
+        let gatekeeper = OnboardingGateKeeper()
+        let manager = makeGatedManager(GatedAuthAPIClient(
+            gatekeeper: gatekeeper,
+            outcome: .succeed(AuthStatusResponse(authEnabled: true, loggedIn: false))
+        ))
+        let viewModel = OnboardingViewModel()
+        viewModel.serverURLString = "https://example.com"
+
+        let first = Task { await viewModel.testConnection(authManager: manager) }
+        await gatekeeper.waitUntilProbeStarted(count: 1)
+
+        let second = Task { await viewModel.testConnection(authManager: manager) }
+        await gatekeeper.waitUntilProbeStarted(count: 2)
+
+        XCTAssertTrue(viewModel.isWorking)
+
+        gatekeeper.releaseOne()
+        await first.value
+        XCTAssertTrue(viewModel.isWorking, "older defer must not clear newer operation's busy state")
+
+        gatekeeper.releaseAll()
+        await second.value
+        XCTAssertFalse(viewModel.isWorking)
+    }
+
+    // Edit during connect(): the operation must be refused outright while the
+    // form is locked (inputs frozen), so no second connect can interleave.
+    @MainActor
+    func testConnectWhileLockedIsRefused() async {
+        let gatekeeper = OnboardingGateKeeper()
+        let client = GatedAuthAPIClient(
+            gatekeeper: gatekeeper,
+            outcome: .succeed(AuthStatusResponse(authEnabled: false, loggedIn: true))
+        )
+        let manager = makeGatedManager(client)
+        let viewModel = OnboardingViewModel()
+        viewModel.serverURLString = "https://example.com"
+
+        let connectTask = Task { await viewModel.connect(authManager: manager) }
+        await gatekeeper.waitUntilProbeStarted(count: 1)
+
+        XCTAssertTrue(viewModel.isConnectionLocked, "inputs frozen for the whole connect")
+        XCTAssertTrue(viewModel.isPasswordRequired == false, "trusted-header probe hides password field")
+
+        let loginsBefore = client.configuredPasswords.count
+
+        // Return-key during lock must be refused by the guard.
+        await viewModel.connect(authManager: manager)
+
+        gatekeeper.releaseAll()
+        await connectTask.value
+
+        XCTAssertFalse(viewModel.isConnectionLocked, "lock released after settle")
+        XCTAssertTrue(viewModel.authStatus != nil || viewModel.errorMessage != nil,
+                      "the accepted connect settled to a visible outcome")
+    }
+
+    // Configure reaches AuthManager exactly once per accepted connect.
+    @MainActor
+    func testConfigureRunsOncePerAcceptedConnect() async {
+        let gatekeeper = OnboardingGateKeeper()
+        let client = GatedAuthAPIClient(
+            gatekeeper: gatekeeper,
+            outcome: .succeed(AuthStatusResponse(authEnabled: false, loggedIn: false))
+        )
+        let manager = makeGatedManager(client)
+        let viewModel = OnboardingViewModel()
+        viewModel.serverURLString = "https://example.com"
+
+        await viewModel.connect(authManager: manager)
+
+        // authEnabled=false → configure skips login entirely (no password path).
+        XCTAssertEqual(client.configuredPasswords.count, 0, "passwordless configure must not attempt login")
+        XCTAssertFalse(viewModel.isConnectionLocked)
+        XCTAssertFalse(viewModel.isWorking)
+    }
+}
+
 
     // MARK: - Helpers
 

--- a/HermesMobileTests/OnboardingViewModelIdentityTests.swift
+++ b/HermesMobileTests/OnboardingViewModelIdentityTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import HermesMobile
+
+/// Regression matrix for the #285 review: connection-identity binding,
+/// stale-probe fencing, and configure ownership in `OnboardingViewModel`.
+@MainActor
+final class OnboardingViewModelIdentityTests: XCTestCase {
+    // MARK: - Identity semantics
+
+    func testCanonicallyEquivalentURLsShareIdentity() throws {
+        let viewModel = OnboardingViewModel()
+        viewModel.serverURLString = "https://example.com"
+        let before = try XCTUnwrap(identity(of: viewModel))
+
+        viewModel.serverURLString = "https://example.com/"
+        XCTAssertEqual(try identity(of: viewModel), before, "trailing slash must not churn")
+
+        viewModel.serverURLString = "  https://EXAMPLE.com/path?query=1#frag  "
+        XCTAssertEqual(try identity(of: viewModel), before, "case/whitespace/path/query/fragment are normalized away")
+    }
+
+    func testHeaderNameCaseAndOrderDoNotChangeIdentity() {
+        let viewModel = OnboardingViewModel()
+        viewModel.customHeaders = [
+            CustomHeader(name: "X-API-Key", value: "k1"),
+            CustomHeader(name: "Authorization", value: "Bearer abc")
+        ]
+        let before = currentIdentity(viewModel)
+
+        viewModel.customHeaders = [
+            CustomHeader(name: "authorization", value: "Bearer abc"),
+            CustomHeader(name: "x-api-key", value: "k1")
+        ]
+
+        XCTAssertEqual(currentIdentity(viewModel), before)
+    }
+
+    func testDuplicateNameReorderChangesEffectiveCredentialAndInvalidates() {
+        let viewModel = makeProbedViewModel(headers: [
+            CustomHeader(name: "X-Auth", value: "a"),
+            CustomHeader(name: "X-Auth", value: "b")
+        ])
+        XCTAssertNotNil(viewModel.authStatus)
+
+        // Effective X-Auth flips b -> a (setValue is last-write-wins), so the
+        // cached trusted-header status no longer describes this credential.
+        viewModel.customHeaders = [
+            CustomHeader(name: "X-Auth", value: "b"),
+            CustomHeader(name: "X-Auth", value: "a")
+        ]
+
+        XCTAssertNil(viewModel.authStatus, "duplicate-name reorder changes the sent credential and must invalidate")
+        XCTAssertNil(viewModel.connectionMessage)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    func testNewlineBrokenRowIsNotPartOfIdentity() {
+        let viewModel = makeProbedViewModel(headers: [])
+        XCTAssertNotNil(viewModel.authStatus)
+
+        // A row whose raw value contains a newline is never sent
+        // (CustomHeader.isApplicable), so adding it must not change identity —
+        // and conversely removing a broken row must not preserve stale state.
+        viewModel.customHeaders = [CustomHeader(name: "X-Broken", value: "line1\nline2")]
+
+        // Broken row is filtered from identity; identity equals the empty set,
+        // which matches the probed empty-header identity → no churn.
+        XCTAssertNotNil(viewModel.authStatus)
+
+        // But replacing it with an applicable row does change identity.
+        viewModel.customHeaders = [CustomHeader(name: "Authorization", value: "Bearer xyz")]
+        XCTAssertNil(viewModel.authStatus, "applicable header changes the credential and must invalidate")
+    }
+
+    func testURLEditClearsInheritedBannersEvenWithoutProbe() {
+        var errorMessage: String? = "Previous server rejected the request."
+        let viewModel = OnboardingViewModel(
+            savedServer: URL(string: "https://old.example.com"),
+            initialErrorMessage: errorMessage
+        )
+        errorMessage = nil
+
+        XCTAssertNotNil(viewModel.errorMessage, "initial error restored")
+
+        viewModel.serverURLString = "https://new.example.com"
+
+        XCTAssertNil(viewModel.errorMessage, "inherited banner has no owner once inputs change")
+        XCTAssertNil(viewModel.connectionMessage)
+    }
+
+// MARK: - Blocking client double
+
+/// Gates `health()` until the test releases it, so a probe can be held in
+/// flight while inputs change.
+@MainActor
+final class OnboardingGateKeeper: @unchecked Sendable {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private(set) var startedCount = 0
+
+    func waitUntilProbeStarted(count: Int) async {
+        while startedCount < count {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+
+    func gate() async {
+        startedCount += 1
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            continuations.append(continuation)
+        }
+    }
+
+    func releaseOne() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+
+    func releaseAll() {
+        while !continuations.isEmpty {
+            continuations.removeFirst().resume()
+        }
+    }
+}
+
+final class GatedAuthAPIClient: AuthAPIClient, @unchecked Sendable {
+    let gatekeeper: OnboardingGateKeeper
+    init(gatekeeper: OnboardingGateKeeper) { self.gatekeeper = gatekeeper }
+
+    func health() async throws -> HealthResponse {
+        await gatekeeper.gate()
+        return HealthResponse(status: "ok", sessions: nil, activeStreams: nil, uptimeSeconds: nil)
+    }
+
+    func authStatus() async throws -> AuthStatusResponse {
+        AuthStatusResponse(authEnabled: true, loggedIn: false, passwordAuthEnabled: true)
+    }
+
+    func login(password: String) async throws -> LoginResponse {
+        LoginResponse(ok: true, message: nil, error: nil)
+    }
+
+    func logout() async throws -> LoginResponse {
+        LoginResponse(ok: true, message: nil, error: nil)
+    }
+}
+
+    // MARK: - Helpers
+
+    private func identity(of viewModel: OnboardingViewModel) throws -> String {
+        _ = viewModel // identity is derived from public inputs; recompute via invalidation side effect
+        return currentIdentity(viewModel)
+    }
+
+    /// Reads the identity by round-tripping through invalidation: mutating any
+    /// input recomputes it. Uses a sentinel edit that cannot collide with real
+    /// header content.
+    private func currentIdentity(_ viewModel: OnboardingViewModel) -> String {
+        viewModel.probeConnectionIdentityForTesting()
+    }
+
+    private func makeProbedViewModel(headers: [CustomHeader]) -> OnboardingViewModel {
+        let viewModel = OnboardingViewModel(
+            savedServer: URL(string: "https://trusted.example.com"),
+            savedHeaders: headers
+        )
+        viewModel.authStatus = AuthStatusResponse(authEnabled: true, loggedIn: true)
+        // Seed the probed identity the way testConnection would after success.
+        viewModel.seedProbedIdentityForTesting()
+        return viewModel
+    }
+}

--- a/HermesMobileTests/OnboardingViewModelIdentityTests.swift
+++ b/HermesMobileTests/OnboardingViewModelIdentityTests.swift
@@ -3,6 +3,14 @@ import XCTest
 
 /// Regression matrix for the #285 review: connection-identity binding,
 /// stale-probe fencing, and configure ownership in `OnboardingViewModel`.
+///
+/// Async schedules are driven by a *phase-aware* gate: every network call site
+/// (`health`, `authStatus`) registers under its own name, so each test releases
+/// exactly the events the real schedule produces — a full accepted `connect()`
+/// emits FOUR gated events (the ViewModel's probe pair, then the internal
+/// re-probe pair inside `AuthManager.configure`). Waiters are deadline-bounded,
+/// so a routing regression fails its assertion instead of hanging the target
+/// (PR #294 re-gate at 5b68be65c).
 @MainActor
 final class OnboardingViewModelIdentityTests: XCTestCase {
     // MARK: - Identity semantics
@@ -88,95 +96,113 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
         XCTAssertNil(viewModel.connectionMessage)
     }
 
-// MARK: - Gated client double (drives real async schedules)
+    // MARK: - Phase-aware gated client double (drives real async schedules)
 
-/// Gates `health()` so a probe can be held in flight while inputs change.
-@MainActor
-final class OnboardingGateKeeper: @unchecked Sendable {
-    private var continuations: [CheckedContinuation<Void, Never>] = []
-    private(set) var startedCount = 0
-
-    func waitUntilProbeStarted(count: Int) async {
-        while startedCount < count {
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
+    /// Distinct call sites inside `AuthManager`'s probe: `testConnection(client:)`
+    /// awaits `health()` and then `authStatus()`, so a parked probe is always in
+    /// exactly one known phase.
+    private enum GatePhase: String {
+        case health
+        case authStatus
     }
 
-    func gate() async {
-        startedCount += 1
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            continuations.append(continuation)
-        }
-    }
-
-    func releaseOne() {
-        guard !continuations.isEmpty else { return }
-        continuations.removeFirst().resume()
-    }
-
-    func releaseAll() {
-        while !continuations.isEmpty {
-            continuations.removeFirst().resume()
-        }
-    }
-}
-
-enum GatedProbeOutcome {
-    case succeed(AuthStatusResponse)
-    case fail(String)
-}
-
-final class GatedAuthAPIClient: AuthAPIClient, @unchecked Sendable {
-    let gatekeeper: OnboardingGateKeeper
-    var outcome: GatedProbeOutcome
-    /// Records configure side effects so tests can assert what ACTUALLY ran.
-    private(set) var configuredServers: [String] = []
-    private(set) var configuredPasswords: [String] = []
-
-    init(gatekeeper: OnboardingGateKeeper, outcome: GatedProbeOutcome) {
-        self.gatekeeper = gatekeeper
-        self.outcome = outcome
-    }
-
-    func health() async throws -> HealthResponse {
-        await gatekeeper.gate()
-        return HealthResponse(status: "ok", sessions: nil, activeStreams: nil, uptimeSeconds: nil)
-    }
-
-    func authStatus() async throws -> AuthStatusResponse {
-        await gatekeeper.gate()
-        switch outcome {
-        case .succeed(let status):
-            return status
-        case .fail(let message):
-            throw URLError(.badServerResponse, userInfo: [NSLocalizedDescriptionKey: message])
-        }
-    }
-
-    func login(password: String) async throws -> LoginResponse {
-        configuredPasswords.append(password)
-        return LoginResponse(ok: true, message: nil, error: nil)
-    }
-
-    func logout() async throws -> LoginResponse {
-        LoginResponse(ok: true, message: nil, error: nil)
-    }
-}
-
-extension OnboardingViewModelIdentityTests {
     @MainActor
-    func makeGatedManager(_ client: GatedAuthAPIClient) -> AuthManager {
-        AuthManager(
-            clientFactory: { _ in client },
-            serverRegistry: ServerRegistry.inMemory()
-        )
+    final class OnboardingGateKeeper: @unchecked Sendable {
+        private(set) var recordedPhases: [GatePhase] = []
+        private var pending: [(phase: GatePhase, continuation: CheckedContinuation<Void, Never>)] = []
+        /// When set, further gate entries return immediately — drains the
+        /// abandoned tail of a superseded schedule without extra bookkeeping.
+        private var autoRelease = false
+
+        /// Deadline-bounded waiter: fails the test instead of hanging when the
+        /// production schedule never reaches the expected number of gate events.
+        func waitForEvents(_ count: Int, _ comment: String = "", timeout seconds: Double = 5) async {
+            let deadline = Date().addingTimeInterval(seconds)
+            while recordedPhases.count < count {
+                if Date() >= deadline {
+                    XCTFail("timed out after \(seconds)s waiting for \(count) gate event(s); saw \(recordedPhases.map(\.rawValue)) \(comment)")
+                    return
+                }
+                await Task.yield()
+                try? await Task.sleep(nanoseconds: 2_000_000)
+            }
+        }
+
+        func gate(_ phase: GatePhase) async {
+            recordedPhases.append(phase)
+            if autoRelease { return }
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                pending.append((phase, continuation))
+            }
+        }
+
+        func releaseNext() {
+            guard !pending.isEmpty else { return }
+            pending.removeFirst().continuation.resume()
+        }
+
+        func releaseAll() {
+            while !pending.isEmpty {
+                pending.removeFirst().continuation.resume()
+            }
+        }
+
+        /// Releases everything currently parked AND stops parking new arrivals.
+        func drainEverything() {
+            autoRelease = true
+            releaseAll()
+        }
     }
+
+    enum GatedProbeOutcome {
+        case succeed(AuthStatusResponse)
+        case fail(String)
+    }
+
+    final class GatedAuthAPIClient: AuthAPIClient, @unchecked Sendable {
+        let gatekeeper: OnboardingGateKeeper
+        var outcome: GatedProbeOutcome
+        /// Records configure side effects so tests can assert what ACTUALLY ran.
+        private(set) var configuredServers: [String] = []
+        private(set) var configuredPasswords: [String] = []
+
+        init(gatekeeper: OnboardingGateKeeper, outcome: GatedProbeOutcome) {
+            self.gatekeeper = gatekeeper
+            self.outcome = outcome
+        }
+
+        func health() async throws -> HealthResponse {
+            await gatekeeper.gate(.health)
+            return HealthResponse(status: "ok", sessions: nil, activeStreams: nil, uptimeSeconds: nil)
+        }
+
+        func authStatus() async throws -> AuthStatusResponse {
+            await gatekeeper.gate(.authStatus)
+            switch outcome {
+            case .succeed(let status):
+                return status
+            case .fail(let message):
+                throw URLError(.badServerResponse, userInfo: [NSLocalizedDescriptionKey: message])
+            }
+        }
+
+        func login(password: String) async throws -> LoginResponse {
+            // Login is deliberately UNGATED: it is the third call of the
+            // configure password path and carries no schedule decision.
+            configuredPasswords.append(password)
+            return LoginResponse(ok: true, message: nil, error: nil)
+        }
+
+        func logout() async throws -> LoginResponse {
+            LoginResponse(ok: true, message: nil, error: nil)
+        }
+    }
+
+    // MARK: - Stale probe fencing
 
     // Stale A success cannot publish over B: A is held, the user retargets to
     // B, then A completes — its result must be discarded and B must still be
     // free to probe.
-    @MainActor
     func testStaleProbeSuccessForChangedIdentityIsDiscarded() async {
         let gatekeeper = OnboardingGateKeeper()
         let manager = makeGatedManager(GatedAuthAPIClient(
@@ -187,10 +213,10 @@ extension OnboardingViewModelIdentityTests {
         viewModel.serverURLString = "https://first.example.com"
 
         let probeTask = Task { await viewModel.testConnection(authManager: manager) }
-        await gatekeeper.waitUntilProbeStarted(count: 1)
+        await gatekeeper.waitForEvents(1, "probe should park inside health()")
 
         viewModel.serverURLString = "https://second.example.com"
-        gatekeeper.releaseAll()
+        gatekeeper.drainEverything()
         await probeTask.value
 
         XCTAssertNil(viewModel.authStatus, "stale success for old identity must be discarded")
@@ -199,7 +225,6 @@ extension OnboardingViewModelIdentityTests {
     }
 
     // Stale A rejection cannot publish its error over B.
-    @MainActor
     func testStaleProbeFailureForChangedIdentityIsDiscarded() async {
         let gatekeeper = OnboardingGateKeeper()
         let manager = makeGatedManager(GatedAuthAPIClient(
@@ -210,19 +235,22 @@ extension OnboardingViewModelIdentityTests {
         viewModel.serverURLString = "https://first.example.com"
 
         let probeTask = Task { await viewModel.testConnection(authManager: manager) }
-        await gatekeeper.waitUntilProbeStarted(count: 1)
+        await gatekeeper.waitForEvents(1, "probe should park inside health()")
 
         viewModel.serverURLString = "https://second.example.com"
-        gatekeeper.releaseAll()
+        gatekeeper.drainEverything()
         await probeTask.value
 
         XCTAssertNil(viewModel.errorMessage, "stale rejection must not surface under new identity")
         XCTAssertNil(viewModel.authStatus)
     }
 
-    // Overlapping generations: only the newest operation owns isWorking.
-    @MainActor
-    func testOverlappingProbesOnlyLatestOwnsIsWorking() async {
+    // MARK: - Connection lock (inputs frozen across probe AND configure)
+
+    // The production lock deliberately forbids overlapping operations, so the
+    // right assertion is REFUSAL: a second entry point while locked must be a
+    // no-op that leaves the owning operation's busy state untouched.
+    func testOperationWhileLockedIsRefusedAndOwnerKeepsBusyState() async {
         let gatekeeper = OnboardingGateKeeper()
         let manager = makeGatedManager(GatedAuthAPIClient(
             gatekeeper: gatekeeper,
@@ -231,26 +259,31 @@ extension OnboardingViewModelIdentityTests {
         let viewModel = OnboardingViewModel()
         viewModel.serverURLString = "https://example.com"
 
-        let first = Task { await viewModel.testConnection(authManager: manager) }
-        await gatekeeper.waitUntilProbeStarted(count: 1)
-
-        let second = Task { await viewModel.testConnection(authManager: manager) }
-        await gatekeeper.waitUntilProbeStarted(count: 2)
-
+        let owner = Task { await viewModel.testConnection(authManager: manager) }
+        await gatekeeper.waitForEvents(1, "owner probe should park inside health()")
         XCTAssertTrue(viewModel.isWorking)
 
-        gatekeeper.releaseOne()
-        await first.value
-        XCTAssertTrue(viewModel.isWorking, "older defer must not clear newer operation's busy state")
+        // Both entry points refuse while the lock is held.
+        await viewModel.connect(authManager: manager)
+        await viewModel.testConnection(authManager: manager)
 
-        gatekeeper.releaseAll()
-        await second.value
-        XCTAssertFalse(viewModel.isWorking)
+        XCTAssertTrue(viewModel.isWorking, "refused operations must not clear the owner's busy state")
+        XCTAssertTrue(viewModel.isConnectionLocked)
+        XCTAssertNil(viewModel.errorMessage, "refusal must be a silent no-op")
+        XCTAssertNil(viewModel.connectionMessage)
+        XCTAssertEqual(gatekeeper.recordedPhases.count, 1, "no network activity may start while locked")
+
+        gatekeeper.drainEverything()
+        await owner.value
+        XCTAssertFalse(viewModel.isWorking, "only the owning operation clears busy state")
+        XCTAssertFalse(viewModel.isConnectionLocked)
     }
 
     // Edit during connect(): the operation must be refused outright while the
     // form is locked (inputs frozen), so no second connect can interleave.
-    @MainActor
+    // The accepted connect walks its REAL four-phase schedule: the ViewModel's
+    // own probe (health, authStatus) followed by configure's internal re-probe
+    // (health, authStatus).
     func testConnectWhileLockedIsRefused() async {
         let gatekeeper = OnboardingGateKeeper()
         let client = GatedAuthAPIClient(
@@ -262,45 +295,140 @@ extension OnboardingViewModelIdentityTests {
         viewModel.serverURLString = "https://example.com"
 
         let connectTask = Task { await viewModel.connect(authManager: manager) }
-        await gatekeeper.waitUntilProbeStarted(count: 1)
+        await gatekeeper.waitForEvents(1, "accepted connect should park in its probe's health()")
 
         XCTAssertTrue(viewModel.isConnectionLocked, "inputs frozen for the whole connect")
-        XCTAssertTrue(viewModel.isPasswordRequired == false, "trusted-header probe hides password field")
+        XCTAssertTrue(viewModel.isWorking)
+        XCTAssertNil(viewModel.authStatus, "probe still in flight — capability-derived UI must not be asserted yet")
 
         let loginsBefore = client.configuredPasswords.count
 
         // Return-key during lock must be refused by the guard.
         await viewModel.connect(authManager: manager)
+        XCTAssertEqual(gatekeeper.recordedPhases.count, 1, "refused connect starts no network work")
 
-        gatekeeper.releaseAll()
+        // Settle the accepted connect through all four phases: release each
+        // gate only after its successor has parked, keeping the schedule
+        // deterministic.
+        for expected in 2...4 {
+            gatekeeper.releaseNext()
+            await gatekeeper.waitForEvents(expected, "connect schedule phase \(expected)")
+        }
+        gatekeeper.releaseNext()
+
         await connectTask.value
 
+        XCTAssertEqual(client.configuredPasswords.count, loginsBefore, "passwordless configure must not attempt login")
         XCTAssertFalse(viewModel.isConnectionLocked, "lock released after settle")
-        XCTAssertTrue(viewModel.authStatus != nil || viewModel.errorMessage != nil,
-                      "the accepted connect settled to a visible outcome")
+        XCTAssertFalse(viewModel.isWorking)
+        XCTAssertNotNil(viewModel.authStatus, "accepted connect settles to a probed status")
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertFalse(viewModel.isPasswordRequired, "trusted-header status hides the password field AFTER settle")
+        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")))
     }
 
-    // Configure reaches AuthManager exactly once per accepted connect.
-    @MainActor
+    // Configure reaches AuthManager exactly once per accepted connect: one
+    // keychain persist, one registry activation, zero login attempts on a
+    // passwordless server.
     func testConfigureRunsOncePerAcceptedConnect() async {
         let gatekeeper = OnboardingGateKeeper()
         let client = GatedAuthAPIClient(
             gatekeeper: gatekeeper,
             outcome: .succeed(AuthStatusResponse(authEnabled: false, loggedIn: false))
         )
-        let manager = makeGatedManager(client)
+        let keychain = InMemoryKeychainStore()
+        let manager = makeGatedManager(client, keychain: keychain)
         let viewModel = OnboardingViewModel()
         viewModel.serverURLString = "https://example.com"
 
-        await viewModel.connect(authManager: manager)
+        await runConnectToCompletion(viewModel, authManager: manager, gatekeeper: gatekeeper)
 
+        XCTAssertEqual(keychain.saveCounts[.serverURL], 1, "exactly one persist per accepted connect")
+        XCTAssertEqual(keychain.savedValues[.serverURL], "https://example.com")
+        XCTAssertEqual(manager.servers.count, 1, "exactly one registry activation")
         // authEnabled=false → configure skips login entirely (no password path).
         XCTAssertEqual(client.configuredPasswords.count, 0, "passwordless configure must not attempt login")
         XCTAssertFalse(viewModel.isConnectionLocked)
         XCTAssertFalse(viewModel.isWorking)
+        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")))
+    }
+
+    // Full password path: probe demands auth, configure logs in with the typed
+    // password and persists the session.
+    func testConfigurePasswordPathLogsInWithTypedPassword() async {
+        let gatekeeper = OnboardingGateKeeper()
+        let client = GatedAuthAPIClient(
+            gatekeeper: gatekeeper,
+            outcome: .succeed(AuthStatusResponse(authEnabled: true, loggedIn: false))
+        )
+        let keychain = InMemoryKeychainStore()
+        let manager = makeGatedManager(client, keychain: keychain)
+        let viewModel = OnboardingViewModel()
+        viewModel.serverURLString = "https://example.com"
+        viewModel.password = "typed-secret"
+
+        // Probe pair + configure's probe pair; login itself is ungated.
+        await runConnectToCompletion(viewModel, authManager: manager, gatekeeper: gatekeeper)
+
+        XCTAssertEqual(client.configuredPasswords, ["typed-secret"], "configure must log in with the typed password")
+        XCTAssertEqual(keychain.savedValues[.serverURL], "https://example.com")
+        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")))
+        XCTAssertFalse(viewModel.isConnectionLocked)
+        XCTAssertFalse(viewModel.isWorking)
+    }
+
+    // MARK: - Schedule helpers
+
+    /// Drives the canonical accepted-connect schedule: probe pair (health,
+    /// authStatus), then configure's internal re-probe pair, releasing each
+    /// phase in order so every await settles before its successor is released.
+    @MainActor
+    final class AcceptedConnectDriver {
+        let gatekeeper: OnboardingGateKeeper
+
+        init(gatekeeper: OnboardingGateKeeper) {
+            self.gatekeeper = gatekeeper
+        }
+
+        /// Runs connect() as a task and settles it through all four phases,
+        /// releasing each gate only after its successor has parked.
+        func runAndSettle(
+            _ operation: @escaping @MainActor () async -> Void
+        ) async {
+            let task = Task { await operation() }
+            await gatekeeper.waitForEvents(1, "accepted connect should park in its probe's health()")
+            // Events 2…4 only fire AFTER the preceding phase is released, so
+            // waiting for them up front would deadlock — release one phase,
+            // then wait for exactly the next event.
+            for expected in 2...4 {
+                gatekeeper.releaseNext()
+                await gatekeeper.waitForEvents(expected, "connect schedule phase \(expected)")
+            }
+            gatekeeper.releaseNext()
+            await task.value
+        }
+    }
+
+    /// Convenience wrapper for inline connect() drives.
+    private func runConnectToCompletion(
+        _ viewModel: OnboardingViewModel,
+        authManager: AuthManager,
+        gatekeeper: OnboardingGateKeeper
+    ) async {
+        await AcceptedConnectDriver(gatekeeper: gatekeeper)
+            .runAndSettle { await viewModel.connect(authManager: authManager) }
     }
 }
 
+extension OnboardingViewModelIdentityTests {
+    @MainActor
+    func makeGatedManager(_ client: GatedAuthAPIClient, keychain: InMemoryKeychainStore = InMemoryKeychainStore()) -> AuthManager {
+        AuthManager(
+            keychain: keychain,
+            clientFactory: { _ in client },
+            serverRegistry: ServerRegistry.inMemory()
+        )
+    }
 
     // MARK: - Helpers
 

--- a/HermesMobileTests/OnboardingViewModelIdentityTests.swift
+++ b/HermesMobileTests/OnboardingViewModelIdentityTests.swift
@@ -62,6 +62,18 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
         XCTAssertNil(viewModel.errorMessage)
     }
 
+    func testEditingHeaderValueThroughElementBindingInvalidates() {
+        let viewModel = makeProbedViewModel(headers: [
+            CustomHeader(name: "Authorization", value: "Bearer old")
+        ])
+
+        viewModel.customHeaders[0].value = "Bearer new"
+
+        XCTAssertNil(viewModel.authStatus, "element edits from CustomHeadersEditor must invalidate")
+        XCTAssertNil(viewModel.connectionMessage)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
     func testNewlineBrokenRowIsNotPartOfIdentity() {
         let viewModel = makeProbedViewModel(headers: [])
         XCTAssertNotNil(viewModel.authStatus)
@@ -101,7 +113,7 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
     /// Distinct call sites inside `AuthManager`'s probe: `testConnection(client:)`
     /// awaits `health()` and then `authStatus()`, so a parked probe is always in
     /// exactly one known phase.
-    private enum GatePhase: String {
+    enum GatePhase: String {
         case health
         case authStatus
     }
@@ -110,26 +122,33 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
     final class OnboardingGateKeeper: @unchecked Sendable {
         private(set) var recordedPhases: [GatePhase] = []
         private var pending: [(phase: GatePhase, continuation: CheckedContinuation<Void, Never>)] = []
+        private var eventWaiters: [(count: Int, expectation: XCTestExpectation)] = []
         /// When set, further gate entries return immediately — drains the
         /// abandoned tail of a superseded schedule without extra bookkeeping.
         private var autoRelease = false
 
-        /// Deadline-bounded waiter: fails the test instead of hanging when the
-        /// production schedule never reaches the expected number of gate events.
+        /// Event-driven waiter with a failure bound. On timeout it drains the
+        /// schedule so the owning task can settle instead of hanging at task.value.
         func waitForEvents(_ count: Int, _ comment: String = "", timeout seconds: Double = 5) async {
-            let deadline = Date().addingTimeInterval(seconds)
-            while recordedPhases.count < count {
-                if Date() >= deadline {
-                    XCTFail("timed out after \(seconds)s waiting for \(count) gate event(s); saw \(recordedPhases.map(\.rawValue)) \(comment)")
-                    return
-                }
-                await Task.yield()
-                try? await Task.sleep(nanoseconds: 2_000_000)
+            guard recordedPhases.count < count else { return }
+
+            let expectation = XCTestExpectation(description: "wait for \(count) gate event(s) \(comment)")
+            eventWaiters.append((count, expectation))
+
+            let result = await XCTWaiter.fulfillment(of: [expectation], timeout: seconds)
+            guard result == .completed else {
+                eventWaiters.removeAll { $0.expectation === expectation }
+                XCTFail("timed out after \(seconds)s waiting for \(count) gate event(s); saw \(recordedPhases.map(\.rawValue)) \(comment)")
+                drainEverything()
+                return
             }
         }
 
         func gate(_ phase: GatePhase) async {
             recordedPhases.append(phase)
+            let readyWaiters = eventWaiters.filter { $0.count <= recordedPhases.count }
+            eventWaiters.removeAll { $0.count <= recordedPhases.count }
+            readyWaiters.forEach { $0.expectation.fulfill() }
             if autoRelease { return }
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 pending.append((phase, continuation))
@@ -324,7 +343,7 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
         XCTAssertNotNil(viewModel.authStatus, "accepted connect settles to a probed status")
         XCTAssertNil(viewModel.errorMessage)
         XCTAssertFalse(viewModel.isPasswordRequired, "trusted-header status hides the password field AFTER settle")
-        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")))
+        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")!))
     }
 
     // Configure reaches AuthManager exactly once per accepted connect: one
@@ -350,7 +369,7 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
         XCTAssertEqual(client.configuredPasswords.count, 0, "passwordless configure must not attempt login")
         XCTAssertFalse(viewModel.isConnectionLocked)
         XCTAssertFalse(viewModel.isWorking)
-        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")))
+        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")!))
     }
 
     // Full password path: probe demands auth, configure logs in with the typed
@@ -372,7 +391,7 @@ final class OnboardingViewModelIdentityTests: XCTestCase {
 
         XCTAssertEqual(client.configuredPasswords, ["typed-secret"], "configure must log in with the typed password")
         XCTAssertEqual(keychain.savedValues[.serverURL], "https://example.com")
-        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")))
+        XCTAssertEqual(manager.state, .loggedIn(server: URL(string: "https://example.com")!))
         XCTAssertFalse(viewModel.isConnectionLocked)
         XCTAssertFalse(viewModel.isWorking)
     }


### PR DESCRIPTION
## Problem

PR #265 added honest trusted-header/OIDC onboarding, but `OnboardingViewModel` kept the probed `authStatus` when the user edited the server URL or custom headers. The form can then hide the password field using stale trusted-header state, skip the required re-probe in `connect()` (`if authStatus == nil`), and fail against the newly entered password-protected server with no way to provide the requested password.

Reported as #285:

1. Enter a trusted-header server + headers → Test Connection → probe reports already signed in, password field hides.
2. Edit the URL or headers to point at a password-protected server.
3. Tap Connect without retesting.
4. Stale status remains non-nil, `connect()` skips probe, form stays shaped for old server. `AuthManager.configure` rejects while password control is still hidden.

## Fix

Bind `authStatus` to the normalized connection identity that produced it:

- **Identity** = `AuthManager.normalizedServerURL(serverURLString).absoluteString.lowercased()` (strips `www.webui.`, path/query/fragment, applies correct `http` vs `https` default) + sorted `customHeaders.sanitizedForStorage().map(name:value)` — matches server-side probing exactly.
- Store `probedConnectionIdentity` and `probeGeneration` (both `@ObservationIgnored`).
- `didSet` on `serverURLString` / `customHeaders` calls `invalidateProbedAuthStatusIfNeeded()` — only when `current != probed` does it nil `authStatus` + both banners (`connectionMessage`, `errorMessage`). Whitespace/canonically equivalent edits stay equal after normalization, so no flicker.
- `testConnection` and the `authStatus == nil` branch of `connect` now capture `generation` + `identityAtStart` and guard both before writing `authStatus` / banners — an older in-flight probe cannot overwrite state for a newer identity.
- `password` edits intentionally do **not** invalidate — password is a credential, not part of server capability.

Without a prior probe (`probedIdentity == nil`) identity edits are no-ops until the first successful probe, so typing before any probe never nss stale state.

## Testing

Manual verification of #285 acceptance tests:

- Trusted-header probe → URL change to password server → password field appears, Connect re-probes.
- Trusted-header probe → header change/removal → stale signed-in discarded.
- OIDC-only/passwordless status similarly invalidated.
- Whitespace-only / `https://example.com/` vs `example.com` stays equal → no churn.
- Old in-flight probe result ignored when identity changed during network flight.

Existing `OnboardingFlowTests` only covers `OnboardingFlowPolicy`; no `OnboardingViewModel` coverage existed or broken.

## Evidence

- `OnboardingViewModel.swift:9-12` four mutable inputs vs one cached `authStatus` with `connect:77` re-probe gate `if authStatus == nil`.
- `OnboardingConnectPage.swift` `TextField("", text: $viewModel.serverURLString)` + `CustomHeadersEditor(headers: $viewModel.customHeaders)` mutation paths.
- `AuthManager.normalizedServerURL:559-580` + `CustomHeader.sanitizedForStorage:105` — reused for identity.
- `CustomHeader` `ForEach($headers)` `Billing` note — `didSet` on array plus identity comparison handles add/remove/name/value edits reliably.

Fixes #285


