### PR TITLE
fix(voice): guard oversized transcription uploads

### DIFF
--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -272,6 +272,48 @@ final class ComposerVoiceInputController {
 
     static let serverRecordingBitrate = 32_000
     static let serverRecordingFileExtension = "m4a"
+    static let maximumServerRecordingUploadBytes = 19 * 1_024 * 1_024
+
+    enum ServerRecordingUploadPreparation: Equatable {
+        case upload(Data)
+        case onDeviceFallback
+    }
+
+    enum ServerRecordingUploadPreparationError: LocalizedError {
+        case fileSize(Error)
+        case dataLoad(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .fileSize(let error), .dataLoad(let error):
+                return error.localizedDescription
+            }
+        }
+    }
+
+    /// Checks the file's size before loading it into memory. A recording over
+    /// the client boundary goes straight to the existing on-device fallback.
+    static func prepareServerRecordingUpload(
+        fileSize: () throws -> Int,
+        dataLoader: () throws -> Data
+    ) throws -> ServerRecordingUploadPreparation {
+        let size: Int
+        do {
+            size = try fileSize()
+        } catch {
+            throw ServerRecordingUploadPreparationError.fileSize(error)
+        }
+
+        guard size <= maximumServerRecordingUploadBytes else {
+            return .onDeviceFallback
+        }
+
+        do {
+            return .upload(try dataLoader())
+        } catch {
+            throw ServerRecordingUploadPreparationError.dataLoad(error)
+        }
+    }
 
     private func startServerRecording() throws {
         stopAudio(cancelTask: true)
@@ -358,8 +400,53 @@ final class ComposerVoiceInputController {
             return
         }
 
+        let uploadPreparation: ServerRecordingUploadPreparation
         do {
-            let audioData = try Data(contentsOf: recordingURL)
+            uploadPreparation = try Self.prepareServerRecordingUpload(
+                fileSize: {
+                    let values = try recordingURL.resourceValues(forKeys: [.fileSizeKey])
+                    guard let size = values.fileSize else {
+                        throw CocoaError(.fileReadUnknown)
+                    }
+                    return size
+                },
+                dataLoader: {
+                    try Data(contentsOf: recordingURL)
+                }
+            )
+        } catch let error as ServerRecordingUploadPreparationError {
+            switch error {
+            case .fileSize:
+                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+                fail(error.localizedDescription, logCategory: .speechUnavailable)
+            case .dataLoad:
+                await fallbackFromServerFailure(
+                    recordingURL: recordingURL,
+                    transcriptionID: transcriptionID,
+                    message: error.localizedDescription
+                )
+            }
+            return
+        } catch {
+            cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
+            fail(error.localizedDescription, logCategory: .speechUnavailable)
+            return
+        }
+
+        let audioData: Data
+        switch uploadPreparation {
+        case .upload(let data):
+            audioData = data
+        case .onDeviceFallback:
+            await fallbackFromServerFailure(
+                recordingURL: recordingURL,
+                transcriptionID: transcriptionID,
+                message: CocoaError(.fileReadTooLarge).localizedDescription
+            )
+            return
+        }
+
+        do {
             let response = try await apiClient.transcribeAudio(
                 data: audioData,
                 filename: recordingURL.lastPathComponent

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -274,45 +274,23 @@ final class ComposerVoiceInputController {
     static let serverRecordingFileExtension = "m4a"
     static let maximumServerRecordingUploadBytes = 19 * 1_024 * 1_024
 
-    enum ServerRecordingUploadPreparation: Equatable {
-        case upload(Data)
-        case onDeviceFallback
-    }
-
-    enum ServerRecordingUploadPreparationError: LocalizedError {
-        case fileSize(Error)
-        case dataLoad(Error)
-
-        var errorDescription: String? {
-            switch self {
-            case .fileSize(let error), .dataLoad(let error):
-                return error.localizedDescription
-            }
+    static func serverRecordingFileSize(at url: URL) throws -> Int {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        guard let size = values.fileSize else {
+            throw CocoaError(.fileReadUnknown)
         }
+        return size
     }
 
-    /// Checks the file's size before loading it into memory. A recording over
-    /// the client boundary goes straight to the existing on-device fallback.
-    static func prepareServerRecordingUpload(
-        fileSize: () throws -> Int,
+    /// Returns `nil` before reading an oversized recording into memory.
+    static func loadServerRecordingForUpload(
+        fileSize: Int,
         dataLoader: () throws -> Data
-    ) throws -> ServerRecordingUploadPreparation {
-        let size: Int
-        do {
-            size = try fileSize()
-        } catch {
-            throw ServerRecordingUploadPreparationError.fileSize(error)
+    ) rethrows -> Data? {
+        guard fileSize <= maximumServerRecordingUploadBytes else {
+            return nil
         }
-
-        guard size <= maximumServerRecordingUploadBytes else {
-            return .onDeviceFallback
-        }
-
-        do {
-            return .upload(try dataLoader())
-        } catch {
-            throw ServerRecordingUploadPreparationError.dataLoad(error)
-        }
+        return try dataLoader()
     }
 
     private func startServerRecording() throws {
@@ -400,44 +378,33 @@ final class ComposerVoiceInputController {
             return
         }
 
-        let uploadPreparation: ServerRecordingUploadPreparation
+        let fileSize: Int
         do {
-            uploadPreparation = try Self.prepareServerRecordingUpload(
-                fileSize: {
-                    let values = try recordingURL.resourceValues(forKeys: [.fileSizeKey])
-                    guard let size = values.fileSize else {
-                        throw CocoaError(.fileReadUnknown)
-                    }
-                    return size
-                },
-                dataLoader: {
-                    try Data(contentsOf: recordingURL)
-                }
-            )
-        } catch let error as ServerRecordingUploadPreparationError {
-            switch error {
-            case .fileSize:
-                cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
-                fail(error.localizedDescription, logCategory: .speechUnavailable)
-            case .dataLoad:
-                await fallbackFromServerFailure(
-                    recordingURL: recordingURL,
-                    transcriptionID: transcriptionID,
-                    message: error.localizedDescription
-                )
-            }
-            return
+            fileSize = try Self.serverRecordingFileSize(at: recordingURL)
         } catch {
             cleanupRecordingFile(recordingURL, transcriptionID: transcriptionID)
             fail(error.localizedDescription, logCategory: .speechUnavailable)
             return
         }
 
-        let audioData: Data
-        switch uploadPreparation {
-        case .upload(let data):
-            audioData = data
-        case .onDeviceFallback:
+        let audioData: Data?
+        do {
+            audioData = try Self.loadServerRecordingForUpload(
+                fileSize: fileSize,
+                dataLoader: {
+                    try Data(contentsOf: recordingURL)
+                }
+            )
+        } catch {
+            await fallbackFromServerFailure(
+                recordingURL: recordingURL,
+                transcriptionID: transcriptionID,
+                message: error.localizedDescription
+            )
+            return
+        }
+
+        guard let audioData else {
             await fallbackFromServerFailure(
                 recordingURL: recordingURL,
                 transcriptionID: transcriptionID,

--- a/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
+++ b/HermesMobile/Features/Chat/ComposerVoiceInputController.swift
@@ -272,6 +272,8 @@ final class ComposerVoiceInputController {
 
     static let serverRecordingBitrate = 32_000
     static let serverRecordingFileExtension = "m4a"
+    // Leave 1 MiB below the server's configurable 20 MiB default for the
+    // multipart envelope. A lower custom limit still uses the existing fallback.
     static let maximumServerRecordingUploadBytes = 19 * 1_024 * 1_024
 
     static func serverRecordingFileSize(at url: URL) throws -> Int {

--- a/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
+++ b/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
@@ -18,9 +18,19 @@ final class ComposerVoiceInputServerRecordingTests: XCTestCase {
     func testRecordingAtUploadBoundaryLoadsForServerTranscription() {
         var dataLoadCount = 0
         let expectedData = Data("recording".utf8)
+        let expectedBoundary = 19 * 1_024 * 1_024
+
+        XCTAssertEqual(
+            ComposerVoiceInputController.maximumServerRecordingUploadBytes,
+            expectedBoundary
+        )
+        XCTAssertLessThan(
+            ComposerVoiceInputController.maximumServerRecordingUploadBytes,
+            PendingAttachment.maximumUploadBytes
+        )
 
         let data = ComposerVoiceInputController.loadServerRecordingForUpload(
-            fileSize: ComposerVoiceInputController.maximumServerRecordingUploadBytes,
+            fileSize: expectedBoundary,
             dataLoader: {
                 dataLoadCount += 1
                 return expectedData
@@ -46,22 +56,13 @@ final class ComposerVoiceInputServerRecordingTests: XCTestCase {
         XCTAssertEqual(dataLoadCount, 0)
     }
 
-    func testFileSizeFailureSkipsDataLoad() {
-        var dataLoadCount = 0
+    func testMissingRecordingFailsFileSizeInspection() {
         let missingFile = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
 
         XCTAssertThrowsError(
-            try ComposerVoiceInputController.loadServerRecordingForUpload(
-                fileSize: ComposerVoiceInputController.serverRecordingFileSize(at: missingFile),
-                dataLoader: {
-                    dataLoadCount += 1
-                    return Data("should-not-load".utf8)
-                }
-            )
+            try ComposerVoiceInputController.serverRecordingFileSize(at: missingFile)
         )
-
-        XCTAssertEqual(dataLoadCount, 0)
     }
 
     // Recording has no duration cap: it runs until the user stops it. This

--- a/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
+++ b/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import XCTest
 @testable import HermesMobile
 
+@MainActor
 final class ComposerVoiceInputServerRecordingTests: XCTestCase {
     func testServerRecordingSettingsAreMonoAACWithSpeechBitrate() {
         let settings = ComposerVoiceInputController.serverRecordingSettings
@@ -14,6 +15,57 @@ final class ComposerVoiceInputServerRecordingTests: XCTestCase {
         XCTAssertEqual(ComposerVoiceInputController.serverRecordingFileExtension, "m4a")
     }
 
+    func testRecordingAtUploadBoundaryLoadsForServerTranscription() throws {
+        var dataLoadCount = 0
+        let expectedData = Data("recording".utf8)
+
+        let preparation = try ComposerVoiceInputController.prepareServerRecordingUpload(
+            fileSize: { ComposerVoiceInputController.maximumServerRecordingUploadBytes },
+            dataLoader: {
+                dataLoadCount += 1
+                return expectedData
+            }
+        )
+
+        XCTAssertEqual(preparation, .upload(expectedData))
+        XCTAssertEqual(dataLoadCount, 1)
+    }
+
+    func testRecordingOneByteOverUploadBoundarySkipsDataLoadAndServerUpload() throws {
+        var dataLoadCount = 0
+
+        let preparation = try ComposerVoiceInputController.prepareServerRecordingUpload(
+            fileSize: { ComposerVoiceInputController.maximumServerRecordingUploadBytes + 1 },
+            dataLoader: {
+                dataLoadCount += 1
+                return Data("should-not-load".utf8)
+            }
+        )
+
+        XCTAssertEqual(preparation, .onDeviceFallback)
+        XCTAssertEqual(dataLoadCount, 0)
+    }
+
+    func testFileSizeFailureSkipsDataLoad() {
+        var dataLoadCount = 0
+
+        XCTAssertThrowsError(
+            try ComposerVoiceInputController.prepareServerRecordingUpload(
+                fileSize: { throw TestFileError.metadataUnavailable },
+                dataLoader: {
+                    dataLoadCount += 1
+                    return Data("should-not-load".utf8)
+                }
+            )
+        ) { error in
+            guard case .fileSize = error as? ComposerVoiceInputController.ServerRecordingUploadPreparationError else {
+                return XCTFail("Expected file-size error, got \(error)")
+            }
+        }
+
+        XCTAssertEqual(dataLoadCount, 0)
+    }
+
     // Recording has no duration cap: it runs until the user stops it. This
     // documents why that is safe — even a 30-minute dictation at the configured
     // bitrate stays comfortably below the server's default 20 MB upload ceiling.
@@ -22,4 +74,8 @@ final class ComposerVoiceInputServerRecordingTests: XCTestCase {
         let approxBytes = ComposerVoiceInputController.serverRecordingBitrate / 8 * thirtyMinutesInSeconds
         XCTAssertLessThan(approxBytes, PendingAttachment.maximumUploadBytes)
     }
+}
+
+private enum TestFileError: Error {
+    case metadataUnavailable
 }

--- a/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
+++ b/HermesMobileTests/ComposerVoiceInputServerRecordingTests.swift
@@ -15,53 +15,51 @@ final class ComposerVoiceInputServerRecordingTests: XCTestCase {
         XCTAssertEqual(ComposerVoiceInputController.serverRecordingFileExtension, "m4a")
     }
 
-    func testRecordingAtUploadBoundaryLoadsForServerTranscription() throws {
+    func testRecordingAtUploadBoundaryLoadsForServerTranscription() {
         var dataLoadCount = 0
         let expectedData = Data("recording".utf8)
 
-        let preparation = try ComposerVoiceInputController.prepareServerRecordingUpload(
-            fileSize: { ComposerVoiceInputController.maximumServerRecordingUploadBytes },
+        let data = ComposerVoiceInputController.loadServerRecordingForUpload(
+            fileSize: ComposerVoiceInputController.maximumServerRecordingUploadBytes,
             dataLoader: {
                 dataLoadCount += 1
                 return expectedData
             }
         )
 
-        XCTAssertEqual(preparation, .upload(expectedData))
+        XCTAssertEqual(data, expectedData)
         XCTAssertEqual(dataLoadCount, 1)
     }
 
-    func testRecordingOneByteOverUploadBoundarySkipsDataLoadAndServerUpload() throws {
+    func testRecordingOneByteOverUploadBoundarySkipsDataLoadAndServerUpload() {
         var dataLoadCount = 0
 
-        let preparation = try ComposerVoiceInputController.prepareServerRecordingUpload(
-            fileSize: { ComposerVoiceInputController.maximumServerRecordingUploadBytes + 1 },
+        let data = ComposerVoiceInputController.loadServerRecordingForUpload(
+            fileSize: ComposerVoiceInputController.maximumServerRecordingUploadBytes + 1,
             dataLoader: {
                 dataLoadCount += 1
                 return Data("should-not-load".utf8)
             }
         )
 
-        XCTAssertEqual(preparation, .onDeviceFallback)
+        XCTAssertNil(data)
         XCTAssertEqual(dataLoadCount, 0)
     }
 
     func testFileSizeFailureSkipsDataLoad() {
         var dataLoadCount = 0
+        let missingFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
 
         XCTAssertThrowsError(
-            try ComposerVoiceInputController.prepareServerRecordingUpload(
-                fileSize: { throw TestFileError.metadataUnavailable },
+            try ComposerVoiceInputController.loadServerRecordingForUpload(
+                fileSize: ComposerVoiceInputController.serverRecordingFileSize(at: missingFile),
                 dataLoader: {
                     dataLoadCount += 1
                     return Data("should-not-load".utf8)
                 }
             )
-        ) { error in
-            guard case .fileSize = error as? ComposerVoiceInputController.ServerRecordingUploadPreparationError else {
-                return XCTFail("Expected file-size error, got \(error)")
-            }
-        }
+        )
 
         XCTAssertEqual(dataLoadCount, 0)
     }
@@ -74,8 +72,4 @@ final class ComposerVoiceInputServerRecordingTests: XCTestCase {
         let approxBytes = ComposerVoiceInputController.serverRecordingBitrate / 8 * thirtyMinutesInSeconds
         XCTAssertLessThan(approxBytes, PendingAttachment.maximumUploadBytes)
     }
-}
-
-private enum TestFileError: Error {
-    case metadataUnavailable
 }


### PR DESCRIPTION
Fixes #322

## What changed

Server First recordings now check their on-disk size before Hermex reads them into memory. Files up to and including 19 MiB use the server. Larger files skip the upload and go through the existing on-device fallback and cleanup behavior.

A file metadata failure stops before both the read and upload.

Verified the server contract against pinned upstream copy commit `399cd7ab19ce43f77d3c3a68bb575e9eed9cd6af`: `HERMES_WEBUI_MAX_UPLOAD_MB` defaults to 20 MiB, and `handle_transcribe` returns 413 when multipart `Content-Length` exceeds the configured limit.

## How it was tested

- Focused `ComposerVoiceInputServerRecordingTests`: 6 passed
- Full XCTest suite on iPhone 17 through XcodeBuildMCP: 1,747 passed, 0 failed, 2 skipped
- `git diff --check`: passed

Owner checks:

- [ ] On a physical device, transcribe a normal Server First recording.
- [ ] Exercise long-form recording and low-storage failure behavior.

## Checklist

- [x] The full test suite passes locally
- [x] No Codable models changed
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes

Implemented by GPT-5.6-sol through the Codex harness in T3 Code.