### PR TITLE
fix: show all models (incl. extra_models) in composer + settings pickers

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerSelectorSheets.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSelectorSheets.swift
@@ -152,7 +152,7 @@ struct ComposerModelPickerSheet: View {
                     .padding(.leading, 10)
 
                 LazyVStack(spacing: 1) {
-                    ForEach(group.models, id: \.self) { option in
+                    ForEach(group.allModels, id: \.self) { option in
                         modelOptionRow(option, allowsDelete: group.id == savedCustomGroupID)
                     }
                 }
@@ -165,7 +165,7 @@ struct ComposerModelPickerSheet: View {
                     .foregroundStyle(.primary)
                     .lineLimit(1)
 
-                Text("\(group.models.count)")
+                Text("\(group.allModels.count)")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
 
@@ -267,7 +267,7 @@ struct ComposerModelPickerSheet: View {
             baseGroups = modelGroups
         } else {
             baseGroups = modelGroups.compactMap { group in
-                let filteredModels = group.models.filter { option in
+                let filteredModels = group.allModels.filter { option in
                     matches(option, query: query)
                 }
 
@@ -315,7 +315,7 @@ struct ComposerModelPickerSheet: View {
     }
 
     private var storedCustomOptions: [ModelCatalogOption] {
-        let catalogKeys = Set(modelGroups.flatMap(\.models).map(\.favoriteKey))
+        let catalogKeys = Set(modelGroups.flatMap(\.allModels).map(\.favoriteKey))
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         var seen = Set<ModelFavoriteKey>()
         var result: [ModelCatalogOption] = []
@@ -351,7 +351,7 @@ struct ComposerModelPickerSheet: View {
 
     private var selectedCustomOption: ModelCatalogOption? {
         guard let selectedModelID, !selectedModelID.isEmpty else { return nil }
-        let catalogOptions = modelGroups.flatMap(\.models)
+        let catalogOptions = modelGroups.flatMap(\.allModels)
         if catalogOptions.firstMatchingSelection(
             modelID: selectedModelID,
             providerID: selectedModelProviderID

--- a/HermesMobile/Features/Settings/DefaultModelPickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultModelPickerView.swift
@@ -108,10 +108,10 @@ struct DefaultModelPickerView: View {
             ForEach(filteredGroups) { group in
                 ModelPickerCard(title: group.name) {
                     VStack(spacing: 0) {
-                        ForEach(Array(group.models.enumerated()), id: \.element.id) { index, model in
+                        ForEach(Array(group.allModels.enumerated()), id: \.element.id) { index, model in
                             modelRow(model)
 
-                            if index < group.models.count - 1 {
+                            if index < group.allModels.count - 1 {
                                 Divider()
                             }
                         }
@@ -126,7 +126,7 @@ struct DefaultModelPickerView: View {
         guard !query.isEmpty else { return groups }
 
         return groups.compactMap { group in
-            let matchingModels = group.models.filter { model in
+            let matchingModels = group.allModels.filter { model in
                 model.displayName.lowercased().contains(query)
                     || model.id.lowercased().contains(query)
                     || group.name.lowercased().contains(query)

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -681,9 +681,18 @@ struct ModelCatalogGroup: Identifiable, Equatable, Sendable {
 }
 
 extension ModelCatalogGroup {
-    var slashAutocompleteModels: [ModelCatalogOption] {
+    /// The full catalog for this provider: `models` + `extraModels`, deduplicated
+    /// by id with order preserved (`models` first). The pickers render this list
+    /// so nothing the server ships under `extra_models` is hidden behind a
+    /// "featured subset" overflow.
+    var allModels: [ModelCatalogOption] {
         var seen = Set<String>()
         return (models + extraModels).filter { seen.insert($0.id).inserted }
+    }
+
+    /// Slash autocomplete surfaces the same full catalog as the pickers.
+    var slashAutocompleteModels: [ModelCatalogOption] {
+        allModels
     }
 }
 

--- a/HermesMobileTests/ModelCatalogTests.swift
+++ b/HermesMobileTests/ModelCatalogTests.swift
@@ -77,6 +77,35 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertEqual(response.displayName(for: "@nous:qwen/qwen3-coder"), "Qwen3 Coder (via Nous)")
     }
 
+    func testAllModelsMergesModelsAndExtraModelsDeduplicatedByID() {
+        let group = ModelCatalogGroup(
+            id: "nous",
+            name: "Nous",
+            providerID: "nous",
+            models: [
+                ModelCatalogOption(id: "@nous:alpha", displayName: "Alpha", providerID: "nous"),
+                ModelCatalogOption(id: "@nous:shared", displayName: "Shared (featured)", providerID: "nous")
+            ],
+            extraModels: [
+                ModelCatalogOption(id: "@nous:shared", displayName: "Shared (extra)", providerID: "nous"),
+                ModelCatalogOption(id: "@nous:beta", displayName: "Beta", providerID: "nous")
+            ]
+        )
+
+        // Deduplicated by id, order preserved (models first); the featured copy
+        // wins when an id appears in both lists.
+        XCTAssertEqual(
+            group.allModels.map(\.id),
+            ["@nous:alpha", "@nous:shared", "@nous:beta"]
+        )
+        XCTAssertEqual(
+            group.allModels.first { $0.id == "@nous:shared" }?.displayName,
+            "Shared (featured)"
+        )
+        XCTAssertEqual(group.allModels.count, 3)
+        XCTAssertEqual(group.slashAutocompleteModels, group.allModels)
+    }
+
     // MARK: - /api/models/live (issue #236)
 
     func testModelsLiveResponseDecodesUpstreamShape() throws {


### PR DESCRIPTION
## Problem
The server ships provider groups with a featured-subset overflow: `models` (visible) plus `extra_models` (remainder). The composer and Settings pickers rendered only `group.models`, hiding every overflow model — on a live server with 15+334 (Nous) and 15+40 (OpenRouter), 374 models were invisible to users.

## Fix
Add `ModelCatalogGroup.allModels` (models + extraModels, deduped by id, order preserved) and render/search/count from it in:
- `ComposerModelPickerSheet` (rows, group counts, search filter, favorites catalog, selected-option lookup)
- `DefaultModelPickerView` (Settings)
- `slashAutocompleteModels` now aliases `allModels`

New unit test: `testAllModelsMergesModelsAndExtraModelsDeduplicatedByID`.

## Verification
- No Swift toolchain on the author's machine; build/tests rely on this PR's CI (macOS runner).
- Diff is picker-scoped: 4 files, +47/−9.

Authored by Tax (KombLabs), tested via CI.