### PR TITLE
fix(chat): scope reasoning effort changes to sessions

### DIFF
--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -1128,13 +1128,22 @@ final class ChatViewModel {
             return false
         }
 
+        guard let sessionID = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionID.isEmpty else {
+            composerConfigurationErrorMessage = String(localized: "The server did not provide a session ID.")
+            return false
+        }
+
         isUpdatingComposerConfiguration = true
         composerConfigurationErrorMessage = nil
         lastError = nil
         defer { isUpdatingComposerConfiguration = false }
 
         do {
-            let response = try await client.saveReasoningEffort(selectedEffort)
+            let response = try await client.saveReasoningEffort(
+                selectedEffort,
+                sessionID: sessionID
+            )
             selectedReasoningEffort = response.effectiveEffort ?? selectedEffort
             return true
         } catch {
@@ -2852,7 +2861,16 @@ final class ChatViewModel {
             if Self.reasoningDisplayArgs.contains(reasoning) {
                 _ = try await client.saveReasoningDisplay(reasoning)
             } else if Self.reasoningEffortArgs.contains(reasoning) {
-                let response = try await client.saveReasoningEffort(reasoning)
+                guard let sessionID = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !sessionID.isEmpty else {
+                    let message = String(localized: "The server did not provide a session ID.")
+                    composerConfigurationErrorMessage = message
+                    return .unsupported(friendlyMessage: message)
+                }
+                let response = try await client.saveReasoningEffort(
+                    reasoning,
+                    sessionID: sessionID
+                )
                 selectedReasoningEffort = response.effectiveEffort ?? reasoning
             } else {
                 return .unsupported(friendlyMessage: String(localized: "Unknown reasoning level: \(reasoning)."))

--- a/HermesMobile/Networking/APIClient+ServerPanels.swift
+++ b/HermesMobile/Networking/APIClient+ServerPanels.swift
@@ -37,11 +37,14 @@ extension APIClient {
         try await send(endpoint: .reasoning(model: model, provider: provider), method: "GET")
     }
 
-    func saveReasoningEffort(_ effort: String) async throws -> ReasoningStatusResponse {
+    func saveReasoningEffort(
+        _ effort: String,
+        sessionID: String
+    ) async throws -> ReasoningStatusResponse {
         try await send(
             endpoint: .reasoning(),
             method: "POST",
-            body: ReasoningEffortRequest(effort: effort)
+            body: ReasoningEffortRequest(effort: effort, sessionId: sessionID)
         )
     }
 
@@ -184,6 +187,7 @@ private struct DefaultModelRequest: Encodable {
 
 private struct ReasoningEffortRequest: Encodable {
     let effort: String
+    let sessionId: String
 }
 
 private struct ReasoningDisplayRequest: Encodable {

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -329,6 +329,8 @@ final class APIClientConfigurationTests: APIClientTestCase {
             let data = try XCTUnwrap(apiTestBodyData(from: request))
             let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
             XCTAssertEqual(body?["effort"] as? String, "xhigh")
+            XCTAssertEqual(body?["session_id"] as? String, "session-abc")
+            XCTAssertNil(body?["sessionId"])
 
             return apiTestJSONResponse("""
             {
@@ -338,7 +340,10 @@ final class APIClientConfigurationTests: APIClientTestCase {
             """, for: request)
         }
 
-        let response = try await client.saveReasoningEffort("xhigh")
+        let response = try await client.saveReasoningEffort(
+            "xhigh",
+            sessionID: "session-abc"
+        )
 
         XCTAssertEqual(response.ok, true)
         XCTAssertEqual(response.effectiveEffort, "xhigh")

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -6225,6 +6225,9 @@ final class ChatViewModelSendTests: XCTestCase {
         ) { request in
             switch request.url?.path {
             case "/api/reasoning" where request.httpMethod == "POST":
+                let body = try XCTUnwrap(apiTestJSONBody(from: request))
+                XCTAssertEqual(body["effort"] as? String, "xhigh")
+                XCTAssertEqual(body["session_id"] as? String, "session-abc")
                 return apiTestJSONResponse(#"{"ok": true, "reasoning_effort": "xhigh"}"#, for: request)
             case "/api/session/update":
                 return apiTestJSONResponse("""
@@ -6277,6 +6280,58 @@ final class ChatViewModelSendTests: XCTestCase {
         // "xhigh" is not supported by the new model: snap to the server's
         // coerced reasoning_effort.
         XCTAssertEqual(viewModel.selectedReasoningEffort, "high")
+    }
+
+    @MainActor
+    func testReasoningEffortSlashCommandSendsActiveSessionID() async throws {
+        let viewModel = try makeViewModel(
+            sessionSummary: makeSession(model: "gpt-5.4", modelProvider: "openai")
+        ) { request in
+            XCTAssertEqual(request.url?.path, "/api/reasoning")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let body = try XCTUnwrap(apiTestJSONBody(from: request))
+            XCTAssertEqual(body["effort"] as? String, "high")
+            XCTAssertEqual(body["session_id"] as? String, "session-abc")
+            return apiTestJSONResponse(#"{"ok": true, "reasoning_effort": "high"}"#, for: request)
+        }
+
+        let result = await viewModel.executeSlashCommand(
+            try XCTUnwrap(SlashCommandCatalog.command(named: "reasoning")),
+            args: "high"
+        )
+
+        XCTAssertEqual(result, .executed(message: nil))
+        XCTAssertEqual(viewModel.selectedReasoningEffort, "high")
+        XCTAssertNil(viewModel.composerConfigurationErrorMessage)
+    }
+
+    @MainActor
+    func testReasoningEffortChangesWithBlankSessionIDAreBlockedLocally() async throws {
+        let session = SessionSummary(
+            sessionId: "   ",
+            title: "Planning",
+            workspace: "/tmp/workspace",
+            model: "gpt-5.4",
+            modelProvider: "openai"
+        )
+        let viewModel = try makeViewModel(sessionSummary: session) { request in
+            XCTFail("Changing reasoning effort without a session ID must not call \(request.url?.path ?? "nil").")
+            throw URLError(.badURL)
+        }
+
+        let didSelect = await viewModel.selectReasoningEffort("high")
+        XCTAssertFalse(didSelect)
+        XCTAssertEqual(viewModel.composerConfigurationErrorMessage, "The server did not provide a session ID.")
+
+        let slashResult = await viewModel.executeSlashCommand(
+            try XCTUnwrap(SlashCommandCatalog.command(named: "reasoning")),
+            args: "high"
+        )
+        XCTAssertEqual(
+            slashResult,
+            .unsupported(friendlyMessage: "The server did not provide a session ID.")
+        )
+        XCTAssertEqual(viewModel.composerConfigurationErrorMessage, "The server did not provide a session ID.")
     }
 
     @MainActor


### PR DESCRIPTION
## Linked issue

Fixes #180

## What changed

Reasoning effort changes failed with HTTP 400 because Hermex omitted the active session ID. The composer picker and `/reasoning <level>` now send `session_id`, while missing or blank IDs fail locally with a clear message. Display-only reasoning commands remain unchanged.

The issue records the live-server error and source audit for the required request shape. Older handlers ignore the added key, so this remains compatible with the pinned upstream version.

## How it was tested

- XcodeBuildMCP focused run on iPhone 17: 4 passed, 0 failed
- XcodeBuildMCP full suite on iPhone 17: 1,724 passed, 0 failed, 2 skipped
- XcodeBuildMCP simulator build: succeeded
- `git diff --check`: passed
- `scripts/check-swift-file-sizes`: warning-only, with no new oversized file

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination "platform=iOS Simulator,name=iPhone 17"`)
- [x] No response decoding models changed
- [x] No new third-party dependencies
- [x] The request shape comes from the live-server failure and source audit recorded in #180

Implemented by OpenAI gpt-5.6-sol in the T3 Code Codex harness.