### PR TITLE
fix(chat): clear recovered connection warnings

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -55,6 +55,7 @@ protocol ChatStreamCoordinatorDelegate: AnyObject {
     func streamCoordinatorDidFinishStream()
     func streamCoordinatorDidReceiveErrorMessage(_ message: String)
     func streamCoordinatorDidReceiveRecoveryError(_ error: Error)
+    func streamCoordinatorDidConfirmRecovery()
     func streamCoordinatorDidStartConnection(isReplay: Bool)
     func streamCoordinatorDidResetRecoveryState()
 
@@ -358,6 +359,7 @@ final class ChatStreamCoordinator {
                 streamID: streamID,
                 runGeneration: runGeneration
             ) else { return }
+            delegate?.streamCoordinatorDidConfirmRecovery()
 
             if response.active == true {
                 let completedLoad = await loadMessagesForReconnect(reconnectTaskID: reconnectTaskID)
@@ -439,6 +441,8 @@ final class ChatStreamCoordinator {
 
         do {
             let response = try await client.chatStreamStatus(streamID: expectedStreamID)
+            guard activeStreamID == expectedStreamID, !isConnectionSuspended else { return }
+            delegate?.streamCoordinatorDidConfirmRecovery()
             guard response.active == false else { return }
 
             await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)
@@ -534,6 +538,7 @@ final class ChatStreamCoordinator {
     }
 
     func markProgress(now: Date = Date()) {
+        delegate?.streamCoordinatorDidConfirmRecovery()
         lastProgressDate = now
         lastTransportActivityDate = now
         lastRecoveryStatusCheckDate = nil
@@ -681,6 +686,7 @@ final class ChatStreamCoordinator {
         case .transportError(let message):
             handleTransportError(message)
         case .heartbeat:
+            delegate?.streamCoordinatorDidConfirmRecovery()
             // #227: a heartbeat proves the transport is alive without carrying
             // semantic progress — drop an already-shown "Checking stream" state
             // immediately. Never demote .reconnecting; that chip is owned by
@@ -734,6 +740,7 @@ final class ChatStreamCoordinator {
         do {
             let response = try await client.chatStreamStatus(streamID: expectedStreamID)
             guard activeStreamID == expectedStreamID, !isConnectionSuspended else { return }
+            delegate?.streamCoordinatorDidConfirmRecovery()
 
             if response.active == false {
                 await delegate?.streamCoordinatorLoadMessages(modelContext: modelContext)

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -223,7 +223,10 @@ final class ChatViewModel {
     var activeStreamRecoveryState: ActiveStreamRecoveryState { streamCoordinator.recoveryState }
     var liveTokensPerSecond: Double? { streamCoordinator.liveTokensPerSecond }
     private(set) var errorMessage: String?
-    private(set) var sendErrorMessage: String?
+    private(set) var sendErrorMessage: String? {
+        didSet { sendErrorIsFromStreamRecovery = false }
+    }
+    @ObservationIgnored private var sendErrorIsFromStreamRecovery = false
     private(set) var messageActionErrorMessage: String?
     private(set) var cacheErrorMessage: String?
     private(set) var lastError: Error?
@@ -5182,6 +5185,12 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
     func streamCoordinatorDidReceiveRecoveryError(_ error: Error) {
         lastError = error
         sendErrorMessage = error.localizedDescription
+        sendErrorIsFromStreamRecovery = true
+    }
+
+    func streamCoordinatorDidConfirmRecovery() {
+        guard sendErrorIsFromStreamRecovery else { return }
+        sendErrorMessage = nil
     }
 
     func streamCoordinatorDidStartConnection(isReplay: Bool) {

--- a/HermesMobile/Networking/APIError.swift
+++ b/HermesMobile/Networking/APIError.swift
@@ -31,13 +31,13 @@ enum APIError: LocalizedError {
             case 404:
                 return String(localized: "The server endpoint was not found. Check that the URL points to a Hermes Web UI server.")
             case 408:
-                return String(localized: "The server took too long to respond. Check that the Mac is awake and the server is running.")
+                return String(localized: "The server did not respond in time. Check that the server is running and the connection is available.")
             case 429:
                 return String(localized: "The server is receiving too many requests. Wait a moment, then try again.")
             case 500:
                 return String(localized: "The Hermes server hit an internal error. Check the server logs, then try again.")
             case 502, 503, 504:
-                return String(localized: "The server or Cloudflare tunnel is unavailable. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected.")
+                return String(localized: "Could not connect to the server. Check that hermes-webui is running and the tunnel is connected.")
             default:
                 if let message = Self.serverErrorMessage(from: body) {
                     return String(localized: "Server returned HTTP \(statusCode): \(message)")
@@ -143,7 +143,7 @@ private extension APIError {
 
         switch urlError.code {
         case .timedOut:
-            return String(localized: "The server did not respond in time. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected.")
+            return String(localized: "The server did not respond in time. Check that the server is running and the connection is available.")
         case .cannotFindHost, .dnsLookupFailed:
             return String(localized: "Could not find that server. Check the URL and Cloudflare DNS hostname.")
         case .cannotConnectToHost, .networkConnectionLost:

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -82095,108 +82095,108 @@
         }
       }
     },
-    "The server did not respond in time. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected." : {
+    "The server did not respond in time. Check that the server is running and the connection is available." : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "لم يستجب الخادم في الوقت المحدد. تأكد من أن جهاز Mac نشط، وأن hermes-webui قيد التشغيل، وأن النفق متصل."
+            "value" : "لم يستجب الخادم في الوقت المحدد. تأكد من أن الخادم قيد التشغيل وأن الاتصال متاح."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Der Server hat nicht rechtzeitig geantwortet. Prüfe, ob der Mac wach ist, hermes-webui läuft und der Tunnel verbunden ist."
+            "value" : "Der Server hat nicht rechtzeitig geantwortet. Prüfe, ob der Server läuft und die Verbindung verfügbar ist."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "El servidor no respondió a tiempo. Verifica que el Mac esté activo, que hermes-webui esté en ejecución y que el túnel esté conectado."
+            "value" : "El servidor no respondió a tiempo. Verifica que el servidor esté en ejecución y que la conexión esté disponible."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Le serveur n'a pas répondu à temps. Vérifiez que le Mac est éveillé, que hermes-webui est en cours d'exécution et que le tunnel est connecté."
+            "value" : "Le serveur n'a pas répondu à temps. Vérifiez que le serveur est en cours d'exécution et que la connexion est disponible."
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "השרת לא הגיב בזמן. ודא שה-Mac ער, ש-hermes-webui פועל, ושהמנהרה מחוברת."
+            "value" : "השרת לא הגיב בזמן. ודא שהשרת פועל ושהחיבור זמין."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Il server non ha risposto in tempo. Verifica che il Mac sia attivo, che hermes-webui sia in esecuzione e che il tunnel sia connesso."
+            "value" : "Il server non ha risposto in tempo. Verifica che il server sia in esecuzione e che la connessione sia disponibile."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "サーバが時間内に応答しませんでした。Macがスリープしていないこと、hermes-webuiが実行中であること、トンネルが接続されていることを確認してください。"
+            "value" : "サーバが時間内に応答しませんでした。サーバが実行中で、接続が利用可能であることを確認してください。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "서버가 제때 응답하지 않았어요. Mac이 켜져 있고, hermes-webui가 실행 중이며, 터널이 연결되어 있는지 확인하세요."
+            "value" : "서버가 제때 응답하지 않았어요. 서버가 실행 중이고 연결을 사용할 수 있는지 확인하세요."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "De server reageerde niet op tijd. Controleer of de Mac wakker is, hermes-webui actief is en de tunnel is verbonden."
+            "value" : "De server reageerde niet op tijd. Controleer of de server actief is en de verbinding beschikbaar is."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Serwer nie odpowiedział na czas. Sprawdź, czy Mac jest aktywny, hermes-webui działa, a tunel jest połączony."
+            "value" : "Serwer nie odpowiedział na czas. Sprawdź, czy serwer działa i połączenie jest dostępne."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "O servidor não respondeu a tempo. Verifique se o Mac está ativo, se o hermes-webui está em execução e se o túnel está conectado."
+            "value" : "O servidor não respondeu a tempo. Verifique se o servidor está em execução e se a conexão está disponível."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Сервер не ответил вовремя. Убедитесь, что Mac не спит, hermes-webui запущен, а туннель подключён."
+            "value" : "Сервер не ответил вовремя. Убедитесь, что сервер запущен и подключение доступно."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Sunucu zamanında yanıt vermedi. Mac'in uyanık olduğunu, hermes-webui'nin çalıştığını ve tünelin bağlı olduğunu kontrol edin."
+            "value" : "Sunucu zamanında yanıt vermedi. Sunucunun çalıştığını ve bağlantının kullanılabilir olduğunu kontrol edin."
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "سرور نے بروقت جواب نہیں دیا۔ یقینی بنائیں کہ Mac بیدار ہے، hermes-webui چل رہا ہے، اور ٹنل منسلک ہے۔"
+            "value" : "سرور نے بروقت جواب نہیں دیا۔ یقینی بنائیں کہ سرور چل رہا ہے اور کنکشن دستیاب ہے۔"
           }
         },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "伺服器未及時回應。請檢查 Mac 是否已喚醒、hermes-webui 是否正在執行以及通道是否已連線。"
+            "value" : "伺服器未及時回應。請檢查伺服器是否正在執行以及連線是否可用。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "服务器未及时响应。请检查 Mac 是否已唤醒、hermes-webui 是否正在运行以及隧道是否已连接。"
+            "value" : "服务器未及时响应。请检查服务器是否正在运行以及连接是否可用。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "伺服器未及時回應。請檢查 Mac 是否已喚醒、hermes-webui 是否正在執行，以及通道是否已連線。"
+            "value" : "伺服器未及時回應。請檢查伺服器是否正在執行，以及連線是否可用。"
           }
         }
       }

--- a/HermesMobileTests/APIClientAuthAndErrorTests.swift
+++ b/HermesMobileTests/APIClientAuthAndErrorTests.swift
@@ -173,7 +173,7 @@ final class APIClientAuthAndErrorTests: APIClientTestCase {
             let message = APIError.http(statusCode: statusCode, body: body).localizedDescription
             XCTAssertEqual(
                 message,
-                "The server or Cloudflare tunnel is unavailable. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected."
+                "Could not connect to the server. Check that hermes-webui is running and the tunnel is connected."
             )
             XCTAssertFalse(message.contains("<html>"))
             XCTAssertFalse(message.localizedCaseInsensitiveContains("bad gateway"))
@@ -207,7 +207,7 @@ final class APIClientAuthAndErrorTests: APIClientTestCase {
 
         XCTAssertEqual(
             error.localizedDescription,
-            "The server did not respond in time. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected."
+            "The server did not respond in time. Check that the server is running and the connection is available."
         )
     }
 

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -133,6 +133,47 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testSuccessfulReconnectConfirmsRecoveryAfterTransientStatusFailure() async {
+        let statusRequestCount = CoordinatorLockedCounter()
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            if statusRequestCount.increment() == 1 {
+                throw URLError(.timedOut)
+            }
+            return apiTestJSONResponse(#"{"active": true, "stream_id": "stream-123"}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+
+        await coordinator.reconnectIfNeeded()
+
+        XCTAssertEqual(delegate.recoveryErrors.count, 1)
+        XCTAssertEqual(delegate.confirmedRecoveryCount, 0)
+
+        await coordinator.reconnectIfNeeded()
+
+        XCTAssertEqual(delegate.confirmedRecoveryCount, 1)
+        XCTAssertFalse(coordinator.isConnectionSuspended)
+        XCTAssertEqual(streamClient.startedURLs.count, 2)
+    }
+
+    @MainActor
+    func testValidStreamActivityConfirmsRecovery() {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.token("Recovered response"))
+        streamClient.emit(.heartbeat)
+
+        XCTAssertEqual(delegate.confirmedRecoveryCount, 2)
+    }
+
+    @MainActor
     func testConcurrentForegroundReconnectRequestsShareOneRecoveryAttempt() async {
         let firstStatusStarted = expectation(description: "first stream status request started")
         let releaseFirstStatus = DispatchSemaphore(value: 0)
@@ -1898,6 +1939,7 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
     private(set) var finishCount = 0
     private(set) var errorMessages: [String] = []
     private(set) var recoveryErrors: [String] = []
+    private(set) var confirmedRecoveryCount = 0
     private(set) var startConnectionReplayValues: [Bool] = []
     private(set) var resetRecoveryCount = 0
     private(set) var tokens: [String] = []
@@ -1966,6 +2008,10 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
 
     func streamCoordinatorDidReceiveRecoveryError(_ error: Error) {
         recoveryErrors.append(error.localizedDescription)
+    }
+
+    func streamCoordinatorDidConfirmRecovery() {
+        confirmedRecoveryCount += 1
     }
 
     func streamCoordinatorDidStartConnection(isReplay: Bool) {

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -31,6 +31,42 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testValidStreamProgressClearsRecoveryOwnedComposerError() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/start")
+            return apiTestJSONResponse(
+                #"{"session_id": "session-abc", "stream_id": "stream-123"}"#,
+                for: request
+            )
+        }
+
+        let didStart = await viewModel.sendMessage("Keep working")
+        XCTAssertTrue(didStart)
+        viewModel.streamCoordinatorDidReceiveRecoveryError(APIError.network(underlying: URLError(.timedOut)))
+        XCTAssertNotNil(viewModel.sendErrorMessage)
+
+        streamClient.emit(.token("Recovered response"))
+
+        XCTAssertNil(viewModel.sendErrorMessage)
+    }
+
+    @MainActor
+    func testRecoveryConfirmationDoesNotClearLaterComposerError() throws {
+        let viewModel = try makeViewModel { request in
+            XCTFail("This test should not make a network request: \(request)")
+            throw URLError(.badURL)
+        }
+
+        viewModel.streamCoordinatorDidReceiveRecoveryError(APIError.network(underlying: URLError(.timedOut)))
+        viewModel.setSendErrorMessage("The response failed on the server.")
+
+        viewModel.streamCoordinatorDidConfirmRecovery()
+
+        XCTAssertEqual(viewModel.sendErrorMessage, "The response failed on the server.")
+    }
+
+    @MainActor
     func testListenCreatesSpeechSynthesizerOnlyWhenRequested() async throws {
         let speechSynthesizer = SpySpeechSynthesizer()
         var createdSynthesizers = 0
@@ -3150,7 +3186,7 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertFalse(viewModel.isViewingCachedData)
         XCTAssertEqual(
             viewModel.errorMessage,
-            "The server or Cloudflare tunnel is unavailable. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected."
+            "Could not connect to the server. Check that hermes-webui is running and the tunnel is connected."
         )
         XCTAssertNotNil(viewModel.lastError)
     }

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -99,7 +99,7 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertFalse(viewModel.isViewingCachedData)
         XCTAssertEqual(
             viewModel.errorMessage,
-            "The server did not respond in time. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected."
+            "The server did not respond in time. Check that the server is running and the connection is available."
         )
         XCTAssertNotNil(viewModel.lastError)
     }
@@ -130,7 +130,7 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertTrue(CacheFallbackPolicy.shouldUseCache(for: sessionLoadError))
         XCTAssertEqual(
             viewModel.errorMessage,
-            "The server did not respond in time. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected."
+            "The server did not respond in time. Check that the server is running and the connection is available."
         )
 
         await viewModel.searchSessions(query: "later", debounceNanoseconds: 0)
@@ -139,7 +139,7 @@ final class SessionListMutationTests: XCTestCase {
         XCTAssertTrue(CacheFallbackPolicy.shouldUseCache(for: try XCTUnwrap(viewModel.sessionLoadError)))
         XCTAssertEqual(
             viewModel.errorMessage,
-            "The server did not respond in time. Check that the Mac is awake, hermes-webui is running, and the tunnel is connected."
+            "The server did not respond in time. Check that the server is running and the connection is available."
         )
     }
 


### PR DESCRIPTION
## Linked issue

Fixes #207

## What changed

Transient stream-recovery warnings now clear as soon as valid stream activity or a successful status check proves the connection recovered. Recovery warnings are tracked separately so genuine composer errors remain visible. Timeout guidance now works for any server host instead of assuming a Mac.

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP: 1,744 passed, 0 failed, 2 skipped
- Focused recovery, reconnect, composer-error ownership, and API error-copy tests: 308 passed
- Owner check pending: simulate a temporary recovery timeout, then verify the warning disappears when streaming resumes

## Checklist

- [x] The full test suite passes locally
- [x] No Codable model changes
- [x] No new third-party dependencies
- [x] No new API endpoints or JSON shapes

Implemented by GPT-5.6 Sol using the Codex harness in T3 Code.