### PR TITLE
feat(chat): answer disclosures, copies, and Git edges with haptics

### DIFF
--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -174,6 +174,9 @@ enum PrimaryActionTintSettings {
 
 enum AppHaptics {
     static let isEnabledKey = "appHaptics.isEnabled"
+    /// Opt-in selection tick while assistant text streams. Off by default and
+    /// only honored when `isEnabledKey` is also on.
+    static let streamingPulseIsEnabledKey = "appHaptics.streamingPulse.isEnabled"
 }
 
 enum ResponseCompletionNotifications {

--- a/HermesMobile/Features/Chat/ChatHaptics.swift
+++ b/HermesMobile/Features/Chat/ChatHaptics.swift
@@ -49,6 +49,55 @@ enum ChatHaptics {
         emit(.warning, isEnabled: isEnabled, performer: performer)
     }
 
+    /// Any transcript disclosure: tool cards, tool groups, reasoning, marker cards.
+    static func disclosureToggled(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.selection, isEnabled: isEnabled, performer: performer)
+    }
+
+    /// The scroll-to-latest button, a deliberate jump rather than a follow scroll.
+    static func scrolledToLatest(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.selection, isEnabled: isEnabled, performer: performer)
+    }
+
+    /// Every pasteboard write the user asks for: messages, code blocks, files, titles, links.
+    static func copied(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.lightImpact, isEnabled: isEnabled, performer: performer)
+    }
+
+    /// The `running → finished` edge of a Git action shown in the toast overlay.
+    /// Call it once per action outcome, never from a view body.
+    static func gitActionFinished(succeeded: Bool, isEnabled: Bool, performer: Performer? = nil) {
+        emit(succeeded ? .success : .warning, isEnabled: isEnabled, performer: performer)
+    }
+
+    /// One tick of the opt-in pulse while assistant text streams. Callers throttle
+    /// with `StreamingPulseThrottle`; this only honors the enabled flag.
+    static func streamingPulse(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.selection, isEnabled: isEnabled, performer: performer)
+    }
+
+    /// Rate limit for the streaming pulse: at most one tick per `interval`, so a
+    /// fast token stream feels like a faint ticker instead of a buzz.
+    struct StreamingPulseThrottle: Equatable {
+        static let defaultInterval: TimeInterval = 0.32
+
+        var interval: TimeInterval = StreamingPulseThrottle.defaultInterval
+        private var lastPulseAt: TimeInterval?
+
+        /// Records a token arrival. Returns `true` when enough time has passed for a pulse.
+        mutating func shouldPulse(at now: TimeInterval) -> Bool {
+            if let lastPulseAt, now - lastPulseAt < interval {
+                return false
+            }
+            lastPulseAt = now
+            return true
+        }
+
+        mutating func reset() {
+            lastPulseAt = nil
+        }
+    }
+
     private static func emit(_ feedback: ChatHapticFeedback, isEnabled: Bool, performer: Performer?) {
         guard isEnabled else { return }
         (performer ?? Self.perform)(feedback)

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -265,6 +265,7 @@ struct ChatView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @AppStorage(AppHaptics.streamingPulseIsEnabledKey) private var isStreamingPulseEnabled = false
     @AppStorage(StreamingSendBehavior.storageKey) private var streamingSendBehaviorRawValue = StreamingSendBehavior.steer.rawValue
     @AppStorage(ResponseCompletionNotifications.isEnabledKey) private var isResponseCompletionNotificationsEnabled = false
     @AppStorage(AgentRunLiveActivityPrivacy.showsResponseExcerptsKey) private var showsLiveActivityResponseExcerpts = false
@@ -699,6 +700,7 @@ struct ChatView: View {
                 guard viewModel.responseCompletionHapticTrigger > 0 else { return }
                 handleResponseCompletionSideEffects()
             }
+            .onChange(of: viewModel.streamingHapticPulseTrigger, handleStreamingHapticPulse)
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     ChatToolbarTitleLabel(
@@ -1023,8 +1025,10 @@ struct ChatView: View {
                 subtitle: result.branch,
                 detailLines: detailLines
             ))
+            ChatHaptics.gitActionFinished(succeeded: result.pushFailureMessage == nil, isEnabled: isHapticsEnabled)
         case .nothingToCommit:
             gitToastState.dismissProgress()
+            ChatHaptics.gitActionFinished(succeeded: false, isEnabled: isHapticsEnabled)
             gitAlert = .error(String(localized: "There are no changes to commit."))
         case .tooManyChanges:
             // Status was truncated (>500 files): the commit was blocked to avoid silently
@@ -1034,10 +1038,12 @@ struct ChatView: View {
             // against. (Kept separate from .failure, which intentionally stays quiet when its
             // busy/no-session guard returns with no message.) No success toast/SHA.
             gitToastState.dismissProgress()
+            ChatHaptics.gitActionFinished(succeeded: false, isEnabled: isHapticsEnabled)
             gitAlert = .error(gitAvailabilityViewModel.actionErrorMessage
                 ?? String(localized: "Too many changes to quick-commit. Commit in smaller batches, or use git directly."))
         case .failure:
             gitToastState.dismissProgress()
+            ChatHaptics.gitActionFinished(succeeded: false, isEnabled: isHapticsEnabled)
             if let message = gitAvailabilityViewModel.actionErrorMessage {
                 gitAlert = .error(message)
             }
@@ -1072,8 +1078,10 @@ struct ChatView: View {
                     .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
                     .filter { !$0.isEmpty }
             ))
+            ChatHaptics.gitActionFinished(succeeded: true, isEnabled: isHapticsEnabled)
         } else {
             gitToastState.dismissProgress()
+            ChatHaptics.gitActionFinished(succeeded: false, isEnabled: isHapticsEnabled)
             if let message = gitAvailabilityViewModel.actionErrorMessage {
                 gitAlert = .error(message)
             }
@@ -1213,7 +1221,7 @@ struct ChatView: View {
             },
             onUpdateScrollMetrics: updateScrollMetrics,
             onFollowEvent: handleFollowEvent,
-            onDisclosureToggle: suspendBottomAnchorForDisclosure,
+            onDisclosureToggle: handleDisclosureToggle,
             onDismissKeyboard: dismissKeyboard,
             onScrollToBottom: scrollToBottom,
             onScrollToLatestTranscriptMessage: { proxy in
@@ -1251,6 +1259,7 @@ struct ChatView: View {
             },
             onCopy: { context in
                 UIPasteboard.general.string = context.copyText
+                ChatHaptics.copied(isEnabled: isHapticsEnabled)
             },
             inlineCommitContext: inlineCommitContext,
             onInlineCommit: {
@@ -2352,6 +2361,7 @@ struct ChatView: View {
         // Deliberate jump to the latest content. Snap without animation while a
         // response is streaming so the tap lands immediately instead of racing
         // the short follow animations already chasing incoming tokens.
+        ChatHaptics.scrolledToLatest(isEnabled: isHapticsEnabled)
         scrollToLatestContent(
             proxy,
             animated: viewModel.activeStreamID == nil,
@@ -2508,6 +2518,16 @@ struct ChatView: View {
     /// Holds the transcript offset through a disclosure animation so the tapped
     /// row stays under the finger. The latch itself is untouched, so the next
     /// streaming trigger catches up once the toggle has settled.
+    private func handleDisclosureToggle() {
+        ChatHaptics.disclosureToggled(isEnabled: isHapticsEnabled)
+        suspendBottomAnchorForDisclosure()
+    }
+
+    /// One tick per view-model bump; the view model already throttles and skips replay.
+    private func handleStreamingHapticPulse() {
+        ChatHaptics.streamingPulse(isEnabled: isHapticsEnabled && isStreamingPulseEnabled)
+    }
+
     private func suspendBottomAnchorForDisclosure() {
         disclosureSettleGeneration += 1
         let generation = disclosureSettleGeneration

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -333,6 +333,10 @@ final class ChatViewModel {
     private(set) var hasOlderMessages = false
     private(set) var contextWindowSnapshot: ContextWindowSnapshot?
     private(set) var responseCompletionHapticTrigger = 0
+    /// Bumps at most once per throttle interval while live (non-replay) assistant
+    /// text arrives; the view turns each bump into one streaming pulse haptic.
+    private(set) var streamingHapticPulseTrigger = 0
+    private var streamingHapticPulseThrottle = ChatHaptics.StreamingPulseThrottle()
     private(set) var responseCompletionNeedsTranscriptRefresh = false
     private(set) var modelCatalogGroups: [ModelCatalogGroup] = []
     private(set) var agentCommands: [AgentCommand] = []
@@ -4641,6 +4645,12 @@ final class ChatViewModel {
 
         pendingAssistantTokenChunks.append(remainder)
         scheduleStreamingContentFlush()
+        // Replayed text is catch-up, not new work: reattaching to a running
+        // stream must not pulse for every token that already happened.
+        if !isActiveStreamReplayConnection,
+           streamingHapticPulseThrottle.shouldPulse(at: Date().timeIntervalSinceReferenceDate) {
+            streamingHapticPulseTrigger += 1
+        }
         return true
     }
 

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -5333,6 +5333,9 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
     }
 
     func streamCoordinatorDidStartConnection(isReplay: Bool) {
+        // Each connection re-arms the pulse so a reply's first live token always
+        // ticks, even when the previous reply pulsed less than an interval ago.
+        streamingHapticPulseThrottle.reset()
         activeStreamReplayMatchedPrefixLength = 0
         activeStreamReplayMatchedInterimLength = 0
         activeStreamReplayMatchedReasoningLength = 0

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -5333,9 +5333,12 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
     }
 
     func streamCoordinatorDidStartConnection(isReplay: Bool) {
-        // Each connection re-arms the pulse so a reply's first live token always
-        // ticks, even when the previous reply pulsed less than an interval ago.
-        streamingHapticPulseThrottle.reset()
+        // A fresh connection re-arms the pulse so a reply's first live token
+        // always ticks, even when the previous reply pulsed less than an interval
+        // ago. A replay continues the same reply, so its window carries over.
+        if !isReplay {
+            streamingHapticPulseThrottle.reset()
+        }
         activeStreamReplayMatchedPrefixLength = 0
         activeStreamReplayMatchedInterimLength = 0
         activeStreamReplayMatchedReasoningLength = 0

--- a/HermesMobile/Features/Chat/MarkdownRenderer.swift
+++ b/HermesMobile/Features/Chat/MarkdownRenderer.swift
@@ -415,6 +415,7 @@ private struct ChatCodeBlock: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage(ChatTranscriptDisplaySettings.wrapsCodeBlockLinesKey) private var wrapsCodeBlockLines = false
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
     @State private var didCopy = false
     @State private var highlightedCode: NSAttributedString?
 
@@ -443,6 +444,7 @@ private struct ChatCodeBlock: View {
                 Button {
                     UIPasteboard.general.string = content
                     didCopy = true
+                    ChatHaptics.copied(isEnabled: isHapticsEnabled)
                 } label: {
                     Image(systemName: didCopy ? "checkmark" : "square.on.square")
                         .font(.system(size: 18, weight: .semibold))

--- a/HermesMobile/Features/Onboarding/OnboardingComponents.swift
+++ b/HermesMobile/Features/Onboarding/OnboardingComponents.swift
@@ -56,6 +56,7 @@ struct OnboardingCommandPill: View {
     var prefix: String? = "$"
     var copyValue: String?
     @State private var didCopy = false
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
 
     var body: some View {
         HStack(spacing: 10) {
@@ -76,6 +77,7 @@ struct OnboardingCommandPill: View {
                 Button {
                     UIPasteboard.general.string = copyValue
                     didCopy = true
+                    ChatHaptics.copied(isEnabled: isHapticsEnabled)
                 } label: {
                     Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
                         .font(.system(size: 13, weight: .semibold))
@@ -249,7 +251,7 @@ struct OnboardingAgentPromptCard: View {
             Button {
                 UIPasteboard.general.string = prompt
                 hasCopied = true
-                HapticButtonHaptics.tap(style: .light, isEnabled: isHapticsEnabled)
+                ChatHaptics.copied(isEnabled: isHapticsEnabled)
                 withAnimation(.easeInOut(duration: 0.2)) {
                     didCopyRecently = true
                 }

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -736,6 +736,8 @@ struct ScheduledSessionsView: View {
 }
 
 struct SessionRowContextMenu: View {
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+
     let session: SessionSummary
     let projects: [ProjectSummary]
     let isViewingCachedData: Bool
@@ -754,6 +756,7 @@ struct SessionRowContextMenu: View {
 
             Button {
                 UIPasteboard.general.string = fullTitle
+                ChatHaptics.copied(isEnabled: isHapticsEnabled)
             } label: {
                 Label("Copy Full Title", systemImage: "doc.on.doc")
             }
@@ -820,6 +823,7 @@ struct SessionRowContextMenu: View {
             ) {
                 Button {
                     UIPasteboard.general.string = deepLinkURL.absoluteString
+                    ChatHaptics.copied(isEnabled: isHapticsEnabled)
                 } label: {
                     Label("Copy Deeplink", systemImage: "doc.on.doc")
                 }

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -59,6 +59,7 @@ struct SettingsView: View {
     @State private var notificationStatusMessage: String?
     @AppStorage(AppTheme.storageKey) private var appThemeRawValue = AppTheme.system.rawValue
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @AppStorage(AppHaptics.streamingPulseIsEnabledKey) private var isStreamingPulseEnabled = false
     @AppStorage(ResponseCompletionNotifications.isEnabledKey) private var isResponseCompletionNotificationsEnabled = false
     @AppStorage(ResponseCompletionNotifications.hasRequestedPermissionKey) private var hasRequestedResponseCompletionNotificationPermission = false
     @AppStorage(AgentRunLiveActivityPrivacy.showsResponseExcerptsKey) private var showsLiveActivityResponseExcerpts = false
@@ -157,6 +158,18 @@ struct SettingsView: View {
                         systemImage: "iphone.radiowaves.left.and.right",
                         isOn: $isHapticsEnabled
                     )
+
+                    if isHapticsEnabled {
+                        SettingsDivider()
+
+                        SettingsToggleRow(
+                            title: String(localized: "Pulse While Streaming"),
+                            systemImage: "waveform",
+                            isOn: $isStreamingPulseEnabled
+                        )
+
+                        SettingsFootnote(String(localized: "A light tick as each reply streams in."))
+                    }
 
                     SettingsDivider()
 

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -15,6 +15,7 @@ struct FilePreviewView: View {
     @State private var exportErrorMessage: String?
     @State private var saveConfirmationMessage: String?
     @State private var isSavingToPhotos = false
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
 
     init(session: SessionSummary, server: URL, entry: WorkspaceEntry, onAPIError: @escaping (Error) -> Void) {
         self.entry = entry
@@ -188,6 +189,7 @@ struct FilePreviewView: View {
 
             Button {
                 UIPasteboard.general.string = content
+                ChatHaptics.copied(isEnabled: isHapticsEnabled)
             } label: {
                 Label("Copy", systemImage: "doc.on.doc")
             }

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -113962,6 +113962,218 @@
           }
         }
       }
+    },
+    "Pulse While Streaming" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نبض أثناء البث"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pulsieren beim Streamen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pulso durante la transmisión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pulsation pendant la diffusion"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פעימה בזמן הזרמה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pulsazione durante lo streaming"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ストリーミング中に振動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "스트리밍 중 진동"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pulseren tijdens streamen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pulsowanie podczas strumieniowania"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pulsar durante o stream"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Пульсация при потоковой передаче"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Akış Sırasında Titreşim"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اسٹریم کے دوران ہلکی تھرتھراہٹ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "串流時輕震"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "流式传输时轻震"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "串流時輕震"
+          }
+        }
+      }
+    },
+    "A light tick as each reply streams in." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نبضة خفيفة أثناء بث كل رد."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ein leichtes Ticken, während jede Antwort gestreamt wird."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Un ligero toque mientras se transmite cada respuesta."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Une légère pulsation pendant la diffusion de chaque réponse."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "תקתוק קל בזמן הזרמת כל תשובה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Un leggero tocco durante lo streaming di ogni risposta."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "各応答のストリーミング中に軽く振動します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "각 응답이 스트리밍될 때 가볍게 진동해요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Een lichte tik terwijl elk antwoord streamt."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lekkie tyknięcie podczas przesyłania strumieniowego każdej odpowiedzi."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um toque leve conforme cada resposta é transmitida."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Лёгкая вибрация по мере потоковой передачи каждого ответа."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Her yanıt akarken hafif bir titreşim."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ہر جواب اسٹریم ہوتے ہوئے ایک ہلکی تھرتھراہٹ۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每則回覆串流時輕微震動。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每条回复流式传输时轻微震动。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每則回覆串流時輕微震動。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ChatHapticsTests.swift
+++ b/HermesMobileTests/ChatHapticsTests.swift
@@ -13,6 +13,11 @@ final class ChatHapticsTests: XCTestCase {
         ChatHaptics.clarificationSubmitted(isEnabled: false) { feedback.append($0) }
         ChatHaptics.configurationSelected(isEnabled: false) { feedback.append($0) }
         ChatHaptics.destructiveConfirmationAccepted(isEnabled: false) { feedback.append($0) }
+        ChatHaptics.disclosureToggled(isEnabled: false) { feedback.append($0) }
+        ChatHaptics.scrolledToLatest(isEnabled: false) { feedback.append($0) }
+        ChatHaptics.copied(isEnabled: false) { feedback.append($0) }
+        ChatHaptics.gitActionFinished(succeeded: true, isEnabled: false) { feedback.append($0) }
+        ChatHaptics.streamingPulse(isEnabled: false) { feedback.append($0) }
 
         XCTAssertTrue(feedback.isEmpty)
     }
@@ -32,6 +37,12 @@ final class ChatHapticsTests: XCTestCase {
         ChatHaptics.clarificationSubmitted(isEnabled: true) { feedback.append($0) }
         ChatHaptics.configurationSelected(isEnabled: true) { feedback.append($0) }
         ChatHaptics.destructiveConfirmationAccepted(isEnabled: true) { feedback.append($0) }
+        ChatHaptics.disclosureToggled(isEnabled: true) { feedback.append($0) }
+        ChatHaptics.scrolledToLatest(isEnabled: true) { feedback.append($0) }
+        ChatHaptics.copied(isEnabled: true) { feedback.append($0) }
+        ChatHaptics.gitActionFinished(succeeded: true, isEnabled: true) { feedback.append($0) }
+        ChatHaptics.gitActionFinished(succeeded: false, isEnabled: true) { feedback.append($0) }
+        ChatHaptics.streamingPulse(isEnabled: true) { feedback.append($0) }
 
         XCTAssertEqual(feedback, [
             .lightImpact,
@@ -44,8 +55,27 @@ final class ChatHapticsTests: XCTestCase {
             .warning,
             .selection,
             .selection,
-            .warning
+            .warning,
+            .selection,
+            .selection,
+            .lightImpact,
+            .success,
+            .warning,
+            .selection
         ])
+    }
+
+    func testStreamingPulseThrottleAllowsOneTickPerInterval() {
+        var throttle = ChatHaptics.StreamingPulseThrottle()
+
+        XCTAssertTrue(throttle.shouldPulse(at: 10.0), "first token pulses immediately")
+        XCTAssertFalse(throttle.shouldPulse(at: 10.1))
+        XCTAssertFalse(throttle.shouldPulse(at: 10.31), "just under the 320 ms window stays quiet")
+        XCTAssertTrue(throttle.shouldPulse(at: 10.32))
+        XCTAssertFalse(throttle.shouldPulse(at: 10.5), "the window restarts from the last pulse, not the last token")
+
+        throttle.reset()
+        XCTAssertTrue(throttle.shouldPulse(at: 10.51), "reset makes the next token pulse again")
     }
 
     @MainActor

--- a/HermesMobileTests/ChatHapticsTests.swift
+++ b/HermesMobileTests/ChatHapticsTests.swift
@@ -78,6 +78,27 @@ final class ChatHapticsTests: XCTestCase {
         XCTAssertTrue(throttle.shouldPulse(at: 10.51), "reset makes the next token pulse again")
     }
 
+    /// The pulse trigger bumps on the first live token, stays quiet inside the
+    /// throttle window, and re-arms when the next connection starts so a fast
+    /// follow-up reply still ticks on its first token.
+    @MainActor
+    func testStreamingPulseTriggerReArmsPerConnection() {
+        let viewModel = ChatViewModel(
+            session: SessionSummary(sessionId: "session-1"),
+            server: URL(string: "https://example.test")!
+        )
+
+        viewModel.streamCoordinatorDidStartConnection(isReplay: false)
+        XCTAssertTrue(viewModel.streamCoordinatorAppendToken("Hello"))
+        XCTAssertEqual(viewModel.streamingHapticPulseTrigger, 1)
+        XCTAssertTrue(viewModel.streamCoordinatorAppendToken(" world"))
+        XCTAssertEqual(viewModel.streamingHapticPulseTrigger, 1, "second token inside the window stays quiet")
+
+        viewModel.streamCoordinatorDidStartConnection(isReplay: false)
+        XCTAssertTrue(viewModel.streamCoordinatorAppendToken("Again"))
+        XCTAssertEqual(viewModel.streamingHapticPulseTrigger, 2, "a new connection re-arms the first pulse")
+    }
+
     @MainActor
     func testConfigurationNoOpSelectionsDoNotReportSuccess() async {
         let viewModel = ChatViewModel(

--- a/HermesMobileTests/ChatHapticsTests.swift
+++ b/HermesMobileTests/ChatHapticsTests.swift
@@ -97,6 +97,10 @@ final class ChatHapticsTests: XCTestCase {
         viewModel.streamCoordinatorDidStartConnection(isReplay: false)
         XCTAssertTrue(viewModel.streamCoordinatorAppendToken("Again"))
         XCTAssertEqual(viewModel.streamingHapticPulseTrigger, 2, "a new connection re-arms the first pulse")
+
+        viewModel.streamCoordinatorDidStartConnection(isReplay: true)
+        XCTAssertTrue(viewModel.streamCoordinatorAppendToken(" continued"))
+        XCTAssertEqual(viewModel.streamingHapticPulseTrigger, 2, "a replay continues the same reply and keeps its window")
     }
 
     @MainActor


### PR DESCRIPTION
## Linked issue

Small-interaction haptics polish; no tracking issue.

## What changed

Tapping a tool card, tool group, reasoning block, or compaction card, jumping to the latest message, copying a message, code block, file, session title, deeplink, or onboarding command, and finishing a quick commit, push, pull, or fetch all answered silently. Only send, complete, cancel, and approve gave feedback.

`ChatHaptics` gains four verbs and the existing sites call them, so every new buzz honors the existing Haptic Feedback switch:

- `disclosureToggled` (selection) fires from the one shared disclosure handler in `ChatView`, which already covers every transcript disclosure.
- `scrolledToLatest` (selection) fires on the scroll-to-bottom button.
- `copied` (light impact) fires at every pasteboard write: message copy, code-block copy, file preview copy, session title and deeplink copy, both onboarding copy buttons.
- `gitActionFinished(succeeded:)` (success or warning) fires once per quick-commit and remote-action outcome, right where the toast changes phase. A commit whose push failed reports warning.

New opt-in **Pulse While Streaming** toggle under Haptic Feedback, off by default and hidden when haptics are off. The view model bumps a trigger at most once per 320 ms while live assistant text arrives; replay connections (reattaching mid-stream) never pulse. The two new Settings strings are translated for all 17 shipped languages.

## How it was tested

- Full XCTest suite on iPhone 17 simulator via XcodeBuildMCP `test_sim`: 1791 passed, 0 failed, 2 pre-existing skips.
- `ChatHapticsTests` extended for the new verbs and a focused throttle test (first token pulses, next within 320 ms stays quiet, window restarts from the last pulse, reset re-arms).
- `LocalizationCatalogTests` covers the two new keys in every shipped language.
- Manual: needs a physical device to feel haptics; steps in the review handoff.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no networking changes)

Built by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)