### PR TITLE
fix(chat): preserve partial streams after relaunch

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -31,6 +31,16 @@ struct ChatStreamLoadPreparation: Equatable {
     let shouldPrepareSuspendedStreamResume: Bool
 }
 
+struct ChatStreamSnapshotRestoreResult: Equatable {
+    let didRestoreSnapshot: Bool
+    let lastEventID: String?
+
+    static let notRestored = ChatStreamSnapshotRestoreResult(
+        didRestoreSnapshot: false,
+        lastEventID: nil
+    )
+}
+
 @MainActor
 protocol ChatStreamCoordinatorDelegate: AnyObject {
     var streamCoordinatorSessionID: String? { get }
@@ -46,7 +56,7 @@ protocol ChatStreamCoordinatorDelegate: AnyObject {
     func streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: Bool)
     func streamCoordinatorSaveSnapshotIfNeeded()
     @discardableResult
-    func streamCoordinatorRestoreSnapshotIfAvailable(streamID: String) -> String?
+    func streamCoordinatorRestoreSnapshotIfAvailable(streamID: String) -> ChatStreamSnapshotRestoreResult
     func streamCoordinatorRemoveSnapshot(streamID: String?)
     func streamCoordinatorFlushPinnedLocalNoticesToTranscript()
     func streamCoordinatorDrainQueuedSlashMessageIfIdle()
@@ -108,6 +118,7 @@ final class ChatStreamCoordinator {
     @ObservationIgnored private(set) var lastTransportActivityDate: Date?
     private(set) var liveTokensPerSecond: Double?
     @ObservationIgnored private var lastRecoveryStatusCheckDate: Date?
+    @ObservationIgnored private var hasInMemorySnapshotForActiveStream = false
     private(set) var isReplayConnection = false
     // Foreground activation and view appearance can both request recovery for the
     // same suspended stream. Share one recovery task so callers cannot duplicate
@@ -159,6 +170,7 @@ final class ChatStreamCoordinator {
         isTransportFinished = false
         isConnectionSuspended = false
         setLiveTokensPerSecondIfChanged(nil)
+        hasInMemorySnapshotForActiveStream = false
         invalidateReconnectTask()
     }
 
@@ -182,6 +194,7 @@ final class ChatStreamCoordinator {
         runGeneration &+= 1
         invalidateReconnectTask()
         activeStreamID = streamID
+        hasInMemorySnapshotForActiveStream = false
         isConnectionSuspended = false
         if replayAfterSeq == nil {
             lastEventID = nil
@@ -220,6 +233,7 @@ final class ChatStreamCoordinator {
 
         lastEventID = streamClient.lastEventID ?? lastEventID
         delegate?.streamCoordinatorSaveSnapshotIfNeeded()
+        hasInMemorySnapshotForActiveStream = true
         liveActivityManager.markStale()
         isConnectionSuspended = true
         streamClient.stop()
@@ -273,6 +287,7 @@ final class ChatStreamCoordinator {
 
         if usedCacheFallback {
             activeStreamID = nil
+            hasInMemorySnapshotForActiveStream = false
             isConnectionSuspended = false
             delegate?.streamCoordinatorStreamingAssistantMessageID = nil
             resetRecoveryState()
@@ -286,9 +301,13 @@ final class ChatStreamCoordinator {
                 activeStreamID = streamID
                 delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
                 isConnectionSuspended = true
-                restoreSnapshotIfAvailable(streamID: streamID)
+                let didRestoreSnapshot = restoreSnapshotIfAvailable(streamID: streamID)
+                if preparation.activeStreamIDBeforeLoad != streamID {
+                    hasInMemorySnapshotForActiveStream = didRestoreSnapshot
+                }
             } else {
                 activeStreamID = nil
+                hasInMemorySnapshotForActiveStream = false
                 isConnectionSuspended = false
                 resetRecoveryState()
             }
@@ -299,7 +318,10 @@ final class ChatStreamCoordinator {
             if let streamID {
                 activeStreamID = streamID
                 delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
-                restoreSnapshotIfAvailable(streamID: streamID)
+                let didRestoreSnapshot = restoreSnapshotIfAvailable(streamID: streamID)
+                if preparation.activeStreamIDBeforeLoad != streamID {
+                    hasInMemorySnapshotForActiveStream = didRestoreSnapshot
+                }
                 if delegate?.streamCoordinatorStreamingAssistantMessageID == nil {
                     delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
                 }
@@ -377,8 +399,18 @@ final class ChatStreamCoordinator {
                 if delegate?.streamCoordinatorStreamingAssistantMessageID == nil {
                     delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
                 }
+                // A cold process has no snapshot cursor. Ask the server journal
+                // for the run from the beginning so the loaded partial transcript
+                // can be filled in immediately instead of waiting for `done`.
+                // Existing foreground/background resumes keep their ordinary
+                // connection when this process still owns an in-memory snapshot.
+                let replayAfterSeq = response.replayAvailable == true
+                    && !hasInMemorySnapshotForActiveStream
+                    && lastEventID == nil
+                    ? 0
+                    : nil
                 isConnectionSuspended = false
-                start(streamID: streamID)
+                start(streamID: streamID, replayAfterSeq: replayAfterSeq)
             } else if response.replayAvailable == true {
                 guard reconnectTaskIsCurrent(
                     reconnectTaskID: reconnectTaskID,
@@ -713,6 +745,7 @@ final class ChatStreamCoordinator {
 
         lastEventID = streamClient.lastEventID ?? lastEventID
         delegate?.streamCoordinatorSaveSnapshotIfNeeded()
+        hasInMemorySnapshotForActiveStream = true
         liveActivityManager.markStale()
         isConnectionSuspended = true
         streamClient.stop()
@@ -816,6 +849,7 @@ final class ChatStreamCoordinator {
         delegate?.streamCoordinatorRemoveSnapshot(streamID: activeStreamID)
         delegate?.streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: true)
         activeStreamID = nil
+        hasInMemorySnapshotForActiveStream = false
         lastEventID = nil
         setLiveTokensPerSecondIfChanged(nil)
         delegate?.streamCoordinatorStreamingAssistantMessageID = nil
@@ -874,6 +908,7 @@ final class ChatStreamCoordinator {
         delegate?.streamCoordinatorFlushPinnedLocalNoticesToTranscript()
         delegate?.streamCoordinatorRemoveSnapshot(streamID: finishedStreamID)
         activeStreamID = nil
+        hasInMemorySnapshotForActiveStream = false
         lastEventID = nil
         setLiveTokensPerSecondIfChanged(nil)
         delegate?.streamCoordinatorStreamingAssistantMessageID = nil
@@ -1012,12 +1047,15 @@ final class ChatStreamCoordinator {
         )
     }
 
-    private func restoreSnapshotIfAvailable(streamID: String) {
+    @discardableResult
+    private func restoreSnapshotIfAvailable(streamID: String) -> Bool {
+        let result = delegate?.streamCoordinatorRestoreSnapshotIfAvailable(streamID: streamID) ?? .notRestored
+
         guard lastEventID == nil else {
-            _ = delegate?.streamCoordinatorRestoreSnapshotIfAvailable(streamID: streamID)
-            return
+            return result.didRestoreSnapshot
         }
 
-        lastEventID = delegate?.streamCoordinatorRestoreSnapshotIfAvailable(streamID: streamID) ?? lastEventID
+        lastEventID = result.lastEventID ?? lastEventID
+        return result.didRestoreSnapshot
     }
 }

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -447,6 +447,10 @@ final class ChatViewModel {
     private var activeStreamReplayMatchedPrefixLength = 0
     private var activeStreamReplayMatchedInterimLength = 0
     private var activeStreamReplayMatchedReasoningLength = 0
+    private var activeStreamReplayLoadedReasoningText = ""
+    private var activeStreamReplayLoadedToolCalls: [ToolCall] = []
+    private var activeStreamReplayLoadedToolMatchIndex = 0
+    private var activeStreamReplayPendingLoadedToolMatchIndex: Int?
     private var activeStreamReplayToolMatchIndex = 0
     private var activeStreamReplayPendingToolMatchIndex: Int?
     private var latestServerLoadHadAssistantResponseAfterLatestUser = false
@@ -3932,14 +3936,14 @@ final class ChatViewModel {
     }
 
     @discardableResult
-    private func restoreActiveStreamSnapshotIfAvailable(streamID: String) -> String? {
+    private func restoreActiveStreamSnapshotIfAvailable(streamID: String) -> ChatStreamSnapshotRestoreResult {
         guard let sessionID,
               let snapshot = ActiveChatStreamSnapshotStore.shared.snapshot(
                 server: server,
                 sessionID: sessionID,
                 streamID: streamID
               )
-        else { return nil }
+        else { return .notRestored }
 
         let merge = Self.mergingLoadedMessages(messages, withActiveStreamSnapshot: snapshot)
         messages = merge.messages
@@ -3967,7 +3971,10 @@ final class ChatViewModel {
         attachmentCoordinator.mergeLocalAttachmentPreviews(snapshot.localAttachmentPreviews)
         pinnedLocalNotices = snapshot.pinnedLocalNotices
         scheduleStreamingScrollTrigger()
-        return snapshot.activeStreamLastEventID
+        return ChatStreamSnapshotRestoreResult(
+            didRestoreSnapshot: true,
+            lastEventID: snapshot.activeStreamLastEventID
+        )
     }
 
     private func removeActiveStreamSnapshot(streamID: String?) {
@@ -4333,7 +4340,9 @@ final class ChatViewModel {
         _ = ensureStreamingAssistantMessage()
         let remainder: String
         if isActiveStreamReplayConnection {
-            let effectiveContent = liveReasoningText + pendingReasoningChunks.joined()
+            let effectiveContent = activeStreamReplayLoadedReasoningText
+                + liveReasoningText
+                + pendingReasoningChunks.joined()
             remainder = deduplicatedReplayText(
                 text,
                 existingContent: effectiveContent,
@@ -4373,6 +4382,11 @@ final class ChatViewModel {
             toolCallAnchorMessageID = messageID
         }
 
+        if let duplicateLoadedIndex = duplicateLoadedReplayToolStartIndex(for: payload) {
+            activeStreamReplayPendingLoadedToolMatchIndex = duplicateLoadedIndex
+            return false
+        }
+
         if let duplicateReplayIndex = duplicateReplayToolStartIndex(for: payload) {
             activeStreamReplayPendingToolMatchIndex = duplicateReplayIndex
             return false
@@ -4395,6 +4409,10 @@ final class ChatViewModel {
         let messageID = ensureStreamingAssistantMessage()
         if toolCallAnchorMessageID == nil {
             toolCallAnchorMessageID = messageID
+        }
+
+        if duplicateLoadedReplayToolCompletion(for: payload) {
+            return false
         }
 
         if let duplicateReplayIndex = duplicateReplayToolCompletionIndex(for: payload) {
@@ -4468,6 +4486,68 @@ final class ChatViewModel {
         }
 
         return index
+    }
+
+    private func duplicateLoadedReplayToolStartIndex(for payload: ToolStreamEvent) -> Int? {
+        guard isActiveStreamReplayConnection else { return nil }
+
+        if let stableID = payload.stableID?.nonEmptyReplayMatchText,
+           let index = activeStreamReplayLoadedToolCalls.firstIndex(where: { $0.matchesStableToolID(stableID) }) {
+            return index
+        }
+
+        guard activeStreamReplayLoadedToolMatchIndex < activeStreamReplayLoadedToolCalls.count else {
+            return nil
+        }
+
+        let index = activeStreamReplayLoadedToolMatchIndex
+        return activeStreamReplayLoadedToolCalls[index].matchesReplayToolStart(payload) ? index : nil
+    }
+
+    private func duplicateLoadedReplayToolCompletion(for payload: ToolStreamEvent) -> Bool {
+        guard isActiveStreamReplayConnection else { return false }
+
+        let index: Int?
+        if let stableID = payload.stableID?.nonEmptyReplayMatchText {
+            index = activeStreamReplayLoadedToolCalls.firstIndex { $0.matchesStableToolID(stableID) }
+        } else if let pendingIndex = activeStreamReplayPendingLoadedToolMatchIndex,
+                  pendingIndex < activeStreamReplayLoadedToolCalls.count,
+                  activeStreamReplayLoadedToolCalls[pendingIndex].matchesReplayToolCompletion(payload) {
+            index = pendingIndex
+        } else if activeStreamReplayLoadedToolMatchIndex < activeStreamReplayLoadedToolCalls.count,
+                  activeStreamReplayLoadedToolCalls[activeStreamReplayLoadedToolMatchIndex]
+                    .matchesReplayToolCompletion(payload) {
+            index = activeStreamReplayLoadedToolMatchIndex
+        } else {
+            index = nil
+        }
+
+        guard let index else { return false }
+        activeStreamReplayLoadedToolMatchIndex = max(activeStreamReplayLoadedToolMatchIndex, index + 1)
+        activeStreamReplayPendingLoadedToolMatchIndex = nil
+        return true
+    }
+
+    private func loadedReplayReasoningText() -> String {
+        guard let streamingAssistantMessageID,
+              let message = messages.first(where: { $0.messageId == streamingAssistantMessageID })
+        else { return "" }
+
+        return Self.reasoningTexts(from: message).joined(separator: "\n")
+    }
+
+    private func loadedReplayToolCalls() -> [ToolCall] {
+        let currentTurnAnchors = Set(
+            TranscriptTurnClassifier.currentTurnAssistantAnchorIDs(
+                in: messages,
+                messageOffset: messagesOffset
+            )
+        )
+        return completedToolCallGroups
+            .filter { group in
+                group.anchorMessageID.map(currentTurnAnchors.contains) ?? false
+            }
+            .flatMap(\.toolCalls)
     }
 
     private func stableReplayToolIndex(for payload: ToolStreamEvent) -> Int? {
@@ -5148,7 +5228,7 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
     }
 
     @discardableResult
-    func streamCoordinatorRestoreSnapshotIfAvailable(streamID: String) -> String? {
+    func streamCoordinatorRestoreSnapshotIfAvailable(streamID: String) -> ChatStreamSnapshotRestoreResult {
         restoreActiveStreamSnapshotIfAvailable(streamID: streamID)
     }
 
@@ -5197,6 +5277,10 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
         activeStreamReplayMatchedPrefixLength = 0
         activeStreamReplayMatchedInterimLength = 0
         activeStreamReplayMatchedReasoningLength = 0
+        activeStreamReplayLoadedReasoningText = isReplay ? loadedReplayReasoningText() : ""
+        activeStreamReplayLoadedToolCalls = isReplay ? loadedReplayToolCalls() : []
+        activeStreamReplayLoadedToolMatchIndex = 0
+        activeStreamReplayPendingLoadedToolMatchIndex = nil
         activeStreamReplayToolMatchIndex = 0
         activeStreamReplayPendingToolMatchIndex = nil
     }
@@ -5205,6 +5289,10 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
         activeStreamReplayMatchedPrefixLength = 0
         activeStreamReplayMatchedInterimLength = 0
         activeStreamReplayMatchedReasoningLength = 0
+        activeStreamReplayLoadedReasoningText = ""
+        activeStreamReplayLoadedToolCalls = []
+        activeStreamReplayLoadedToolMatchIndex = 0
+        activeStreamReplayPendingLoadedToolMatchIndex = nil
         activeStreamReplayToolMatchIndex = 0
         activeStreamReplayPendingToolMatchIndex = nil
     }

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -133,6 +133,38 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testForegroundReconnectSnapshotWithoutCursorDoesNotReplayFromStart() async throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        delegate.restoresSnapshot = true
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate) { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/stream/status")
+            return apiTestJSONResponse(
+                #"{"active": true, "stream_id": "stream-123", "replay_available": true}"#,
+                for: request
+            )
+        }
+        delegate.onLoadMessages = {
+            let preparation = coordinator.prepareForSessionLoad()
+            coordinator.reconcileSessionLoad(
+                loadedActiveStreamID: "stream-123",
+                preparation: preparation,
+                usedCacheFallback: false
+            )
+        }
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.suspendActiveStreamConnection()
+
+        await coordinator.reconnectIfNeeded()
+
+        let resumedURL = try XCTUnwrap(streamClient.startedURLs.last)
+        let queryItems = URLComponents(url: resumedURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertNil(queryItems.first(where: { $0.name == "replay" }))
+        XCTAssertNil(queryItems.first(where: { $0.name == "after_seq" }))
+    }
+
+    @MainActor
     func testSuccessfulReconnectConfirmsRecoveryAfterTransientStatusFailure() async {
         let statusRequestCount = CoordinatorLockedCounter()
         let streamClient = CoordinatorSpySSEStreamingClient()
@@ -1946,6 +1978,7 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
     private(set) var donePayloads: [DoneStreamEvent] = []
     private(set) var pendingSteerLeftovers: [String] = []
     var latestAssistantMessageID: String? = "assistant-latest"
+    var restoresSnapshot = false
     var restoredSnapshotEventID: String?
     var appendTokenResult = true
     var doneHasCompletedTranscript = false
@@ -1973,9 +2006,12 @@ private final class CoordinatorDelegateSpy: ChatStreamCoordinatorDelegate {
         saveSnapshotCount += 1
     }
 
-    func streamCoordinatorRestoreSnapshotIfAvailable(streamID: String) -> String? {
+    func streamCoordinatorRestoreSnapshotIfAvailable(streamID: String) -> ChatStreamSnapshotRestoreResult {
         restoredSnapshotStreamIDs.append(streamID)
-        return restoredSnapshotEventID
+        return ChatStreamSnapshotRestoreResult(
+            didRestoreSnapshot: restoresSnapshot || restoredSnapshotEventID != nil,
+            lastEventID: restoredSnapshotEventID
+        )
     }
 
     func streamCoordinatorRemoveSnapshot(streamID: String?) {

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -2312,6 +2312,213 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testColdReopenActiveStreamReplaysFromStartWithoutDuplicatingLoadedState() async throws {
+        ChatViewModel.resetActiveStreamSnapshotsForTesting()
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Recovery",
+                    "active_stream_id": "stream-123",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "Inspect the report",
+                        "timestamp": 1770000100,
+                        "message_id": "user-1"
+                      },
+                      {
+                        "role": "assistant",
+                        "content": "Partial answer.",
+                        "reasoning": "Plan the inspection.",
+                        "attachments": [
+                          {"name": "report.txt", "path": "/tmp/report.txt"}
+                        ],
+                        "timestamp": 1770000101,
+                        "message_id": "assistant-1"
+                      }
+                    ],
+                    "tool_calls": [
+                      {
+                        "name": "read_file",
+                        "snippet": "Read report.txt",
+                        "tid": "tool-1",
+                        "assistant_msg_idx": 1,
+                        "args": {"path": "/tmp/report.txt"}
+                      }
+                    ]
+                  }
+                }
+                """, for: request)
+            case "/api/chat/stream/status":
+                return apiTestJSONResponse("""
+                {
+                  "active": true,
+                  "stream_id": "stream-123",
+                  "replay_available": true
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        await viewModel.reconnectStreamIfNeeded()
+
+        let replayURL = try XCTUnwrap(streamClient.startedURLs.last)
+        let replayQueryItems = URLComponents(url: replayURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(replayQueryItems.first(where: { $0.name == "stream_id" })?.value, "stream-123")
+        XCTAssertEqual(replayQueryItems.first(where: { $0.name == "replay" })?.value, "1")
+        XCTAssertEqual(replayQueryItems.first(where: { $0.name == "after_seq" })?.value, "0")
+
+        let replayedToolStart = ToolStreamEvent(
+            eventType: "tool.started",
+            name: "read_file",
+            preview: "Reading report.txt",
+            args: ["path": .string("/tmp/report.txt")],
+            duration: nil,
+            isError: nil,
+            stableID: "tool-1"
+        )
+        let replayedToolCompletion = ToolStreamEvent(
+            eventType: "tool.completed",
+            name: "read_file",
+            preview: "Read report.txt",
+            args: ["path": .string("/tmp/report.txt")],
+            duration: 0.2,
+            isError: false,
+            stableID: "tool-1"
+        )
+        let approval = ApprovalPendingResponse(
+            pending: PendingApproval(
+                approvalId: "approval-1",
+                command: "open report.txt",
+                description: "Open the report"
+            ),
+            pendingCount: 1
+        )
+        let clarification = ClarificationPendingResponse(
+            pending: PendingClarification(
+                clarifyId: "clarify-1",
+                question: "Inspect every section?",
+                sessionId: "session-abc"
+            ),
+            pendingCount: 1
+        )
+
+        streamClient.emit(.reasoning("Plan the inspection."), lastEventID: "stream-123:1")
+        streamClient.emit(.toolStarted(replayedToolStart), lastEventID: "stream-123:2")
+        streamClient.emit(.toolCompleted(replayedToolCompletion), lastEventID: "stream-123:3")
+        streamClient.emit(.approvalPending(approval), lastEventID: "stream-123:4")
+        streamClient.emit(.clarificationPending(clarification), lastEventID: "stream-123:5")
+        streamClient.emit(.token("Partial "), lastEventID: "stream-123:6")
+        streamClient.emit(.token("answer."), lastEventID: "stream-123:7")
+        streamClient.emit(.token(" Continued."), lastEventID: "stream-123:8")
+
+        XCTAssertEqual(viewModel.messages.last?.content, "Partial answer. Continued.")
+        XCTAssertEqual(viewModel.messages.last?.attachments?.count, 1)
+        XCTAssertEqual(viewModel.displayedReasoningGroups.map(\.text), ["Plan the inspection."])
+        XCTAssertEqual(viewModel.latestTurnToolCalls.map(\.id), ["tool-1"])
+        XCTAssertEqual(viewModel.approvalPrompt?.pending.approvalId, "approval-1")
+        XCTAssertEqual(viewModel.clarificationPrompt?.pending.clarifyId, "clarify-1")
+
+        let completedSession = try makeSessionDetail("""
+        {
+          "session_id": "session-abc",
+          "title": "Recovery complete",
+          "messages": [
+            {
+              "role": "user",
+              "content": "Inspect the report",
+              "timestamp": 1770000100,
+              "message_id": "user-1"
+            },
+            {
+              "role": "assistant",
+              "content": "Partial answer. Continued and complete.",
+              "reasoning": "Plan the inspection.",
+              "attachments": [
+                {"name": "report.txt", "path": "/tmp/report.txt"}
+              ],
+              "timestamp": 1770000101,
+              "message_id": "assistant-1"
+            }
+          ],
+          "tool_calls": [
+            {
+              "name": "read_file",
+              "snippet": "Read report.txt",
+              "tid": "tool-1",
+              "assistant_msg_idx": 1,
+              "args": {"path": "/tmp/report.txt"}
+            }
+          ]
+        }
+        """)
+        streamClient.emit(.done(DoneStreamEvent(session: completedSession)), lastEventID: "stream-123:9")
+        streamClient.emit(.streamEnd, lastEventID: "stream-123:10")
+
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), [
+            "Inspect the report",
+            "Partial answer. Continued and complete."
+        ])
+        XCTAssertEqual(viewModel.messages.filter { $0.role == "assistant" }.count, 1)
+        XCTAssertEqual(viewModel.latestTurnToolCalls.map(\.id), ["tool-1"])
+        XCTAssertNil(viewModel.activeStreamID)
+    }
+
+    @MainActor
+    func testColdReopenActiveStreamFallsBackToOrdinaryReconnectWithoutJournal() async throws {
+        ChatViewModel.resetActiveStreamSnapshotsForTesting()
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "active_stream_id": "stream-123",
+                    "messages": [
+                      {"role": "user", "content": "Keep working", "message_id": "user-1"},
+                      {"role": "assistant", "content": "Server prefix. ", "message_id": "assistant-1"}
+                    ]
+                  }
+                }
+                """, for: request)
+            case "/api/chat/stream/status":
+                return apiTestJSONResponse("""
+                {
+                  "active": true,
+                  "stream_id": "stream-123",
+                  "replay_available": false
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        await viewModel.reconnectStreamIfNeeded()
+
+        let reconnectURL = try XCTUnwrap(streamClient.startedURLs.last)
+        let queryItems = URLComponents(url: reconnectURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertNil(queryItems.first(where: { $0.name == "replay" }))
+        XCTAssertNil(queryItems.first(where: { $0.name == "after_seq" }))
+
+        streamClient.emit(.token("new tail."))
+        XCTAssertEqual(viewModel.messages.last?.content, "Server prefix. new tail.")
+    }
+
+    @MainActor
     func testActiveStreamStatusRefreshReloadsTranscriptWhenSSECompletionIsMissed() async throws {
         let streamClient = SpySSEStreamingClient()
         var didRequestStatus = false
@@ -5424,7 +5631,10 @@ final class ChatViewModelSendTests: XCTestCase {
             duration: 0.15,
             isError: false
         )))
-        originalStreamClient.emit(.token("Once Raj reached the river. "))
+        originalStreamClient.emit(
+            .token("Once Raj reached the river. "),
+            lastEventID: "stream-123:4"
+        )
 
         originalViewModel.suspendStreamForNavigation()
 
@@ -5459,7 +5669,8 @@ final class ChatViewModelSendTests: XCTestCase {
                 return apiTestJSONResponse("""
                 {
                   "active": true,
-                  "stream_id": "stream-123"
+                  "stream_id": "stream-123",
+                  "replay_available": true
                 }
                 """, for: request)
             default:
@@ -5474,6 +5685,10 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(didRequestStatus)
         XCTAssertEqual(sessionReloadCount, 2)
         XCTAssertEqual(reopenedStreamClient.startedURLs.count, 1)
+        let reconnectURL = try XCTUnwrap(reopenedStreamClient.startedURLs.last)
+        let reconnectQueryItems = URLComponents(url: reconnectURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertNil(reconnectQueryItems.first(where: { $0.name == "replay" }))
+        XCTAssertNil(reconnectQueryItems.first(where: { $0.name == "after_seq" }))
         XCTAssertEqual(reopenedViewModel.activeStreamID, "stream-123")
         XCTAssertEqual(reopenedViewModel.liveReasoningText, "Planning the tiger story.")
         XCTAssertEqual(reopenedViewModel.liveToolCalls.count, 1)


### PR DESCRIPTION
## Linked issue

Fixes #316

## What changed

Relaunching Hermex during an active response could hide the already-streamed prefix until the response finished. Cold recovery now replays the server's durable run journal from the beginning only when no process-local snapshot or event cursor survived, and deduplicates that replay against the partial transcript loaded from the server.

Normal navigation, background recovery with a cursor, replay-unavailable fallback, and the final server transcript remain unchanged.

## How it was tested

- Full `HermesMobileTests` suite passed on the iPhone 17 simulator with `xcodebuild test-without-building`.
- Focused coordinator/recovery run: 62 tests passed.
- Existing replay/deduplication set: 14 tests passed.
- Signed Debug build installed and launched on the iPhone 17 simulator.
- Physical iPhone swipe-kill → relaunch-before-completion → final settlement: passed.
- Verified the active-run replay contract in upstream `hermes-webui` source `399cd7ab19ce43f77d3c3a68bb575e9eed9cd6af`.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no `Codable` model changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

Implemented by OpenAI Codex (GPT-5) in the Codex desktop app.
