### PR TITLE
chore: ignore local research notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Config/Local.xcconfig
 # Local reference material
 UPDATES.md
 .obsidian/
+docs/research/
 
 # Local agent tooling (per-machine caches, skills, session state)
 node_modules/


### PR DESCRIPTION
## Linked issue

Maintainer-requested housekeeping before #180. This does not close the issue.

## What changed

Local research notes were showing up as untracked repository work. `docs/research/` is now ignored so those notes stay local.

## How it was tested

- `git diff --check origin/master...HEAD`
- Confirmed the PR diff contains only the `docs/research/` ignore rule
- XCTest not run because this changes Git metadata only

## Checklist

- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination "platform=iOS Simulator,name=iPhone 17"`)
- [x] No new or changed `Codable` models
- [x] No new third-party dependencies
- [x] No API changes

Made by GPT-5.6 Sol through the T3 Code Codex harness.