### PR TITLE
fix(sessions): continue CLI and messaging sessions

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -71,7 +71,7 @@ struct MessageComposerView: View {
     let isCompressingSession: Bool
     let isWaitingForStream: Bool
     let isCancellingStream: Bool
-    let isOfflineReadOnly: Bool
+    let readOnlyMessage: String?
     let isChromeCompact: Bool
     let errorMessage: String?
     let configurationErrorMessage: String?
@@ -147,6 +147,7 @@ struct MessageComposerView: View {
     @State private var recentModelKeys = ModelRecentsStore.shared.recentKeys
     @State private var keyboardIsVisible = false
     @State private var shouldRestoreFocusAfterPresentation = false
+
     @State private var deferredUploadFocusPhase: DeferredUploadFocusPhase = .none
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
     @State private var showPhotoPicker = false
@@ -158,6 +159,10 @@ struct MessageComposerView: View {
     @State private var didAutoStartVoiceInput = false
     @AppStorage(ComposerSTTProviderPreference.storageKey) private var sttProviderPreferenceRawValue = ComposerSTTProviderPreference.defaultValue.rawValue
     @AppStorage(SectionVisibilitySettings.chatGitKey) private var showsGitControls = true
+
+    private var isReadOnly: Bool {
+        readOnlyMessage != nil
+    }
 
     private enum DeferredUploadFocusPhase: Equatable {
         case none
@@ -311,7 +316,7 @@ struct MessageComposerView: View {
                         isFocused: $isFocused,
                         inputHeight: $textInputHeight,
                         measuredHeight: $textFieldHeight,
-                        isDisabled: isOfflineReadOnly,
+                        isDisabled: isReadOnly,
                         isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
                         verticalPadding: textFieldVerticalPadding,
                         onKeyboardSend: actionButtonTapped,
@@ -447,7 +452,7 @@ struct MessageComposerView: View {
                 workspaceRoots: workspaceRoots,
                 selectedWorkspacePath: displayedWorkspacePath,
                 suggestions: workspaceSuggestions,
-                managementServer: isOfflineReadOnly ? nil : workspaceManagementServer,
+                managementServer: isReadOnly ? nil : workspaceManagementServer,
                 onLoadSuggestions: onLoadWorkspaceSuggestions,
                 onSelect: { path in
                     optimisticWorkspacePath = path
@@ -714,7 +719,7 @@ struct MessageComposerView: View {
                 branches: gitViewModel.branches,
                 isLoading: gitViewModel.isLoadingBranches,
                 isSwitching: gitViewModel.isSwitchingBranch,
-                isDisabled: isOfflineReadOnly || isWaitingForStream,
+                isDisabled: isReadOnly || isWaitingForStream,
                 onSelect: onSelectGitBranch,
                 onCreate: onCreateGitBranch,
                 onRefresh: onRefreshGitBranches
@@ -831,8 +836,8 @@ struct MessageComposerView: View {
     }
 
     private var composerStatus: (text: String, isError: Bool, isDismissible: Bool)? {
-        if isOfflineReadOnly {
-            return (String(localized: "Reconnect to send messages."), false, false)
+        if let readOnlyMessage {
+            return (readOnlyMessage, false, false)
         } else if isWaitingForStream && isCancellingStream {
             return (String(localized: "Stopping response..."), false, false)
         } else if isCompressingSession {
@@ -931,7 +936,7 @@ struct MessageComposerView: View {
     }
 
     private var isConfigurationControlDisabled: Bool {
-        isOfflineReadOnly || isSending || isCompressingSession || isWaitingForStream || isUpdatingConfiguration
+        isReadOnly || isSending || isCompressingSession || isWaitingForStream || isUpdatingConfiguration
     }
 
     private var isVoiceInputDisabled: Bool {
@@ -939,7 +944,7 @@ struct MessageComposerView: View {
             return false
         }
 
-        return isOfflineReadOnly
+        return isReadOnly
             || isSending
             || isCompressingSession
             || isWaitingForStream
@@ -952,7 +957,7 @@ struct MessageComposerView: View {
     /// Recording mid-stream is fine (it queues like any send), so unlike dictation
     /// this does not block on `isWaitingForStream`.
     private var isVoiceNoteRecordingDisabled: Bool {
-        isOfflineReadOnly
+        isReadOnly
             || isSending
             || isSendingVoiceNote
             || isCompressingSession
@@ -1019,7 +1024,7 @@ struct MessageComposerView: View {
     }
 
     private var isActionButtonDisabled: Bool {
-        if isOfflineReadOnly {
+        if isReadOnly {
             return true
         }
 
@@ -1106,7 +1111,7 @@ struct MessageComposerView: View {
     }
 
     private var canFocusTextView: Bool {
-        !isOfflineReadOnly && !isUploadingAttachment && uploadAttachmentErrorMessage == nil
+        !isReadOnly && !isUploadingAttachment && uploadAttachmentErrorMessage == nil
     }
 
     private func prepareForComposerPresentation() {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -399,7 +399,7 @@ struct ChatView: View {
             isCompressingSession: viewModel.isCompressingSession,
             isWaitingForStream: viewModel.activeStreamID != nil,
             isCancellingStream: viewModel.isCancellingStream,
-            isOfflineReadOnly: viewModel.isViewingCachedData,
+            readOnlyMessage: composerReadOnlyMessage,
             isChromeCompact: isComposerChromeCompact,
             errorMessage: viewModel.sendErrorMessage,
             configurationErrorMessage: viewModel.composerConfigurationErrorMessage,
@@ -541,6 +541,26 @@ struct ChatView: View {
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         )
+    }
+
+    private var composerReadOnlyMessage: String? {
+        Self.composerReadOnlyMessage(
+            for: session,
+            isViewingCachedData: viewModel.isViewingCachedData
+        )
+    }
+
+    static func composerReadOnlyMessage(
+        for session: SessionSummary,
+        isViewingCachedData: Bool
+    ) -> String? {
+        if isViewingCachedData {
+            return String(localized: "Reconnect to send messages.")
+        }
+        if session.isSessionReadOnly {
+            return String(localized: "Read-only")
+        }
+        return nil
     }
 
     private func transcriptMediaPreviewView(for item: TranscriptMediaPreviewItem) -> some View {

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -21,7 +21,7 @@ enum SessionRowActionPolicy {
     }
 
     static func canDuplicate(_ session: SessionSummary) -> Bool {
-        offersMutationActions(for: session) && !isExternalSession(session)
+        offersMutationActions(for: session) && !session.requiresExternalImport
     }
 
     static func canExport(_ session: SessionSummary, isViewingCachedData: Bool) -> Bool {
@@ -43,26 +43,6 @@ enum SessionRowActionPolicy {
         return HermesDeepLink.sessionURL(sessionID: sessionID)
     }
 
-    private static func isExternalSession(_ session: SessionSummary) -> Bool {
-        let sessionSource = normalizedSource(session.sessionSource)
-        let rawSource = normalizedSource(session.rawSource) ?? normalizedSource(session.sourceTag)
-        let source = sessionSource ?? rawSource
-
-        if source == "webui" { return false }
-        if sessionSource == "messaging" { return true }
-
-        switch rawSource {
-        case "weixin", "telegram", "discord", "slack", "email", "wecom", "wecom_callback", "matrix":
-            return true
-        default:
-            return session.isCliSession == true
-        }
-    }
-
-    private static func normalizedSource(_ source: String?) -> String? {
-        let normalized = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return normalized?.isEmpty == false ? normalized : nil
-    }
 }
 
 enum SessionListMotion {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -27,6 +27,8 @@ struct SessionListView: View {
     @State private var sessionPendingRename: SessionSummary?
     @State private var sessionPendingDeletion: SessionSummary?
     @State private var sessionPendingProjectCreation: SessionSummary?
+    @State private var sessionOpenErrorMessage: String?
+    @State private var sessionOpenTask: Task<Void, Never>?
     @State private var sessionExportShareItem: SessionExportShareItem?
     @State private var isPresentingProjectCreation = false
     @State private var isPresentingAddServer = false
@@ -146,6 +148,11 @@ struct SessionListView: View {
                 }
                 .presentationDetents([.height(180), .medium])
             }
+            .alert("Session Action Failed", isPresented: sessionOpenErrorIsPresented) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(sessionOpenErrorMessage ?? "")
+            }
             .sheet(item: $sessionPendingProjectCreation) { session in
                 ProjectCreationSheet(
                     existingProjectCount: viewModel.projects.count,
@@ -248,6 +255,10 @@ struct SessionListView: View {
                 openPendingSharedImportIfNeeded()
                 openRequestedNewChatIfNeeded()
                 refreshAfterReturningIfNeeded()
+            }
+            .onDisappear {
+                sessionOpenTask?.cancel()
+                viewModel.invalidateSessionOpening()
             }
             .onChange(of: pendingSharedImport) {
                 openPendingSharedImportIfNeeded()
@@ -470,9 +481,7 @@ struct SessionListView: View {
                     selectedProjectID: $selectedProjectID,
                     projectPendingDeletion: $projectPendingDeletion,
                     projectPendingRename: $projectPendingRename,
-                    openDestination: { destination in
-                        navigationState.select(destination)
-                    },
+                    openDestination: selectDestination,
                     switchActiveProfile: { profile in
                         Task { await switchActiveProfile(profile) }
                     },
@@ -495,7 +504,7 @@ struct SessionListView: View {
                         : nil,
                     userIsExpanded: $scheduledSessionsAreExpanded,
                     actions: sessionRowActions,
-                    viewAll: { navigationState.select(.scheduled) }
+                    viewAll: { selectDestination(.scheduled) }
                 )
             }
 
@@ -636,7 +645,7 @@ struct SessionListView: View {
             if searchChromeIsExpanded {
                 closeSearch()
             } else {
-                navigationState.select(.settings(nil))
+                selectDestination(.settings(nil))
             }
         } label: {
             ZStack {
@@ -683,7 +692,7 @@ struct SessionListView: View {
                         authManager.switchActiveServer(to: account)
                     },
                     addServer: { isPresentingAddServer = true },
-                    manageServers: { navigationState.select(.settings(.servers)) }
+                    manageServers: { selectDestination(.settings(.servers)) }
                 )
             }
         }
@@ -773,7 +782,7 @@ struct SessionListView: View {
 
     private var archivedEntryRow: some View {
         HapticButton {
-            navigationState.select(.archived)
+            selectDestination(.archived)
         } label: {
             HStack(spacing: 12) {
                 Image(systemName: "archivebox")
@@ -933,7 +942,7 @@ struct SessionListView: View {
                 Task { await refreshSessionsAndActiveProfile() }
             },
             open: { session in
-                selectSession(session)
+                startOpeningSession(session)
             },
             togglePinned: { session in
                 Task { await togglePinned(session) }
@@ -1203,7 +1212,7 @@ struct SessionListView: View {
             return
         }
 
-        navigationState.select(
+        selectDestination(
             PendingNewChatRoute(
                 initialDraft: draft,
                 initialAttachments: sharedImport.attachments
@@ -1253,7 +1262,7 @@ struct SessionListView: View {
     private func openRequestedNewChatIfNeeded() {
         guard let request = requestedNewChat else { return }
         requestedNewChat = nil
-        navigationState.select(
+        selectDestination(
             PendingNewChatRoute(
                 autoStartsVoiceInput: request.autoStartsVoiceInput,
                 profileName: request.profileName
@@ -1262,12 +1271,54 @@ struct SessionListView: View {
     }
 
     private func openNewChat() {
-        navigationState.select(PendingNewChatRoute())
+        selectDestination(PendingNewChatRoute())
     }
 
     private func selectSession(_ session: SessionSummary) {
-        navigationState.select(session)
+        selectDestination(session)
         persistLastSelectedSession()
+    }
+
+    private func selectDestination(_ session: SessionSummary) {
+        viewModel.invalidateSessionOpening()
+        navigationState.select(session)
+    }
+
+    private func selectDestination(_ route: PendingNewChatRoute) {
+        viewModel.invalidateSessionOpening()
+        navigationState.select(route)
+    }
+
+    private func selectDestination(_ utility: SessionListUtilityDestination) {
+        viewModel.invalidateSessionOpening()
+        navigationState.select(utility)
+    }
+
+    private func startOpeningSession(_ session: SessionSummary) {
+        sessionOpenTask?.cancel()
+        sessionOpenTask = Task { await openSession(session) }
+    }
+
+    private func openSession(_ session: SessionSummary) async {
+        let sessionToOpen = await viewModel.sessionForOpening(session, modelContext: modelContext)
+        guard !Task.isCancelled else { return }
+
+        if let message = viewModel.actionErrorMessage {
+            sessionOpenErrorMessage = message
+        }
+
+        if let sessionToOpen {
+            selectSession(sessionToOpen)
+        }
+    }
+
+    private var sessionOpenErrorIsPresented: Binding<Bool> {
+        Binding(
+            get: { sessionOpenErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented { sessionOpenErrorMessage = nil }
+            }
+        )
     }
 
     private func rememberCreatedSession(_ session: SessionSummary) {

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -502,37 +502,89 @@ final class SessionListViewModel {
                 return nil
             }
 
-            let importedSession = session.mergingImportedDetail(detail)
-            guard importedSession.sessionId == sessionID else {
+            guard let importedSession = storeOpenedExternalSession(
+                detail,
+                listedSession: session,
+                expectedSessionID: sessionID,
+                modelContext: modelContext
+            ) else {
                 actionErrorMessage = String(localized: "The server did not return the linked session.")
                 return nil
             }
 
-            if let index = sessions.firstIndex(where: { $0.sessionId == sessionID }) {
-                sessions[index] = importedSession
-            }
-
-            if let modelContext, importedSession.shouldAppearInSessionList {
-                do {
-                    try CacheStore.cacheSession(importedSession, serverURL: server, in: modelContext)
-                } catch {
-                    cacheErrorMessage = error.localizedDescription
-                }
-            }
-
             return importedSession
-        } catch {
+        } catch let importError {
             guard !Task.isCancelled,
                   generation == sessionOpenGeneration,
-                  !isCancellationError(error)
+                  !isCancellationError(importError)
             else {
                 return nil
             }
 
-            lastError = error
-            actionErrorMessage = (error as? APIError)?.serverMessage ?? error.localizedDescription
-            return nil
+            // WebUI treats import as a refresh: if it fails, an already imported
+            // session may still be available through the canonical detail route.
+            do {
+                let response = try await client.session(
+                    id: sessionID,
+                    includeMessages: false,
+                    messageLimit: nil
+                )
+                guard !Task.isCancelled, generation == sessionOpenGeneration else { return nil }
+                guard let detail = response.session,
+                      let existingSession = storeOpenedExternalSession(
+                          detail,
+                          listedSession: session,
+                          expectedSessionID: sessionID,
+                          modelContext: modelContext
+                      )
+                else {
+                    recordSessionImportFailure(importError)
+                    return nil
+                }
+
+                return existingSession
+            } catch {
+                guard !Task.isCancelled,
+                      generation == sessionOpenGeneration,
+                      !isCancellationError(error)
+                else {
+                    return nil
+                }
+
+                recordSessionImportFailure(importError)
+                return nil
+            }
         }
+    }
+
+    private func storeOpenedExternalSession(
+        _ detail: SessionDetail,
+        listedSession: SessionSummary,
+        expectedSessionID: String,
+        modelContext: ModelContext?
+    ) -> SessionSummary? {
+        let currentSession = sessions.first(where: { $0.sessionId == expectedSessionID }) ?? listedSession
+        let resolvedSession = currentSession.mergingImportedDetail(detail)
+        guard resolvedSession.sessionId == expectedSessionID else { return nil }
+
+        if let index = sessions.firstIndex(where: { $0.sessionId == expectedSessionID }) {
+            sessions[index] = resolvedSession
+        }
+
+        if let modelContext, resolvedSession.shouldAppearInSessionList {
+            do {
+                try CacheStore.cacheSession(resolvedSession, serverURL: server, in: modelContext)
+            } catch {
+                cacheErrorMessage = error.localizedDescription
+            }
+        }
+
+        return resolvedSession
+    }
+
+    private func recordSessionImportFailure(_ error: Error) {
+        lastError = error
+        actionErrorMessage = (error as? APIError)?.serverMessage ?? error.localizedDescription
     }
 
     func invalidateSessionOpening() {

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -81,6 +81,7 @@ final class SessionListViewModel {
 
     private(set) var remoteContentSearchSessionIDs: [String] = []
     private var activeRemoteSearchQuery: String?
+    private var sessionOpenGeneration = 0
 
     private let client: APIClient
     private let sessionMutator: SessionMutator
@@ -470,6 +471,72 @@ final class SessionListViewModel {
             actionErrorMessage = error.localizedDescription
             return nil
         }
+    }
+
+    /// Imports external sessions before navigation, matching hermes-webui's
+    /// `_openSidebarSession`. A newer tap invalidates any older response so a
+    /// slow import cannot replace the user's current destination.
+    func sessionForOpening(
+        _ session: SessionSummary,
+        modelContext: ModelContext? = nil
+    ) async -> SessionSummary? {
+        sessionOpenGeneration &+= 1
+        let generation = sessionOpenGeneration
+        actionErrorMessage = nil
+        lastError = nil
+
+        guard !isViewingCachedData, session.requiresExternalImport else {
+            return session
+        }
+
+        guard let sessionID = Self.nonEmpty(session.sessionId) else {
+            actionErrorMessage = String(localized: "The server did not provide a session ID.")
+            return nil
+        }
+
+        do {
+            let response = try await client.importExternalSession(id: sessionID)
+            guard !Task.isCancelled, generation == sessionOpenGeneration else { return nil }
+            guard let detail = response.session else {
+                actionErrorMessage = String(localized: "The server did not return the linked session.")
+                return nil
+            }
+
+            let importedSession = SessionSummary(from: detail)
+            guard importedSession.sessionId == sessionID else {
+                actionErrorMessage = String(localized: "The server did not return the linked session.")
+                return nil
+            }
+
+            if let index = sessions.firstIndex(where: { $0.sessionId == sessionID }) {
+                sessions[index] = importedSession
+            }
+
+            if let modelContext, importedSession.shouldAppearInSessionList {
+                do {
+                    try CacheStore.cacheSession(importedSession, serverURL: server, in: modelContext)
+                } catch {
+                    cacheErrorMessage = error.localizedDescription
+                }
+            }
+
+            return importedSession
+        } catch {
+            guard !Task.isCancelled,
+                  generation == sessionOpenGeneration,
+                  !isCancellationError(error)
+            else {
+                return nil
+            }
+
+            lastError = error
+            actionErrorMessage = (error as? APIError)?.serverMessage ?? error.localizedDescription
+            return nil
+        }
+    }
+
+    func invalidateSessionOpening() {
+        sessionOpenGeneration &+= 1
     }
 
     func setPinned(

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -502,7 +502,7 @@ final class SessionListViewModel {
                 return nil
             }
 
-            let importedSession = SessionSummary(from: detail)
+            let importedSession = session.mergingImportedDetail(detail)
             guard importedSession.sessionId == sessionID else {
                 actionErrorMessage = String(localized: "The server did not return the linked session.")
                 return nil

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -70,6 +70,14 @@ struct SessionRowView: View {
             labels.append(String(localized: "Cached"))
         }
 
+        if let sourceLabel = session.sourceDisplayLabel {
+            labels.append(sourceLabel)
+        }
+
+        if session.isSessionReadOnly {
+            labels.append(String(localized: "Read-only"))
+        }
+
         return labels
     }
 
@@ -169,7 +177,7 @@ struct SessionRowView: View {
     private var supplementalArea: some View {
         if dynamicTypeSize.isAccessibilitySize {
             VStack(alignment: .leading, spacing: 4) {
-                if !visibleStateBadges.isEmpty {
+                if showsStateBadges {
                     stateBadgesRow
                 }
 
@@ -179,7 +187,7 @@ struct SessionRowView: View {
             }
         } else {
             HStack(alignment: .firstTextBaseline, spacing: 7) {
-                if !visibleStateBadges.isEmpty {
+                if showsStateBadges {
                     stateBadgesRow
                 }
 
@@ -192,6 +200,10 @@ struct SessionRowView: View {
 
     private var stateBadgesRow: some View {
         HStack(spacing: 5) {
+            if let sourceLabel = session.sourceDisplayLabel {
+                SessionSourceBadge(label: sourceLabel)
+            }
+
             ForEach(visibleStateBadges) { badge in
                 SessionRowStateBadge(badge: badge)
             }
@@ -218,11 +230,19 @@ struct SessionRowView: View {
             badges.append(.cached)
         }
 
+        if session.isSessionReadOnly {
+            badges.append(.readOnly)
+        }
+
         return badges
     }
 
+    private var showsStateBadges: Bool {
+        session.sourceDisplayLabel != nil || !visibleStateBadges.isEmpty
+    }
+
     private var showsSupplementalContent: Bool {
-        metadataLabel != nil || !visibleStateBadges.isEmpty
+        metadataLabel != nil || showsStateBadges
     }
 
     private var rowContentSpacing: CGFloat {
@@ -275,6 +295,7 @@ struct SessionRowView: View {
 private enum SessionRowStateBadgeKind: String, Identifiable {
     case streaming
     case cached
+    case readOnly
 
     var id: String { rawValue }
 
@@ -284,6 +305,8 @@ private enum SessionRowStateBadgeKind: String, Identifiable {
             return String(localized: "Live")
         case .cached:
             return String(localized: "Cached")
+        case .readOnly:
+            return String(localized: "Read-only")
         }
     }
 
@@ -293,7 +316,23 @@ private enum SessionRowStateBadgeKind: String, Identifiable {
             return .green
         case .cached:
             return .orange
+        case .readOnly:
+            return .gray
         }
+    }
+}
+
+private struct SessionSourceBadge: View {
+    let label: String
+
+    var body: some View {
+        Text(label)
+            .font(AppFont.caption2(weight: .semibold))
+            .foregroundStyle(Color.accentColor)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(Color.accentColor.opacity(0.12), in: Capsule())
+            .accessibilityHidden(true)
     }
 }
 

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -176,23 +176,37 @@ struct SessionRowView: View {
     @ViewBuilder
     private var supplementalArea: some View {
         if dynamicTypeSize.isAccessibilitySize {
-            VStack(alignment: .leading, spacing: 4) {
-                if showsStateBadges {
-                    stateBadgesRow
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
+                    if !visibleStateBadges.isEmpty {
+                        stateBadgesRow
+                    }
+
+                    if let metadataLabel {
+                        metadataText(metadataLabel)
+                    }
                 }
 
-                if let metadataLabel {
-                    metadataText(metadataLabel)
+                Spacer(minLength: 8)
+
+                if let sourceLabel = session.sourceDisplayLabel {
+                    SessionSourceBadge(label: sourceLabel)
                 }
             }
         } else {
             HStack(alignment: .firstTextBaseline, spacing: 7) {
-                if showsStateBadges {
+                if !visibleStateBadges.isEmpty {
                     stateBadgesRow
                 }
 
                 if let metadataLabel {
                     metadataText(metadataLabel)
+                }
+
+                Spacer(minLength: 8)
+
+                if let sourceLabel = session.sourceDisplayLabel {
+                    SessionSourceBadge(label: sourceLabel)
                 }
             }
         }
@@ -200,10 +214,6 @@ struct SessionRowView: View {
 
     private var stateBadgesRow: some View {
         HStack(spacing: 5) {
-            if let sourceLabel = session.sourceDisplayLabel {
-                SessionSourceBadge(label: sourceLabel)
-            }
-
             ForEach(visibleStateBadges) { badge in
                 SessionRowStateBadge(badge: badge)
             }

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -410,6 +410,46 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         matchType = nil
     }
 
+    /// Applies the import response without dropping list metadata that the
+    /// detail endpoint does not consistently return.
+    func mergingImportedDetail(_ detail: SessionDetail) -> SessionSummary {
+        let imported = SessionSummary(from: detail)
+        return SessionSummary(
+            sessionId: imported.sessionId ?? sessionId,
+            title: imported.title ?? title,
+            workspace: imported.workspace ?? workspace,
+            model: imported.model ?? model,
+            modelProvider: imported.modelProvider ?? modelProvider,
+            messageCount: imported.messageCount ?? messageCount,
+            createdAt: imported.createdAt ?? createdAt,
+            updatedAt: imported.updatedAt ?? updatedAt,
+            lastMessageAt: imported.lastMessageAt ?? lastMessageAt,
+            pinned: imported.pinned ?? pinned,
+            archived: imported.archived ?? archived,
+            projectId: imported.projectId ?? projectId,
+            profile: imported.profile ?? profile,
+            inputTokens: imported.inputTokens ?? inputTokens,
+            outputTokens: imported.outputTokens ?? outputTokens,
+            estimatedCost: imported.estimatedCost ?? estimatedCost,
+            activeStreamId: imported.activeStreamId ?? activeStreamId,
+            isStreaming: imported.isStreaming ?? isStreaming,
+            isCliSession: imported.isCliSession ?? isCliSession,
+            userMessageCount: imported.userMessageCount ?? userMessageCount,
+            hasPendingUserMessage: imported.hasPendingUserMessage ?? hasPendingUserMessage,
+            pendingStartedAt: imported.pendingStartedAt ?? pendingStartedAt,
+            worktreePath: imported.worktreePath ?? worktreePath,
+            sourceTag: imported.sourceTag ?? sourceTag,
+            rawSource: imported.rawSource ?? rawSource,
+            sessionSource: imported.sessionSource ?? sessionSource,
+            sourceLabel: imported.sourceLabel ?? sourceLabel,
+            parentSessionId: imported.parentSessionId ?? parentSessionId,
+            relationshipType: imported.relationshipType ?? relationshipType,
+            readOnly: imported.readOnly ?? readOnly,
+            isReadOnly: imported.isReadOnly ?? isReadOnly,
+            matchType: imported.matchType ?? matchType
+        )
+    }
+
     /// Mirrors all stored fields so local title patches preserve session-list metadata.
     /// Update this when `SessionSummary` gains a new stored property.
     func replacingTitle(with title: String) -> SessionSummary {

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -451,6 +451,11 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
 }
 
 extension SessionSummary {
+    private static let messagingSourceMarkers: Set<String> = [
+        "discord", "email", "matrix", "slack", "telegram", "wecom", "wecom_callback", "weixin"
+    ]
+    private static let cliSourceMarkers: Set<String> = ["acp", "cli", "desktop", "tui"]
+
     /// Delegated children are identified only by an explicit source marker.
     /// Parent linkage is shared by ordinary forks and compression continuations,
     /// so it must never classify a row as a subagent on its own.
@@ -474,6 +479,56 @@ extension SessionSummary {
     /// true value preserves that safety for other imported sessions.
     var isSessionReadOnly: Bool {
         isDelegatedSubagentSession || readOnly == true || isReadOnly == true
+    }
+
+    /// External sessions need the same import step hermes-webui performs before
+    /// opening them. An explicit WebUI source wins over stale CLI flags left on
+    /// an already-imported sidecar.
+    var requiresExternalImport: Bool {
+        if Self.normalizedSourceMarker(sessionSource) == "webui" { return false }
+        if Self.normalizedSourceMarker(sessionSource) == "messaging" { return true }
+
+        let markers = [rawSource, sourceTag, sourceLabel]
+            .compactMap(Self.normalizedSourceMarker)
+        return isCliSession == true
+            || markers.contains(where: Self.messagingSourceMarkers.contains)
+            || markers.contains(where: Self.cliSourceMarkers.contains)
+    }
+
+    /// The source chip shown by hermes-webui, preferring the server's label and
+    /// falling back to stable brand/acronym casing for older servers.
+    var sourceDisplayLabel: String? {
+        guard requiresExternalImport else { return nil }
+
+        if let label = Self.nonEmpty(sourceLabel), label.lowercased() != "webui" {
+            return label
+        }
+
+        let marker = [rawSource, sourceTag, sessionSource]
+            .compactMap(Self.normalizedSourceMarker)
+            .first { $0 != "messaging" && $0 != "webui" }
+
+        switch marker {
+        case "cli": return "CLI"
+        case "tui": return "TUI"
+        case "acp": return "ACP"
+        case "telegram": return "Telegram"
+        case "discord": return "Discord"
+        case "slack": return "Slack"
+        case "email": return "Email"
+        case "matrix": return "Matrix"
+        case "weixin": return "WeChat"
+        case "wecom": return "WeCom"
+        case "wecom_callback": return "WeCom Callback"
+        case "desktop": return "Desktop"
+        case let marker?:
+            return marker
+                .replacingOccurrences(of: "_", with: " ")
+                .replacingOccurrences(of: "-", with: " ")
+                .capitalized
+        case nil:
+            return isCliSession == true ? "CLI" : "Messaging"
+        }
     }
 
     var shouldAppearInSessionList: Bool {

--- a/HermesMobile/Networking/APIClient+Sessions.swift
+++ b/HermesMobile/Networking/APIClient+Sessions.swift
@@ -49,6 +49,16 @@ extension APIClient {
         try await send(endpoint: .sessionStatus(id: id), method: "GET")
     }
 
+    /// Imports a CLI or messaging session into the WebUI-owned session store.
+    /// The returned session is authoritative for whether continuation is safe.
+    func importExternalSession(id: String) async throws -> SessionResponse {
+        try await send(
+            endpoint: .importCLISession,
+            method: "POST",
+            body: SessionIDRequest(sessionId: id)
+        )
+    }
+
     func createSession(workspace: String?, model: String?, modelProvider: String?, profile: String?) async throws -> SessionResponse {
         try await send(
             endpoint: .newSession,

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -9,6 +9,7 @@ enum Endpoint {
     case sessionsSearch(query: String, content: Bool, depth: Int)
     case session(id: String, includeMessages: Bool, messageLimit: Int?, messageBefore: Int?, expandRenderable: Bool = false)
     case sessionStatus(id: String)
+    case importCLISession
     case newSession
     case renameSession
     case deleteSession
@@ -146,6 +147,8 @@ enum Endpoint {
             return "/api/session"
         case .sessionStatus:
             return "/api/session/status"
+        case .importCLISession:
+            return "/api/session/import_cli"
         case .newSession:
             return "/api/session/new"
         case .renameSession:

--- a/HermesMobileTests/APIClientSessionListTests.swift
+++ b/HermesMobileTests/APIClientSessionListTests.swift
@@ -7,6 +7,39 @@ import UniformTypeIdentifiers
 @testable import HermesMobile
 
 final class APIClientSessionListTests: APIClientTestCase {
+    func testImportExternalSessionPostsSessionIDAndDecodesSourceMetadata() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/session/import_cli")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+            let body = try XCTUnwrap(apiTestBodyData(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+            XCTAssertEqual(json, ["session_id": "telegram-1"])
+
+            return apiTestJSONResponse("""
+            {
+              "session": {
+                "session_id": "telegram-1",
+                "title": "Support chat",
+                "is_cli_session": true,
+                "raw_source": "telegram",
+                "session_source": "messaging",
+                "source_label": "Telegram",
+                "read_only": false
+              },
+              "imported": true
+            }
+            """, for: request)
+        }
+
+        let response = try await client.importExternalSession(id: "telegram-1")
+
+        XCTAssertEqual(response.session?.sessionId, "telegram-1")
+        XCTAssertEqual(response.session?.sourceLabel, "Telegram")
+        XCTAssertEqual(response.session?.readOnly, false)
+    }
+
     func testSessionsDecodesSnakeCaseResponse() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/sessions")

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -56,6 +56,7 @@ final class ContractReadinessTests: XCTestCase {
                 path: "/api/session/status",
                 query: ["session_id": "session-123"]
             ),
+            .init(name: "import external session", method: "POST", endpoint: .importCLISession, path: "/api/session/import_cli"),
             .init(name: "new session", method: "POST", endpoint: .newSession, path: "/api/session/new"),
             .init(name: "rename session", method: "POST", endpoint: .renameSession, path: "/api/session/rename"),
             .init(name: "delete session", method: "POST", endpoint: .deleteSession, path: "/api/session/delete"),

--- a/HermesMobileTests/CacheStoreTests.swift
+++ b/HermesMobileTests/CacheStoreTests.swift
@@ -150,6 +150,33 @@ final class CacheStoreTests: XCTestCase {
         XCTAssertEqual(cached.filter(hidden.shows).compactMap(\.sessionId), ["ordinary-cli"])
     }
 
+    func testCachedSessionsPreserveExternalSourceLabelAndImportClassification() throws {
+        let context = try makeContext()
+        let serverURL = URL(string: "https://example.test")!
+        let cachedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let session = SessionSummary(
+            sessionId: "telegram",
+            title: "Support chat",
+            archived: false,
+            isCliSession: true,
+            rawSource: "telegram",
+            sessionSource: "messaging",
+            sourceLabel: "Telegram"
+        )
+
+        try CacheStore.cacheSession(session, serverURL: serverURL, in: context, cachedAt: cachedAt)
+
+        let cached = try XCTUnwrap(
+            CacheStore.cachedSessions(
+                serverURL: serverURL,
+                in: context,
+                now: cachedAt.addingTimeInterval(60)
+            ).first
+        )
+        XCTAssertTrue(cached.requiresExternalImport)
+        XCTAssertEqual(cached.sourceDisplayLabel, "Telegram")
+    }
+
     func testCacheMessagesWritesLoadedWindowAndRemovesStaleMessages() throws {
         let context = try makeContext()
         let serverURL = URL(string: "https://example.test")!

--- a/HermesMobileTests/SessionIdentityTests.swift
+++ b/HermesMobileTests/SessionIdentityTests.swift
@@ -101,6 +101,80 @@ final class SessionIdentityTests: XCTestCase {
         )
     }
 
+    func testExternalSessionSourceLabelsPreferServerValueAndUseStableFallbacks() {
+        let serverLabeled = SessionSummary(
+            sessionId: "telegram",
+            isCliSession: true,
+            rawSource: "telegram",
+            sessionSource: "messaging",
+            sourceLabel: "Telegram Business"
+        )
+        let legacyTelegram = SessionSummary(
+            sessionId: "legacy-telegram",
+            rawSource: "telegram",
+            sessionSource: "messaging"
+        )
+        let legacyCLI = SessionSummary(sessionId: "cli", sourceTag: "cli")
+
+        XCTAssertTrue(serverLabeled.requiresExternalImport)
+        XCTAssertEqual(serverLabeled.sourceDisplayLabel, "Telegram Business")
+        XCTAssertTrue(legacyTelegram.requiresExternalImport)
+        XCTAssertEqual(legacyTelegram.sourceDisplayLabel, "Telegram")
+        XCTAssertTrue(legacyCLI.requiresExternalImport)
+        XCTAssertEqual(legacyCLI.sourceDisplayLabel, "CLI")
+    }
+
+    func testWebUISourceOverridesStaleCLIFlag() {
+        let imported = SessionSummary(
+            sessionId: "imported",
+            isCliSession: true,
+            rawSource: "telegram",
+            sessionSource: "webui",
+            sourceLabel: "WebUI"
+        )
+
+        XCTAssertFalse(imported.requiresExternalImport)
+        XCTAssertNil(imported.sourceDisplayLabel)
+    }
+
+    func testSessionRowAccessibilityIncludesSourceAndReadOnlyState() {
+        let session = SessionSummary(
+            sessionId: "telegram",
+            isCliSession: true,
+            rawSource: "telegram",
+            sourceLabel: "Telegram",
+            readOnly: true
+        )
+
+        XCTAssertEqual(
+            SessionRowView.accessibilityStateLabels(for: session, isViewingCachedData: false),
+            ["Telegram", "Read-only"]
+        )
+    }
+
+    func testChatComposerReadOnlyMessageUsesServerAndOfflineState() {
+        XCTAssertEqual(
+            ChatView.composerReadOnlyMessage(
+                for: SessionSummary(sessionId: "read-only", readOnly: true),
+                isViewingCachedData: false
+            ),
+            "Read-only"
+        )
+        XCTAssertEqual(
+            ChatView.composerReadOnlyMessage(
+                for: SessionSummary(sessionId: "offline"),
+                isViewingCachedData: true
+            ),
+            "Reconnect to send messages."
+        )
+        XCTAssertNil(
+            ChatView.composerReadOnlyMessage(
+                for: SessionSummary(sessionId: "writable"),
+                isViewingCachedData: false
+            )
+        )
+    }
+
     func testSessionSummaryFallbackIDIsDeterministicWithoutSessionID() throws {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2394,9 +2394,123 @@ final class SessionListMutationTests: XCTestCase {
     }
 
     @MainActor
+    func testOpeningExternalSessionFallsBackToCanonicalDetailAndRemainsRefreshable() async throws {
+        var requestedPaths: [String] = []
+        let viewModel = try makeViewModel { request in
+            let path = request.url?.path ?? "nil"
+            requestedPaths.append(path)
+
+            switch path {
+            case "/api/sessions":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [{
+                    "session_id": "telegram-existing",
+                    "title": "Support chat",
+                    "is_cli_session": true,
+                    "raw_source": "telegram",
+                    "source_label": "Telegram"
+                  }]
+                }
+                """, for: request)
+            case "/api/session/import_cli":
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 503,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+                return (try XCTUnwrap(response), Data(#"{"error":"Refresh unavailable"}"#.utf8))
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "telegram-existing",
+                    "title": "Support chat",
+                    "workspace": "/workspace",
+                    "is_cli_session": true,
+                    "raw_source": "telegram",
+                    "source_label": "Telegram",
+                    "read_only": false,
+                    "messages": []
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(path)")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        let listed = try XCTUnwrap(viewModel.sessions.first)
+        let firstOpen = await viewModel.sessionForOpening(listed)
+        let secondOpen = await viewModel.sessionForOpening(try XCTUnwrap(firstOpen))
+
+        XCTAssertEqual(firstOpen?.sessionId, "telegram-existing")
+        XCTAssertEqual(secondOpen?.sessionId, "telegram-existing")
+        XCTAssertEqual(viewModel.sessions.first, secondOpen)
+        XCTAssertNil(viewModel.actionErrorMessage)
+        XCTAssertEqual(
+            requestedPaths,
+            [
+                "/api/sessions",
+                "/api/session/import_cli",
+                "/api/session",
+                "/api/session/import_cli",
+                "/api/session"
+            ]
+        )
+    }
+
+    @MainActor
+    func testOpeningExternalSessionCanonicalFallbackKeepsReadOnlyAuthority() async throws {
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/session/import_cli":
+                throw URLError(.timedOut)
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "telegram-read-only",
+                    "is_cli_session": true,
+                    "raw_source": "telegram",
+                    "source_label": "Telegram",
+                    "read_only": true,
+                    "messages": []
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+        let listed = SessionSummary(
+            sessionId: "telegram-read-only",
+            isCliSession: true,
+            rawSource: "telegram",
+            sourceLabel: "Telegram"
+        )
+
+        let result = await viewModel.sessionForOpening(listed)
+        let opened = try XCTUnwrap(result)
+
+        XCTAssertTrue(opened.isSessionReadOnly)
+        XCTAssertEqual(
+            ChatView.composerReadOnlyMessage(for: opened, isViewingCachedData: false),
+            "Read-only"
+        )
+        XCTAssertNil(viewModel.actionErrorMessage)
+    }
+
+    @MainActor
     func testOpeningExternalSessionFailureKeepsRowAndSurfacesServerMessage() async throws {
         let serverMessage = "Messaging sessions cannot be imported"
+        var requestedPaths: [String] = []
         let viewModel = try makeViewModel { request in
+            requestedPaths.append(request.url?.path ?? "nil")
             switch request.url?.path {
             case "/api/sessions":
                 return apiTestJSONResponse("""
@@ -2418,6 +2532,8 @@ final class SessionListMutationTests: XCTestCase {
                     headerFields: ["Content-Type": "application/json"]
                 )
                 return (try XCTUnwrap(response), Data(#"{"error":"\#(serverMessage)"}"#.utf8))
+            case "/api/session":
+                throw URLError(.cannotFindHost)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)
@@ -2432,6 +2548,64 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertEqual(viewModel.sessions, [listed])
         XCTAssertEqual(viewModel.actionErrorMessage, serverMessage)
         XCTAssertNotNil(viewModel.lastError)
+        XCTAssertEqual(
+            requestedPaths,
+            ["/api/sessions", "/api/session/import_cli", "/api/session"]
+        )
+    }
+
+    @MainActor
+    func testStaleCanonicalFallbackCannotReplaceNewerDestination() async throws {
+        let detailRequestStarted = expectation(description: "canonical fallback request started")
+        let releaseDetailRequest = DispatchSemaphore(value: 0)
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/session/import_cli":
+                throw URLError(.timedOut)
+            case "/api/session":
+                detailRequestStarted.fulfill()
+                releaseDetailRequest.wait()
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "telegram-stale",
+                    "title": "Stale result",
+                    "is_cli_session": true,
+                    "raw_source": "telegram"
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+        let staleSession = SessionSummary(
+            sessionId: "telegram-stale",
+            title: "Original title",
+            isCliSession: true,
+            rawSource: "telegram"
+        )
+        let newerDestination = SessionSummary(
+            sessionId: "webui-newer",
+            title: "Newer destination",
+            sessionSource: "webui"
+        )
+
+        let staleOpen = Task { @MainActor in
+            await viewModel.sessionForOpening(staleSession)
+        }
+        await fulfillment(of: [detailRequestStarted], timeout: 1)
+
+        let openedNewerDestination = await viewModel.sessionForOpening(newerDestination)
+        releaseDetailRequest.signal()
+        let staleResult = await staleOpen.value
+
+        XCTAssertEqual(openedNewerDestination, newerDestination)
+        XCTAssertNil(staleResult)
+        XCTAssertTrue(viewModel.sessions.isEmpty)
+        XCTAssertNil(viewModel.actionErrorMessage)
+        XCTAssertNil(viewModel.lastError)
     }
 
     @MainActor

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2297,6 +2297,11 @@ final class SessionListMutationTests: XCTestCase {
                   "sessions": [{
                     "session_id": "telegram-1",
                     "title": "Support chat",
+                    "pinned": true,
+                    "project_id": "support",
+                    "last_message_at": 1770000123,
+                    "active_stream_id": "stream-live",
+                    "is_streaming": true,
                     "is_cli_session": true,
                     "raw_source": "telegram",
                     "session_source": "messaging",
@@ -2335,12 +2340,22 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertEqual(opened?.sessionId, "telegram-1")
         XCTAssertEqual(opened?.sourceDisplayLabel, "Telegram")
         XCTAssertEqual(opened?.readOnly, false)
+        XCTAssertEqual(opened?.pinned, true)
+        XCTAssertEqual(opened?.projectId, "support")
+        XCTAssertEqual(opened?.lastMessageAt, 1_770_000_123)
+        XCTAssertEqual(opened?.activeStreamId, "stream-live")
+        XCTAssertEqual(opened?.isStreaming, true)
         XCTAssertEqual(viewModel.sessions.first, opened)
         let cached = try XCTUnwrap(
             CacheStore.cachedSessions(serverURL: URL(string: "https://example.test")!, in: context).first
         )
         XCTAssertEqual(cached.sourceDisplayLabel, "Telegram")
         XCTAssertEqual(cached.readOnly, false)
+        XCTAssertEqual(cached.pinned, true)
+        XCTAssertEqual(cached.projectId, "support")
+        XCTAssertEqual(cached.lastMessageAt, 1_770_000_123)
+        XCTAssertEqual(cached.activeStreamId, "stream-live")
+        XCTAssertEqual(cached.isStreaming, true)
     }
 
     @MainActor

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2287,6 +2287,155 @@ final class SessionListMutationTests: XCTestCase {
     }
 
     @MainActor
+    func testOpeningExternalSessionImportsAndCachesAuthoritativeSession() async throws {
+        let context = try makeContext()
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [{
+                    "session_id": "telegram-1",
+                    "title": "Support chat",
+                    "is_cli_session": true,
+                    "raw_source": "telegram",
+                    "session_source": "messaging",
+                    "source_label": "Telegram"
+                  }]
+                }
+                """, for: request)
+            case "/api/session/import_cli":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "telegram-1",
+                    "title": "Support chat",
+                    "workspace": "/workspace",
+                    "model": "test-model",
+                    "is_cli_session": true,
+                    "raw_source": "telegram",
+                    "session_source": "messaging",
+                    "source_label": "Telegram",
+                    "read_only": false,
+                    "messages": []
+                  },
+                  "imported": true
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load(modelContext: context)
+        let listed = try XCTUnwrap(viewModel.sessions.first)
+        let opened = await viewModel.sessionForOpening(listed, modelContext: context)
+
+        XCTAssertEqual(opened?.sessionId, "telegram-1")
+        XCTAssertEqual(opened?.sourceDisplayLabel, "Telegram")
+        XCTAssertEqual(opened?.readOnly, false)
+        XCTAssertEqual(viewModel.sessions.first, opened)
+        let cached = try XCTUnwrap(
+            CacheStore.cachedSessions(serverURL: URL(string: "https://example.test")!, in: context).first
+        )
+        XCTAssertEqual(cached.sourceDisplayLabel, "Telegram")
+        XCTAssertEqual(cached.readOnly, false)
+    }
+
+    @MainActor
+    func testOpeningExternalReadOnlySessionKeepsComposerBlocked() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/session/import_cli")
+            return apiTestJSONResponse("""
+            {
+              "session": {
+                "session_id": "telegram-read-only",
+                "is_cli_session": true,
+                "raw_source": "telegram",
+                "source_label": "Telegram",
+                "read_only": true,
+                "messages": []
+              },
+              "imported": false
+            }
+            """, for: request)
+        }
+        let listed = SessionSummary(
+            sessionId: "telegram-read-only",
+            isCliSession: true,
+            rawSource: "telegram",
+            sourceLabel: "Telegram"
+        )
+
+        let result = await viewModel.sessionForOpening(listed)
+        let opened = try XCTUnwrap(result)
+
+        XCTAssertTrue(opened.isSessionReadOnly)
+        XCTAssertEqual(
+            ChatView.composerReadOnlyMessage(for: opened, isViewingCachedData: false),
+            "Read-only"
+        )
+    }
+
+    @MainActor
+    func testOpeningExternalSessionFailureKeepsRowAndSurfacesServerMessage() async throws {
+        let serverMessage = "Messaging sessions cannot be imported"
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [{
+                    "session_id": "telegram-1",
+                    "title": "Support chat",
+                    "is_cli_session": true,
+                    "raw_source": "telegram",
+                    "source_label": "Telegram"
+                  }]
+                }
+                """, for: request)
+            case "/api/session/import_cli":
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 403,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+                return (try XCTUnwrap(response), Data(#"{"error":"\#(serverMessage)"}"#.utf8))
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        let listed = try XCTUnwrap(viewModel.sessions.first)
+        let opened = await viewModel.sessionForOpening(listed)
+
+        XCTAssertNil(opened)
+        XCTAssertEqual(viewModel.sessions, [listed])
+        XCTAssertEqual(viewModel.actionErrorMessage, serverMessage)
+        XCTAssertNotNil(viewModel.lastError)
+    }
+
+    @MainActor
+    func testOpeningWebUISessionSkipsImportRequest() async throws {
+        var requestedPaths: [String] = []
+        let viewModel = try makeViewModel { request in
+            requestedPaths.append(request.url?.path ?? "nil")
+            XCTFail("WebUI sessions must not reach the import endpoint.")
+            throw URLError(.badURL)
+        }
+        let session = SessionSummary(sessionId: "webui", sessionSource: "webui")
+
+        let opened = await viewModel.sessionForOpening(session)
+
+        XCTAssertEqual(opened, session)
+        XCTAssertTrue(requestedPaths.isEmpty)
+    }
+
+    @MainActor
     func testDuplicatePolicyRejectsExternalSessionsBeforeAnyRequest() async throws {
         var requestedPaths: [String] = []
         let viewModel = try makeViewModel { request in


### PR DESCRIPTION
## Linked issue

Fixes #211

## What changed

Hermex now labels external sessions with their source, including CLI and messaging providers such as Telegram. Opening one follows hermes-webui by importing it into the WebUI session store before navigating, then uses the returned session metadata as authoritative. Import failures remain on the list and surface the server error; sessions the server keeps read-only open with a disabled composer.

The contract was verified against hermes-webui `_openSidebarSession` and `_handle_session_import_cli` at upstream commit `399cd7ab19ce43f77d3c3a68bb575e9eed9cd6af`: `POST /api/session/import_cli` with `session_id`, returning `{ session, imported }`.

## How it was tested

- Full XCTest suite: `xcodebuild -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,id=E78D6EDB-57C9-4A73-8B9A-12116F87A974' test` — passed
- Signed Debug build for iPhone 17 — built, installed, and launched successfully
- Focused coverage for endpoint/body decoding, source labels, cache round-trips, authoritative imports, read-only imports, failure rollback, and WebUI bypass

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes

Implemented by GPT-5.6 Sol in T3 Code through the Codex harness.