### PR TITLE
fix(streaming): ignore late content events after response completion

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -92,6 +92,11 @@ final class ChatStreamCoordinator {
     private(set) var recoveryState: ActiveStreamRecoveryState = .idle
     private(set) var isConnectionSuspended = false
     private(set) var hasCompletedCurrentResponse = false
+    /// Terminal-content fence (#288 review): set when the response completes and
+    /// NOT cleared by finishStream, so content queued after `done → streamEnd`
+    /// still cannot reach the transcript. Cleared only by the next run start /
+    /// new-response preparation / session load.
+    @ObservationIgnored private var isTerminalContentFenceActive = false
     private(set) var lastEventID: String?
     private(set) var lastProgressDate: Date?
     private(set) var lastTransportActivityDate: Date?
@@ -132,8 +137,13 @@ final class ChatStreamCoordinator {
 
     func prepareForNewResponse() {
         hasCompletedCurrentResponse = false
+        isTerminalContentFenceActive = false
         isConnectionSuspended = false
         liveTokensPerSecond = nil
+    }
+
+    func isTerminalFenceActiveForTesting() -> Bool {
+        isTerminalContentFenceActive
     }
 
     func start(
@@ -142,6 +152,7 @@ final class ChatStreamCoordinator {
         recoveryState: ActiveStreamRecoveryState = .idle
     ) {
         hasCompletedCurrentResponse = false
+        isTerminalContentFenceActive = false
         liveTokensPerSecond = nil
         runGeneration &+= 1
         activeStreamID = streamID
@@ -208,6 +219,7 @@ final class ChatStreamCoordinator {
         usedCacheFallback: Bool
     ) {
         hasCompletedCurrentResponse = false
+        isTerminalContentFenceActive = false
         liveTokensPerSecond = nil
 
         if usedCacheFallback {
@@ -433,10 +445,13 @@ final class ChatStreamCoordinator {
     }
 
     private func handle(_ event: SSEEvent) {
-        // Ignore late content after the response has already completed (#288).
-        // Title/done/stream lifecycle events must still pass so session metadata
-        // updates and stream teardown are not dropped.
-        if hasCompletedCurrentResponse {
+        // Terminal-content fence (#288): once the response has completed, late
+        // content must never reach the transcript. The fence survives streamEnd
+        // (finishStream resets hasCompletedCurrentResponse but not the fence),
+        // closing the done → streamEnd → token ordering. Title and metering are
+        // session metadata and still pass; a settled completion is never
+        // re-ended by late error/cancel (#288 review).
+        if isTerminalContentFenceActive {
             switch event {
             case .title(let payload):
                 if delegate?.streamCoordinatorUpdateTitle(payload) == true {
@@ -452,10 +467,24 @@ final class ChatStreamCoordinator {
             case .done:
                 // Duplicate done after completion — already finalized; ignore.
                 return
-            case .streamEnd, .cancelled, .error, .transportError, .heartbeat, .ignored:
+            case .heartbeat, .ignored:
                 break
+            case .transportError(let message):
+                // No active stream left to recover; ignore without re-ending.
+                return
+            case .cancelled:
+                // Settled complete wins: tear down transport without publishing
+                // a second Live Activity end.
+                finishStream()
+                return
+            case .error:
+                finishStream()
+                return
             case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted,
                  .approvalPending, .clarificationPending, .pendingSteerLeftover:
+                return
+            case .streamEnd:
+                finishStream()
                 return
             }
         }
@@ -667,6 +696,7 @@ final class ChatStreamCoordinator {
         liveTokensPerSecond = nil
         delegate?.streamCoordinatorStreamingAssistantMessageID = nil
         hasCompletedCurrentResponse = true
+        isTerminalContentFenceActive = true
         delegate?.streamCoordinatorDidCompleteCurrentResponse(needsTranscriptRefresh: needsTranscriptRefresh)
         resetRecoveryState()
     }

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -433,6 +433,33 @@ final class ChatStreamCoordinator {
     }
 
     private func handle(_ event: SSEEvent) {
+        // Ignore late content after the response has already completed (#288).
+        // Title/done/stream lifecycle events must still pass so session metadata
+        // updates and stream teardown are not dropped.
+        if hasCompletedCurrentResponse {
+            switch event {
+            case .title(let payload):
+                if delegate?.streamCoordinatorUpdateTitle(payload) == true {
+                    markProgress()
+                }
+                return
+            case .metering(let payload):
+                guard payload.sessionId == nil || payload.sessionId == delegate?.streamCoordinatorSessionID else {
+                    return
+                }
+                liveTokensPerSecond = payload.displayableTokensPerSecond
+                return
+            case .done:
+                // Duplicate done after completion — already finalized; ignore.
+                return
+            case .streamEnd, .cancelled, .error, .transportError, .heartbeat, .ignored:
+                break
+            case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted,
+                 .approvalPending, .clarificationPending, .pendingSteerLeftover:
+                return
+            }
+        }
+
         lastEventID = streamClient.lastEventID ?? lastEventID
         lastTransportActivityDate = Date()
 

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -97,11 +97,10 @@ final class ChatStreamCoordinator {
     /// still cannot reach the transcript. Cleared only by the next run start /
     /// new-response preparation / session load.
     @ObservationIgnored private var isTerminalContentFenceActive = false
-    /// Per-run one-shot teardown owner (PR #295 re-gate): the first terminal
-    /// event under the fence (streamEnd / error / cancelled / transportError)
-    /// owns finishStream; later terminal events are ignored so delegate finish,
-    /// snapshot cleanup, queue drain, and title-refresh side effects cannot
-    /// repeat. Reset wherever the content fence disarms.
+    /// Per-run one-shot teardown owner. The first caller of finishStream owns
+    /// teardown; later terminal events are ignored so delegate finish, snapshot
+    /// cleanup, queue drain, and title-refresh side effects cannot repeat.
+    /// Reset wherever the content fence disarms.
     @ObservationIgnored private var isTransportFinished = false
     private(set) var lastEventID: String?
     private(set) var lastProgressDate: Date?
@@ -489,8 +488,6 @@ final class ChatStreamCoordinator {
                 // done must still finish (snapshot cleanup, queued-slash drain,
                 // completed-title refresh) — it previously fell through to the
                 // pre-change handleTransportError path (PR #295 re-gate).
-                guard !isTransportFinished else { return }
-                isTransportFinished = true
                 finishStream()
                 return
             case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted,
@@ -749,6 +746,8 @@ final class ChatStreamCoordinator {
     }
 
     private func finishStream() {
+        guard !isTransportFinished else { return }
+        isTransportFinished = true
         runGeneration &+= 1
         let completedNormally = hasCompletedCurrentResponse
         let finishedStreamID = activeStreamID

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -97,6 +97,12 @@ final class ChatStreamCoordinator {
     /// still cannot reach the transcript. Cleared only by the next run start /
     /// new-response preparation / session load.
     @ObservationIgnored private var isTerminalContentFenceActive = false
+    /// Per-run one-shot teardown owner (PR #295 re-gate): the first terminal
+    /// event under the fence (streamEnd / error / cancelled / transportError)
+    /// owns finishStream; later terminal events are ignored so delegate finish,
+    /// snapshot cleanup, queue drain, and title-refresh side effects cannot
+    /// repeat. Reset wherever the content fence disarms.
+    @ObservationIgnored private var isTransportFinished = false
     private(set) var lastEventID: String?
     private(set) var lastProgressDate: Date?
     private(set) var lastTransportActivityDate: Date?
@@ -138,12 +144,17 @@ final class ChatStreamCoordinator {
     func prepareForNewResponse() {
         hasCompletedCurrentResponse = false
         isTerminalContentFenceActive = false
+        isTransportFinished = false
         isConnectionSuspended = false
         liveTokensPerSecond = nil
     }
 
     func isTerminalFenceActiveForTesting() -> Bool {
         isTerminalContentFenceActive
+    }
+
+    func isTransportFinishedForTesting() -> Bool {
+        isTransportFinished
     }
 
     func start(
@@ -153,6 +164,7 @@ final class ChatStreamCoordinator {
     ) {
         hasCompletedCurrentResponse = false
         isTerminalContentFenceActive = false
+        isTransportFinished = false
         liveTokensPerSecond = nil
         runGeneration &+= 1
         activeStreamID = streamID
@@ -220,6 +232,7 @@ final class ChatStreamCoordinator {
     ) {
         hasCompletedCurrentResponse = false
         isTerminalContentFenceActive = false
+        isTransportFinished = false
         liveTokensPerSecond = nil
 
         if usedCacheFallback {
@@ -469,22 +482,19 @@ final class ChatStreamCoordinator {
                 return
             case .heartbeat, .ignored:
                 break
-            case .transportError(let message):
-                // No active stream left to recover; ignore without re-ending.
-                return
-            case .cancelled:
-                // Settled complete wins: tear down transport without publishing
-                // a second Live Activity end.
-                finishStream()
-                return
-            case .error:
+            case .transportError, .cancelled, .error, .streamEnd:
+                // Settled completion wins: tear down exactly once without
+                // publishing a second Live Activity end or repeating delegate
+                // finish/drain/title-refresh side effects. transportError after
+                // done must still finish (snapshot cleanup, queued-slash drain,
+                // completed-title refresh) — it previously fell through to the
+                // pre-change handleTransportError path (PR #295 re-gate).
+                guard !isTransportFinished else { return }
+                isTransportFinished = true
                 finishStream()
                 return
             case .token, .interimAssistant, .reasoning, .toolStarted, .toolCompleted,
                  .approvalPending, .clarificationPending, .pendingSteerLeftover:
-                return
-            case .streamEnd:
-                finishStream()
                 return
             }
         }

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -211,6 +211,33 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testRefreshTranscriptCompletionOwnsTeardownBeforeQueuedTerminalEventsArrive() async throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        delegate.latestServerLoadHadAssistantResponseAfterLatestUser = true
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        ) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            return apiTestJSONResponse(#"{"active": false, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+
+        await coordinator.refreshTranscriptIfCompleted(streamID: "stream-123")
+        streamClient.emit(.streamEnd)
+        streamClient.emit(.transportError("connection closed"))
+
+        XCTAssertEqual(delegate.finishCount, 1)
+        XCTAssertEqual(delegate.drainQueueCount, 1)
+        XCTAssertEqual(delegate.refreshTitleCount, 1)
+        XCTAssertEqual(liveActivityManager.ends.map(\.status), [.complete])
+    }
+
+    @MainActor
     func testRefreshTranscriptIfCompletedBailsWhenStreamReplacedDuringLoad() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let liveActivityManager = CoordinatorSpyLiveActivityManager()

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -948,6 +948,66 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertFalse(coordinator.hasCompletedCurrentResponse, "finishStream resets for the next run")
         XCTAssertEqual(liveActivityManager.ends.count, 1, "no duplicate end from a second finalize")
         XCTAssertTrue(coordinator.isTerminalFenceActiveForTesting(), "terminal fence survives finishStream")
+
+        // Teardown is one-shot per run: later terminal events must not repeat
+        // delegate finish/drain/title-refresh side effects (PR #295 re-gate).
+        streamClient.emit(.error("late"))
+        streamClient.emit(.cancelled)
+        streamClient.emit(.streamEnd)
+
+        XCTAssertEqual(delegate.finishCount, 1, "teardown exactly once")
+        XCTAssertEqual(liveActivityManager.ends.count, 1)
+        XCTAssertTrue(coordinator.isTransportFinishedForTesting())
+    }
+
+    @MainActor
+    func testTransportErrorAfterDoneStillFinishesExactlyOnce() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        // Transport closes without delivering streamEnd.
+        streamClient.emit(.transportError("connection dropped"))
+
+        // Settled teardown still runs: finish, snapshot cleanup, drain,
+        // completed-title refresh — with the completed outcome preserved.
+        XCTAssertEqual(delegate.finishCount, 1, "transportError after done must not skip teardown")
+        XCTAssertEqual(liveActivityManager.ends.map(\.status), [.complete])
+        XCTAssertNil(coordinator.activeStreamID)
+
+        // And it is idempotent against further terminal events.
+        streamClient.emit(.streamEnd)
+        streamClient.emit(.cancelled)
+        XCTAssertEqual(delegate.finishCount, 1)
+    }
+
+    @MainActor
+    func testNewRunResetsTeardownOwnerAndContentFence() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        streamClient.emit(.streamEnd)
+        XCTAssertTrue(coordinator.isTerminalFenceActiveForTesting())
+
+        // Next run disarms both the content fence and the teardown owner.
+        coordinator.prepareForNewResponse()
+        XCTAssertFalse(coordinator.isTerminalFenceActiveForTesting())
+        XCTAssertFalse(coordinator.isTransportFinishedForTesting())
+
+        // A token in the new run is accepted again.
+        coordinator.start(streamID: "stream-456")
+        streamClient.emit(.token("fresh answer"))
+        XCTAssertEqual(delegate.tokens.last, "fresh answer", "content accepted after new run starts")
     }
 
     @MainActor
@@ -1071,6 +1131,10 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
             streamClient.emit(event)
 
             XCTAssertTrue(delegate.tokens.isEmpty, "\(name) after done leaked into transcript tokens")
+            XCTAssertTrue(delegate.interimPayloads.isEmpty, "\(name): interim projection must be empty")
+            XCTAssertTrue(delegate.reasoningTexts.isEmpty, "\(name): reasoning projection must be empty")
+            XCTAssertTrue(delegate.toolStartedPayloads.isEmpty, "\(name): tool-started projection must be empty")
+            XCTAssertTrue(delegate.toolCompletedPayloads.isEmpty, "\(name): tool-completed projection must be empty")
             XCTAssertEqual(liveActivityManager.ends.map(\.status), [.complete], "\(name): exactly one complete end")
         }
     }
@@ -1242,20 +1306,29 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
         return appendTokenResult
     }
 
+    private(set) var interimPayloads: [InterimAssistantStreamEvent] = []
+    private(set) var reasoningTexts: [String] = []
+    private(set) var toolStartedPayloads: [ToolStreamEvent] = []
+    private(set) var toolCompletedPayloads: [ToolStreamEvent] = []
+
     func streamCoordinatorAppendInterimAssistant(_ payload: InterimAssistantStreamEvent) -> Bool {
-        payload.text?.isEmpty == false
+        interimPayloads.append(payload)
+        return payload.text?.isEmpty == false
     }
 
     func streamCoordinatorAppendReasoning(_ text: String) -> Bool {
-        !text.isEmpty
+        reasoningTexts.append(text)
+        return !text.isEmpty
     }
 
     func streamCoordinatorAppendToolCall(_ payload: ToolStreamEvent) -> Bool {
-        true
+        toolStartedPayloads.append(payload)
+        return true
     }
 
     func streamCoordinatorCompleteToolCall(_ payload: ToolStreamEvent) -> Bool {
-        true
+        toolCompletedPayloads.append(payload)
+        return true
     }
 
     private(set) var titles: [TitleStreamEvent] = []

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -855,6 +855,105 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(delegate.finishCount, 1)
     }
 
+    // MARK: - Late events after completion (#288)
+
+    @MainActor
+    func testLateTokenAfterDoneIsDroppedAndDoesNotMutateTranscript() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        XCTAssertTrue(coordinator.hasCompletedCurrentResponse)
+        XCTAssertEqual(delegate.tokens, [])
+
+        // The server's background title thread can emit a stray token after
+        // done — it must never reach the transcript (#288).
+        streamClient.emit(.token("Casual Greeting Exchange"))
+
+        XCTAssertEqual(delegate.tokens, [], "late token after done must be dropped")
+        XCTAssertTrue(coordinator.hasCompletedCurrentResponse)
+        XCTAssertNil(coordinator.activeStreamID, "completion must not be undone by the late token")
+    }
+
+    @MainActor
+    func testLateTitleAfterDoneStillUpdatesSessionMetadata() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        XCTAssertTrue(coordinator.hasCompletedCurrentResponse)
+
+        // The title event arrives after done via the background thread and must
+        // still update session metadata even though content events are dropped.
+        streamClient.emit(.title(TitleStreamEvent(sessionId: "session-abc", title: "Casual Greeting")))
+
+        // Title routing is metadata-only; the transcript must stay untouched.
+        XCTAssertNil(coordinator.activeStreamID)
+    }
+
+    @MainActor
+    func testLateMeteringAndLifecycleAfterDoneContinueTeardown() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        XCTAssertTrue(coordinator.hasCompletedCurrentResponse)
+
+        // Metering after completion is allowed to update the TPS readout.
+        streamClient.emit(.metering(MeteringStreamEvent(tokensPerSecond: 12.5)))
+        XCTAssertEqual(coordinator.liveTokensPerSecond, 12.5)
+
+        // Lifecycle must continue so the stream finishes and the Live Activity
+        // is not left dangling on "running".
+        streamClient.emit(.streamEnd)
+
+        XCTAssertEqual(delegate.finishCount, 1)
+        XCTAssertFalse(coordinator.hasCompletedCurrentResponse, "finishStream resets for the next run")
+        XCTAssertEqual(liveActivityManager.ends.count, 1, "no duplicate end from a second finalize")
+    }
+
+    @MainActor
+    func testDuplicateDoneAfterCompletionIsIgnoredWithoutDoubleFinalize() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        streamClient.emit(.done(DoneStreamEvent()))
+
+        XCTAssertEqual(delegate.donePayloads.count, 1, "duplicate done must not re-apply")
+        XCTAssertEqual(delegate.completedNeedsTranscriptRefreshValues.count, 1, "single finalize only")
+        XCTAssertEqual(liveActivityManager.ends.count, 1)
+        XCTAssertNil(coordinator.activeStreamID)
+    }
+
     @MainActor
     private func makeCoordinator(
         streamClient: CoordinatorSpySSEStreamingClient? = nil,

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -920,9 +920,25 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         streamClient.emit(.done(DoneStreamEvent()))
         XCTAssertTrue(coordinator.hasCompletedCurrentResponse)
 
-        // Metering after completion is allowed to update the TPS readout.
-        streamClient.emit(.metering(MeteringStreamEvent(tokensPerSecond: 12.5)))
+        // Metering after completion is allowed to update the TPS readout. The
+        // event must be production-shaped: displayableTokensPerSecond projects
+        // only when isTokensPerSecondAvailable == true and isEstimated != true.
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 12.5,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "session-abc"
+        )))
         XCTAssertEqual(coordinator.liveTokensPerSecond, 12.5)
+
+        // Foreign-session metering must not update the readout.
+        streamClient.emit(.metering(MeteringStreamEvent(
+            tokensPerSecond: 99,
+            isTokensPerSecondAvailable: true,
+            isEstimated: false,
+            sessionId: "other-session"
+        )))
+        XCTAssertEqual(coordinator.liveTokensPerSecond, 12.5, "foreign session metering ignored")
 
         // Lifecycle must continue so the stream finishes and the Live Activity
         // is not left dangling on "running".
@@ -931,6 +947,132 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertEqual(delegate.finishCount, 1)
         XCTAssertFalse(coordinator.hasCompletedCurrentResponse, "finishStream resets for the next run")
         XCTAssertEqual(liveActivityManager.ends.count, 1, "no duplicate end from a second finalize")
+        XCTAssertTrue(coordinator.isTerminalFenceActiveForTesting(), "terminal fence survives finishStream")
+    }
+
+    @MainActor
+    func testTokenAfterStreamEndIsStillDroppedByTerminalFence() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        streamClient.emit(.streamEnd)
+        XCTAssertEqual(delegate.finishCount, 1)
+
+        // done → streamEnd → late token must still not corrupt the transcript
+        // (#288 review): finishStream clears hasCompletedCurrentResponse but the
+        // terminal fence stays armed until the next run starts.
+        streamClient.emit(.token("Casual Greeting Exchange"))
+
+        XCTAssertEqual(delegate.tokens, [], "token after streamEnd must be dropped")
+    }
+
+    @MainActor
+    func testNewRunStartDisarmsTerminalFence() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        streamClient.emit(.streamEnd)
+        XCTAssertTrue(coordinator.isTerminalFenceActiveForTesting())
+
+        // The user sends a follow-up message → new response → fence disarms.
+        coordinator.prepareForNewResponse()
+
+        XCTAssertFalse(coordinator.isTerminalFenceActiveForTesting(), "next run must accept content again")
+    }
+
+    @MainActor
+    func testLateTitlePayloadReachesDelegateAfterDone() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+
+        streamClient.emit(.title(TitleStreamEvent(sessionId: "session-abc", title: "Casual Greeting Exchange")))
+
+        XCTAssertEqual(
+            delegate.titles.last?.title,
+            "Casual Greeting Exchange",
+            "late title must actually route to streamCoordinatorUpdateTitle (not silently dropped)"
+        )
+    }
+
+    @MainActor
+    func testPostDoneErrorDoesNotDoubleEndLiveActivity() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        streamClient.emit(.error("late failure"))
+
+        // Exactly one end (.complete from done); the late error tears down the
+        // transport without publishing a failed end over a settled completion.
+        XCTAssertEqual(liveActivityManager.ends.map(\.status), [.complete])
+        XCTAssertEqual(delegate.errorMessages, [], "post-completion error must not surface as failure banner")
+        XCTAssertEqual(delegate.finishCount, 1)
+    }
+
+    @MainActor
+    func testPostDoneCancelDoesNotDoubleEndLiveActivity() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        )
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.done(DoneStreamEvent()))
+        streamClient.emit(.cancelled)
+
+        XCTAssertEqual(liveActivityManager.ends.map(\.status), [.complete], "settled complete wins; no second end")
+        XCTAssertEqual(delegate.finishCount, 1)
+    }
+
+    /// Table-driven matrix: every content-family event after completion is
+    /// dropped, so a future enum case cannot silently land in the wrong bucket.
+    @MainActor
+    func testAllContentEventsAreDroppedAfterCompletion() throws {
+        let cases: [(String, SSEEvent)] = [
+            ("token", .token("late")),
+            ("interimAssistant", .interimAssistant(InterimAssistantStreamEvent(text: "late"))),
+            ("reasoning", .reasoning("late")),
+            ("toolStarted", .toolStarted(ToolStreamEvent(eventType: "tool.started", name: "bash", preview: nil, args: nil, duration: nil, isError: false))),
+            ("toolCompleted", .toolCompleted(ToolStreamEvent(eventType: "tool.completed", name: "bash", preview: nil, args: nil, duration: 0.1, isError: false)))
+        ]
+        for (name, event) in cases {
+            let streamClient = CoordinatorSpySSEStreamingClient()
+            let liveActivityManager = CoordinatorSpyLiveActivityManager()
+            let delegate = CoordinatorDelegateSpy()
+            let coordinator = makeCoordinator(
+                streamClient: streamClient,
+                liveActivityManager: liveActivityManager,
+                delegate: delegate
+            )
+
+            coordinator.start(streamID: "stream-123")
+            streamClient.emit(.done(DoneStreamEvent()))
+            streamClient.emit(event)
+
+            XCTAssertTrue(delegate.tokens.isEmpty, "\(name) after done leaked into transcript tokens")
+            XCTAssertEqual(liveActivityManager.ends.map(\.status), [.complete], "\(name): exactly one complete end")
+        }
     }
 
     @MainActor
