### PR TITLE
fix: refresh session list when app returns to foreground

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -2,6 +2,20 @@ import SwiftUI
 import SwiftData
 import UIKit
 
+enum SessionListForegroundRefreshPolicy {
+    static func shouldRefresh(
+        previousPhase: ScenePhase,
+        currentPhase: ScenePhase,
+        didCompleteInitialLoad: Bool,
+        isLoading: Bool
+    ) -> Bool {
+        previousPhase != .active
+            && currentPhase == .active
+            && didCompleteInitialLoad
+            && !isLoading
+    }
+}
+
 @MainActor
 struct SessionListView: View {
     private static let searchChromeIconVisualSize: CGFloat = 36
@@ -22,6 +36,7 @@ struct SessionListView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel: SessionListViewModel
     @State private var navigationState: SessionNavigationState
     @State private var sessionPendingRename: SessionSummary?
@@ -259,6 +274,16 @@ struct SessionListView: View {
             .onDisappear {
                 sessionOpenTask?.cancel()
                 viewModel.invalidateSessionOpening()
+            }
+            .onChange(of: scenePhase) { previousPhase, currentPhase in
+                guard SessionListForegroundRefreshPolicy.shouldRefresh(
+                    previousPhase: previousPhase,
+                    currentPhase: currentPhase,
+                    didCompleteInitialLoad: didCompleteInitialLoad,
+                    isLoading: viewModel.isLoading
+                ) else { return }
+
+                Task { await refreshSessionsAndActiveProfile() }
             }
             .onChange(of: pendingSharedImport) {
                 openPendingSharedImportIfNeeded()

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 @testable import HermesMobile
 
@@ -283,6 +284,39 @@ final class SessionNavigationStateTests: XCTestCase {
         XCTAssertEqual(
             SessionNavigationPersistence.load(for: secondServer, defaults: defaults),
             "second-session"
+        )
+    }
+
+    func testCompletedSessionListRefreshesWhenTheAppReturnsToForeground() {
+        XCTAssertTrue(
+            SessionListForegroundRefreshPolicy.shouldRefresh(
+                previousPhase: .background,
+                currentPhase: .active,
+                didCompleteInitialLoad: true,
+                isLoading: false
+            )
+        )
+    }
+
+    func testInitialSceneActivationDoesNotDuplicateTheInitialLoad() {
+        XCTAssertFalse(
+            SessionListForegroundRefreshPolicy.shouldRefresh(
+                previousPhase: .inactive,
+                currentPhase: .active,
+                didCompleteInitialLoad: false,
+                isLoading: false
+            )
+        )
+    }
+
+    func testForegroundActivationDoesNotOverlapAnExistingRefresh() {
+        XCTAssertFalse(
+            SessionListForegroundRefreshPolicy.shouldRefresh(
+                previousPhase: .background,
+                currentPhase: .active,
+                didCompleteInitialLoad: true,
+                isLoading: true
+            )
         )
     }
 }


### PR DESCRIPTION
Fixes #205 — re-applies the fix from closed PR #206, which was closed unmerged.

## Problem

When the app is backgrounded (lock screen, app switch) and a run makes progress on the server, returning to the already-mounted session list does not issue a fresh `GET /api/sessions` — the list stays stale until pull-to-refresh or a navigation event. Reproduction steps are in issue #205.

## Change

- Observe `scenePhase` in `SessionListView` and refresh sessions + active profile on warm foreground return.
- Refresh is suppressed during the initial load and while another refresh is already in flight, via a small testable policy enum (`SessionListForegroundRefreshPolicy`).
- Existing initial-load, navigation-return, and pull-to-refresh paths are unchanged.

## Regression tests

- Refresh fires on background → active transition after initial load.
- Initial scene activation does not duplicate the initial load.
- Foreground activation does not overlap an in-flight refresh.

Note: this is the same diff as PR #206, which was closed without merging; the issue was then closed manually. Cherry-picked onto current master (verified `git apply -C1` applies; context for the test file moved but the patch is otherwise identical).