### PR TITLE
fix(settings): hide all chat git controls

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -150,6 +150,8 @@
 		C0DE21000000000000000001 /* ChatMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE21000000000000000002 /* ChatMotion.swift */; };
 		C0DE25000000000000000001 /* ChatScrollPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE25000000000000000002 /* ChatScrollPolicy.swift */; };
 		C0DE25000000000000000003 /* ChatScrollPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE25000000000000000004 /* ChatScrollPolicyTests.swift */; };
+		C27800000000000000000001 /* ChatGitControlsVisibilityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27800000000000000000002 /* ChatGitControlsVisibilityPolicy.swift */; };
+		C27800000000000000000003 /* ChatGitControlsVisibilityPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27800000000000000000004 /* ChatGitControlsVisibilityPolicyTests.swift */; };
 		C0DE22000000000000000001 /* ChatHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000002 /* ChatHaptics.swift */; };
 		C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000004 /* ChatHapticsTests.swift */; };
 		C08800000000000000000001 /* SessionHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08800000000000000000002 /* SessionHaptics.swift */; };
@@ -497,6 +499,8 @@
 		C0DE21000000000000000002 /* ChatMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMotion.swift; sourceTree = "<group>"; };
 		C0DE25000000000000000002 /* ChatScrollPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollPolicy.swift; sourceTree = "<group>"; };
 		C0DE25000000000000000004 /* ChatScrollPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollPolicyTests.swift; sourceTree = "<group>"; };
+		C27800000000000000000002 /* ChatGitControlsVisibilityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGitControlsVisibilityPolicy.swift; sourceTree = "<group>"; };
+		C27800000000000000000004 /* ChatGitControlsVisibilityPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGitControlsVisibilityPolicyTests.swift; sourceTree = "<group>"; };
 		C0DE22000000000000000002 /* ChatHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHaptics.swift; sourceTree = "<group>"; };
 		C0DE22000000000000000004 /* ChatHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHapticsTests.swift; sourceTree = "<group>"; };
 		C08800000000000000000002 /* SessionHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHaptics.swift; sourceTree = "<group>"; };
@@ -818,6 +822,7 @@
 				C14300000000000000000004 /* StreamingMarkdownSupportTests.swift */,
 				C13000000000000000000002 /* ChatVerticalScrollAxisGuardTests.swift */,
 				C0DE25000000000000000004 /* ChatScrollPolicyTests.swift */,
+				C27800000000000000000004 /* ChatGitControlsVisibilityPolicyTests.swift */,
 				1A2B3C4D5E6F7000000000DD /* SSEClientTests.swift */,
 				C22600000000000000000002 /* ScriptedSSEStreamFixture.swift */,
 				C22600000000000000000004 /* StreamReconnectContractTests.swift */,
@@ -1036,6 +1041,7 @@
 				C0DE20000000000000000002 /* ChatTactileButtonStyle.swift */,
 				C0DE21000000000000000002 /* ChatMotion.swift */,
 				C0DE25000000000000000002 /* ChatScrollPolicy.swift */,
+				C27800000000000000000002 /* ChatGitControlsVisibilityPolicy.swift */,
 				C0DE22000000000000000002 /* ChatHaptics.swift */,
 				105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */,
 				A04200000000000000000004 /* ApprovalRequestOverlay.swift */,
@@ -1585,6 +1591,7 @@
 				C0DE20000000000000000001 /* ChatTactileButtonStyle.swift in Sources */,
 				C0DE21000000000000000001 /* ChatMotion.swift in Sources */,
 				C0DE25000000000000000001 /* ChatScrollPolicy.swift in Sources */,
+				C27800000000000000000001 /* ChatGitControlsVisibilityPolicy.swift in Sources */,
 				C0DE22000000000000000001 /* ChatHaptics.swift in Sources */,
 				C08800000000000000000001 /* SessionHaptics.swift in Sources */,
 				031031031031031031031009 /* DisplayMathView.swift in Sources */,
@@ -1691,6 +1698,7 @@
 				C14300000000000000000003 /* StreamingMarkdownSupportTests.swift in Sources */,
 				C13000000000000000000001 /* ChatVerticalScrollAxisGuardTests.swift in Sources */,
 				C0DE25000000000000000003 /* ChatScrollPolicyTests.swift in Sources */,