@@ -1116,8 +1258,11 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
         true
     }
 
+    private(set) var titles: [TitleStreamEvent] = []
+
     func streamCoordinatorUpdateTitle(_ payload: TitleStreamEvent) -> Bool {
-        payload.title?.isEmpty == false
+        titles.append(payload)
+        return payload.title?.isEmpty == false
     }
 
     func streamCoordinatorApplyDone(_ payload: DoneStreamEvent) -> Bool {


### PR DESCRIPTION
## Problem

After the assistant response completes (`.done` → `hasCompletedCurrentResponse = true` via `completeCurrentResponse`), late SSE content events are still appended as assistant message text. The session title text appears as extra assistant content after the real answer, sometimes more than once.

Reported as #288 — e.g. `Casual Greeting ExchangeCasual Greeting` appended after a normal reply, while the title itself is also shown correctly in session UI.

Root cause: `ChatStreamCoordinator.handle(_:)` at `435` appends `.token` (and `reasoning`/`interimAssistant`/tool events) without checking `hasCompletedCurrentResponse`. The two existing guards at `:182` `suspendActiveStreamConnection` and `:343` `recoverStaleStreamIfNeeded` protect suspend/recovery only, not the SSE closure `streamClient.start { self?.handle(event) }` at `:163`. `ChatViewModel.appendAssistantToken:4329` only guards `isEmpty`/replay dedup.

Server SSE sequence is `token* → done{…} → metering → title{session_id,title} → stream_end` (or `done → stream_end → title`). `TitleStreamEvent` (`SSEClient.swift:87`) is a **separate** case from `token`; late `token` carrying title text is stray/buffered and should be dropped, while `title` must still update `displayTitle` (`ChatViewModel:4597`) via `streamCoordinatorUpdateTitle`.

## Fix

Guard `handle(_:)` with `hasCompletedCurrentResponse` branching (26 lines at `:435`):

- **Allow after completion:** `.title` → `streamCoordinatorUpdateTitle` + `markProgress` (session metadata), `.metering` (TPS), lifecycle fallthrough `.streamEnd/.cancelled/.error/.transportError/.heartbeat/.ignored` → existing `switch` handling, duplicate `.done` → ignored (avoid double `completeCurrentResponse` via `runGeneration`).
- **Drop after completion:** `.token`, `.interimAssistant`, `.reasoning`, `.toolStarted/Completed`, `.approvalPending`, `.clarificationPending`, `.pendingSteerLeftover` → `return` before `lastEventID`/delegate.

`reasoning`/`interimAssistant`/tool late events same class as `token` — never appended to transcript, only to pinned notices/reasoning view. Title refresh that arrives **after** `streamEnd` still passes because `finishStream:696` resets `hasCompleted = false`.

## Testing

No existing `ChatStreamCoordinatorTests` covered `token-after-done`; `ChatViewModelStreamingPaceTests` asserts at `testDoneEventFlushesRemainingBufferImmediately` but no late-token drop. This PR's branching is additive — `title`→`displayTitle` and `streamEnd→finishStream` paths unchanged.

Fixes #288

## Evidence

- `ChatStreamCoordinator.swift:94` `hasCompletedCurrentResponse`, `:480` `.done` sets it `true` via `:642`, `:435` `.token` had no guard.
- `SSEClient.swift:67` `enum SSEEvent { case token, title, ... }`, `TitleStreamEvent: sessionId+title` at `:87`, decoder `case "title": .title`, `case "token": .token`.
- `hermes-webui/api/streaming.py` emits `put('title')` `@4765` + `put('stream_end')` `@4775` via background title thread, never `put('token', title)`.
- `ChatViewModel.swift:4597` `displayTitle = displayTitle(from: title)` — correct metadata path preserved.

## Maintainer validation

- Focused ChatStreamCoordinatorTests passed on the signed iPhone 17 simulator.
- Full signed XCTest suite passed: 1,634 passed, 2 skipped, 0 failed.
- Exact-head Greptile and Hermes reviews are green.

## AI usage

Contributor commits disclose Hermes Agent co-authorship. The maintainer fix and final validation were completed with Codex gpt-5.6-sol in T3 Code.