### PR TITLE
chore: document the Tailscale ATS exception and the PR triage stance

### DIFF
--- a/HermesMobile/Resources/Info.plist
+++ b/HermesMobile/Resources/Info.plist
@@ -39,6 +39,16 @@
 	<string>$(KEYCHAIN_SERVICE)</string>
 	<key>HermesURLScheme</key>
 	<string>$(HERMES_URL_SCHEME)</string>
+	<!-- LOAD-BEARING: do not remove. This CIDR exception permits cleartext HTTP
+	     to the Tailscale CGNAT range, which is the documented physical-device
+	     connection path (see DEVELOPMENT.md). iOS ATS *does* match raw-IP
+	     connections against a CIDR-style exception-domain key: verified by an
+	     app-hosted unit test, where 100.64.0.1 reaches the network (URLSession
+	     -1001 timeout) with this entry and is blocked (-1022 ATS) without it,
+	     while out-of-range 8.8.8.8 stays blocked either way. A previous audit
+	     claimed this key was dead config on the premise that CIDR is not a
+	     supported ATS form; that premise is empirically false and removing the
+	     entry regresses device connectivity. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -23,7 +23,7 @@ Use heredocs for multi-line issue bodies and comments.
 
 ## Pull Requests as a Triage Surface
 
-**PRs as a request surface: no.**
+**PRs as a request surface: no.** Bug reports and feature requests belong in issues, not in PR comments. Review comments on an open PR are still actionable — triage and address them as described below.
 
 ## Branch and PR Workflow
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -21,6 +21,10 @@ Infer the repo from `git remote -v` when possible; `gh` does this automatically 
 
 Use heredocs for multi-line issue bodies and comments.
 
+## Pull Requests as a Triage Surface
+
+**PRs as a request surface: no.**
+
 ## Branch and PR Workflow
 
 GitHub Issues are the work queue; pull requests are the review and merge record.


### PR DESCRIPTION
## Linked issue

No issue — maintainer annotations.

## What changed

- `HermesMobile/Resources/Info.plist`: a comment on the `NSExceptionDomains` CIDR entry for the Tailscale CGNAT range explaining that it is load-bearing. iOS ATS does match raw-IP connections against a CIDR exception key (verified by an app-hosted unit test: `100.64.0.1` reaches the network with the entry and is blocked with `-1022` without it; out-of-range `8.8.8.8` stays blocked either way). A previous audit claimed the key was dead config on a false premise; removing it regresses physical-device connectivity.
- `docs/agents/issue-tracker.md`: records that PRs are not a request/triage surface.

Comment and doc changes only; no runtime behavior changes.

## How it was tested

CI runs the full XCTest suite because `HermesMobile/` is touched. No code changed.

## Checklist

- [x] The full test suite passes — CI
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes — n/a

Built with Claude Code (Claude Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)