### PR TITLE
fix(chat): auto-dismiss steering confirmation

### DIFF
--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1111,8 +1111,8 @@ struct ChatView: View {
     private var composerAccessoryStack: some View {
         if composerAccessoryVisibleItemCount > 0 {
             VStack(spacing: composerAccessoryVerticalSpacing) {
-                if !viewModel.pinnedLocalNotices.isEmpty {
-                    PinnedLocalNoticeStack(notices: viewModel.pinnedLocalNotices)
+                if !composerLocalNotices.isEmpty {
+                    PinnedLocalNoticeStack(notices: composerLocalNotices)
                         .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
                 }
 
@@ -1132,7 +1132,7 @@ struct ChatView: View {
             .zIndex(8)
             .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: composerAccessoryVisibleItemCount)
             .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: activeRunStatusPresentation)
-            .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: viewModel.pinnedLocalNotices)
+            .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: composerLocalNotices)
             .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: showsApprovalBypassStatus)
         }
     }
@@ -1294,7 +1294,15 @@ struct ChatView: View {
     }
 
     private var pinnedNoticeSpacerHeight: CGFloat {
-        viewModel.pinnedLocalNotices.isEmpty ? 0 : CGFloat(viewModel.pinnedLocalNotices.count) * 60
+        composerLocalNotices.isEmpty ? 0 : CGFloat(composerLocalNotices.count) * 60
+    }
+
+    private var composerLocalNotices: [String] {
+        var notices = viewModel.pinnedLocalNotices
+        if let steeringConfirmationNotice = viewModel.steeringConfirmationNotice {
+            notices.append(steeringConfirmationNotice)
+        }
+        return notices
     }
 
     private var activeRunStatusPresentation: ChatActiveRunStatusPresentation? {
@@ -1329,7 +1337,7 @@ struct ChatView: View {
 
     private var composerAccessoryVisibleItemCount: Int {
         var count = 0
-        if !viewModel.pinnedLocalNotices.isEmpty {
+        if !composerLocalNotices.isEmpty {
             count += 1
         }
         if activeRunStatusPresentation != nil {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -355,6 +355,7 @@ final class ChatViewModel {
     var uploadAttachmentErrorMessage: String? { attachmentCoordinator.uploadAttachmentErrorMessage }
     var localAttachmentPreviews: [String: [String: Data]] { attachmentCoordinator.localAttachmentPreviews }
     private(set) var pinnedLocalNotices: [String] = []
+    private(set) var steeringConfirmationNotice: String?
     var approvalPrompt: ApprovalPromptState? { pendingActionCoordinator.approvalPrompt }
     var isRespondingToApproval: Bool { pendingActionCoordinator.isRespondingToApproval }
     var approvalErrorMessage: String? { pendingActionCoordinator.approvalErrorMessage }
@@ -385,6 +386,8 @@ final class ChatViewModel {
     private let listenRemoteControlCenter: any ListenRemoteControlControlling
     private let userDefaults: UserDefaults
     private let pollingIntervals: ChatPollingIntervals
+    private let steeringConfirmationDismissDelay: @Sendable () async throws -> Void
+    @ObservationIgnored private var steeringConfirmationDismissTask: Task<Void, Never>?
     // Real-time window over which rapid streaming updates coalesce into a single
     // scroll trigger / first content flush. Injectable so tests can drive
     // coalescing deterministically; production keeps the 16ms default.
@@ -469,6 +472,9 @@ final class ChatViewModel {
         liveActivityManager: (any AgentLiveActivityManaging)? = nil,
         showsLiveActivityResponseExcerpts: Bool = false,
         pollingIntervals: ChatPollingIntervals = .standard,
+        steeringConfirmationDismissDelay: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(nanoseconds: 3_000_000_000)
+        },
         streamingScrollCoalescingDelayNanoseconds: UInt64 = 16_000_000,
         streamingWordRevealCadenceNanoseconds: UInt64 = 48_000_000,
         streamingMaxRevealLagNanoseconds: UInt64 = 1_000_000_000,
@@ -510,6 +516,7 @@ final class ChatViewModel {
         self.liveActivityManager = resolvedLiveActivityManager
         self.showsLiveActivityResponseExcerpts = showsLiveActivityResponseExcerpts
         self.pollingIntervals = pollingIntervals
+        self.steeringConfirmationDismissDelay = steeringConfirmationDismissDelay
         self.streamingScrollCoalescingDelayNanoseconds = streamingScrollCoalescingDelayNanoseconds
         self.streamingWordRevealCadenceNanoseconds = streamingWordRevealCadenceNanoseconds
         self.streamingMaxRevealLagNanoseconds = streamingMaxRevealLagNanoseconds
@@ -528,6 +535,7 @@ final class ChatViewModel {
 
     deinit {
         backgroundPollTask?.cancel()
+        steeringConfirmationDismissTask?.cancel()
         pendingStreamingScrollTriggerTask?.cancel()
         pendingStreamingContentFlushTask?.cancel()
         listenPreparationTask?.cancel()
@@ -2498,6 +2506,7 @@ final class ChatViewModel {
         liveToolCalls = []
         liveReasoningText = ""
         pinnedLocalNotices = []
+        dismissSteeringConfirmation()
         streamingAssistantMessageID = nil
         toolCallAnchorMessageID = nil
         reasoningAnchorMessageID = nil
@@ -2616,7 +2625,8 @@ final class ChatViewModel {
         do {
             let response = try await client.steerChat(sessionID: sessionID, text: message)
             if response.accepted == true {
-                return .executed(message: String(localized: "Steering hint delivered."))
+                showSteeringConfirmation(String(localized: "Steering hint delivered."))
+                return .executed(message: nil)
             }
         } catch {
             lastError = error
@@ -3410,6 +3420,30 @@ final class ChatViewModel {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         pinnedLocalNotices.append(trimmed)
+    }
+
+    private func showSteeringConfirmation(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        steeringConfirmationDismissTask?.cancel()
+        steeringConfirmationNotice = trimmed
+        let dismissDelay = steeringConfirmationDismissDelay
+        steeringConfirmationDismissTask = Task { @MainActor [weak self] in
+            do {
+                try await dismissDelay()
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.dismissSteeringConfirmation()
+        }
+    }
+
+    private func dismissSteeringConfirmation() {
+        steeringConfirmationDismissTask?.cancel()
+        steeringConfirmationDismissTask = nil
+        steeringConfirmationNotice = nil
     }
 
     private func appendLocalMessage(_ text: String, role: String, idPrefix: String) -> String? {
@@ -5255,6 +5289,7 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
 
     func streamCoordinatorDidFinishStream() {
         flushPendingStreamingContent()
+        dismissSteeringConfirmation()
         responseCompletionNeedsTranscriptRefresh = false
     }
 

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8303,6 +8303,98 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(requestCount, 1)
     }
 
+    @MainActor
+    func testSuccessfulSteeringUsesOneTransientConfirmationAndRestartsDismissal() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let dismissalDelay = ManualAsyncDelay()
+        var steerRequests = 0
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            steeringConfirmationDismissDelay: { await dismissalDelay.wait() }
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(
+                    #"{"session_id":"session-abc","stream_id":"stream-123"}"#,
+                    for: request
+                )
+            case "/api/chat/steer":
+                steerRequests += 1
+                return apiTestJSONResponse(#"{"accepted":true}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Start a response")
+        XCTAssertTrue(didStart)
+
+        let steerCommand = try XCTUnwrap(SlashCommandCatalog.command(named: "steer"))
+        let slashResult = await viewModel.executeSlashCommand(steerCommand, args: "First hint")
+        XCTAssertEqual(slashResult, .executed(message: nil))
+        XCTAssertEqual(viewModel.steeringConfirmationNotice, "Steering hint delivered.")
+        await dismissalDelay.waitForRegistrationCount(1)
+
+        let normalSendResult = await viewModel.submitStreamingMessage("Second hint", behavior: .steer)
+        XCTAssertEqual(normalSendResult, .executed(message: nil))
+        await dismissalDelay.waitForRegistrationCount(2)
+
+        XCTAssertEqual(steerRequests, 2)
+        XCTAssertEqual(viewModel.steeringConfirmationNotice, "Steering hint delivered.")
+        XCTAssertTrue(viewModel.pinnedLocalNotices.isEmpty)
+
+        await dismissalDelay.resumeNext()
+        await drainMainActor()
+
+        XCTAssertEqual(viewModel.steeringConfirmationNotice, "Steering hint delivered.")
+
+        await dismissalDelay.resumeNext()
+        await drainMainActor()
+
+        XCTAssertNil(viewModel.steeringConfirmationNotice)
+        XCTAssertFalse(viewModel.messages.contains { $0.content == "Steering hint delivered." })
+    }
+
+    @MainActor
+    func testStreamCompletionDiscardsSteeringConfirmationInsteadOfPersistingIt() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let dismissalDelay = ManualAsyncDelay()
+        let viewModel = try makeViewModel(
+            streamClient: streamClient,
+            steeringConfirmationDismissDelay: { await dismissalDelay.wait() }
+        ) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse(
+                    #"{"session_id":"session-abc","stream_id":"stream-123"}"#,
+                    for: request
+                )
+            case "/api/chat/steer":
+                return apiTestJSONResponse(#"{"accepted":true}"#, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Start a response")
+        XCTAssertTrue(didStart)
+        _ = await viewModel.submitStreamingMessage("Steer it", behavior: .steer)
+        await dismissalDelay.waitForRegistrationCount(1)
+        XCTAssertNotNil(viewModel.steeringConfirmationNotice)
+
+        streamClient.emit(.streamEnd)
+
+        XCTAssertNil(viewModel.steeringConfirmationNotice)
+        XCTAssertTrue(viewModel.pinnedLocalNotices.isEmpty)
+        XCTAssertFalse(viewModel.messages.contains { $0.content == "Steering hint delivered." })
+
+        await dismissalDelay.resumeNext()
+        await drainMainActor()
+        XCTAssertNil(viewModel.steeringConfirmationNotice)
+    }
+
     /// Issue #202: a queued slash message whose send fails must not be retried in a tight loop.
     /// This is the verify-first verdict test — it queues one message behind a live stream, makes
     /// every drained send fail, triggers the drain, and counts how many times the send is retried.
@@ -8472,6 +8564,9 @@ final class ChatViewModelSendTests: XCTestCase {
         sessionSummary: SessionSummary? = nil,
         liveActivityManager: (any AgentLiveActivityManaging)? = nil,
         pollingIntervals: ChatPollingIntervals = .standard,
+        steeringConfirmationDismissDelay: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(nanoseconds: 3_000_000_000)
+        },
         streamingScrollCoalescingDelayNanoseconds: UInt64 = 16_000_000,
         speechSynthesizerFactory: @escaping () -> any ChatSpeechSynthesizing = { AVSpeechSynthesizer() },
         listenAudioSession: (any ListenAudioSessionControlling)? = nil,
@@ -8505,6 +8600,7 @@ final class ChatViewModelSendTests: XCTestCase {
             clarifyStreamClient: clarifyStreamClient ?? SpySSEStreamingClient(),
             liveActivityManager: liveActivityManager,
             pollingIntervals: pollingIntervals,
+            steeringConfirmationDismissDelay: steeringConfirmationDismissDelay,
             streamingScrollCoalescingDelayNanoseconds: streamingScrollCoalescingDelayNanoseconds,
             speechSynthesizerFactory: speechSynthesizerFactory,
             // Default to a spy so unit tests never drive the live shared AVAudioSession.
@@ -8900,6 +8996,41 @@ private final class SpySSEStreamingClient: SSEStreamingClient {
         onEvent?(event)
         if automaticallyFlushPendingStreamingContent {
             flushPendingStreamingContent?()
+        }
+    }
+}
+
+private actor ManualAsyncDelay {
+    private var waiters: [UnsafeContinuation<Void, Never>] = []
+    private var registrationCount = 0
+    private var registrationObservers: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    func wait() async {
+        await withUnsafeContinuation { continuation in
+            waiters.append(continuation)
+            registrationCount += 1
+            resumeSatisfiedRegistrationObservers()
+        }
+    }
+
+    func waitForRegistrationCount(_ expectedCount: Int) async {
+        guard registrationCount < expectedCount else { return }
+
+        await withCheckedContinuation { continuation in
+            registrationObservers.append((expectedCount, continuation))
+        }
+    }
+
+    func resumeNext() {
+        guard !waiters.isEmpty else { return }
+        waiters.removeFirst().resume()
+    }
+
+    private func resumeSatisfiedRegistrationObservers() {
+        let satisfied = registrationObservers.filter { $0.count <= registrationCount }
+        registrationObservers.removeAll { $0.count <= registrationCount }
+        for observer in satisfied {
+            observer.continuation.resume()
         }
     }
 }


### PR DESCRIPTION
## Linked issue

Fixes #183

## What changed

Successful steering now shows one transient confirmation above the composer. A later steering hint replaces it and restarts its three-second lifetime, while stream completion discards it instead of moving it into the transcript.

Failure and fallback notices keep their existing pinned behavior.

## How it was tested

- `git diff --check`
- XcodeBuildMCP focused run: 2 steering confirmation tests passed
- XcodeBuildMCP iPhone 17 simulator build: succeeded
- XcodeBuildMCP full XCTest suite: 1,752 passed, 0 failed, 2 skipped
- `scripts/check-swift-file-sizes`: warning-only, with no new file introduced

Owner check: in a signed simulator build connected to a server, steer an active response twice and confirm one card remains, disappears three seconds after the latest hint, and never enters the transcript when the response ends.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no models changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no API contract changed)

Implemented by GPT-5.6-sol in the T3 Code Codex harness.
