### PR TITLE
fix(chat): serialize foreground stream recovery

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -108,6 +108,18 @@ final class ChatStreamCoordinator {
     private(set) var liveTokensPerSecond: Double?
     private var lastRecoveryStatusCheckDate: Date?
     private(set) var isReplayConnection = false
+    // Foreground activation and view appearance can both request recovery for the
+    // same suspended stream. Share one recovery task so callers cannot duplicate
+    // status checks or transcript loads. Identity and generation fence late work
+    // from a replacement run.
+    private var reconnectTask: (
+        id: UUID,
+        streamID: String,
+        runGeneration: Int,
+        modelContext: ModelContext?,
+        task: Task<Void, Never>
+    )?
+    private var reconnectTranscriptLoadTaskID: UUID?
     // Bumped whenever the active run starts or finalizes. Captured before an async
     // transcript load so a concurrent cancel/completion during the load can't be
     // double-finalized (PR #266 review #2).
@@ -146,6 +158,7 @@ final class ChatStreamCoordinator {
         isTransportFinished = false
         isConnectionSuspended = false
         liveTokensPerSecond = nil
+        invalidateReconnectTask()
     }
 
     func isTerminalFenceActiveForTesting() -> Bool {
@@ -166,6 +179,7 @@ final class ChatStreamCoordinator {
         isTransportFinished = false
         liveTokensPerSecond = nil
         runGeneration &+= 1
+        invalidateReconnectTask()
         activeStreamID = streamID
         isConnectionSuspended = false
         if replayAfterSeq == nil {
@@ -233,6 +247,7 @@ final class ChatStreamCoordinator {
         isTerminalContentFenceActive = false
         isTransportFinished = false
         liveTokensPerSecond = nil
+        defer { invalidateReconnectTaskIfItDoesNotMatchCurrentStream() }
 
         if usedCacheFallback {
             activeStreamID = nil
@@ -273,50 +288,123 @@ final class ChatStreamCoordinator {
 
     func reconnectIfNeeded(modelContext: ModelContext? = nil) async {
         guard let activeStreamID, isConnectionSuspended else { return }
-        let generation = runGeneration
+        if var reconnectTask {
+            if reconnectTask.modelContext == nil, let modelContext {
+                reconnectTask.modelContext = modelContext
+                self.reconnectTask = reconnectTask
+            }
+            await reconnectTask.task.value
+            return
+        }
+
+        let reconnectTaskID = UUID()
+        let reconnectGeneration = runGeneration
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performReconnectIfNeeded(
+                reconnectTaskID: reconnectTaskID,
+                streamID: activeStreamID,
+                runGeneration: reconnectGeneration
+            )
+            guard self.reconnectTask?.id == reconnectTaskID else { return }
+            self.reconnectTask = nil
+        }
+        reconnectTask = (
+            id: reconnectTaskID,
+            streamID: activeStreamID,
+            runGeneration: reconnectGeneration,
+            modelContext: modelContext,
+            task: task
+        )
+        await task.value
+    }
+
+    private func performReconnectIfNeeded(
+        reconnectTaskID: UUID,
+        streamID: String,
+        runGeneration: Int
+    ) async {
+        guard reconnectTaskIsCurrent(
+            reconnectTaskID: reconnectTaskID,
+            streamID: streamID,
+            runGeneration: runGeneration
+        ) else { return }
 
         do {
-            let response = try await client.chatStreamStatus(streamID: activeStreamID)
-            guard self.activeStreamID == activeStreamID, isConnectionSuspended else { return }
+            let response = try await client.chatStreamStatus(streamID: streamID)
+            guard reconnectTaskIsCurrent(
+                reconnectTaskID: reconnectTaskID,
+                streamID: streamID,
+                runGeneration: runGeneration
+            ) else { return }
 
             if response.active == true {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
-                guard self.activeStreamID == activeStreamID, isConnectionSuspended else { return }
+                let completedLoad = await loadMessagesForReconnect(reconnectTaskID: reconnectTaskID)
+                guard completedLoad,
+                      reconnectTaskIsCurrent(
+                          reconnectTaskID: reconnectTaskID,
+                          streamID: streamID,
+                          runGeneration: runGeneration
+                      )
+                else { return }
 
-                let streamIDToResume = activeStreamID
                 if delegate?.streamCoordinatorStreamingAssistantMessageID == nil {
-                    restoreSnapshotIfAvailable(streamID: streamIDToResume)
+                    restoreSnapshotIfAvailable(streamID: streamID)
                 }
                 if delegate?.streamCoordinatorStreamingAssistantMessageID == nil {
                     delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
                 }
                 isConnectionSuspended = false
-                start(streamID: streamIDToResume)
+                start(streamID: streamID)
             } else if response.replayAvailable == true {
+                guard reconnectTaskIsCurrent(
+                    reconnectTaskID: reconnectTaskID,
+                    streamID: streamID,
+                    runGeneration: runGeneration
+                ) else { return }
                 let replayAfterSeq = Self.runJournalReplayAfterSeq(from: lastEventID) ?? 0
-                self.activeStreamID = activeStreamID
                 isConnectionSuspended = false
-                start(streamID: activeStreamID, replayAfterSeq: replayAfterSeq)
+                start(streamID: streamID, replayAfterSeq: replayAfterSeq)
             } else {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
-                // Bail if a concurrent completion/cancel/new run finalized or
-                // replaced this run during the load (see canFinalizeRunAfterLoad).
-                guard canFinalizeRunAfterLoad(streamID: activeStreamID, capturedGeneration: generation) else { return }
+                let completedLoad = await loadMessagesForReconnect(reconnectTaskID: reconnectTaskID)
+                guard completedLoad,
+                      reconnectTaskOwnsFinalization(
+                          reconnectTaskID: reconnectTaskID,
+                          streamID: streamID,
+                          runGeneration: runGeneration
+                      ),
+                      canFinalizeRunAfterLoad(streamID: streamID, capturedGeneration: runGeneration)
+                else { return }
 
                 // #246: the server reports the run is over. Finalize it (and end
                 // the Live Activity) instead of re-arming and leaving it dangling
                 // on "running" when no assistant reply surfaced.
-                finalizeInactiveStream(streamID: activeStreamID)
+                finalizeInactiveStream(streamID: streamID)
             }
         } catch {
             if (error as? APIError)?.indicatesMissingStream == true,
-               self.activeStreamID == activeStreamID,
-               isConnectionSuspended {
-                await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
-                guard canFinalizeRunAfterLoad(streamID: activeStreamID, capturedGeneration: generation) else { return }
-                finalizeInactiveStream(streamID: activeStreamID)
+               reconnectTaskIsCurrent(
+                   reconnectTaskID: reconnectTaskID,
+                   streamID: streamID,
+                   runGeneration: runGeneration
+               ) {
+                let completedLoad = await loadMessagesForReconnect(reconnectTaskID: reconnectTaskID)
+                guard completedLoad,
+                      reconnectTaskOwnsFinalization(
+                          reconnectTaskID: reconnectTaskID,
+                          streamID: streamID,
+                          runGeneration: runGeneration
+                      ),
+                      canFinalizeRunAfterLoad(streamID: streamID, capturedGeneration: runGeneration)
+                else { return }
+                finalizeInactiveStream(streamID: streamID)
                 return
             }
+            guard reconnectTaskIsCurrent(
+                reconnectTaskID: reconnectTaskID,
+                streamID: streamID,
+                runGeneration: runGeneration
+            ) else { return }
             delegate?.streamCoordinatorDidReceiveRecoveryError(error)
         }
     }
@@ -695,6 +783,7 @@ final class ChatStreamCoordinator {
 
     private func completeCurrentResponse(needsTranscriptRefresh: Bool) {
         runGeneration &+= 1
+        invalidateReconnectTask()
         liveActivityManager.end(status: .complete, activity: String(localized: "Response complete"), errorSummary: nil)
         delegate?.streamCoordinatorRemoveSnapshot(streamID: activeStreamID)
         delegate?.streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: true)
@@ -749,6 +838,7 @@ final class ChatStreamCoordinator {
         guard !isTransportFinished else { return }
         isTransportFinished = true
         runGeneration &+= 1
+        invalidateReconnectTask()
         let completedNormally = hasCompletedCurrentResponse
         let finishedStreamID = activeStreamID
         streamClient.stop()
@@ -780,6 +870,79 @@ final class ChatStreamCoordinator {
         self.recoveryState = recoveryState
         isReplayConnection = isReplay
         delegate?.streamCoordinatorDidStartConnection(isReplay: isReplay)
+    }
+
+    private func loadMessagesForReconnect(reconnectTaskID: UUID) async -> Bool {
+        guard reconnectTask?.id == reconnectTaskID else { return false }
+        reconnectTranscriptLoadTaskID = reconnectTaskID
+        await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
+        let completedLoad = reconnectTranscriptLoadTaskID == reconnectTaskID
+        if completedLoad {
+            reconnectTranscriptLoadTaskID = nil
+        }
+        return completedLoad
+    }
+
+    private func reconnectTaskIsCurrent(
+        reconnectTaskID: UUID,
+        streamID: String,
+        runGeneration: Int
+    ) -> Bool {
+        guard !Task.isCancelled,
+              let reconnectTask,
+              reconnectTask.id == reconnectTaskID,
+              reconnectTask.streamID == streamID,
+              reconnectTask.runGeneration == runGeneration,
+              self.runGeneration == runGeneration,
+              activeStreamID == streamID,
+              isConnectionSuspended
+        else { return false }
+        return true
+    }
+
+    private func reconnectTaskOwnsFinalization(
+        reconnectTaskID: UUID,
+        streamID: String,
+        runGeneration: Int
+    ) -> Bool {
+        guard !Task.isCancelled,
+              let reconnectTask,
+              reconnectTask.id == reconnectTaskID,
+              reconnectTask.streamID == streamID,
+              reconnectTask.runGeneration == runGeneration,
+              self.runGeneration == runGeneration
+        else { return false }
+        return activeStreamID == streamID || activeStreamID == nil
+    }
+
+    private func recoveryModelContext(for reconnectTaskID: UUID) -> ModelContext? {
+        guard reconnectTask?.id == reconnectTaskID else { return nil }
+        return reconnectTask?.modelContext
+    }
+
+    private func invalidateReconnectTask() {
+        let task = reconnectTask?.task
+        reconnectTask = nil
+        reconnectTranscriptLoadTaskID = nil
+        task?.cancel()
+    }
+
+    private func invalidateReconnectTaskIfItDoesNotMatchCurrentStream() {
+        guard let reconnectTask,
+              reconnectTask.runGeneration == runGeneration
+        else {
+            invalidateReconnectTask()
+            return
+        }
+
+        if activeStreamID == nil, reconnectTranscriptLoadTaskID == reconnectTask.id {
+            return
+        }
+
+        guard isConnectionSuspended, activeStreamID == reconnectTask.streamID else {
+            invalidateReconnectTask()
+            return
+        }
     }
 
     private func resetRecoveryState() {

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -873,14 +873,24 @@ final class ChatStreamCoordinator {
     }
 
     private func loadMessagesForReconnect(reconnectTaskID: UUID) async -> Bool {
-        guard reconnectTask?.id == reconnectTaskID else { return false }
-        reconnectTranscriptLoadTaskID = reconnectTaskID
-        await delegate?.streamCoordinatorLoadMessages(modelContext: recoveryModelContext(for: reconnectTaskID))
-        let completedLoad = reconnectTranscriptLoadTaskID == reconnectTaskID
-        if completedLoad {
+        while reconnectTask?.id == reconnectTaskID {
+            let modelContext = recoveryModelContext(for: reconnectTaskID)
+            reconnectTranscriptLoadTaskID = reconnectTaskID
+            await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
+            guard reconnectTranscriptLoadTaskID == reconnectTaskID else { return false }
+
+            // The transport-error path can begin recovery without persistence
+            // access. If a foreground caller supplied it while that nil-context
+            // load was in flight, repeat the shared load once so optimistic
+            // messages and the cache participate in reconciliation.
+            if modelContext == nil, recoveryModelContext(for: reconnectTaskID) != nil {
+                continue
+            }
+
             reconnectTranscriptLoadTaskID = nil
+            return true
         }
-        return completedLoad
+        return false
     }
 
     private func reconnectTaskIsCurrent(

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -161,6 +161,51 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testJoiningReconnectRepeatsInFlightNilContextLoadWithModelContext() async throws {
+        let firstLoadSuspended = expectation(description: "nil-context transcript load suspended")
+        let joiningReconnectStarted = expectation(description: "joining reconnect request started")
+        var releaseFirstLoad: CheckedContinuation<Void, Never>?
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            _ = statusRequestCount.increment()
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+        delegate.onLoadMessages = {
+            guard delegate.loadMessagesCount == 1 else { return }
+            await withCheckedContinuation { continuation in
+                releaseFirstLoad = continuation
+                firstLoadSuspended.fulfill()
+            }
+        }
+        let modelContext = try makeModelContext()
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstLoadSuspended], timeout: 1)
+
+        let joiningReconnect = Task { @MainActor in
+            joiningReconnectStarted.fulfill()
+            await coordinator.reconnectIfNeeded(modelContext: modelContext)
+        }
+        await fulfillment(of: [joiningReconnectStarted], timeout: 1)
+
+        let continuation = try XCTUnwrap(releaseFirstLoad)
+        releaseFirstLoad = nil
+        continuation.resume()
+        await firstReconnect.value
+        await joiningReconnect.value
+
+        XCTAssertEqual(statusRequestCount.value, 1)
+        XCTAssertEqual(delegate.loadMessageReceivedModelContextValues, [false, true])
+        XCTAssertEqual(streamClient.startedURLs.count, 2)
+    }
+
+    @MainActor
     func testForegroundReconnectStartsNewRecoveryAfterStreamReplacement() async {
         let firstStatusStarted = expectation(description: "first stream status request started")
         let secondStatusStarted = expectation(description: "second stream status request started")

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -81,6 +81,264 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testConcurrentForegroundReconnectRequestsShareOneRecoveryAttempt() async {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            if statusRequestCount.increment() == 1 {
+                firstStatusStarted.fulfill()
+                releaseFirstStatus.wait()
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        let secondReconnectStarted = expectation(description: "second reconnect request started")
+        let secondReconnectReturned = CoordinatorLockedCounter()
+        let secondReconnect = Task { @MainActor in
+            secondReconnectStarted.fulfill()
+            await coordinator.reconnectIfNeeded()
+            _ = secondReconnectReturned.increment()
+        }
+        await fulfillment(of: [secondReconnectStarted], timeout: 1)
+
+        XCTAssertEqual(statusRequestCount.value, 1)
+        XCTAssertEqual(secondReconnectReturned.value, 0)
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(secondReconnectReturned.value, 1)
+        XCTAssertEqual(delegate.loadMessagesCount, 1)
+        XCTAssertEqual(streamClient.startedURLs.count, 2)
+    }
+
+    @MainActor
+    func testJoiningReconnectUsesNonNilModelContextBeforeTranscriptReload() async throws {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            firstStatusStarted.fulfill()
+            releaseFirstStatus.wait()
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+        let modelContext = try makeModelContext()
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        let joiningReconnectStarted = expectation(description: "joining reconnect request started")
+        let secondReconnect = Task { @MainActor in
+            joiningReconnectStarted.fulfill()
+            await coordinator.reconnectIfNeeded(modelContext: modelContext)
+        }
+        await fulfillment(of: [joiningReconnectStarted], timeout: 1)
+
+        releaseFirstStatus.signal()
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(delegate.loadMessageReceivedModelContextValues, [true])
+    }
+
+    @MainActor
+    func testForegroundReconnectStartsNewRecoveryAfterStreamReplacement() async {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
+                firstStatusStarted.fulfill()
+                releaseFirstStatus.wait()
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-old")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        coordinator.start(streamID: "stream-new")
+        coordinator.suspendActiveStreamConnection()
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        releaseFirstStatus.signal()
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(coordinator.activeStreamID, "stream-new")
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+        XCTAssertEqual(streamClient.startedURLs.count, 3)
+    }
+
+    @MainActor
+    func testForegroundReconnectDoesNotResumeSupersededSameStreamGeneration() async {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
+                firstStatusStarted.fulfill()
+                releaseFirstStatus.wait()
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        releaseFirstStatus.signal()
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(streamClient.startedURLs.count, 3)
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+    }
+
+    @MainActor
+    func testForegroundReconnectStartsNewRecoveryAfterSessionLoadReplacesStream() async {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
+                firstStatusStarted.fulfill()
+                releaseFirstStatus.wait()
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-old")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        let preparation = coordinator.prepareForSessionLoad()
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-new",
+            preparation: preparation,
+            usedCacheFallback: false
+        )
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        releaseFirstStatus.signal()
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(coordinator.activeStreamID, "stream-new")
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+    }
+
+    @MainActor
+    func testForegroundReconnectStartsNewRecoveryAfterPriorStreamFinishesAndNewSessionLoads() async {
+        let firstStatusStarted = expectation(description: "first stream status request started")
+        let secondStatusStarted = expectation(description: "second stream status request started")
+        let releaseFirstStatus = DispatchSemaphore(value: 0)
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            let requestNumber = statusRequestCount.increment()
+            if requestNumber == 1 {
+                firstStatusStarted.fulfill()
+                releaseFirstStatus.wait()
+            } else if requestNumber == 2 {
+                secondStatusStarted.fulfill()
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-new"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-old")
+        coordinator.suspendActiveStreamConnection()
+        let firstReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        await fulfillment(of: [firstStatusStarted], timeout: 1)
+
+        streamClient.emit(.streamEnd)
+        let preparation = coordinator.prepareForSessionLoad()
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-new",
+            preparation: preparation,
+            usedCacheFallback: false
+        )
+        let secondReconnect = Task { @MainActor in
+            await coordinator.reconnectIfNeeded()
+        }
+        releaseFirstStatus.signal()
+        await fulfillment(of: [secondStatusStarted], timeout: 1)
+        await firstReconnect.value
+        await secondReconnect.value
+
+        XCTAssertEqual(statusRequestCount.value, 2)
+        XCTAssertEqual(coordinator.activeStreamID, "stream-new")
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+    }
+
+    @MainActor
     func testForegroundReconnectActiveStreamDoesNotRestartAfterReplacementDuringLoad() async throws {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()
@@ -1187,6 +1445,16 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
         XCTAssertNil(coordinator.activeStreamID)
     }
 
+    private func makeModelContext() throws -> ModelContext {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: CachedSession.self,
+            CachedMessage.self,
+            configurations: configuration
+        )
+        return ModelContext(container)
+    }
+
     @MainActor
     private func makeCoordinator(
         streamClient: CoordinatorSpySSEStreamingClient? = nil,
@@ -1239,6 +1507,7 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
     var streamCoordinatorStreamingAssistantMessageID: String?
 
     private(set) var loadMessagesCount = 0
+    private(set) var loadMessageReceivedModelContextValues: [Bool] = []
     private(set) var startMonitoringCount = 0
     private(set) var stopMonitoringClearPromptValues: [Bool] = []
     private(set) var saveSnapshotCount = 0
@@ -1264,6 +1533,7 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
 
     func streamCoordinatorLoadMessages(modelContext: ModelContext?) async {
         loadMessagesCount += 1
+        loadMessageReceivedModelContextValues.append(modelContext != nil)
         await onLoadMessages?()
     }
 
@@ -1379,6 +1649,24 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
         guard !trimmed.isEmpty else { return false }
         pendingSteerLeftovers.append(trimmed)
         return true
+    }
+}
+
+private final class CoordinatorLockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
     }
 }
 


### PR DESCRIPTION
## Linked issue

Fixes #310

## What changed

- Serialize overlapping foreground reconnect requests behind one recovery task, so they share the status check, transcript reload, and stream restart.
- Key recovery ownership by task, stream, and run generation; cancel and fence stale work when another run or session load takes ownership.
- Let a joining caller provide the `ModelContext` used by the shared transcript reload, including an upgrade that arrives while a nil-context load is already in flight.
- Add deterministic regression coverage for concurrent callers, context upgrades, stream replacement, same-ID generation replacement, and session-load replacement.

The mechanism and regression matrix were adapted from #175 by @TheEpTic; the implementation commit preserves co-author credit.

## How it was tested

- `git diff --check` — passed
- `scripts/check-swift-file-sizes` — warning-only policy passed; existing oversized files reported
- Focused reconnect matrix on iPhone 17 Pro Max, iOS 26.5 — passed
- Full `HermesMobile` XCTest suite on iPhone 17 Pro Max, iOS 26.5 — 1,705 passed, 2 skipped, 0 failed
- PR Build and Test and CI Gate — passed

## Owner manual checks

- Start a long response, background Hermex, then foreground it while recovery begins; confirm the transcript reloads once and streaming resumes.
- During recovery, navigate away and back; confirm there is no duplicate restart, duplicated transcript content, or stale error.
- Repeat with a response that finishes while Hermex is backgrounded; confirm the final transcript and Live Activity settle correctly.

## Follow-up

#315 tracks the pre-existing case where a nil-context reload can discard an uncached optimistic slash-command message. That ChatViewModel reconciliation bug is separate from #310's reconnect-task serialization.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'`)
- [x] New/changed `Codable` models decode tolerantly — not applicable; no model changes
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes; the existing stream-status contract is unchanged

Implemented with GPT-5.6 Sol in Cursor's agent harness.