### PR TITLE
fix(networking): show the server's reason on HTTP 403

### DIFF
--- a/HermesMobile/Networking/APIError.swift
+++ b/HermesMobile/Networking/APIError.swift
@@ -22,12 +22,17 @@ enum APIError: LocalizedError {
             case -1:
                 return String(localized: "The server response could not be read. Check that the URL points to a Hermes Web UI server.")
             case 400:
-                if let message = Self.serverErrorMessage(from: body) {
+                if let message = Self.displayableServerMessage(from: body) {
                     return String(localized: "The server rejected the request: \(message)")
                 }
                 return String(localized: "The server rejected the request.")
             case 403:
-                return String(localized: "The server refused access. Check the server password and permissions.")
+                // A 403 is a per-request refusal (read-only imported session, missing
+                // permission), not a bad password: 401 owns the password copy.
+                if let message = Self.displayableServerMessage(from: body) {
+                    return String(localized: "The server refused the request: \(message)")
+                }
+                return String(localized: "The server refused the request. Check the server permissions and try again.")
             case 404:
                 return String(localized: "The server endpoint was not found. Check that the URL points to a Hermes Web UI server.")
             case 408:
@@ -39,7 +44,7 @@ enum APIError: LocalizedError {
             case 502, 503, 504:
                 return String(localized: "Could not connect to the server. Check that hermes-webui is running and the tunnel is connected.")
             default:
-                if let message = Self.serverErrorMessage(from: body) {
+                if let message = Self.displayableServerMessage(from: body) {
                     return String(localized: "Server returned HTTP \(statusCode): \(message)")
                 }
                 return String(localized: "Server returned HTTP \(statusCode).")
@@ -168,6 +173,17 @@ private extension APIError {
     static func isVanishedSession(statusCode: Int, body: String?) -> Bool {
         guard statusCode == 404 else { return false }
         return serverErrorMessage(from: body)?.localizedCaseInsensitiveContains("Session not found") == true
+    }
+
+    /// Longest server-provided message we interpolate into user-facing copy.
+    static let displayedServerMessageLimit = 200
+
+    /// The structured server message, bounded for display. Shared by every HTTP
+    /// branch that shows server text so an oversized body never floods an alert.
+    static func displayableServerMessage(from body: String?) -> String? {
+        guard let message = serverErrorMessage(from: body) else { return nil }
+        guard message.count > displayedServerMessageLimit else { return message }
+        return String(message.prefix(displayedServerMessageLimit)) + "…"
     }
 
     static func serverErrorMessage(from body: String?) -> String? {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -84957,112 +84957,6 @@
         }
       }
     },
-    "The server refused access. Check the server password and permissions." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "رفض الخادم الوصول. تحقق من كلمة مرور الخادم والأذونات."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Der Server hat den Zugriff verweigert. Überprüfe das Server-Passwort und die Berechtigungen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "El servidor rechazó el acceso. Verifica la contraseña y los permisos del servidor."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Le serveur a refusé l'accès. Vérifiez le mot de passe et les autorisations du serveur."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "השרת סירב לגישה. בדוק את סיסמת השרת וההרשאות."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Il server ha rifiutato l'accesso. Verifica la password e i permessi del server."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "サーバがアクセスを拒否しました。サーバのパスワードと権限を確認してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "서버가 접근을 거부했어요. 서버 비밀번호와 권한을 확인하세요."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "De server weigerde toegang. Controleer het serverwachtwoord en de machtigingen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Serwer odmówił dostępu. Sprawdź hasło serwera i uprawnienia."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "O servidor recusou o acesso. Verifique a senha e as permissões do servidor."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Сервер отказал в доступе. Проверьте пароль сервера и разрешения."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Sunucu erişimi reddetti. Sunucu parolasını ve izinleri kontrol edin."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "سرور نے رسائی سے انکار کر دیا۔ سرور پاس ورڈ اور اجازتوں کی جانچ کریں۔"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "伺服器拒絕存取。請檢查伺服器密碼和權限。"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "服务器拒绝访问。请检查服务器密码和权限。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "伺服器拒絕存取。請檢查伺服器密碼和權限。"
-          }
-        }
-      }
-    },
     "The server rejected the request." : {
       "localizations" : {
         "ar" : {
@@ -113853,6 +113747,218 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "隱藏 Git 選單、分支選擇器和提交控制項。"
+          }
+        }
+      }
+    },
+    "The server refused the request: %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رفض الخادم الطلب: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Der Server hat die Anfrage verweigert: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "El servidor rechazó la solicitud: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Le serveur a refusé la requête : %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "השרת סירב לבקשה: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Il server ha rifiutato la richiesta: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "サーバがリクエストを拒否しました: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "서버가 요청을 거부했어요: %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "De server weigerde het verzoek: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Serwer odrzucił żądanie: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O servidor recusou a solicitação: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сервер отклонил запрос: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sunucu isteği reddetti: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سرور نے درخواست مسترد کر دی: %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器拒絕了請求：%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "服务器拒绝了请求：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器拒絕了請求：%@"
+          }
+        }
+      }
+    },
+    "The server refused the request. Check the server permissions and try again." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رفض الخادم الطلب. تحقق من أذونات الخادم ثم حاول مرة أخرى."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Der Server hat die Anfrage verweigert. Überprüfe die Server-Berechtigungen und versuche es erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "El servidor rechazó la solicitud. Verifica los permisos del servidor e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Le serveur a refusé la requête. Vérifiez les autorisations du serveur, puis réessayez."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "השרת סירב לבקשה. בדוק את הרשאות השרת ונסה שוב."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Il server ha rifiutato la richiesta. Verifica i permessi del server e riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "サーバがリクエストを拒否しました。サーバの権限を確認して、もう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "서버가 요청을 거부했어요. 서버 권한을 확인한 뒤 다시 시도하세요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "De server weigerde het verzoek. Controleer de servermachtigingen en probeer het opnieuw."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Serwer odrzucił żądanie. Sprawdź uprawnienia serwera i spróbuj ponownie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O servidor recusou a solicitação. Verifique as permissões do servidor e tente novamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сервер отклонил запрос. Проверьте разрешения сервера и повторите попытку."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sunucu isteği reddetti. Sunucu izinlerini kontrol edip yeniden deneyin."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سرور نے درخواست مسترد کر دی۔ سرور کی اجازتوں کی جانچ کریں اور دوبارہ کوشش کریں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器拒絕了請求。請檢查伺服器權限，然後再試一次。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "服务器拒绝了请求。请检查服务器权限，然后重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "伺服器拒絕了請求。請檢查伺服器權限，然後再試一次。"
           }
         }
       }