+				C27800000000000000000003 /* ChatGitControlsVisibilityPolicyTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000DC /* SSEClientTests.swift in Sources */,
 				C22600000000000000000001 /* ScriptedSSEStreamFixture.swift in Sources */,
 				C22600000000000000000003 /* StreamReconnectContractTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatGitControlsVisibilityPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatGitControlsVisibilityPolicy.swift
@@ -1,0 +1,32 @@
+/// Decides whether turn-end git controls belong in the chat transcript.
+///
+/// The Settings toggle is checked here with the existing workspace and turn
+/// conditions so every transcript git surface follows the same visibility rule.
+enum ChatGitControlsVisibilityPolicy {
+    static func showsInlineCommitButton(
+        showsGitControls: Bool,
+        hasRepository: Bool,
+        isStreaming: Bool,
+        latestMessageRole: String?,
+        hasCommittableChanges: Bool,
+        isCommitting: Bool
+    ) -> Bool {
+        showsGitControls
+            && hasRepository
+            && !isStreaming
+            && latestMessageRole == "assistant"
+            && (hasCommittableChanges || isCommitting)
+    }
+
+    static func showsTurnChangesRecap(
+        showsGitControls: Bool,
+        hasRepository: Bool,
+        isStreaming: Bool,
+        latestMessageRole: String?
+    ) -> Bool {
+        showsGitControls
+            && hasRepository
+            && !isStreaming
+            && latestMessageRole == "assistant"
+    }
+}

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -948,11 +948,14 @@ struct ChatView: View {
     /// Only for git workspaces, when the latest message is an assistant turn (not while a
     /// response streams), and there is something to commit (or a commit is in flight).
     private var inlineCommitContext: ChatInlineCommitContext? {
-        guard gitAvailabilityViewModel.hasRepository,
-              viewModel.activeStreamID == nil,
-              latestTranscriptMessageRole == "assistant",
-              gitAvailabilityViewModel.hasCommittableChanges || gitAvailabilityViewModel.isCommitting
-        else { return nil }
+        guard ChatGitControlsVisibilityPolicy.showsInlineCommitButton(
+            showsGitControls: showsGitControls,
+            hasRepository: gitAvailabilityViewModel.hasRepository,
+            isStreaming: viewModel.activeStreamID != nil,
+            latestMessageRole: latestTranscriptMessageRole,
+            hasCommittableChanges: gitAvailabilityViewModel.hasCommittableChanges,
+            isCommitting: gitAvailabilityViewModel.isCommitting
+        ) else { return nil }
         return ChatInlineCommitContext(
             runningPhase: gitAvailabilityViewModel.commitPhase,
             isDisabled: gitWriteAvailability.writesDisabled
@@ -963,10 +966,12 @@ struct ChatView: View {
     /// workspaces once the response finishes (status has refreshed) and the latest turn
     /// actually changed files.
     private var turnChangesRecapSummary: TurnFileChangeSummary? {
-        guard gitAvailabilityViewModel.hasRepository,
-              viewModel.activeStreamID == nil,
-              latestTranscriptMessageRole == "assistant"
-        else { return nil }
+        guard ChatGitControlsVisibilityPolicy.showsTurnChangesRecap(
+            showsGitControls: showsGitControls,
+            hasRepository: gitAvailabilityViewModel.hasRepository,
+            isStreaming: viewModel.activeStreamID != nil,
+            latestMessageRole: latestTranscriptMessageRole
+        ) else { return nil }
         let summary = TurnFileChangeAggregator.summarize(
             toolCalls: viewModel.latestTurnToolCalls,
             status: gitAvailabilityViewModel.status

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -306,7 +306,7 @@ struct SettingsView: View {
                         isOn: $showsChatGitControls
                     )
 
-                    SettingsFootnote(String(localized: "Covers both the git menu in the chat toolbar and the branch picker in the composer."))
+                    SettingsFootnote(String(localized: "Hides the git menu, branch picker, and commit controls."))
                 }
 
                 SettingsCard(title: String(localized: "Main Page")) {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -113750,6 +113750,112 @@
           }
         }
       }
+    },
+    "Hides the git menu, branch picker, and commit controls." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يخفي قائمة Git ومنتقي الفروع وعناصر التحكم في الالتزام."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Blendet das Git-Menü, die Branch-Auswahl und die Commit-Steuerelemente aus."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oculta el menú de Git, el selector de ramas y los controles de commit."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Masque le menu Git, le sélecteur de branches et les commandes de commit."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מסתיר את תפריט Git, בורר הענפים ופקדי ה-commit."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nasconde il menu Git, il selettore dei branch e i controlli di commit."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gitメニュー、ブランチ選択、コミットコントロールを非表示にします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Git 메뉴, 브랜치 선택기 및 커밋 컨트롤을 숨겨요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verbergt het Git-menu, de branchkiezer en de commitknoppen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ukrywa menu Git, selektor gałęzi i opcje zatwierdzania zmian."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oculta o menu do Git, o seletor de branches e os controles de commit."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Скрывает меню Git, выбор ветки и элементы управления коммитами."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Git menüsünü, dal seçiciyi ve commit denetimlerini gizler."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Git مینو، برانچ منتخب کنندہ، اور کمٹ کنٹرولز کو چھپاتا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "隱藏 Git 選單、分支選擇器及提交控制項。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "隐藏 Git 菜单、分支选择器和提交控件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "隱藏 Git 選單、分支選擇器和提交控制項。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ChatGitControlsVisibilityPolicyTests.swift
+++ b/HermesMobileTests/ChatGitControlsVisibilityPolicyTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import HermesMobile
+
+final class ChatGitControlsVisibilityPolicyTests: XCTestCase {
+    func testDisabledSettingHidesBothTurnEndGitSurfaces() {
+        XCTAssertFalse(
+            ChatGitControlsVisibilityPolicy.showsInlineCommitButton(
+                showsGitControls: false,
+                hasRepository: true,
+                isStreaming: false,
+                latestMessageRole: "assistant",
+                hasCommittableChanges: true,
+                isCommitting: false
+            )
+        )
+        XCTAssertFalse(
+            ChatGitControlsVisibilityPolicy.showsTurnChangesRecap(
+                showsGitControls: false,
+                hasRepository: true,
+                isStreaming: false,
+                latestMessageRole: "assistant"
+            )
+        )
+    }
+
+    func testEnabledSettingPreservesInlineCommitConditions() {
+        XCTAssertTrue(showsInlineCommit())
+        XCTAssertFalse(showsInlineCommit(hasRepository: false))
+        XCTAssertFalse(showsInlineCommit(isStreaming: true))
+        XCTAssertFalse(showsInlineCommit(latestMessageRole: "user"))
+        XCTAssertFalse(showsInlineCommit(hasCommittableChanges: false))
+        XCTAssertTrue(showsInlineCommit(hasCommittableChanges: false, isCommitting: true))
+    }
+
+    func testEnabledSettingPreservesTurnChangesRecapConditions() {
+        XCTAssertTrue(showsTurnChangesRecap())
+        XCTAssertFalse(showsTurnChangesRecap(hasRepository: false))
+        XCTAssertFalse(showsTurnChangesRecap(isStreaming: true))
+        XCTAssertFalse(showsTurnChangesRecap(latestMessageRole: "user"))
+    }
+
+    private func showsInlineCommit(
+        hasRepository: Bool = true,
+        isStreaming: Bool = false,
+        latestMessageRole: String? = "assistant",
+        hasCommittableChanges: Bool = true,
+        isCommitting: Bool = false
+    ) -> Bool {
+        ChatGitControlsVisibilityPolicy.showsInlineCommitButton(
+            showsGitControls: true,
+            hasRepository: hasRepository,
+            isStreaming: isStreaming,
+            latestMessageRole: latestMessageRole,
+            hasCommittableChanges: hasCommittableChanges,
+            isCommitting: isCommitting
+        )
+    }
+
+    private func showsTurnChangesRecap(
+        hasRepository: Bool = true,
+        isStreaming: Bool = false,
+        latestMessageRole: String? = "assistant"
+    ) -> Bool {
+        ChatGitControlsVisibilityPolicy.showsTurnChangesRecap(
+            showsGitControls: true,
+            hasRepository: hasRepository,
+            isStreaming: isStreaming,
+            latestMessageRole: latestMessageRole
+        )
+    }
+}


### PR DESCRIPTION
## Linked issue

Fixes #278

## What changed

Turning Git Actions off still left the inline Commit & Push button and File changes recap visible. The existing setting now hides every git control in chat, while the current repository and turn-state rules remain unchanged when it is on.

A small pure policy owns the two turn-end visibility decisions. The Settings footnote now describes the full behavior and is translated in all 17 shipped languages.

## How it was tested

- Full XCTest suite on iPhone 17 through XcodeBuildMCP: 1,757 passed, 0 failed, 2 skipped
- Focused visibility and localization tests: 10 passed
- `git diff --check` and localization parsed-subtree comparison passed
- Owner manually verified that all four controls appear when enabled, disappear immediately when disabled, and return when re-enabled
- Screenshots omitted because this state requires a live git-backed chat and would expose owner workspace content; the owner validated it interactively

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] No `Codable` models changed
- [x] No new third-party dependencies
- [x] No API endpoints or JSON shapes changed

Built with GPT-5.6 Sol in T3 Code through the Codex harness.
