### PR TITLE
fix(chat): make transcript auto-follow an explicit latch

### DIFF
--- a/HermesMobile/Features/Chat/ChatScrollPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatScrollPolicy.swift
@@ -4,37 +4,90 @@ import SwiftUI
 
 /// Pure decision rules for the chat transcript's auto-scroll behavior.
 ///
-/// The transcript keeps app-owned follow-bottom intent separate from
-/// user-owned manual scrolling, and a short cooldown after any user
-/// interaction prevents streaming layout growth from yanking the viewport
-/// while a manual scroll is still settling.
+/// Auto-follow is an explicit latch driven by scroll gestures rather than a
+/// distance test: touching the transcript switches it off, and only a gesture
+/// that settles at the true bottom, a scroll-to-bottom tap, or a send switches
+/// it back on. Layout growth from streaming tokens never flips the latch on its
+/// own, so a reader parked above the end stays parked. The distance thresholds
+/// below only drive the scroll-to-bottom button and the reading-older chrome.
 enum ChatScrollPolicy {
     /// Existing transcripts should enter at their latest content as part of the
     /// scroll view's first layout, before the destination becomes visible.
     static let initialTranscriptAnchor = UnitPoint.bottom
 
     /// Rich Markdown can finish measuring after the scroll view's initial
-    /// layout. Keep those size changes bottom-pinned only while the app still
-    /// owns follow-latest intent; return nil as soon as the reader scrolls away.
-    static func sizeChangeAnchor(shouldFollowLatestMessage: Bool) -> UnitPoint? {
-        shouldFollowLatestMessage ? .bottom : nil
+    /// layout. Keep those size changes bottom-pinned only while follow is
+    /// latched on and no disclosure toggle is settling; otherwise return nil so
+    /// the reader's offset, and the row they just tapped, stay where they are.
+    static func sizeChangeAnchor(
+        shouldFollowLatestMessage: Bool,
+        isDisclosureSettling: Bool = false
+    ) -> UnitPoint? {
+        shouldFollowLatestMessage && !isDisclosureSettling ? .bottom : nil
     }
 
-    /// Distance (pt) from the bottom within which we treat the transcript as
-    /// pinned to the latest content while idle.
+    /// Distance (pt) from the bottom within which the scroll-to-bottom button
+    /// stays hidden while idle.
     static let bottomDetectionThreshold: CGFloat = 80
 
     /// Looser bottom threshold while a response is streaming, so small layout
-    /// jitter from incoming tokens does not flip follow state off.
+    /// jitter from incoming tokens does not flash the scroll-to-bottom button.
     static let streamingBottomDetectionThreshold: CGFloat = 160
 
     /// Extra distance past the bottom threshold required before the composer
     /// chrome collapses into its compact "reading older" presentation.
     static let readingOlderHysteresis: CGFloat = 64
 
-    /// How long automatic follow-scroll stays paused after the user last
-    /// interacted with the scroll view.
-    static let userScrollCooldown: TimeInterval = 0.25
+    /// Strict bottom tolerance (pt) that re-arms follow when a gesture ends there.
+    static let followReArmThreshold: CGFloat = 12
+
+    /// How long a finished drag waits for momentum to announce itself before the
+    /// release position is treated as final. Finger-lift velocity is not a
+    /// reliable signal: a gentle fling can report zero and still decelerate.
+    static let dragSettleDelay: TimeInterval = 0.16
+
+    /// Gap between momentum ticks that means deceleration has stopped.
+    static let momentumSettleDelay: TimeInterval = 0.05
+
+    /// How long the bottom size-change anchor stays suspended after a disclosure
+    /// toggle. Covers the disclosure animation plus a frame, since the row's
+    /// height changes on every frame of that animation.
+    static let disclosureAnchorSuspension: TimeInterval = 0.25
+
+    /// Scroll-gesture events that drive the follow latch.
+    enum FollowEvent: Equatable {
+        /// An explicit jump to the latest content: scroll-to-bottom tap or send.
+        case reset
+        /// The user started dragging the transcript.
+        case userScrollBegin
+        /// The user's gesture settled: a drag with no momentum after
+        /// `dragSettleDelay`, or deceleration coming to rest.
+        case userScrollEnd(isAtBottom: Bool)
+        /// The content offset changed for any other reason: streaming growth,
+        /// keyboard presentation, a programmatic scroll, or a live gesture.
+        case contentScrolled(isAtBottom: Bool, isUserScrolling: Bool)
+    }
+
+    /// Reduces one event onto the current latch state.
+    static func resolveFollow(current: Bool, event: FollowEvent) -> Bool {
+        switch event {
+        case .reset:
+            return true
+        case .userScrollBegin:
+            return false
+        case .userScrollEnd(let isAtBottom):
+            return isAtBottom
+        case .contentScrolled(let isAtBottom, let isUserScrolling):
+            if isUserScrolling {
+                return false
+            }
+            return isAtBottom ? true : current
+        }
+    }
+
+    static func isAtBottom(distanceFromBottom: CGFloat) -> Bool {
+        distanceFromBottom <= followReArmThreshold
+    }
 
     static func bottomThreshold(isStreaming: Bool) -> CGFloat {
         isStreaming ? streamingBottomDetectionThreshold : bottomDetectionThreshold
@@ -50,28 +103,19 @@ enum ChatScrollPolicy {
     static func shouldEnterReadingOlder(distanceFromBottom: CGFloat, isStreaming: Bool) -> Bool {
         distanceFromBottom > bottomThreshold(isStreaming: isStreaming) + readingOlderHysteresis
     }
+}
 
-    static func cooldownDeadline(after date: Date = Date()) -> Date {
-        date.addingTimeInterval(userScrollCooldown)
-    }
+/// Transcript disclosure controls (reasoning blocks, tool cards, tool groups)
+/// call this right before they toggle so the transcript can suspend its bottom
+/// anchor and keep the tapped row stationary through the size change.
+struct ChatDisclosureToggledKey: EnvironmentKey {
+    static let defaultValue: () -> Void = {}
+}
 
-    /// Automatic follow-scroll is paused while the user is actively touching the
-    /// scroll view and for a brief cooldown window afterward. Explicit user
-    /// actions (tapping scroll-to-bottom, sending a message) bypass this.
-    static func isAutoScrollPaused(
-        isUserInteracting: Bool,
-        cooldownUntil: Date?,
-        now: Date = Date()
-    ) -> Bool {
-        if isUserInteracting {
-            return true
-        }
-
-        guard let cooldownUntil else {
-            return false
-        }
-
-        return now < cooldownUntil
+extension EnvironmentValues {
+    var chatDisclosureToggled: () -> Void {
+        get { self[ChatDisclosureToggledKey.self] }
+        set { self[ChatDisclosureToggledKey.self] = newValue }
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatScrollPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatScrollPolicy.swift
@@ -71,21 +71,37 @@ enum ChatScrollPolicy {
         case contentScrolled(isAtBottom: Bool, isUserScrolling: Bool)
     }
 
+    /// The follow latch. `isFollowing` is the answer; the second flag lets an
+    /// explicit reset outlive a gesture that was still coasting when it landed.
+    struct FollowLatch: Equatable {
+        var isFollowing = true
+        /// Set by `.reset`. Until the gesture settles or a new drag begins, live
+        /// offset changes still flagged as user scrolling belong to momentum
+        /// that predates the explicit action and must not switch follow off.
+        var ignoresCoastingGesture = false
+    }
+
     /// Reduces one event onto the current latch state.
-    static func resolveFollow(current: Bool, event: FollowEvent) -> Bool {
+    static func resolveFollow(current: FollowLatch, event: FollowEvent) -> FollowLatch {
+        var latch = current
         switch event {
         case .reset:
-            return true
+            latch.isFollowing = true
+            latch.ignoresCoastingGesture = true
         case .userScrollBegin:
-            return false
+            latch.isFollowing = false
+            latch.ignoresCoastingGesture = false
         case .userScrollEnd(let isAtBottom):
-            return isAtBottom || current
+            latch.isFollowing = isAtBottom || current.isFollowing
+            latch.ignoresCoastingGesture = false
         case .contentScrolled(let isAtBottom, let isUserScrolling):
-            if isUserScrolling {
-                return false
+            if isUserScrolling, !current.ignoresCoastingGesture {
+                latch.isFollowing = false
+            } else if isAtBottom {
+                latch.isFollowing = true
             }
-            return isAtBottom ? true : current
         }
+        return latch
     }
 
     static func isAtBottom(distanceFromBottom: CGFloat) -> Bool {

--- a/HermesMobile/Features/Chat/ChatScrollPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatScrollPolicy.swift
@@ -61,7 +61,10 @@ enum ChatScrollPolicy {
         /// The user started dragging the transcript.
         case userScrollBegin
         /// The user's gesture settled: a drag with no momentum after
-        /// `dragSettleDelay`, or deceleration coming to rest.
+        /// `dragSettleDelay`, or deceleration coming to rest. Re-arms at the
+        /// bottom; elsewhere it keeps whatever the latch already is, so a
+        /// send or scroll-to-bottom tap that landed while the gesture was
+        /// still settling is not undone by the late settle report.
         case userScrollEnd(isAtBottom: Bool)
         /// The content offset changed for any other reason: streaming growth,
         /// keyboard presentation, a programmatic scroll, or a live gesture.
@@ -76,7 +79,7 @@ enum ChatScrollPolicy {
         case .userScrollBegin:
             return false
         case .userScrollEnd(let isAtBottom):
-            return isAtBottom
+            return isAtBottom || current
         case .contentScrolled(let isAtBottom, let isUserScrolling):
             if isUserScrolling {
                 return false

--- a/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
@@ -6,18 +6,25 @@ struct ChatScrollMetrics: Equatable {
     let isUserInteracting: Bool
 }
 
+/// Reports the transcript's scroll geometry and the gesture events that drive
+/// the follow latch (`ChatScrollPolicy.FollowEvent`). Metrics arrive on every
+/// offset or size change; follow events arrive only when a drag begins and when
+/// the gesture, including any momentum, has settled.
 struct ChatScrollObserver: UIViewRepresentable {
     let isStreaming: Bool
     let prependScrollPositionController: ChatPrependScrollPositionController?
+    let onFollowEvent: @MainActor (ChatScrollPolicy.FollowEvent) -> Void
     let onMetrics: @MainActor (ChatScrollMetrics) -> Void
 
     init(
         isStreaming: Bool,
         prependScrollPositionController: ChatPrependScrollPositionController? = nil,
+        onFollowEvent: @escaping @MainActor (ChatScrollPolicy.FollowEvent) -> Void = { _ in },
         onMetrics: @escaping @MainActor (ChatScrollMetrics) -> Void
     ) {
         self.isStreaming = isStreaming
         self.prependScrollPositionController = prependScrollPositionController
+        self.onFollowEvent = onFollowEvent
         self.onMetrics = onMetrics
     }
 
@@ -29,6 +36,7 @@ struct ChatScrollObserver: UIViewRepresentable {
         Coordinator(
             metricContext: metricContext,
             prependScrollPositionController: prependScrollPositionController,
+            onFollowEvent: onFollowEvent,
             onMetrics: onMetrics
         )
     }
@@ -39,6 +47,7 @@ struct ChatScrollObserver: UIViewRepresentable {
 
     func updateUIView(_ uiView: ObserverView, context: Context) {
         context.coordinator.onMetrics = onMetrics
+        context.coordinator.onFollowEvent = onFollowEvent
         context.coordinator.prependScrollPositionController = prependScrollPositionController
         uiView.coordinator = context.coordinator
         context.coordinator.updateMetricContext(metricContext)
@@ -95,13 +104,20 @@ struct ChatScrollObserver: UIViewRepresentable {
         }
 
         var onMetrics: @MainActor (ChatScrollMetrics) -> Void
+        var onFollowEvent: @MainActor (ChatScrollPolicy.FollowEvent) -> Void
 
         private weak var scrollView: UIScrollView?
+        private weak var observedPanGesture: UIPanGestureRecognizer?
         private var observations: [NSKeyValueObservation] = []
         private var metricContext: MetricContext
         private var lastMetrics: ChatScrollMetrics?
         private var pendingMetrics: ChatScrollMetrics?
         private var hasScheduledMetricDelivery = false
+        /// True from the first drag movement until the gesture, including any
+        /// momentum, comes to rest. Mirrors the "user scroll session" the follow
+        /// latch reasons about.
+        private var isUserScrollSessionActive = false
+        private var settleWorkItem: DispatchWorkItem?
         var prependScrollPositionController: ChatPrependScrollPositionController? {
             didSet {
                 guard oldValue !== prependScrollPositionController else { return }
@@ -115,10 +131,12 @@ struct ChatScrollObserver: UIViewRepresentable {
         init(
             metricContext: MetricContext,
             prependScrollPositionController: ChatPrependScrollPositionController?,
+            onFollowEvent: @escaping @MainActor (ChatScrollPolicy.FollowEvent) -> Void,
             onMetrics: @escaping @MainActor (ChatScrollMetrics) -> Void
         ) {
             self.metricContext = metricContext
             self.prependScrollPositionController = prependScrollPositionController
+            self.onFollowEvent = onFollowEvent
             self.onMetrics = onMetrics
         }
 
@@ -140,8 +158,13 @@ struct ChatScrollObserver: UIViewRepresentable {
 
             observations.removeAll()
             lastMetrics = nil
+            endUserScrollSessionSilently()
             self.scrollView = scrollView
             prependScrollPositionController?.attach(to: scrollView)
+
+            observedPanGesture?.removeTarget(self, action: nil)
+            scrollView.panGestureRecognizer.addTarget(self, action: #selector(handlePanGesture(_:)))
+            observedPanGesture = scrollView.panGestureRecognizer
 
             observations = [
                 scrollView.observe(\.contentOffset, options: [.new]) { [weak self] _, _ in
@@ -157,6 +180,9 @@ struct ChatScrollObserver: UIViewRepresentable {
 
         func detach() {
             observations.removeAll()
+            observedPanGesture?.removeTarget(self, action: nil)
+            observedPanGesture = nil
+            endUserScrollSessionSilently()
             prependScrollPositionController?.detach()
             lastMetrics = nil
             pendingMetrics = nil
@@ -164,16 +190,99 @@ struct ChatScrollObserver: UIViewRepresentable {
             scrollView = nil
         }
 
-        func reportMetrics(delivery: MetricDelivery) {
-            guard let scrollView else { return }
+        // MARK: Follow latch events
 
+        @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+            switch gesture.state {
+            case .began:
+                cancelSettle()
+                isUserScrollSessionActive = true
+                onFollowEvent(.userScrollBegin)
+            case .ended, .cancelled, .failed:
+                guard isUserScrollSessionActive, let scrollView else { return }
+                // Remember where the finger lifted: streaming growth during the
+                // momentum-detection window must not turn a release at the live
+                // edge into an opt-out from follow.
+                let releaseIsAtBottom = isAtBottom(scrollView)
+                scheduleSettle(after: ChatScrollPolicy.dragSettleDelay) { [weak self] in
+                    guard let self, let scrollView = self.scrollView else { return }
+                    // Momentum announced itself; its ticks now own the session.
+                    if scrollView.isDecelerating { return }
+                    self.finishUserScrollSession(isAtBottom: releaseIsAtBottom)
+                }
+            default:
+                break
+            }
+        }
+
+        /// Each momentum tick pushes the settle check out; the check that
+        /// survives runs once deceleration has stopped moving the content.
+        private func trackMomentum(_ scrollView: UIScrollView) {
+            guard isUserScrollSessionActive, scrollView.isDecelerating else { return }
+            scheduleSettle(after: ChatScrollPolicy.momentumSettleDelay) { [weak self] in
+                self?.finishUserScrollSessionIfSettled()
+            }
+        }
+
+        private func finishUserScrollSessionIfSettled() {
+            guard isUserScrollSessionActive, let scrollView else { return }
+            // A finger back on the glass either becomes a new drag (pan .began)
+            // or lifts without one (pan .failed); both paths re-enter above.
+            if scrollView.isDragging || scrollView.isTracking { return }
+            if scrollView.isDecelerating {
+                scheduleSettle(after: ChatScrollPolicy.momentumSettleDelay) { [weak self] in
+                    self?.finishUserScrollSessionIfSettled()
+                }
+                return
+            }
+            finishUserScrollSession(isAtBottom: isAtBottom(scrollView))
+        }
+
+        private func finishUserScrollSession(isAtBottom: Bool) {
+            cancelSettle()
+            isUserScrollSessionActive = false
+            onFollowEvent(.userScrollEnd(isAtBottom: isAtBottom))
+        }
+
+        private func endUserScrollSessionSilently() {
+            cancelSettle()
+            isUserScrollSessionActive = false
+        }
+
+        private func scheduleSettle(after delay: TimeInterval, _ body: @escaping @MainActor () -> Void) {
+            cancelSettle()
+            let workItem = DispatchWorkItem {
+                MainActor.assumeIsolated(body)
+            }
+            settleWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        }
+
+        private func cancelSettle() {
+            settleWorkItem?.cancel()
+            settleWorkItem = nil
+        }
+
+        private func isAtBottom(_ scrollView: UIScrollView) -> Bool {
+            guard let distance = distanceFromBottom(of: scrollView) else { return false }
+            return ChatScrollPolicy.isAtBottom(distanceFromBottom: distance)
+        }
+
+        private func distanceFromBottom(of scrollView: UIScrollView) -> CGFloat? {
             let inset = scrollView.adjustedContentInset
             let visibleHeight = scrollView.bounds.height - inset.top - inset.bottom
-            guard visibleHeight > 0 else { return }
+            guard visibleHeight > 0 else { return nil }
 
             let currentOffset = scrollView.contentOffset.y + inset.top
             let maximumOffset = scrollView.contentSize.height - visibleHeight
-            let distanceFromBottom = max(0, maximumOffset - currentOffset)
+            return max(0, maximumOffset - currentOffset)
+        }
+
+        func reportMetrics(delivery: MetricDelivery) {
+            guard let scrollView else { return }
+            trackMomentum(scrollView)
+
+            guard let distanceFromBottom = distanceFromBottom(of: scrollView) else { return }
             let metrics = ChatScrollMetrics(
                 distanceFromBottom: distanceFromBottom,
                 isUserInteracting: scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -5,11 +5,6 @@ struct ChatTranscriptView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var prependScrollPositionController = ChatPrependScrollPositionController()
-    /// While true the bottom size-change anchor and follow-driven scrolls are
-    /// suspended so a disclosure toggle near the end grows or shrinks in place
-    /// instead of moving the view.
-    @State private var isDisclosureSettling = false
-    @State private var disclosureSettleGeneration = 0
 
     let isLoading: Bool
     let errorMessage: String?
@@ -33,6 +28,9 @@ struct ChatTranscriptView: View {
     let showsAssistantTypingIndicator: Bool
     let showsScrollToBottomButton: Bool
     let shouldFollowLatestMessage: Bool
+    /// True while a disclosure toggle animates; suspends the bottom size-change
+    /// anchor and follow-driven scrolls so the tapped row stays stationary.
+    let isDisclosureSettling: Bool
     let latestTranscriptMessageRole: String?
     let isScrolledNearBottom: Bool
     let activeStreamID: String?
@@ -61,6 +59,7 @@ struct ChatTranscriptView: View {
     let onLoadOlderMessages: () async -> Bool
     let onUpdateScrollMetrics: (ChatScrollMetrics) -> Void
     let onFollowEvent: (ChatScrollPolicy.FollowEvent) -> Void
+    let onDisclosureToggle: () -> Void
     let onDismissKeyboard: () -> Void
     let onScrollToBottom: (ScrollViewProxy) -> Void
     let onScrollToLatestTranscriptMessage: (ScrollViewProxy) -> Void
@@ -207,24 +206,9 @@ struct ChatTranscriptView: View {
     }
 
     /// Follow-driven scrolls run only while the latch is on and no disclosure
-    /// toggle is mid-animation; the latch itself is untouched, so the next
-    /// streaming trigger catches up once the toggle has settled.
+    /// toggle is mid-animation.
     private var isFollowingLatestContent: Bool {
         shouldFollowLatestMessage && !isDisclosureSettling
-    }
-
-    /// Holds the current offset through a disclosure animation so the tapped
-    /// row stays under the finger.
-    private func suspendBottomAnchorForDisclosure() {
-        disclosureSettleGeneration += 1
-        let generation = disclosureSettleGeneration
-        isDisclosureSettling = true
-
-        Task { @MainActor in
-            try? await Task.sleep(for: .seconds(ChatScrollPolicy.disclosureAnchorSuspension))
-            guard generation == disclosureSettleGeneration else { return }
-            isDisclosureSettling = false
-        }
     }
 
     private func transcriptScrollContent(
@@ -312,7 +296,7 @@ struct ChatTranscriptView: View {
         .padding(.horizontal, transcriptHorizontalPadding)
         .frame(width: viewportWidth, alignment: .leading)
         .clipped()
-        .environment(\.chatDisclosureToggled, suspendBottomAnchorForDisclosure)
+        .environment(\.chatDisclosureToggled, onDisclosureToggle)
         .background {
             ZStack {
                 ChatScrollObserver(

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -5,8 +5,9 @@ struct ChatTranscriptView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var prependScrollPositionController = ChatPrependScrollPositionController()
-    /// While true the bottom size-change anchor is suspended so a disclosure
-    /// toggle near the end grows or shrinks in place instead of moving the view.
+    /// While true the bottom size-change anchor and follow-driven scrolls are
+    /// suspended so a disclosure toggle near the end grows or shrinks in place
+    /// instead of moving the view.
     @State private var isDisclosureSettling = false
     @State private var disclosureSettleGeneration = 0
 
@@ -172,7 +173,7 @@ struct ChatTranscriptView: View {
                 .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: showsScrollToBottomButton)
                 .background(Color(.systemBackground))
                 .onChange(of: messages.count) {
-                    guard shouldFollowLatestMessage else { return }
+                    guard isFollowingLatestContent else { return }
 
                     if latestTranscriptMessageRole == "user" {
                         onScrollToLatestTranscriptMessage(proxy)
@@ -181,7 +182,7 @@ struct ChatTranscriptView: View {
                     }
                 }
                 .onChange(of: streamingScrollTrigger) {
-                    if shouldFollowLatestMessage {
+                    if isFollowingLatestContent {
                         onScrollToLatestContent(proxy, true)
                     }
                 }
@@ -189,11 +190,11 @@ struct ChatTranscriptView: View {
                     // Cache-first reconcile (#289): the server transcript just replaced
                     // the lighter cached render, so snap back to the bottom (no
                     // animation) unless the reader has scrolled away in the meantime.
-                    guard shouldFollowLatestMessage else { return }
+                    guard isFollowingLatestContent else { return }
                     onScrollToLatestContent(proxy, false)
                 }
                 .onChange(of: clarificationPrompt?.id) {
-                    guard clarificationPrompt != nil, shouldFollowLatestMessage else { return }
+                    guard clarificationPrompt != nil, isFollowingLatestContent else { return }
                     onScrollToBottom(proxy)
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
@@ -205,9 +206,15 @@ struct ChatTranscriptView: View {
         }
     }
 
+    /// Follow-driven scrolls run only while the latch is on and no disclosure
+    /// toggle is mid-animation; the latch itself is untouched, so the next
+    /// streaming trigger catches up once the toggle has settled.
+    private var isFollowingLatestContent: Bool {
+        shouldFollowLatestMessage && !isDisclosureSettling
+    }
+
     /// Holds the current offset through a disclosure animation so the tapped
-    /// row stays under the finger; follow itself is untouched, so the next
-    /// streaming trigger still catches up once the toggle has settled.
+    /// row stays under the finger.
     private func suspendBottomAnchorForDisclosure() {
         disclosureSettleGeneration += 1
         let generation = disclosureSettleGeneration

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -5,6 +5,10 @@ struct ChatTranscriptView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var prependScrollPositionController = ChatPrependScrollPositionController()
+    /// While true the bottom size-change anchor is suspended so a disclosure
+    /// toggle near the end grows or shrinks in place instead of moving the view.
+    @State private var isDisclosureSettling = false
+    @State private var disclosureSettleGeneration = 0
 
     let isLoading: Bool
     let errorMessage: String?
@@ -55,6 +59,7 @@ struct ChatTranscriptView: View {
     let onLoadMessages: () async -> Void
     let onLoadOlderMessages: () async -> Bool
     let onUpdateScrollMetrics: (ChatScrollMetrics) -> Void
+    let onFollowEvent: (ChatScrollPolicy.FollowEvent) -> Void
     let onDismissKeyboard: () -> Void
     let onScrollToBottom: (ScrollViewProxy) -> Void
     let onScrollToLatestTranscriptMessage: (ScrollViewProxy) -> Void
@@ -127,7 +132,8 @@ struct ChatTranscriptView: View {
                     )
                     .defaultScrollAnchor(
                         ChatScrollPolicy.sizeChangeAnchor(
-                            shouldFollowLatestMessage: shouldFollowLatestMessage
+                            shouldFollowLatestMessage: shouldFollowLatestMessage,
+                            isDisclosureSettling: isDisclosureSettling
                         ),
                         for: .sizeChanges
                     )
@@ -196,6 +202,21 @@ struct ChatTranscriptView: View {
                     }
                 }
             }
+        }
+    }
+
+    /// Holds the current offset through a disclosure animation so the tapped
+    /// row stays under the finger; follow itself is untouched, so the next
+    /// streaming trigger still catches up once the toggle has settled.
+    private func suspendBottomAnchorForDisclosure() {
+        disclosureSettleGeneration += 1
+        let generation = disclosureSettleGeneration
+        isDisclosureSettling = true
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(ChatScrollPolicy.disclosureAnchorSuspension))
+            guard generation == disclosureSettleGeneration else { return }
+            isDisclosureSettling = false
         }
     }
 
@@ -284,11 +305,13 @@ struct ChatTranscriptView: View {
         .padding(.horizontal, transcriptHorizontalPadding)
         .frame(width: viewportWidth, alignment: .leading)
         .clipped()
+        .environment(\.chatDisclosureToggled, suspendBottomAnchorForDisclosure)
         .background {
             ZStack {
                 ChatScrollObserver(
                     isStreaming: activeStreamID != nil,
-                    prependScrollPositionController: prependScrollPositionController
+                    prependScrollPositionController: prependScrollPositionController,
+                    onFollowEvent: onFollowEvent
                 ) { metrics in
                     onUpdateScrollMetrics(metrics)
                 }

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -296,8 +296,6 @@ struct ChatView: View {
     @State private var isReadingOlderTranscript = false
     @State private var shouldFollowLatestMessage = true
     @State private var followScrollGeneration = 0
-    @State private var isUserInteractingWithScroll = false
-    @State private var userScrollCooldownUntil: Date?
     /// While set and in the future, auto-follow scrolls snap instead of animating, so
     /// the cache-first → network reconcile re-pins to the bottom without a jump (#289).
     @State private var cacheFirstSnapUntil: Date?
@@ -1209,6 +1207,7 @@ struct ChatView: View {
                 await loadOlderMessages()
             },
             onUpdateScrollMetrics: updateScrollMetrics,
+            onFollowEvent: handleFollowEvent,
             onDismissKeyboard: dismissKeyboard,
             onScrollToBottom: scrollToBottom,
             onScrollToLatestTranscriptMessage: { proxy in
@@ -2383,17 +2382,17 @@ struct ChatView: View {
         animated: Bool,
         isUserInitiated: Bool
     ) {
-        // Auto-follow (streaming tokens, new rows) must not override the user's
-        // scroll position while they are interacting or within the cooldown.
-        if !isUserInitiated, isAutoFollowScrollPaused {
+        // Explicit jumps re-arm the follow latch; automatic follows (streaming
+        // tokens, new rows) only run while the latch is already on.
+        if isUserInitiated {
+            shouldFollowLatestMessage = ChatScrollPolicy.resolveFollow(
+                current: shouldFollowLatestMessage,
+                event: .reset
+            )
+        } else if !shouldFollowLatestMessage {
             return
         }
 
-        if isUserInitiated {
-            userScrollCooldownUntil = nil
-        }
-
-        shouldFollowLatestMessage = true
         isReadingOlderTranscript = false
         followScrollGeneration += 1
         let generation = followScrollGeneration
@@ -2402,8 +2401,8 @@ struct ChatView: View {
             await Task.yield()
             try? await Task.sleep(nanoseconds: 16_000_000)
             guard !Task.isCancelled, generation == followScrollGeneration else { return }
-            // Re-check at fire time: a gesture may have begun during the delay.
-            if !isUserInitiated, isAutoFollowScrollPaused { return }
+            // Re-check at fire time: a drag may have begun during the delay.
+            if !isUserInitiated, !shouldFollowLatestMessage { return }
 
             // Snap (no animation) while inside the cache-first reconcile window so the
             // taller server transcript replacing the cached one doesn't animate a jump
@@ -2484,6 +2483,13 @@ struct ChatView: View {
         }
     }
 
+    private func handleFollowEvent(_ event: ChatScrollPolicy.FollowEvent) {
+        shouldFollowLatestMessage = ChatScrollPolicy.resolveFollow(
+            current: shouldFollowLatestMessage,
+            event: event
+        )
+    }
+
     private func updateScrollMetrics(_ metrics: ChatScrollMetrics) {
         let isStreaming = viewModel.activeStreamID != nil
         let isNearBottom = ChatScrollPolicy.isNearBottom(
@@ -2491,23 +2497,18 @@ struct ChatView: View {
             isStreaming: isStreaming
         )
         isScrolledNearBottom = isNearBottom
-        isUserInteractingWithScroll = metrics.isUserInteracting
-
-        // Touching the scroll view pauses auto-follow for a short window so
-        // streaming layout growth cannot yank the viewport mid-gesture.
-        if metrics.isUserInteracting {
-            userScrollCooldownUntil = ChatScrollPolicy.cooldownDeadline()
-        }
+        handleFollowEvent(.contentScrolled(
+            isAtBottom: ChatScrollPolicy.isAtBottom(distanceFromBottom: metrics.distanceFromBottom),
+            isUserScrolling: metrics.isUserInteracting
+        ))
 
         if isNearBottom {
-            shouldFollowLatestMessage = true
             if isReadingOlderTranscript {
                 withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
                     isReadingOlderTranscript = false
                 }
             }
         } else if metrics.isUserInteracting {
-            shouldFollowLatestMessage = false
             if !isReadingOlderTranscript,
                ChatScrollPolicy.shouldEnterReadingOlder(
                    distanceFromBottom: metrics.distanceFromBottom,
@@ -2520,16 +2521,11 @@ struct ChatView: View {
         }
     }
 
-    private var isAutoFollowScrollPaused: Bool {
-        ChatScrollPolicy.isAutoScrollPaused(
-            isUserInteracting: isUserInteractingWithScroll,
-            cooldownUntil: userScrollCooldownUntil
-        )
-    }
-
     private func prepareTranscriptForExplicitSend() {
-        shouldFollowLatestMessage = true
-        userScrollCooldownUntil = nil
+        shouldFollowLatestMessage = ChatScrollPolicy.resolveFollow(
+            current: shouldFollowLatestMessage,
+            event: .reset
+        )
         if isReadingOlderTranscript {
             withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
                 isReadingOlderTranscript = false

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -294,8 +294,12 @@ struct ChatView: View {
     @State private var draftRevision = 0
     @State private var isScrolledNearBottom = true
     @State private var isReadingOlderTranscript = false
-    @State private var shouldFollowLatestMessage = true
+    @State private var followLatch = ChatScrollPolicy.FollowLatch()
     @State private var followScrollGeneration = 0
+    /// While true the transcript's bottom size-change anchor and follow-driven
+    /// scrolls are suspended so a disclosure toggle grows or shrinks in place.
+    @State private var isDisclosureSettling = false
+    @State private var disclosureSettleGeneration = 0
     /// While set and in the future, auto-follow scrolls snap instead of animating, so
     /// the cache-first → network reconcile re-pins to the bottom without a jump (#289).
     @State private var cacheFirstSnapUntil: Date?
@@ -1166,6 +1170,7 @@ struct ChatView: View {
             showsAssistantTypingIndicator: showsAssistantTypingIndicator,
             showsScrollToBottomButton: showsScrollToBottomButton,
             shouldFollowLatestMessage: shouldFollowLatestMessage,
+            isDisclosureSettling: isDisclosureSettling,
             latestTranscriptMessageRole: latestTranscriptMessageRole,
             isScrolledNearBottom: isScrolledNearBottom,
             activeStreamID: viewModel.activeStreamID,
@@ -1208,6 +1213,7 @@ struct ChatView: View {
             },
             onUpdateScrollMetrics: updateScrollMetrics,
             onFollowEvent: handleFollowEvent,
+            onDisclosureToggle: suspendBottomAnchorForDisclosure,
             onDismissKeyboard: dismissKeyboard,
             onScrollToBottom: scrollToBottom,
             onScrollToLatestTranscriptMessage: { proxy in
@@ -1265,6 +1271,16 @@ struct ChatView: View {
     /// sidebar, settings, and navigation chrome stay in the default direction.
     private var chatLayoutDirection: LayoutDirection {
         ChatTranscriptDisplaySettings.chatLayoutDirection(rtlEnabled: rtlChatLayoutEnabled)
+    }
+
+    private var shouldFollowLatestMessage: Bool {
+        followLatch.isFollowing
+    }
+
+    /// Automatic follows run only while the latch is on and no disclosure
+    /// toggle is mid-animation.
+    private var isFollowingLatestContent: Bool {
+        shouldFollowLatestMessage && !isDisclosureSettling
     }
 
     private var showsScrollToBottomButton: Bool {
@@ -1479,7 +1495,7 @@ struct ChatView: View {
     }
 
     private func loadOlderMessages() async -> Bool {
-        shouldFollowLatestMessage = false
+        followLatch.isFollowing = false
         if !isReadingOlderTranscript {
             withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
                 isReadingOlderTranscript = true
@@ -2383,13 +2399,11 @@ struct ChatView: View {
         isUserInitiated: Bool
     ) {
         // Explicit jumps re-arm the follow latch; automatic follows (streaming
-        // tokens, new rows) only run while the latch is already on.
+        // tokens, new rows) only run while the latch is already on and no
+        // disclosure toggle is settling.
         if isUserInitiated {
-            shouldFollowLatestMessage = ChatScrollPolicy.resolveFollow(
-                current: shouldFollowLatestMessage,
-                event: .reset
-            )
-        } else if !shouldFollowLatestMessage {
+            handleFollowEvent(.reset)
+        } else if !isFollowingLatestContent {
             return
         }
 
@@ -2401,8 +2415,9 @@ struct ChatView: View {
             await Task.yield()
             try? await Task.sleep(nanoseconds: 16_000_000)
             guard !Task.isCancelled, generation == followScrollGeneration else { return }
-            // Re-check at fire time: a drag may have begun during the delay.
-            if !isUserInitiated, !shouldFollowLatestMessage { return }
+            // Re-check at fire time: a drag or a disclosure toggle may have
+            // begun during the delay.
+            if !isUserInitiated, !isFollowingLatestContent { return }
 
             // Snap (no animation) while inside the cache-first reconcile window so the
             // taller server transcript replacing the cached one doesn't animate a jump
@@ -2484,10 +2499,25 @@ struct ChatView: View {
     }
 
     private func handleFollowEvent(_ event: ChatScrollPolicy.FollowEvent) {
-        shouldFollowLatestMessage = ChatScrollPolicy.resolveFollow(
-            current: shouldFollowLatestMessage,
-            event: event
-        )
+        let resolved = ChatScrollPolicy.resolveFollow(current: followLatch, event: event)
+        if resolved != followLatch {
+            followLatch = resolved
+        }
+    }
+
+    /// Holds the transcript offset through a disclosure animation so the tapped
+    /// row stays under the finger. The latch itself is untouched, so the next
+    /// streaming trigger catches up once the toggle has settled.
+    private func suspendBottomAnchorForDisclosure() {
+        disclosureSettleGeneration += 1
+        let generation = disclosureSettleGeneration
+        isDisclosureSettling = true
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(ChatScrollPolicy.disclosureAnchorSuspension))
+            guard generation == disclosureSettleGeneration else { return }
+            isDisclosureSettling = false
+        }
     }
 
     private func updateScrollMetrics(_ metrics: ChatScrollMetrics) {
@@ -2522,10 +2552,7 @@ struct ChatView: View {
     }
 
     private func prepareTranscriptForExplicitSend() {
-        shouldFollowLatestMessage = ChatScrollPolicy.resolveFollow(
-            current: shouldFollowLatestMessage,
-            event: .reset
-        )
+        handleFollowEvent(.reset)
         if isReadingOlderTranscript {
             withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
                 isReadingOlderTranscript = false

--- a/HermesMobile/Features/Chat/MarkerMessageCardView.swift
+++ b/HermesMobile/Features/Chat/MarkerMessageCardView.swift
@@ -9,6 +9,7 @@ struct MarkerMessageCardView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
     @State private var isExpanded = false
 
     var body: some View {
@@ -17,6 +18,7 @@ struct MarkerMessageCardView: View {
 
         VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
             Button {
+                chatDisclosureToggled()
                 withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
                     isExpanded.toggle()
                 }

--- a/HermesMobile/Features/Chat/ReasoningBlockView.swift
+++ b/HermesMobile/Features/Chat/ReasoningBlockView.swift
@@ -7,6 +7,7 @@ struct ReasoningBlockView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var startsExpanded = false
     @State private var userToggledExpansion: Bool?
 
@@ -28,6 +29,7 @@ struct ReasoningBlockView: View {
 
             VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
                 Button {
+                    chatDisclosureToggled()
                     withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
                         userToggledExpansion = !isExpanded
                     }

--- a/HermesMobile/Features/Chat/ToolActivityGroupView.swift
+++ b/HermesMobile/Features/Chat/ToolActivityGroupView.swift
@@ -4,6 +4,7 @@ struct ToolActivityGroupView: View {
     let group: ToolCallGroup
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
     @AppStorage(ChatTranscriptDisplaySettings.toolCardsStartExpandedKey) private var startsExpanded = false
     @State private var userToggledExpansion: Bool?
 
@@ -17,6 +18,7 @@ struct ToolActivityGroupView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
             Button {
+                chatDisclosureToggled()
                 withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
                     userToggledExpansion = !isExpanded
                 }

--- a/HermesMobile/Features/Chat/ToolCallCardView.swift
+++ b/HermesMobile/Features/Chat/ToolCallCardView.swift
@@ -4,6 +4,7 @@ struct ToolCallCardView: View {
     let toolCall: ToolCall
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
     @AppStorage(ChatTranscriptDisplaySettings.toolCardsStartExpandedKey) private var startsExpanded = false
     @State private var userToggledExpansion: Bool?
 
@@ -19,6 +20,7 @@ struct ToolCallCardView: View {
 
         VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
             Button {
+                chatDisclosureToggled()
                 withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
                     userToggledExpansion = !isExpanded
                 }

--- a/HermesMobileTests/ChatScrollPolicyTests.swift
+++ b/HermesMobileTests/ChatScrollPolicyTests.swift
@@ -66,8 +66,14 @@ final class ChatScrollPolicyTests: XCTestCase {
 
     // MARK: Follow latch
 
+    private typealias Latch = ChatScrollPolicy.FollowLatch
+
     private func follow(_ current: Bool, _ event: ChatScrollPolicy.FollowEvent) -> Bool {
-        ChatScrollPolicy.resolveFollow(current: current, event: event)
+        ChatScrollPolicy.resolveFollow(current: Latch(isFollowing: current), event: event).isFollowing
+    }
+
+    private func reduce(_ latch: Latch, _ events: ChatScrollPolicy.FollowEvent...) -> Latch {
+        events.reduce(latch) { ChatScrollPolicy.resolveFollow(current: $0, event: $1) }
     }
 
     func testTouchDownTurnsFollowOff() {
@@ -82,9 +88,33 @@ final class ChatScrollPolicyTests: XCTestCase {
     func testExplicitResetSurvivesLateDragSettlement() {
         // Drag lifted above the bottom, then send or scroll-to-bottom landed inside the
         // 160 ms settle window. The late settle report must not undo the reset.
-        let afterReset = follow(follow(true, .userScrollBegin), .reset)
-        XCTAssertTrue(afterReset)
-        XCTAssertTrue(follow(afterReset, .userScrollEnd(isAtBottom: false)))
+        let latch = reduce(Latch(), .userScrollBegin, .reset, .userScrollEnd(isAtBottom: false))
+        XCTAssertTrue(latch.isFollowing)
+        XCTAssertFalse(latch.ignoresCoastingGesture)
+    }
+
+    func testExplicitResetSurvivesCoastingMomentum() {
+        // Send or scroll-to-bottom while the transcript is still decelerating: the
+        // remaining momentum ticks belong to the gesture that predates the reset.
+        let coasting = reduce(
+            Latch(),
+            .userScrollBegin,
+            .reset,
+            .contentScrolled(isAtBottom: false, isUserScrolling: true)
+        )
+        XCTAssertTrue(coasting.isFollowing)
+
+        // Once that momentum settles, the next real drag turns follow off as usual.
+        let settled = reduce(coasting, .userScrollEnd(isAtBottom: false))
+        XCTAssertTrue(settled.isFollowing)
+        XCTAssertFalse(settled.ignoresCoastingGesture)
+        XCTAssertFalse(reduce(settled, .contentScrolled(isAtBottom: false, isUserScrolling: true)).isFollowing)
+    }
+
+    func testNewDragAfterResetTurnsFollowOff() {
+        let latch = reduce(Latch(), .reset, .userScrollBegin)
+        XCTAssertFalse(latch.isFollowing)
+        XCTAssertFalse(latch.ignoresCoastingGesture)
     }
 
     func testDragEndAtBottomReArmsFollow() {

--- a/HermesMobileTests/ChatScrollPolicyTests.swift
+++ b/HermesMobileTests/ChatScrollPolicyTests.swift
@@ -77,7 +77,14 @@ final class ChatScrollPolicyTests: XCTestCase {
 
     func testDragEndAboveBottomKeepsFollowOff() {
         XCTAssertFalse(follow(false, .userScrollEnd(isAtBottom: false)))
-        XCTAssertFalse(follow(true, .userScrollEnd(isAtBottom: false)))
+    }
+
+    func testExplicitResetSurvivesLateDragSettlement() {
+        // Drag lifted above the bottom, then send or scroll-to-bottom landed inside the
+        // 160 ms settle window. The late settle report must not undo the reset.
+        let afterReset = follow(follow(true, .userScrollBegin), .reset)
+        XCTAssertTrue(afterReset)
+        XCTAssertTrue(follow(afterReset, .userScrollEnd(isAtBottom: false)))
     }
 
     func testDragEndAtBottomReArmsFollow() {

--- a/HermesMobileTests/ChatScrollPolicyTests.swift
+++ b/HermesMobileTests/ChatScrollPolicyTests.swift
@@ -64,58 +64,76 @@ final class ChatScrollPolicyTests: XCTestCase {
         )
     }
 
-    func testAutoScrollPausedWhileUserInteracting() {
-        XCTAssertTrue(
-            ChatScrollPolicy.isAutoScrollPaused(
-                isUserInteracting: true,
-                cooldownUntil: nil
-            )
-        )
+    // MARK: Follow latch
+
+    private func follow(_ current: Bool, _ event: ChatScrollPolicy.FollowEvent) -> Bool {
+        ChatScrollPolicy.resolveFollow(current: current, event: event)
     }
 
-    func testAutoScrollPausedDuringCooldownWindow() {
-        let now = Date()
-        let future = now.addingTimeInterval(0.1)
-
-        XCTAssertTrue(
-            ChatScrollPolicy.isAutoScrollPaused(
-                isUserInteracting: false,
-                cooldownUntil: future,
-                now: now
-            )
-        )
+    func testTouchDownTurnsFollowOff() {
+        XCTAssertFalse(follow(true, .userScrollBegin))
+        XCTAssertFalse(follow(false, .userScrollBegin))
     }
 
-    func testAutoScrollResumesAfterCooldownExpires() {
-        let now = Date()
-        let past = now.addingTimeInterval(-0.1)
-
-        XCTAssertFalse(
-            ChatScrollPolicy.isAutoScrollPaused(
-                isUserInteracting: false,
-                cooldownUntil: past,
-                now: now
-            )
-        )
+    func testDragEndAboveBottomKeepsFollowOff() {
+        XCTAssertFalse(follow(false, .userScrollEnd(isAtBottom: false)))
+        XCTAssertFalse(follow(true, .userScrollEnd(isAtBottom: false)))
     }
 
-    func testAutoScrollNotPausedWithoutInteractionOrCooldown() {
-        XCTAssertFalse(
-            ChatScrollPolicy.isAutoScrollPaused(
-                isUserInteracting: false,
-                cooldownUntil: nil
-            )
-        )
+    func testDragEndAtBottomReArmsFollow() {
+        XCTAssertTrue(follow(false, .userScrollEnd(isAtBottom: true)))
     }
 
-    func testCooldownDeadlineIsUserScrollCooldownInFuture() {
-        let base = Date(timeIntervalSinceReferenceDate: 1_000)
-        let deadline = ChatScrollPolicy.cooldownDeadline(after: base)
+    func testMomentumEndDecidesFromWhereItSettled() {
+        // A fling that stops mid-transcript stays off; one that lands at the end re-arms.
+        XCTAssertFalse(follow(false, .userScrollEnd(isAtBottom: false)))
+        XCTAssertTrue(follow(false, .userScrollEnd(isAtBottom: true)))
+    }
 
+    func testLayoutGrowthWhileOffNeverReArms() {
+        // Streaming tokens push the bottom away; that alone must not re-pin the reader.
+        XCTAssertFalse(follow(false, .contentScrolled(isAtBottom: false, isUserScrolling: false)))
+    }
+
+    func testLayoutGrowthWhileFollowingStaysOn() {
+        // Keyboard presentation and token growth move the offset without a gesture.
+        XCTAssertTrue(follow(true, .contentScrolled(isAtBottom: false, isUserScrolling: false)))
+    }
+
+    func testNonGestureScrollThatLandsAtBottomReArms() {
+        XCTAssertTrue(follow(false, .contentScrolled(isAtBottom: true, isUserScrolling: false)))
+    }
+
+    func testLiveGestureWinsEvenAtBottom() {
+        XCTAssertFalse(follow(true, .contentScrolled(isAtBottom: true, isUserScrolling: true)))
+    }
+
+    func testExplicitActionsBypassTheLatch() {
+        XCTAssertTrue(follow(false, .reset))
+        XCTAssertTrue(follow(true, .reset))
+    }
+
+    func testReArmRequiresStrictBottom() {
+        XCTAssertTrue(ChatScrollPolicy.isAtBottom(distanceFromBottom: ChatScrollPolicy.followReArmThreshold))
+        XCTAssertFalse(ChatScrollPolicy.isAtBottom(distanceFromBottom: ChatScrollPolicy.followReArmThreshold + 1))
+        XCTAssertLessThan(ChatScrollPolicy.followReArmThreshold, ChatScrollPolicy.bottomDetectionThreshold)
+    }
+
+    func testDragSettleWaitsForLateMomentum() {
+        XCTAssertEqual(ChatScrollPolicy.dragSettleDelay, 0.16, accuracy: 0.0001)
+        XCTAssertLessThan(ChatScrollPolicy.momentumSettleDelay, ChatScrollPolicy.dragSettleDelay)
+    }
+
+    func testDisclosureToggleSuspendsBottomAnchorWhileFollowing() {
+        XCTAssertNil(
+            ChatScrollPolicy.sizeChangeAnchor(shouldFollowLatestMessage: true, isDisclosureSettling: true)
+        )
         XCTAssertEqual(
-            deadline.timeIntervalSince(base),
-            ChatScrollPolicy.userScrollCooldown,
-            accuracy: 0.0001
+            ChatScrollPolicy.sizeChangeAnchor(shouldFollowLatestMessage: true, isDisclosureSettling: false),
+            .bottom
+        )
+        XCTAssertNil(
+            ChatScrollPolicy.sizeChangeAnchor(shouldFollowLatestMessage: false, isDisclosureSettling: false)
         )
     }
 }


### PR DESCRIPTION
## What changed

Scrolling up a little while a response streamed did not stick: a quarter-second after the finger lifted, the transcript re-pinned itself to the bottom. Expanding a tool card or thinking block near the end also yanked the whole view because the bottom size-change anchor stayed live.

Auto-follow is now an explicit latch driven by scroll gestures instead of a distance test plus cooldown:

- Touching the transcript (pan begin) turns follow off immediately.
- Follow re-arms only when the gesture settles at the true bottom (within 12 pt), evaluated when the drag ends or when momentum comes to rest. A finished drag waits 160 ms for late momentum before its release position is treated as final, so a gentle fling is one interaction.
- Tapping scroll-to-bottom or sending a message re-arms regardless.
- Streaming growth, keyboard presentation, and other non-gesture offset changes never flip the latch on their own.
- The 80/160 pt distance thresholds remain only for the scroll-to-bottom button and the reading-older chrome.
- Reasoning blocks, tool cards, and tool groups suspend the bottom size-change anchor for the disclosure animation (250 ms) so the tapped row stays stationary. The upstream reference disables it for two frames; Hermex animates the height change, so the suspension covers the animation instead.

`ChatScrollPolicy` owns the reducer and constants. `ChatScrollObserver` reports pan begin/end and momentum settle from the UIKit scroll view. `ChatView` feeds events through the reducer and drops the cooldown state.

## How it was tested

- Full XCTest suite via XcodeBuildMCP `test_sim` on iPhone 17 (iOS 26.5): 1787 passed, 0 failed, 2 pre-existing photo-library skips.
- `ChatScrollPolicyTests` covers touch-down, drag end above and at the bottom, momentum end, layout growth while off and while on (keyboard), non-gesture landing at the bottom, live gesture at the bottom, explicit reset, the strict re-arm threshold, and the disclosure anchor suspension.
- Manual simulator pass is the owner's: scroll up mid-stream and confirm the view stays put; drag back to the bottom and confirm follow resumes; expand a tool card near the end and confirm the row does not move.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no networking changes)

Written by Claude Fable 5.1 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)