### PR TITLE
docs: open PRs ready for review, not as drafts

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -29,7 +29,7 @@ GitHub Issues are the work queue; pull requests are the review and merge record.
 - `ready-for-agent` issues default to express mode (autonomous from approved plan to review-addressed PR). An issue also labeled `needs-manual-validation` forces staged mode, where the owner manually tests before the PR publishes. See `docs/agents/triage-labels.md`.
 - Create a short `issue/<n>-slug` branch for one issue or narrow slice (no-issue branches use `chore/`/`fix/`).
 - Commit completed, validated work locally with the matching handoff updates.
-- Push feature branches and open draft PRs only when the human asks to publish/open a PR.
+- Push feature branches and open PRs only when the human asks to publish/open a PR. Open them ready for review, not as drafts: the review bots only run on ready PRs.
 - Use the PR for review: GitHub/Copilot review, CI, external agent review, and human comments should live there when possible.
 - Address PR review comments by triaging them first; do not blindly accept automated review feedback.
 - Merge into `master` only after validation passes, review feedback is resolved, and the human approves.


### PR DESCRIPTION
## Linked issue

No issue — one-line docs fix following #305.

## What changed

`docs/agents/issue-tracker.md` told agents to open *draft* PRs, but the review bots (AGY, Greptile) only run on PRs marked ready, and the maintainer's practice is to open them ready. One line updated.

## How it was tested

Docs-only; no code changes.

## Checklist

- [x] The full test suite passes locally — n/a, docs only
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes — n/a

Built with Claude Code (Claude Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)