### PR TITLE
fix(chat): render inline assignment math

### DIFF
--- a/HermesMobile/Features/Chat/MarkdownMathFormatter.swift
+++ b/HermesMobile/Features/Chat/MarkdownMathFormatter.swift
@@ -159,8 +159,47 @@ struct MarkdownMathFormatter {
         if trimmed.range(of: #"^[A-Za-z](?:_[A-Za-z0-9]+|\^[A-Za-z0-9]+)?$"#, options: .regularExpression) != nil {
             return true
         }
+        if looksLikeAssignment(trimmed) { return true }
         if trimmed.contains("\\") || trimmed.contains("^") || trimmed.contains("_") { return true }
         return trimmed.range(of: #"[A-Za-z0-9]\s*[=<>+\-*/|]\s*[A-Za-z0-9]"#, options: .regularExpression) != nil
+    }
+
+    /// Recognizes assignment forms whose grouped right-hand side prevented the
+    /// general operator rule from seeing an alphanumeric value after `=`.
+    private static func looksLikeAssignment(_ value: String) -> Bool {
+        let parts = value.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return false }
+
+        let lhs = parts[0].trimmingCharacters(in: .whitespaces)
+        guard lhs.range(
+            of: #"^[A-Za-z](?:_[A-Za-z0-9]+|\^[A-Za-z0-9]+)?$"#,
+            options: .regularExpression
+        ) != nil else {
+            return false
+        }
+
+        let rhs = parts[1].trimmingCharacters(in: .whitespaces)
+        guard !rhs.isEmpty else { return false }
+
+        let allowedSymbols = CharacterSet(charactersIn: #"\_^,+-*/.=<>|[](){}"#)
+            .union(.alphanumerics)
+            .union(.whitespaces)
+        guard rhs.unicodeScalars.allSatisfy(allowedSymbols.contains) else { return false }
+
+        var stack: [Character] = []
+        let closingForOpening: [Character: Character] = ["[": "]", "(": ")", "{": "}"]
+        let openingsForClosing: [Character: Character] = ["]": "[", ")": "(", "}": "{"]
+
+        for character in rhs {
+            if closingForOpening[character] != nil {
+                stack.append(character)
+            } else if let opening = openingsForClosing[character] {
+                guard stack.popLast() == opening else { return false }
+            }
+        }
+
+        guard stack.isEmpty else { return false }
+        return rhs.range(of: #"[0-9\\_^,+\-*/<>|]"#, options: .regularExpression) != nil
     }
 }
 

--- a/HermesMobileTests/MarkdownMathRendererTests.swift
+++ b/HermesMobileTests/MarkdownMathRendererTests.swift
@@ -27,6 +27,49 @@ final class MarkdownMathRendererTests: XCTestCase {
         XCTAssertTrue(rendered.contains(#"\$not math\$"#))
     }
 
+    func testInlineAssignmentsRecognizeVectorsTuplesAndExistingScriptForms() {
+        let input = #"Vectors $E=[4,-2]$ and $O=[6,-2]$; tuple $P=(x,y)$; scripts $W_0=e^0$, $W_2$, $O_0$, and $X_0=\sum x_n$."#
+
+        let rendered = MarkdownMathFormatter.replacingInlineMath(in: input)
+
+        XCTAssertFalse(rendered.contains("$"))
+        XCTAssertTrue(rendered.contains("E=[4,-2]"))
+        XCTAssertTrue(rendered.contains("O=[6,-2]"))
+        XCTAssertTrue(rendered.contains("P=(x,y)"))
+        XCTAssertTrue(rendered.contains("W₀=e⁰"))
+        XCTAssertTrue(rendered.contains("W₂"))
+        XCTAssertTrue(rendered.contains("O₀"))
+        XCTAssertTrue(rendered.contains("X₀=∑ xₙ"))
+    }
+
+    func testInlineAssignmentRecognitionPreservesCurrencyAndProtectedDollars() {
+        let inputs = [
+            "It costs $5 today.",
+            #"Escaped \$E=[4,-2]\$ stays."#,
+            "Unmatched $O=[6,-2] stays.",
+            "Code `$P=(x,y)$` stays.",
+            "```md\n$E=[4,-2]$\n```"
+        ]
+
+        for input in inputs {
+            XCTAssertEqual(MarkdownMathFormatter.replacingInlineMath(in: input), input)
+        }
+    }
+
+    func testProductionLayoutsRecognizeAssignmentsForStreamingAndFinalizedMarkdown() {
+        let input = #"Result: **$E=[4,-2]$** and `$O=[6,-2]$` stays code."#
+
+        let finalized = MarkdownMathLayoutCache.layout(for: input)
+        let streaming = MarkdownMathLayoutCache.uncachedLayout(for: input)
+
+        XCTAssertEqual(finalized, streaming)
+        guard case .plain(let rendered) = finalized else {
+            return XCTFail("Expected inline math to keep the production renderer on its plain layout path.")
+        }
+        XCTAssertTrue(rendered.contains("**E=[4,-2]**"))
+        XCTAssertTrue(rendered.contains("`$O=[6,-2]$`"))
+    }
+
     func testInlineScreenshotCommandsDoNotLeakRawLatex() {
         let input = #"Probability: $P(A \mid B) = \frac{P(B \mid A)P(A)}{P(B)}$ and norm $\Vert x \rVert_2 = \sqrt{\sum_{i=1}^n x_i^2}$."#
 


### PR DESCRIPTION
## Linked issue

Fixes #327

## What changed

Inline vector and tuple assignments such as `$E=[4,-2]$` no longer leak literal dollar delimiters into chat. The formatter now recognizes narrowly scoped assignments with a simple or scripted identifier, balanced grouping, and math-like right-hand content while preserving currency, escaped dollars, unmatched delimiters, and code.

Focused tests cover the reporter expressions, existing scripted and symbolic forms, protected content, and both the streaming and finalized production layout paths.

## How it was tested

- `MarkdownMathRendererTests`: 41 passed, 0 failed
- Full `HermesMobile` XCTest suite on iPhone 17: 1,760 passed, 0 failed, 2 skipped
- `git diff --check`
- `scripts/check-swift-file-sizes` (warning-only; no new oversized file)

Owner check: render the issue expressions in a signed simulator build and confirm the delimiters disappear while currency and code examples stay literal.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no models changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no networking changes)

Implemented by GPT-5.6-sol via Codex in T3 Code.
