### PR TITLE
fix(voice): let Server First dictation run until the user stops it

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		C03250000000000000B104 /* ComposerVoiceNoteRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */; };
 		C03250000000000000B105 /* APIClientTranscribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F105 /* APIClientTranscribeTests.swift */; };
 		C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */; };
+		C03251000000000000B106 /* ComposerVoiceInputServerRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03251000000000000F106 /* ComposerVoiceInputServerRecordingTests.swift */; };
 		C03260000000000000B101 /* APIClient+TTS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F101 /* APIClient+TTS.swift */; };
 		C03270000000000000B101 /* APIClient+SessionExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03270000000000000F101 /* APIClient+SessionExport.swift */; };
 		C03260000000000000B102 /* APIClientTTSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03260000000000000F102 /* APIClientTTSTests.swift */; };
@@ -566,6 +567,7 @@
 		C03250000000000000F104 /* ComposerVoiceNoteRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorder.swift; sourceTree = "<group>"; };
 		C03250000000000000F105 /* APIClientTranscribeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTranscribeTests.swift; sourceTree = "<group>"; };
 		C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceNoteRecorderTests.swift; sourceTree = "<group>"; };
+		C03251000000000000F106 /* ComposerVoiceInputServerRecordingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVoiceInputServerRecordingTests.swift; sourceTree = "<group>"; };
 		C03260000000000000F101 /* APIClient+TTS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+TTS.swift"; sourceTree = "<group>"; };
 		C03270000000000000F101 /* APIClient+SessionExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+SessionExport.swift"; sourceTree = "<group>"; };
 		C03260000000000000F102 /* APIClientTTSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTTSTests.swift; sourceTree = "<group>"; };
@@ -795,6 +797,7 @@
 				C03260000000000000F102 /* APIClientTTSTests.swift */,
 				C03270000000000000F102 /* APIClientSessionExportTests.swift */,
 				C03250000000000000F106 /* ComposerVoiceNoteRecorderTests.swift */,
+				C03251000000000000F106 /* ComposerVoiceInputServerRecordingTests.swift */,
 					C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */,
 					C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */,
 					C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */,
@@ -1667,6 +1670,7 @@
 				C03260000000000000B102 /* APIClientTTSTests.swift in Sources */,
 				C03270000000000000B102 /* APIClientSessionExportTests.swift in Sources */,
 				C03250000000000000B106 /* ComposerVoiceNoteRecorderTests.swift in Sources */,
