### PR TITLE
fix(chat): keep transcript spacing consistent

### DIFF
--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -34,8 +34,7 @@ struct ChatTranscriptView: View {
     let streamingScrollTrigger: Int
     let cacheFirstReconcileScrollToken: Int
     let bottomAnchorID: String
-    let transcriptMessageSpacing: CGFloat
-    let transcriptBlockSpacing: CGFloat
+    let transcriptSpacing: CGFloat
     let transcriptBottomInsetHeight: CGFloat
     let scrollToBottomButtonBottomPadding: CGFloat
     let localAttachmentPreviews: [String: [String: Data]]
@@ -205,7 +204,7 @@ struct ChatTranscriptView: View {
         viewportWidth: CGFloat,
         contentWidth: CGFloat
     ) -> some View {
-        VStack(spacing: transcriptMessageSpacing) {
+        VStack(spacing: transcriptSpacing) {
             olderMessagesButton(proxy: proxy)
 
             if let compressionReferenceCard, compressionReferenceCard.afterRenderID == nil {
@@ -225,7 +224,7 @@ struct ChatTranscriptView: View {
 
                 ChatTranscriptMessageBlock(
                     transcriptMessage: transcriptMessage,
-                    transcriptBlockSpacing: transcriptBlockSpacing,
+                    transcriptSpacing: transcriptSpacing,
                     showsThinkingAndToolCards: showsThinkingAndToolCards,
                     reasoningGroups: reasoningGroups,
                     toolCallGroups: completedToolCallGroupsForAnchor(transcriptMessage.anchorID),
@@ -420,7 +419,6 @@ struct ChatTranscriptView: View {
                 action: onInlineCommit
             )
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 2)
         }
     }
 
@@ -455,7 +453,7 @@ struct ChatTranscriptView: View {
 
 private struct ChatTranscriptMessageBlock: View, Equatable {
     let transcriptMessage: TranscriptMessage
-    let transcriptBlockSpacing: CGFloat
+    let transcriptSpacing: CGFloat
     let showsThinkingAndToolCards: Bool
     let reasoningGroups: [ReasoningGroup]
     let toolCallGroups: [ToolCallGroup]
@@ -495,7 +493,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     // even though their closure props are recreated on every parent body pass.
     static func == (lhs: ChatTranscriptMessageBlock, rhs: ChatTranscriptMessageBlock) -> Bool {
         lhs.transcriptMessage == rhs.transcriptMessage &&
-            lhs.transcriptBlockSpacing == rhs.transcriptBlockSpacing &&
+            lhs.transcriptSpacing == rhs.transcriptSpacing &&
             lhs.showsThinkingAndToolCards == rhs.showsThinkingAndToolCards &&
             lhs.reasoningGroups == rhs.reasoningGroups &&
             lhs.toolCallGroups == rhs.toolCallGroups &&
@@ -516,7 +514,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: transcriptBlockSpacing) {
+        VStack(alignment: .leading, spacing: transcriptSpacing) {
             reasoningBlocks
             liveReasoningBlock
             toolActivityGroups

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -255,8 +255,7 @@ private struct ListenPlaybackBar: View {
 
 struct ChatView: View {
     private let bottomAnchorID = "chat-bottom-anchor"
-    private let transcriptMessageSpacing: CGFloat = 10
-    private let transcriptBlockSpacing: CGFloat = 6
+    private let transcriptSpacing: CGFloat = 8
     private let composerAccessoryVerticalSpacing: CGFloat = 8
     private let activeRunStatusSpacerHeight: CGFloat = 36
     private let approvalBypassStatusSpacerHeight: CGFloat = 38
@@ -1170,8 +1169,7 @@ struct ChatView: View {
             streamingScrollTrigger: viewModel.streamingScrollTrigger,
             cacheFirstReconcileScrollToken: viewModel.cacheFirstReconcileScrollToken,
             bottomAnchorID: bottomAnchorID,
-            transcriptMessageSpacing: transcriptMessageSpacing,
-            transcriptBlockSpacing: transcriptBlockSpacing,
+            transcriptSpacing: transcriptSpacing,
             transcriptBottomInsetHeight: transcriptBottomInsetHeight,
             scrollToBottomButtonBottomPadding: scrollToBottomButtonBottomPadding,
             localAttachmentPreviews: viewModel.localAttachmentPreviews,

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -246,7 +246,9 @@ final class ChatViewModel {
     @ObservationIgnored private var pendingStreamingContentFlushTask: Task<Void, Never>?
     private(set) var completedToolCallGroups: [ToolCallGroup] = []
     private var completedToolCallGroupLookup = ToolCallGroupAnchorLookup()
-    private(set) var completedReasoningGroups: [ReasoningGroup] = []
+    private(set) var completedReasoningGroups: [ReasoningGroup] = [] {
+        didSet { recomputeDisplayedTranscriptMessages() }
+    }
     var displayedReasoningGroups: [ReasoningGroup] {
         Self.reasoningDisplayGroups(
             messages: messages,
@@ -275,9 +277,15 @@ final class ChatViewModel {
     }
 
     private func recomputeDisplayedTranscriptMessages() {
+        let renderedActivityAnchorIDs = Self.transcriptActivityAnchorIDs(
+            reasoningGroups: displayedReasoningGroups,
+            toolCallGroups: completedToolCallGroups
+        )
         displayedTranscriptMessages = Self.transcriptMessages(
             from: messages,
-            messageOffset: messagesOffset
+            messageOffset: messagesOffset,
+            preservingEmptyAssistantID: streamingAssistantMessageID,
+            renderedActivityAnchorIDs: renderedActivityAnchorIDs
         )
         recomputeCompressionReferenceCard()
     }
@@ -311,7 +319,12 @@ final class ChatViewModel {
     }
     private(set) var liveToolCalls: [ToolCall] = []
     private(set) var liveReasoningText = ""
-    private(set) var streamingAssistantMessageID: String?
+    private(set) var streamingAssistantMessageID: String? {
+        didSet {
+            guard oldValue != streamingAssistantMessageID else { return }
+            recomputeDisplayedTranscriptMessages()
+        }
+    }
     private(set) var toolCallAnchorMessageID: String?
     private(set) var reasoningAnchorMessageID: String?
     private(set) var messagesOffset = 0 {
@@ -4305,6 +4318,7 @@ final class ChatViewModel {
 
         completedToolCallGroups = groups
         completedToolCallGroupLookup = lookup
+        recomputeDisplayedTranscriptMessages()
     }
 
     private func appendCompletedToolCallGroup(_ group: ToolCallGroup) {
@@ -5642,16 +5656,41 @@ extension ChatViewModel {
         }
     }
 
-    nonisolated static func transcriptMessages(from messages: [ChatMessage], messageOffset: Int? = nil) -> [TranscriptMessage] {
-        transcriptMessages(from: messages, messageOffset: messageOffset, hidingStreamingAssistantID: nil)
+    nonisolated static func transcriptMessages(
+        from messages: [ChatMessage],
+        messageOffset: Int? = nil,
+        preservingEmptyAssistantID: String? = nil,
+        renderedActivityAnchorIDs: Set<String>? = nil
+    ) -> [TranscriptMessage] {
+        transcriptMessages(
+            from: messages,
+            messageOffset: messageOffset,
+            hidingStreamingAssistantID: nil,
+            preservingEmptyAssistantID: preservingEmptyAssistantID,
+            renderedActivityAnchorIDs: renderedActivityAnchorIDs
+        )
     }
 
     nonisolated static func transcriptMessages(
         from messages: [ChatMessage],
         messageOffset: Int? = nil,
-        hidingStreamingAssistantID streamingAssistantID: String?
+        hidingStreamingAssistantID streamingAssistantID: String?,
+        preservingEmptyAssistantID: String? = nil,
+        renderedActivityAnchorIDs: Set<String>? = nil
     ) -> [TranscriptMessage] {
         let offset = max(0, messageOffset ?? 0)
+        let activityAnchorIDs = renderedActivityAnchorIDs ?? transcriptActivityAnchorIDs(
+            reasoningGroups: reasoningDisplayGroups(
+                messages: messages,
+                messageOffset: messageOffset,
+                archivedGroups: []
+            ),
+            toolCallGroups: ToolCallGroup.groups(
+                persistedToolCalls: [],
+                messages: messages,
+                messageOffset: messageOffset
+            )
+        )
         var transcriptMessages: [TranscriptMessage] = []
         transcriptMessages.reserveCapacity(messages.count)
 
@@ -5667,6 +5706,12 @@ extension ChatViewModel {
                 at: loadedIndex,
                 messageOffset: messageOffset
             )
+            guard anchorID == preservingEmptyAssistantID
+                || activityAnchorIDs.contains(anchorID)
+                || hasTranscriptMessageRowContent(message)
+            else {
+                continue
+            }
             let absoluteIndex = offset + loadedIndex
             let renderID = "transcript:\(absoluteIndex)"
 
@@ -5679,6 +5724,22 @@ extension ChatViewModel {
         }
 
         return transcriptMessages
+    }
+
+    nonisolated private static func transcriptActivityAnchorIDs(
+        reasoningGroups: [ReasoningGroup],
+        toolCallGroups: [ToolCallGroup]
+    ) -> Set<String> {
+        Set(reasoningGroups.compactMap(\.anchorMessageID))
+            .union(toolCallGroups.compactMap(\.anchorMessageID))
+    }
+
+    nonisolated private static func hasTranscriptMessageRowContent(_ message: ChatMessage) -> Bool {
+        if message.content?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return true
+        }
+
+        return message.role == "user" && message.attachments?.isEmpty == false
     }
 
     nonisolated static func compressionReferenceCard(

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -80,7 +80,6 @@ struct MessageBubbleView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
-        .padding(.vertical, 2)
     }
 
     private var assistantMessageRow: some View {
@@ -107,7 +106,6 @@ struct MessageBubbleView: View {
             linkPreview
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 2)
         // While this row is the active streaming message, animate its height
         // growth at the same curve as the bottom-follow scroll so the streaming
         // edge stays visually stationary instead of stepping per word flush.

--- a/HermesMobile/Features/Workspace/GitTurnChangesCard.swift
+++ b/HermesMobile/Features/Workspace/GitTurnChangesCard.swift
@@ -38,7 +38,6 @@ struct GitTurnChangesCard: View {
         .background(Color(.secondarySystemBackground), in: shape)
         .overlay { shape.stroke(dividerColor, lineWidth: 0.5) }
         .clipShape(shape)
-        .padding(.top, 2)
     }
 
     private var header: some View {

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -27,6 +27,80 @@ final class TranscriptMessageTests: XCTestCase {
         XCTAssertEqual(transcriptMessages.map(\.message.id), ["u1", "a1", "a2"])
     }
 
+    func testTranscriptMessagesDropEmptyBlocksButKeepAssistantActivity() {
+        let messages = [
+            ChatMessage(role: "user", content: "Use tools", timestamp: 1, messageId: "u1"),
+            ChatMessage(role: "assistant", content: "  ", timestamp: 2, messageId: "empty"),
+            ChatMessage(
+                role: "assistant",
+                content: "",
+                timestamp: 3,
+                messageId: "reasoning",
+                reasoning: "Inspecting the transcript"
+            ),
+            ChatMessage(
+                role: "assistant",
+                content: nil,
+                timestamp: 4,
+                messageId: "tool-call",
+                toolCalls: [.object(["id": .string("call-1")])]
+            )
+        ]
+
+        let transcriptMessages = ChatViewModel.transcriptMessages(from: messages)
+
+        XCTAssertEqual(transcriptMessages.map(\.message.id), ["u1", "reasoning", "tool-call"])
+    }
+
+    func testTranscriptMessagesDropShellsAfterActivityGroupingAndReasoningDeduplication() {
+        func assistant(_ id: String, reasoning: String?, toolID: String) -> ChatMessage {
+            ChatMessage(
+                role: "assistant",
+                content: "",
+                timestamp: 2,
+                messageId: id,
+                toolCalls: [
+                    .object([
+                        "id": .string(toolID),
+                        "function": .object([
+                            "name": .string("browser_console"),
+                            "arguments": .string("{}")
+                        ])
+                    ])
+                ],
+                reasoning: reasoning
+            )
+        }
+
+        func toolResult(_ id: String) -> ChatMessage {
+            ChatMessage(
+                role: "tool",
+                content: "result",
+                timestamp: 3,
+                messageId: "result-\(id)",
+                toolCallId: id
+            )
+        }
+
+        let messages = [
+            ChatMessage(role: "user", content: "Inspect the app", timestamp: 1, messageId: "u1"),
+            assistant("a1", reasoning: "First visible thought", toolID: "call-1"),
+            toolResult("call-1"),
+            assistant("a2", reasoning: nil, toolID: "call-2"),
+            toolResult("call-2"),
+            assistant("a3", reasoning: nil, toolID: "call-3"),
+            toolResult("call-3"),
+            assistant("a4", reasoning: "Repeated thought", toolID: "call-4"),
+            toolResult("call-4"),
+            assistant("a5", reasoning: "Repeated thought", toolID: "call-5"),
+            toolResult("call-5")
+        ]
+
+        let transcriptMessages = ChatViewModel.transcriptMessages(from: messages)
+
+        XCTAssertEqual(transcriptMessages.map(\.message.id), ["u1", "a1", "a5"])
+    }
+
     func testTranscriptMessagesCanHideActiveStreamingAssistantTurn() {
         let messages = [
             ChatMessage(role: "user", content: "Use tools", timestamp: 1, messageId: "u1"),
@@ -60,8 +134,14 @@ final class TranscriptMessageTests: XCTestCase {
             ChatMessage(role: "assistant", content: "First streamed token.", timestamp: 2, messageId: "stream-1")
         ]
 
-        let initialTranscriptMessages = ChatViewModel.transcriptMessages(from: initialMessages)
-        let updatedTranscriptMessages = ChatViewModel.transcriptMessages(from: updatedMessages)
+        let initialTranscriptMessages = ChatViewModel.transcriptMessages(
+            from: initialMessages,
+            preservingEmptyAssistantID: "stream-1"
+        )
+        let updatedTranscriptMessages = ChatViewModel.transcriptMessages(
+            from: updatedMessages,
+            preservingEmptyAssistantID: "stream-1"
+        )
 
         XCTAssertEqual(initialTranscriptMessages.map(\.anchorID), ["u1", "stream-1"])
         XCTAssertEqual(updatedTranscriptMessages.map(\.anchorID), ["u1", "stream-1"])
@@ -99,11 +179,13 @@ final class TranscriptMessageTests: XCTestCase {
 
         let initialTranscriptMessages = ChatViewModel.transcriptMessages(
             from: initialMessages,
-            messageOffset: 10
+            messageOffset: 10,
+            preservingEmptyAssistantID: "raw:11"
         )
         let updatedTranscriptMessages = ChatViewModel.transcriptMessages(
             from: updatedMessages,
-            messageOffset: 10
+            messageOffset: 10,
+            preservingEmptyAssistantID: "raw:11"
         )
 
         XCTAssertEqual(initialTranscriptMessages.map(\.anchorID), ["raw:10", "raw:11"])


### PR DESCRIPTION
## Linked issue

Fixes #201

## What changed

Transcript rows could accumulate different amounts of vertical space depending on whether activity cards and messages belonged to the same nested block. Empty assistant shells left after activity grouping could also consume one or more invisible gaps.

This gives the transcript one 8pt vertical rhythm, removes the per-row padding that compounded it, and filters empty assistant shells using the final reasoning and tool-activity anchors. The active streaming assistant row remains stable while its first content arrives.

## How it was tested

- Full XCTest suite on the iPhone 17 simulator: 1,754 passed, 2 skipped, 0 failed
- Focused coverage for empty shells after reasoning deduplication and tool-call coalescing
- Signed Debug build installed and launched on iPhone 17
- Owner verified the previously problematic session in the simulator and confirmed the spacing is consistent
- `git diff --check`
- `scripts/check-swift-file-sizes` (warning-only existing oversized files)

Visual baseline and acceptance screenshot: [issue #201](https://github.com/uzairansaruzi/hermex/issues/201)

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no Codable models changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no networking contract changed)

Built with GPT-5.6 in T3 Code through the Codex harness.