--- a/HermesMobileTests/APIClientAuthAndErrorTests.swift
+++ b/HermesMobileTests/APIClientAuthAndErrorTests.swift
@@ -182,6 +182,107 @@ final class APIClientAuthAndErrorTests: APIClientTestCase {
         }
     }
 
+    // MARK: - HTTP 403 (issue #333)
+
+    func testForbiddenChatStartSurfacesServerReasonInsteadOfPasswordCopy() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/chat/start")
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 403,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )
+            let body = Data(#"{"error":"Read-only imported sessions cannot be continued from WebUI"}"#.utf8)
+            return (try XCTUnwrap(response), body)
+        }
+
+        do {
+            _ = try await client.startChat(
+                sessionID: "20260831_041231_abc",
+                message: "hello",
+                workspace: nil,
+                model: nil
+            )
+            XCTFail("Expected HTTP 403 error")
+        } catch let error as APIError {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "The server refused the request: Read-only imported sessions cannot be continued from WebUI"
+            )
+            XCTAssertFalse(error.localizedDescription.localizedCaseInsensitiveContains("password"))
+            XCTAssertEqual(error.privacySafeLogCategory, "http.403")
+        } catch {
+            XCTFail("Expected APIError, got \(error)")
+        }
+    }
+
+    func testForbiddenSurfacesMessageAndDetailPayloadShapes() {
+        XCTAssertEqual(
+            APIError.http(statusCode: 403, body: #"{"message":"Workspace is locked"}"#).localizedDescription,
+            "The server refused the request: Workspace is locked"
+        )
+        XCTAssertEqual(
+            APIError.http(statusCode: 403, body: #"{"detail":"Not permitted"}"#).localizedDescription,
+            "The server refused the request: Not permitted"
+        )
+    }
+
+    func testForbiddenWithoutStructuredBodyUsesGenericFallback() {
+        let fallback = "The server refused the request. Check the server permissions and try again."
+        let bodies: [String?] = [
+            nil,
+            "",
+            "   ",
+            "not json",
+            #"{"error":""}"#,
+            "<html><title>Forbidden</title><body>cloudflare access denied</body></html>",
+        ]
+
+        for body in bodies {
+            let message = APIError.http(statusCode: 403, body: body).localizedDescription
+            XCTAssertEqual(message, fallback, "body: \(String(describing: body))")
+            XCTAssertFalse(message.contains("<"))
+            XCTAssertFalse(message.localizedCaseInsensitiveContains("password"))
+        }
+    }
+
+    func testUnauthorizedAndBadRequestCopyIsUnchangedByForbiddenHandling() {
+        XCTAssertEqual(
+            APIError.unauthorized.localizedDescription,
+            "The password was rejected. Check the server password and try again."
+        )
+        XCTAssertEqual(
+            APIError.http(statusCode: 400, body: #"{"error":"Missing message"}"#).localizedDescription,
+            "The server rejected the request: Missing message"
+        )
+        XCTAssertEqual(
+            APIError.http(statusCode: 400, body: "<html>nope</html>").localizedDescription,
+            "The server rejected the request."
+        )
+    }
+
+    func testDisplayedServerMessageIsBoundedAcrossHTTPBranches() {
+        let long = String(repeating: "x", count: 500)
+        let body = #"{"error":"\#(long)"}"#
+        let clipped = String(repeating: "x", count: 200) + "…"
+
+        XCTAssertEqual(
+            APIError.http(statusCode: 403, body: body).localizedDescription,
+            "The server refused the request: \(clipped)"
+        )
+        XCTAssertEqual(
+            APIError.http(statusCode: 400, body: body).localizedDescription,
+            "The server rejected the request: \(clipped)"
+        )
+        XCTAssertEqual(
+            APIError.http(statusCode: 418, body: body).localizedDescription,
+            "Server returned HTTP 418: \(clipped)"
+        )
+        // The raw body is still available to callers that inspect it programmatically.
+        XCTAssertEqual(APIError.http(statusCode: 403, body: body).serverMessage, long)
+    }
+
     func testHTTPErrorPrivacySafeLogCategoryDoesNotExposeServerBody() {
         let error = APIError.http(
             statusCode: 400,


### PR DESCRIPTION
## Linked issue

Fixes #333

## What changed

Every HTTP 403 was shown as "The server refused access. Check the server password and permissions." After a Hermes upgrade, continuing an imported read-only session returns a 403 whose body says exactly why, so users were told their password was wrong when it wasn't.

The 403 branch in `APIError` now uses the same JSON-only body helper that 400 already uses. A structured `error`, `message`, or `detail` shows as "The server refused the request: \<reason\>". An empty, malformed, or HTML body falls back to "The server refused the request. Check the server permissions and try again." The password copy stays exclusive to 401. Displayed server text is capped at 200 characters, shared by the 400, 403, and default branches. `privacySafeLogCategory` still reports only `http.403`.

The old 403 string was removed from the String Catalog and the two new keys were added for all 17 shipped languages, appended per `docs/agents/i18n.md` and verified with a parsed-subtree diff.

## How it was tested

- New tests in `APIClientAuthAndErrorTests` cover the issue's regression matrix: the exact `POST /api/chat/start` read-only body, `message` and `detail` shapes, empty/malformed/HTML fallback with no raw markup, unchanged 401 and 400 copy, the 200-character bound across branches, and the log category.
- Full XCTest suite via XcodeBuildMCP `test_sim` on iPhone 17: 1776 passed, 0 failed, 2 pre-existing skips.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (no model changes)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (403 bodies come from upstream `bad()` as `{"error": …}`)

Written by Claude Fable 5.1 in Claude Code.