### PR TITLE
perf(chat): keep streaming thinking responsive

### DIFF
--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -230,6 +230,7 @@ struct ChatTranscriptView: View {
                     toolCallGroups: completedToolCallGroupsForAnchor(transcriptMessage.anchorID),
                     liveReasoningText: isReasoningAnchor ? liveReasoningText : "",
                     reasoningAnchorMessageID: isReasoningAnchor ? reasoningAnchorMessageID : nil,
+                    liveReasoningStreamID: isReasoningAnchor ? activeStreamID : nil,
                     liveToolCalls: isToolCallAnchor ? liveToolCalls : [],
                     toolCallAnchorMessageID: isToolCallAnchor ? toolCallAnchorMessageID : nil,
                     streamingAssistantMessageID: isStreamingRow ? streamingAssistantMessageID : nil,
@@ -347,11 +348,14 @@ struct ChatTranscriptView: View {
 
     @ViewBuilder
     private var liveResponseBlocks: some View {
-        if activeStreamID != nil {
+        if let activeStreamID {
             if showsThinkingAndToolCards {
                 if hasLiveReasoningText,
                    !hasDisplayedTranscriptMessage(anchorID: reasoningAnchorMessageID) {
-                    ReasoningBlockView(text: liveReasoningText)
+                    ReasoningBlockView(
+                        text: liveReasoningText,
+                        liveStreamID: activeStreamID
+                    )
                 }
 
                 if !liveToolCalls.isEmpty,
@@ -459,6 +463,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     let toolCallGroups: [ToolCallGroup]
     let liveReasoningText: String
     let reasoningAnchorMessageID: String?
+    let liveReasoningStreamID: String?
     let liveToolCalls: [ToolCall]
     let toolCallAnchorMessageID: String?
     let streamingAssistantMessageID: String?
@@ -499,6 +504,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
             lhs.toolCallGroups == rhs.toolCallGroups &&
             lhs.liveReasoningText == rhs.liveReasoningText &&
             lhs.reasoningAnchorMessageID == rhs.reasoningAnchorMessageID &&
+            lhs.liveReasoningStreamID == rhs.liveReasoningStreamID &&
             lhs.liveToolCalls == rhs.liveToolCalls &&
             lhs.toolCallAnchorMessageID == rhs.toolCallAnchorMessageID &&
             lhs.streamingAssistantMessageID == rhs.streamingAssistantMessageID &&
@@ -569,7 +575,10 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     @ViewBuilder
     private var liveReasoningBlock: some View {
         if shouldRenderLiveReasoningBlock {
-            ReasoningBlockView(text: liveReasoningText)
+            ReasoningBlockView(
+                text: liveReasoningText,
+                liveStreamID: liveReasoningStreamID
+            )
         }
     }
 

--- a/HermesMobile/Features/Chat/ReasoningBlockView.swift
+++ b/HermesMobile/Features/Chat/ReasoningBlockView.swift
@@ -2,11 +2,17 @@ import SwiftUI
 
 struct ReasoningBlockView: View {
     let text: String
+    let liveStreamID: String?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var startsExpanded = false
     @State private var userToggledExpansion: Bool?
+
+    init(text: String, liveStreamID: String? = nil) {
+        self.text = text
+        self.liveStreamID = liveStreamID
+    }
 
     private var isExpanded: Bool {
         ChatTranscriptDisplaySettings.isCardExpanded(
@@ -32,11 +38,7 @@ struct ReasoningBlockView: View {
                 .accessibilityHint(isExpanded ? "Double tap to collapse details." : "Double tap to expand details.")
 
                 if isExpanded {
-                    Text(trimmedText)
-                        .font(AppFont.caption())
-                        .foregroundStyle(.primary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    reasoningText
                         .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
                 }
             }
@@ -90,6 +92,20 @@ struct ReasoningBlockView: View {
             .lineLimit(1)
     }
 
+    @ViewBuilder
+    private var reasoningText: some View {
+        if let liveStreamID {
+            LiveReasoningTextView(text: text)
+                .id(liveStreamID)
+        } else {
+            Text(text)
+                .font(AppFont.caption())
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
     private func summaryText(_ value: String, lineLimit: Int) -> some View {
         Text(value)
             .font(AppFont.caption())
@@ -112,5 +128,139 @@ struct ReasoningBlockView: View {
         }
 
         return "\(oneLine.prefix(80))..."
+    }
+}
+
+struct StreamingReasoningChunk: Identifiable, Equatable {
+    let id: Int
+    let text: String
+}
+
+struct StreamingReasoningTextState: Equatable {
+    static let targetChunkCharacterCount = 1_000
+    static let maximumActiveTailCharacterCount = 1_500
+
+    private(set) var stableChunks: [StreamingReasoningChunk] = []
+    private(set) var activeTail = ""
+    private(set) var sourceText = ""
+    private var nextChunkID = 0
+
+    init(text: String = "") {
+        reset(with: text)
+    }
+
+    var reconstructedText: String {
+        stableChunks.map(\.text).joined() + activeTail
+    }
+
+    mutating func update(with text: String) {
+        guard text != sourceText else { return }
+
+        guard text.utf8.starts(with: sourceText.utf8) else {
+            reset(with: text)
+            return
+        }
+
+        let appendedBytes = text.utf8.dropFirst(sourceText.utf8.count)
+        activeTail.append(String(decoding: appendedBytes, as: UTF8.self))
+        sourceText = text
+        sealStableChunks()
+    }
+
+    mutating func reset(with text: String) {
+        stableChunks = []
+        activeTail = text
+        sourceText = text
+        nextChunkID = 0
+        sealStableChunks()
+    }
+
+    private mutating func sealStableChunks() {
+        while activeTail.count > Self.maximumActiveTailCharacterCount {
+            let boundary = stableChunkBoundary(in: activeTail)
+            let chunkText = String(activeTail[..<boundary])
+            stableChunks.append(
+                StreamingReasoningChunk(id: nextChunkID, text: chunkText)
+            )
+            nextChunkID += 1
+            activeTail.removeSubrange(..<boundary)
+        }
+    }
+
+    /// Prefer a nearby blank line so separate Text views keep paragraph layout.
+    /// The character-count fallback also bounds a paragraph with no line breaks.
+    private func stableChunkBoundary(in text: String) -> String.Index {
+        let target = text.index(
+            text.startIndex,
+            offsetBy: Self.targetChunkCharacterCount,
+            limitedBy: text.endIndex
+        ) ?? text.endIndex
+        let searchStart = text.index(
+            text.startIndex,
+            offsetBy: Self.targetChunkCharacterCount / 2,
+            limitedBy: text.endIndex
+        ) ?? text.endIndex
+        let searchEnd = text.index(
+            text.startIndex,
+            offsetBy: Self.maximumActiveTailCharacterCount,
+            limitedBy: text.endIndex
+        ) ?? text.endIndex
+
+        var candidates: [String.Index] = []
+        var searchCursor = searchStart
+        while searchCursor < searchEnd,
+              let range = text.range(
+                  of: "\n\n",
+                  range: searchCursor..<searchEnd
+              ) {
+            candidates.append(range.upperBound)
+            searchCursor = range.upperBound
+        }
+
+        return candidates.min { lhs, rhs in
+            abs(text.distance(from: target, to: lhs))
+                < abs(text.distance(from: target, to: rhs))
+        } ?? target
+    }
+}
+
+private struct LiveReasoningTextView: View {
+    let text: String
+
+    @State private var state: StreamingReasoningTextState
+
+    init(text: String) {
+        self.text = text
+        _state = State(initialValue: StreamingReasoningTextState(text: text))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(state.stableChunks) { chunk in
+                ReasoningTextFragment(text: chunk.text)
+                    .equatable()
+            }
+
+            if !state.activeTail.isEmpty {
+                ReasoningTextFragment(text: state.activeTail)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(text)
+        .onChange(of: text) { _, newText in
+            state.update(with: newText)
+        }
+    }
+}
+
+private struct ReasoningTextFragment: View, Equatable {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(AppFont.caption())
+            .foregroundStyle(.primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/HermesMobile/Features/Chat/ReasoningBlockView.swift
+++ b/HermesMobile/Features/Chat/ReasoningBlockView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct ReasoningBlockView: View {
     let text: String
@@ -22,8 +23,8 @@ struct ReasoningBlockView: View {
     }
 
     var body: some View {
-        if let trimmedText {
-            let summary = summary(for: trimmedText)
+        if let displayText = ReasoningBlockContent.displayText(from: text) {
+            let summary = summary(for: displayText)
 
             VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
                 Button {
@@ -38,7 +39,7 @@ struct ReasoningBlockView: View {
                 .accessibilityHint(isExpanded ? "Double tap to collapse details." : "Double tap to expand details.")
 
                 if isExpanded {
-                    reasoningText
+                    reasoningText(displayText)
                         .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
                 }
             }
@@ -93,12 +94,12 @@ struct ReasoningBlockView: View {
     }
 
     @ViewBuilder
-    private var reasoningText: some View {
+    private func reasoningText(_ displayText: String) -> some View {
         if let liveStreamID {
-            LiveReasoningTextView(text: text)
+            LiveReasoningTextView(text: displayText)
                 .id(liveStreamID)
         } else {
-            Text(text)
+            Text(displayText)
                 .font(AppFont.caption())
                 .foregroundStyle(.primary)
                 .textSelection(.enabled)
@@ -113,11 +114,6 @@ struct ReasoningBlockView: View {
             .lineLimit(lineLimit)
     }
 
-    private var trimmedText: String? {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
     private func summary(for value: String) -> String {
         let oneLine = value
             .replacingOccurrences(of: "\n", with: " ")
@@ -128,6 +124,13 @@ struct ReasoningBlockView: View {
         }
 
         return "\(oneLine.prefix(80))..."
+    }
+}
+
+enum ReasoningBlockContent {
+    static func displayText(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 
@@ -187,7 +190,7 @@ struct StreamingReasoningTextState: Equatable {
         }
     }
 
-    /// Prefer a nearby blank line so separate Text views keep paragraph layout.
+    /// Prefer a nearby blank line so stable chunk identity follows content structure.
     /// The character-count fallback also bounds a paragraph with no line breaks.
     private func stableChunkBoundary(in text: String) -> String.Index {
         let target = text.index(
@@ -224,6 +227,22 @@ struct StreamingReasoningTextState: Equatable {
     }
 }
 
+enum StreamingReasoningTextStorageUpdate: Equatable {
+    case unchanged
+    case append(String)
+    case replace(String)
+
+    static func make(renderedText: String, newText: String) -> Self {
+        guard renderedText != newText else { return .unchanged }
+        guard newText.utf8.starts(with: renderedText.utf8) else {
+            return .replace(newText)
+        }
+
+        let appendedBytes = newText.utf8.dropFirst(renderedText.utf8.count)
+        return .append(String(decoding: appendedBytes, as: UTF8.self))
+    }
+}
+
 private struct LiveReasoningTextView: View {
     let text: String
 
@@ -235,32 +254,162 @@ private struct LiveReasoningTextView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(state.stableChunks) { chunk in
-                ReasoningTextFragment(text: chunk.text)
-                    .equatable()
-            }
-
-            if !state.activeTail.isEmpty {
-                ReasoningTextFragment(text: state.activeTail)
-            }
-        }
+        StreamingReasoningTextView(state: state)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(text)
+        .allowsHitTesting(false)
         .onChange(of: text) { _, newText in
             state.update(with: newText)
         }
     }
 }
 
-private struct ReasoningTextFragment: View, Equatable {
-    let text: String
+private struct StreamingReasoningTextView: UIViewRepresentable {
+    let state: StreamingReasoningTextState
 
-    var body: some View {
-        Text(text)
-            .font(AppFont.caption())
-            .foregroundStyle(.primary)
-            .frame(maxWidth: .infinity, alignment: .leading)
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.isSelectable = false
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.adjustsFontForContentSizeCategory = true
+        textView.isAccessibilityElement = true
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return textView
+    }
+
+    func updateUIView(_ textView: UITextView, context: Context) {
+        let font = UIFont.preferredFont(forTextStyle: .caption1)
+        let textColor = UIColor.label
+        let layoutDirection = context.environment.layoutDirection
+
+        context.coordinator.update(
+            textView,
+            to: state,
+            font: font,
+            textColor: textColor
+        )
+        textView.textAlignment = layoutDirection == .rightToLeft ? .right : .left
+        textView.accessibilityLabel = state.sourceText
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView: UITextView,
+        context: Context
+    ) -> CGSize? {
+        guard let width = proposal.width else { return nil }
+        let size = uiView.sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        )
+        return CGSize(width: width, height: ceil(size.height))
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private static let chunkIDAttribute = NSAttributedString.Key(
+            "HermexStreamingReasoningChunkID"
+        )
+
+        private var renderedText = ""
+        private var stableChunkIDs: [Int] = []
+        private var stableUTF16Length = 0
+        private var font: UIFont?
+        private var textColor: UIColor?
+
+        func update(
+            _ textView: UITextView,
+            to state: StreamingReasoningTextState,
+            font: UIFont,
+            textColor: UIColor
+        ) {
+            let storageUpdate = StreamingReasoningTextStorageUpdate.make(
+                renderedText: renderedText,
+                newText: state.sourceText
+            )
+
+            switch storageUpdate {
+            case .unchanged:
+                break
+            case .append(let suffix):
+                textView.textStorage.append(
+                    NSAttributedString(
+                        string: suffix,
+                        attributes: [.font: font, .foregroundColor: textColor]
+                    )
+                )
+            case .replace(let replacement):
+                textView.attributedText = NSAttributedString(
+                    string: replacement,
+                    attributes: [.font: font, .foregroundColor: textColor]
+                )
+                stableChunkIDs = []
+                stableUTF16Length = 0
+            }
+
+            renderedText = state.sourceText
+            markNewStableChunks(in: textView.textStorage, from: state)
+            updateAppearance(
+                in: textView,
+                font: font,
+                textColor: textColor
+            )
+
+            if storageUpdate != .unchanged {
+                textView.invalidateIntrinsicContentSize()
+            }
+        }
+
+        private func markNewStableChunks(
+            in textStorage: NSTextStorage,
+            from state: StreamingReasoningTextState
+        ) {
+            let retainedIDs = state.stableChunks.prefix(stableChunkIDs.count).map(\.id)
+            guard Array(retainedIDs) == stableChunkIDs else {
+                stableChunkIDs = []
+                stableUTF16Length = 0
+                textStorage.removeAttribute(
+                    Self.chunkIDAttribute,
+                    range: NSRange(location: 0, length: textStorage.length)
+                )
+                markNewStableChunks(in: textStorage, from: state)
+                return
+            }
+
+            for chunk in state.stableChunks.dropFirst(stableChunkIDs.count) {
+                let length = chunk.text.utf16.count
+                textStorage.addAttribute(
+                    Self.chunkIDAttribute,
+                    value: chunk.id,
+                    range: NSRange(location: stableUTF16Length, length: length)
+                )
+                stableChunkIDs.append(chunk.id)
+                stableUTF16Length += length
+            }
+        }
+
+        private func updateAppearance(
+            in textView: UITextView,
+            font: UIFont,
+            textColor: UIColor
+        ) {
+            guard self.font != font || self.textColor != textColor else { return }
+
+            self.font = font
+            self.textColor = textColor
+            let fullRange = NSRange(location: 0, length: textView.textStorage.length)
+            textView.textStorage.addAttributes(
+                [.font: font, .foregroundColor: textColor],
+                range: fullRange
+            )
+            textView.typingAttributes[.font] = font
+            textView.typingAttributes[.foregroundColor] = textColor
+        }
     }
 }

--- a/HermesMobileTests/StreamingMarkdownSupportTests.swift
+++ b/HermesMobileTests/StreamingMarkdownSupportTests.swift
@@ -48,6 +48,99 @@ final class StreamingMarkdownBlockSplitterTests: XCTestCase {
     }
 }
 
+final class StreamingReasoningTextStateTests: XCTestCase {
+    func testLargePrefixStreamReconstructsExactlyAndPreservesStableChunks() {
+        let paragraph = "Hermes inspects the workspace before choosing the next step.\n\n"
+        let fullText = String(String(repeating: paragraph, count: 1_500).prefix(80_000))
+        var state = StreamingReasoningTextState()
+        var previousChunks: [StreamingReasoningChunk] = []
+
+        for characterCount in stride(from: 2_000, through: 80_000, by: 2_000) {
+            let end = fullText.index(fullText.startIndex, offsetBy: characterCount)
+            state.update(with: String(fullText[..<end]))
+
+            XCTAssertEqual(Array(state.stableChunks.prefix(previousChunks.count)), previousChunks)
+            XCTAssertLessThanOrEqual(
+                state.activeTail.count,
+                StreamingReasoningTextState.maximumActiveTailCharacterCount
+            )
+            previousChunks = state.stableChunks
+        }
+
+        XCTAssertEqual(Array(state.reconstructedText.utf8), Array(fullText.utf8))
+        XCTAssertFalse(state.stableChunks.isEmpty)
+    }
+
+    func testBlankLineBecomesAStableChunkBoundary() {
+        let firstParagraph = String(repeating: "A", count: 900) + "\n\n"
+        let text = firstParagraph + String(repeating: "B", count: 1_000)
+        let state = StreamingReasoningTextState(text: text)
+
+        XCTAssertEqual(state.stableChunks.first?.text, firstParagraph)
+        XCTAssertEqual(state.reconstructedText, text)
+    }
+
+    func testLongUnbrokenTextUsesBoundedGraphemeSafeChunks() {
+        let text = String(repeating: "x", count: 5_000)
+        let state = StreamingReasoningTextState(text: text)
+
+        XCTAssertTrue(state.stableChunks.allSatisfy {
+            $0.text.count == StreamingReasoningTextState.targetChunkCharacterCount
+        })
+        XCTAssertLessThanOrEqual(
+            state.activeTail.count,
+            StreamingReasoningTextState.maximumActiveTailCharacterCount
+        )
+        XCTAssertEqual(state.reconstructedText, text)
+    }
+
+    func testEmojiAndMultiScalarGraphemesStayIntact() {
+        let graphemes = ["👨🏽‍💻", "e\u{301}", "🇺🇸", "🫶🏻"]
+        let text = String(repeating: graphemes.joined(), count: 800)
+        let state = StreamingReasoningTextState(text: text)
+
+        XCTAssertEqual(Array(state.reconstructedText.utf8), Array(text.utf8))
+        XCTAssertTrue(state.stableChunks.allSatisfy { chunk in
+            chunk.text.allSatisfy { graphemes.contains(String($0)) }
+        })
+    }
+
+    func testPrefixAppendCanExtendTheFinalGrapheme() {
+        let initialText = String(repeating: "x", count: 2_000) + "e"
+        let extendedText = initialText + "\u{301}"
+        var state = StreamingReasoningTextState(text: initialText)
+
+        state.update(with: extendedText)
+
+        XCTAssertEqual(Array(state.reconstructedText.utf8), Array(extendedText.utf8))
+        XCTAssertTrue(state.activeTail.hasSuffix("e\u{301}"))
+    }
+
+    func testNonPrefixReplacementDropsPreviousChunks() {
+        let original = String(repeating: "Original paragraph.\n\n", count: 200)
+        let replacement = String(repeating: "Replacement paragraph.\n\n", count: 200)
+        var state = StreamingReasoningTextState(text: original)
+
+        state.update(with: replacement)
+
+        XCTAssertEqual(state.stableChunks.first?.id, 0)
+        XCTAssertTrue(state.stableChunks.first?.text.hasPrefix("Replacement") == true)
+        XCTAssertFalse(state.reconstructedText.contains("Original"))
+        XCTAssertEqual(state.reconstructedText, replacement)
+    }
+
+    func testExplicitNewStreamResetRestartsChunkIdentity() {
+        let firstStream = String(repeating: "First stream.\n\n", count: 200)
+        let secondStream = String(repeating: "Second stream.\n\n", count: 200)
+        var state = StreamingReasoningTextState(text: firstStream)
+
+        state.reset(with: secondStream)
+
+        XCTAssertEqual(state.stableChunks.first?.id, 0)
+        XCTAssertEqual(state.reconstructedText, secondStream)
+    }
+}
+
 /// Width resolution for chat markdown table cells (issue #233). The layout
 /// itself needs a render pass to verify; this covers the pure clamp that
 /// decides the wrap width the cell height is measured at.

--- a/HermesMobileTests/StreamingMarkdownSupportTests.swift
+++ b/HermesMobileTests/StreamingMarkdownSupportTests.swift
@@ -49,6 +49,14 @@ final class StreamingMarkdownBlockSplitterTests: XCTestCase {
 }
 
 final class StreamingReasoningTextStateTests: XCTestCase {
+    func testReasoningBlockDisplayTextPreservesExistingBoundaryTrimming() {
+        XCTAssertEqual(
+            ReasoningBlockContent.displayText(from: " \nReasoning stays complete.\n "),
+            "Reasoning stays complete."
+        )
+        XCTAssertNil(ReasoningBlockContent.displayText(from: " \n\t "))
+    }
+
     func testLargePrefixStreamReconstructsExactlyAndPreservesStableChunks() {
         let paragraph = "Hermes inspects the workspace before choosing the next step.\n\n"
         let fullText = String(String(repeating: paragraph, count: 1_500).prefix(80_000))
@@ -138,6 +146,42 @@ final class StreamingReasoningTextStateTests: XCTestCase {
 
         XCTAssertEqual(state.stableChunks.first?.id, 0)
         XCTAssertEqual(state.reconstructedText, secondStream)
+    }
+
+    func testTextStorageUpdateAppendsOnlyNewSuffix() {
+        let rendered = String(repeating: "Long paragraph without breaks. ", count: 100)
+        let newText = rendered + "Still streaming."
+
+        XCTAssertEqual(
+            StreamingReasoningTextStorageUpdate.make(
+                renderedText: rendered,
+                newText: newText
+            ),
+            .append("Still streaming.")
+        )
+    }
+
+    func testTextStorageUpdateReplacesNonPrefixContent() {
+        XCTAssertEqual(
+            StreamingReasoningTextStorageUpdate.make(
+                renderedText: "Old stream",
+                newText: "Replacement stream"
+            ),
+            .replace("Replacement stream")
+        )
+    }
+
+    func testTextStorageUpdatePreservesCrossUpdateGraphemeBytes() {
+        let rendered = "Planning e"
+        let newText = rendered + "\u{301}"
+
+        XCTAssertEqual(
+            StreamingReasoningTextStorageUpdate.make(
+                renderedText: rendered,
+                newText: newText
+            ),
+            .append("\u{301}")
+        )
     }
 }
 


### PR DESCRIPTION
## Linked issue

Fixes #335

## What changed

Long expanded Thinking cards laid out the full accumulated reasoning text on every streaming update, which made scrolling and controls stall.

Live reasoning now tracks completed text as stable chunks while one non-scrolling TextKit view preserves continuous wrapping. Prefix updates append only the new suffix to its text storage, and replacements or new streams reset the renderer. Collapsed cards do not construct the live renderer, and settled reasoning returns to the existing trimmed, selectable SwiftUI text presentation.

## How it was tested

- Focused streaming-reasoning tests on the current head: 11 passed. Coverage includes deterministic 80 KB reconstruction, stable chunk identity, paragraph and unbroken-text boundaries, Unicode graphemes, incremental text-storage updates, replacement, new-stream reset, and boundary trimming.
- Full XCTest suite on the final head: 1,771 passed, 0 failed, 2 skipped on iPhone 17.
- `git diff --check` passed on the final head.
- Signed Debug build launched on iPhone 17 from the final head.
- Uzair passed the simulator checks for cards starting expanded and expanded mid-stream, scrolling, collapse and reopen, cancellation, settled text selection, Dynamic Type, VoiceOver order, Reduce Motion, and the TextKit continuity follow-up.

## Checklist

- [x] The full test suite passes locally on the final head (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] No `Codable` models changed
- [x] No new third-party dependencies
- [x] No API endpoints or JSON shapes changed

Built by GPT-5.6-sol with the Codex harness in T3 Code.
