### PR TITLE
perf(cache): batch cached-message lookups during transcript upsert

### DIFF
--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -138,6 +138,21 @@ enum CacheStore {
                 sortIndex: offset
             )
         })
+        // One session-scoped fetch serves both the upsert lookups below and the
+        // stale sweep at the end. `CachedMessage.cacheKey` already embeds the
+        // server and session, so this window holds every row a per-message
+        // lookup could have matched. Rows inserted below are absent from the
+        // snapshot, which is what the stale sweep wants: their keys are fresh.
+        let descriptor = FetchDescriptor<CachedMessage>(
+            predicate: #Predicate { cachedMessage in
+                cachedMessage.serverURLString == serverURLString
+                    && cachedMessage.sessionID == sessionID
+            }
+        )
+        let cachedMessages = try context.fetch(descriptor)
+        let cachedMessagesByKey = cachedMessages.reduce(into: [String: CachedMessage]()) {
+            $0[$1.cacheKey] = $1
+        }
 
         for (offset, message) in messages.enumerated() {
             let cacheKey = CachedMessage.cacheKey(
@@ -146,7 +161,7 @@ enum CacheStore {
                 message: message,
                 sortIndex: offset
             )
-            if let cachedMessage = try cachedMessage(cacheKey: cacheKey, in: context) {
+            if let cachedMessage = cachedMessagesByKey[cacheKey] {
                 cachedMessage.apply(message, sortIndex: offset, cachedAt: cachedAt)
             } else {
                 context.insert(CachedMessage(
@@ -159,13 +174,7 @@ enum CacheStore {
             }
         }
 
-        let descriptor = FetchDescriptor<CachedMessage>(
-            predicate: #Predicate { cachedMessage in
-                cachedMessage.serverURLString == serverURLString
-                    && cachedMessage.sessionID == sessionID
-            }
-        )
-        let staleMessages = try context.fetch(descriptor).filter { !freshKeys.contains($0.cacheKey) }
+        let staleMessages = cachedMessages.filter { !freshKeys.contains($0.cacheKey) }
         for staleMessage in staleMessages {
             context.delete(staleMessage)
         }
@@ -273,17 +282,6 @@ enum CacheStore {
         var descriptor = FetchDescriptor<CachedSession>(
             predicate: #Predicate { cachedSession in
                 cachedSession.cacheKey == cacheKey
-            }
-        )
-        descriptor.fetchLimit = 1
-        return try context.fetch(descriptor).first
-    }
-
-    @MainActor
-    private static func cachedMessage(cacheKey: String, in context: ModelContext) throws -> CachedMessage? {
-        var descriptor = FetchDescriptor<CachedMessage>(
-            predicate: #Predicate { cachedMessage in
-                cachedMessage.cacheKey == cacheKey
             }
         )
         descriptor.fetchLimit = 1


### PR DESCRIPTION
## Linked issue

No issue. Salvaged from #217, which bundled this with two changes we are not taking.

## What changed

Caching a transcript issued one SwiftData fetch per message to find the row to update, then a second session-scoped fetch to sweep stale rows — 45 queries to cache a 44-message session.

One session-scoped fetch now serves both. `CachedMessage.cacheKey` already embeds the server and session, so that window holds every row a per-message lookup could have matched. Rows inserted during the pass are absent from the snapshot, which is exactly what the stale sweep wants: their keys are fresh, so the old code filtered them out anyway. Behavior is unchanged; the now-unused `cachedMessage(cacheKey:in:)` helper is removed.

The other two parts of #217 are deliberately excluded:

- **`VStack` → `LazyVStack` + dropping the `.sizeChanges` scroll anchor.** These are not separable — lazy realization churns row heights, the bottom anchor chases them, and #217 resolved that by deleting the anchor and its covering test, silently reverting #137. Left for #32, which needs a benchmark first.
- **`messagePageLimit` 50 → 20.** It also caps the cached read (`ChatViewModel.swift:1315`, `:1489`), and the offline fallback sets `hasOlderMessages = false`, so offline transcripts would lose 60% of their content with no way to load more.

## How it was tested

- Full suite: `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17' -parallel-testing-enabled NO` — **1,667 passed, 0 failed, 2 skipped**. Existing `testCacheMessagesWritesLoadedWindowAndRemovesStaleMessages` already covers all three branches (update-existing, insert-new, stale-delete), so no new test was added.
- Signed Debug build installed and launched on iPhone 17 / iOS 26.5, against a live `hermes-webui`. Inspected the SwiftData store directly after each step:
  - Open a 44-message session → 44 rows, 44 distinct cache keys, `sortIndex` 0–43 contiguous.
  - Reopen it → still 44/44, `cachedAt` advanced on every row (min == max), confirming the update-in-place branch ran at volume with no duplicate inserts.
  - Open a second 42-message session → 42 rows written, **the first session's 44 rows untouched with their older `cachedAt`** — the hoisted stale sweep stays scoped to its own session.
  - Zero duplicate cache keys store-wide; one server URL.
- Cold relaunch → cached transcript renders correctly (Markdown table intact, bottom-anchored).

Read-only against the live server throughout; no sessions were mutated.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (no `Codable` changes)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no wire changes)

---

Cache batching originally by @audichuang in #217; credited as co-author. Salvage, verification, and device testing by Claude Opus 5 (1M context) via Claude Code.