+				C03251000000000000B106 /* ComposerVoiceInputServerRecordingTests.swift in Sources */,
 					C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */,
 					C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */,
 					C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -34,7 +34,6 @@ final class ComposerVoiceInputController {
     private var activatedAudioSessionForRecording = false
     private var audioTapInstalled = false
     @ObservationIgnored private var transcriptionTask: Task<Void, Never>?
-    @ObservationIgnored private var serverRecordingTimeoutTask: Task<Void, Never>?
     private var activeTranscriptionID: UUID?
     private let logger = Logger.hermesVoiceInput
 
@@ -261,15 +260,18 @@ final class ComposerVoiceInputController {
 
     // MARK: - Server STT
 
-    private static let maxServerRecordingDuration: UInt64 = 60
-
-    private static let serverRecordingSettings: [String: Any] = [
-        AVFormatIDKey: Int(kAudioFormatLinearPCM),
-        AVSampleRateKey: 16_000.0,
+    // Mono AAC at a speech bitrate keeps long recordings far below the server's
+    // upload ceiling (~14 MB/hour against a 20 MB default), so recording runs
+    // until the user stops it rather than being cut off by a duration cap.
+    static let serverRecordingSettings: [String: Any] = [
+        AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+        AVSampleRateKey: 44_100.0,
         AVNumberOfChannelsKey: 1,
-        AVLinearPCMBitDepthKey: 16,
-        AVLinearPCMIsFloatKey: false
+        AVEncoderBitRateKey: serverRecordingBitrate
     ]
+
+    static let serverRecordingBitrate = 32_000
+    static let serverRecordingFileExtension = "m4a"
 
     private func startServerRecording() throws {
         stopAudio(cancelTask: true)
@@ -292,7 +294,7 @@ final class ComposerVoiceInputController {
 
         let recordingURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("hermex-composer-stt-\(UUID().uuidString)")
-            .appendingPathExtension("wav")
+            .appendingPathExtension(Self.serverRecordingFileExtension)
         let recorder = try AVAudioRecorder(url: recordingURL, settings: Self.serverRecordingSettings)
         recorder.prepareToRecord()
         guard recorder.record() else {
@@ -303,25 +305,10 @@ final class ComposerVoiceInputController {
         self.recordingURL = recordingURL
         audioRecorder = recorder
         ComposerAudioCaptureState.shared.setCapturing(true)
-        startServerRecordingTimeout()
         logger.info("Server voice input recording started")
     }
 
-    private func startServerRecordingTimeout() {
-        serverRecordingTimeoutTask?.cancel()
-        serverRecordingTimeoutTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: Self.maxServerRecordingDuration * 1_000_000_000)
-            await MainActor.run {
-                guard let self, !Task.isCancelled, self.state == .serverListening else { return }
-                self.stopServerRecordingAndTranscribe()
-            }
-        }
-    }
-
     private func stopServerRecordingAndTranscribe() {
-        serverRecordingTimeoutTask?.cancel()
-        serverRecordingTimeoutTask = nil
-
         guard state == .serverListening,
               let recorder = audioRecorder,
               let recordingURL
@@ -625,8 +612,6 @@ final class ComposerVoiceInputController {
 
     private func stopAudio(cancelTask: Bool) {
         ComposerAudioCaptureState.shared.setCapturing(false)
-        serverRecordingTimeoutTask?.cancel()
-        serverRecordingTimeoutTask = nil
 
         if let recorder = audioRecorder, recorder.isRecording {
             recorder.stop()
@@ -666,9 +651,6 @@ final class ComposerVoiceInputController {
     }
 
     private func discardServerRecording() {
-        serverRecordingTimeoutTask?.cancel()
-        serverRecordingTimeoutTask = nil
-
         if let recorder = audioRecorder, recorder.isRecording {
             recorder.stop()
         }

--- a/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
+++ b/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
@@ -1,0 +1,25 @@
+import AVFoundation
+import XCTest
+@testable import HermesMobile
+
+final class ComposerVoiceInputServerRecordingTests: XCTestCase {
+    func testServerRecordingSettingsAreMonoAACWithSpeechBitrate() {
+        let settings = ComposerVoiceInputController.serverRecordingSettings
+        XCTAssertEqual(settings[AVFormatIDKey] as? Int, Int(kAudioFormatMPEG4AAC))
+        XCTAssertEqual(settings[AVNumberOfChannelsKey] as? Int, 1)
+        XCTAssertEqual(settings[AVEncoderBitRateKey] as? Int, ComposerVoiceInputController.serverRecordingBitrate)
+    }
+
+    func testServerRecordingUsesM4AContainer() {
+        XCTAssertEqual(ComposerVoiceInputController.serverRecordingFileExtension, "m4a")
+    }
+
+    // Recording has no duration cap: it runs until the user stops it. This
+    // documents why that is safe — even a 30-minute dictation at the configured
+    // bitrate stays comfortably below the server's default 20 MB upload ceiling.
+    func testHalfHourRecordingStaysUnderUploadCeiling() {
+        let thirtyMinutesInSeconds = 30 * 60
+        let approxBytes = ComposerVoiceInputController.serverRecordingBitrate / 8 * thirtyMinutesInSeconds
+        XCTAssertLessThan(approxBytes, PendingAttachment.maximumUploadBytes)
+    }
+}


### PR DESCRIPTION
## Linked issue

Fixes #273

## What changed

Server First dictation silently stopped and transcribed at 60 seconds, cutting off long recordings mid-thought. That cap was a client-side timeout added because the recorder captured uncompressed 16 kHz PCM WAV, which grows fast against the server's 20 MB upload ceiling.

This removes the 60-second auto-stop entirely and switches capture to mono AAC in an `.m4a` container at 32 kbps (~14 MB per hour), so recording runs until the user taps Stop and normal long-form recordings stay comfortably under the upload limit. Stop, cancel, submit, failure fallback, and temp-file cleanup paths are unchanged; the on-device fallback (`SFSpeechURLRecognitionRequest`) reads M4A natively. On-device dictation is untouched, and no server contract changed — `/api/transcribe` already accepts the multipart file and preserves its extension.

## How it was tested

- Full XCTest suite on iPhone 17 simulator: 1740 passed, 0 failed, 2 pre-existing skips.
- New focused tests (`ComposerVoiceInputServerRecordingTests`): recorder settings are mono AAC at the controlled bitrate, the container is `.m4a`, and a 30-minute recording stays under the upload ceiling.
- Owner validation pending per issue #273: ≥90-second Server First recording on a physical device, plus cancel/backgrounding/On-device-only checks.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no model changes)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

---

Change made by Claude Fable 5 via Claude Code.