### PR TITLE
feat(chat): show a working-for counter at the transcript tail

### DIFF
--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -254,27 +254,6 @@ enum ChatTranscriptDisplaySettings {
         userToggled ?? startsExpanded
     }
 
-    static func shouldShowAssistantTypingIndicator(
-        hasActiveStream: Bool,
-        isCancellingStream: Bool,
-        hasStreamingAssistantMessage: Bool,
-        hasPendingClarificationPrompt: Bool = false,
-        liveReasoningText: String,
-        hasLiveToolCalls: Bool,
-        showsThinkingAndToolCards: Bool
-    ) -> Bool {
-        guard hasActiveStream, !isCancellingStream else { return false }
-        guard !hasStreamingAssistantMessage else { return false }
-        guard !hasPendingClarificationPrompt else { return false }
-
-        guard showsThinkingAndToolCards else {
-            return true
-        }
-
-        guard liveReasoningText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
-        return !hasLiveToolCalls
-    }
-
     static func shouldUseStreamingBubbleRendering(
         hasActiveStream: Bool,
         messageRole: String?,
@@ -428,6 +407,40 @@ enum ChatActiveRunStatusPolicy {
 
         guard hasActiveStream else { return nil }
         return ChatActiveRunStatusPresentation(kind: .active)
+    }
+}
+
+enum ChatWorkingRowPolicy {
+    /// Start date for the transcript's "Working for" tail row, or nil when the
+    /// row stays hidden: no active run, the run is being stopped, or the agent
+    /// is waiting on a clarification answer rather than working.
+    static func startedAt(
+        activeRunStartedAt: Date?,
+        isCancellingStream: Bool,
+        hasPendingClarificationPrompt: Bool
+    ) -> Date? {
+        guard let activeRunStartedAt, !isCancellingStream, !hasPendingClarificationPrompt else {
+            return nil
+        }
+        return activeRunStartedAt
+    }
+}
+
+enum ChatWorkingElapsedFormatter {
+    /// Compact elapsed time for the tail row: `12s`, `1m 4s`, `1h 2m 3s`.
+    static func label(startedAt: Date, now: Date) -> String {
+        Duration.seconds(elapsedSeconds(startedAt: startedAt, now: now))
+            .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .narrow))
+    }
+
+    /// Spelled-out elapsed time for VoiceOver: `1 minute, 4 seconds`.
+    static func spokenLabel(startedAt: Date, now: Date) -> String {
+        Duration.seconds(elapsedSeconds(startedAt: startedAt, now: now))
+            .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .wide))
+    }
+
+    private static func elapsedSeconds(startedAt: Date, now: Date) -> Int {
+        max(0, Int(now.timeIntervalSince(startedAt).rounded(.down)))
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatMotion.swift
+++ b/HermesMobile/Features/Chat/ChatMotion.swift
@@ -29,10 +29,6 @@ enum ChatMotion {
         reduceMotion ? nil : .easeOut(duration: 0.15)
     }
 
-    static func typingIndicator(reduceMotion: Bool) -> Animation? {
-        reduceMotion ? nil : .easeInOut(duration: 0.9).repeatForever(autoreverses: true)
-    }
-
     static func bottomOverlayTransition(reduceMotion: Bool) -> AnyTransition {
         reduceMotion ? .opacity : .move(edge: .bottom).combined(with: .opacity)
     }

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -99,7 +99,17 @@ final class ChatStreamCoordinator {
     private let timing: ChatStreamCoordinatorTiming
     private var showsLiveActivityResponseExcerpts: Bool
 
-    private(set) var activeStreamID: String?
+    private(set) var activeStreamID: String? {
+        didSet {
+            guard activeStreamID != oldValue else { return }
+            activeRunStartedAt = activeStreamID == nil ? nil : Date()
+        }
+    }
+    /// When the current stream first became known here. Keyed to stream
+    /// identity, so a same-stream reattach keeps the date; a stream discovered
+    /// on session load counts from discovery, since the server does not report
+    /// when it started.
+    private(set) var activeRunStartedAt: Date?
     private(set) var recoveryState: ActiveStreamRecoveryState = .idle
     private(set) var isConnectionSuspended = false
     private(set) var hasCompletedCurrentResponse = false

--- a/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
@@ -701,41 +701,41 @@ final class ChatVerticalScrollAxisGuardView: UIView {
     }
 }
 
-struct AssistantTypingIndicatorView: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.colorScheme) private var colorScheme
-    @State private var isBreathing = false
+/// Transcript tail row for the active run: three static dots and a
+/// "Working for" counter that ticks once a second from the run's start date.
+/// The `TimelineView` scopes each tick to this row, so message rows above it
+/// are not re-evaluated.
+struct ChatWorkingRowView: View {
+    let startedAt: Date
 
     var body: some View {
-        Circle()
-            .fill(dotColor)
-            .frame(width: 16, height: 16)
-            .scaleEffect(reduceMotion ? 1 : (isBreathing ? 1.16 : 0.86))
-            .opacity(reduceMotion ? 0.75 : (isBreathing ? 0.95 : 0.55))
-            .padding(.leading, 4)
-            .padding(.vertical, 8)
-            .accessibilityLabel("Hermex is preparing a response")
-            .onAppear {
-                updateBreathingAnimation()
-            }
-            .onChange(of: reduceMotion) {
-                updateBreathingAnimation()
-            }
-    }
+        TimelineView(.periodic(from: startedAt, by: 1)) { context in
+            HStack(spacing: 8) {
+                dots
 
-    private var dotColor: Color {
-        colorScheme == .dark ? Color.white.opacity(0.92) : Color.black.opacity(0.78)
-    }
-
-    private func updateBreathingAnimation() {
-        guard let animation = ChatMotion.typingIndicator(reduceMotion: reduceMotion) else {
-            isBreathing = false
-            return
+                Text("Working for \(ChatWorkingElapsedFormatter.label(startedAt: startedAt, now: context.date))")
+                    .font(.caption.weight(.medium).monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(
+                String(
+                    localized: "Hermes has been working for \(ChatWorkingElapsedFormatter.spokenLabel(startedAt: startedAt, now: context.date))"
+                )
+            )
         }
+        .padding(.leading, 4)
+        .padding(.vertical, 6)
+    }
 
-        isBreathing = false
-        withAnimation(animation) {
-            isBreathing = true
+    private var dots: some View {
+        HStack(spacing: 4) {
+            ForEach([1.0, 0.8, 0.6], id: \.self) { opacity in
+                Circle()
+                    .fill(.secondary)
+                    .opacity(opacity)
+                    .frame(width: 4, height: 4)
+            }
         }
     }
 }

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -25,7 +25,8 @@ struct ChatTranscriptView: View {
     let clarificationErrorMessage: String?
     let hidesRunStatusAccessibility: Bool
     let showsThinkingAndToolCards: Bool
-    let showsAssistantTypingIndicator: Bool
+    /// Start date for the "Working for" tail row; nil hides the row.
+    let workingRowStartedAt: Date?
     let showsScrollToBottomButton: Bool
     let shouldFollowLatestMessage: Bool
     /// True while a disclosure toggle animates; suspends the bottom size-change
@@ -282,7 +283,7 @@ struct ChatTranscriptView: View {
             transcriptLooseBlocks
             liveResponseBlocks
             inlineClarificationCard
-            typingIndicator
+            workingRow
             turnChangesCard
             inlineCommitButton
 
@@ -408,9 +409,9 @@ struct ChatTranscriptView: View {
     }
 
     @ViewBuilder
-    private var typingIndicator: some View {
-        if showsAssistantTypingIndicator {
-            AssistantTypingIndicatorView()
+    private var workingRow: some View {
+        if let workingRowStartedAt {
+            ChatWorkingRowView(startedAt: workingRowStartedAt)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .accessibilityHidden(hidesRunStatusAccessibility)
         }

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1175,7 +1175,7 @@ struct ChatView: View {
             clarificationErrorMessage: viewModel.clarificationErrorMessage,
             hidesRunStatusAccessibility: activeRunStatusPresentation != nil,
             showsThinkingAndToolCards: showsThinkingAndToolCards,
-            showsAssistantTypingIndicator: showsAssistantTypingIndicator,
+            workingRowStartedAt: workingRowStartedAt,
             showsScrollToBottomButton: showsScrollToBottomButton,
             shouldFollowLatestMessage: shouldFollowLatestMessage,
             isDisclosureSettling: isDisclosureSettling,
@@ -1296,15 +1296,11 @@ struct ChatView: View {
         !isScrolledNearBottom && (viewModel.activeStreamID == nil || !shouldFollowLatestMessage)
     }
 
-    private var showsAssistantTypingIndicator: Bool {
-        ChatTranscriptDisplaySettings.shouldShowAssistantTypingIndicator(
-            hasActiveStream: viewModel.activeStreamID != nil,
+    private var workingRowStartedAt: Date? {
+        ChatWorkingRowPolicy.startedAt(
+            activeRunStartedAt: viewModel.activeRunStartedAt,
             isCancellingStream: viewModel.isCancellingStream,
-            hasStreamingAssistantMessage: viewModel.hasStreamingAssistantMessageContent,
-            hasPendingClarificationPrompt: viewModel.clarificationPrompt != nil,
-            liveReasoningText: viewModel.liveReasoningText,
-            hasLiveToolCalls: !viewModel.liveToolCalls.isEmpty,
-            showsThinkingAndToolCards: showsThinkingAndToolCards
+            hasPendingClarificationPrompt: viewModel.clarificationPrompt != nil
         )
     }
 

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -220,6 +220,7 @@ final class ChatViewModel {
     private(set) var isCancellingStream = false
     private(set) var isViewingCachedData = false
     var activeStreamID: String? { streamCoordinator.activeStreamID }
+    var activeRunStartedAt: Date? { streamCoordinator.activeRunStartedAt }
     var activeStreamRecoveryState: ActiveStreamRecoveryState { streamCoordinator.recoveryState }
     var liveTokensPerSecond: Double? { streamCoordinator.liveTokensPerSecond }
     private(set) var errorMessage: String?
@@ -632,14 +633,6 @@ final class ChatViewModel {
     func isSelectedProfile(_ profile: ProfileSummary) -> Bool {
         guard let profileName = profile.normalizedName else { return false }
         return profileName == (Self.nonEmpty(selectedProfileName) ?? Self.nonEmpty(currentProfile))
-    }
-
-    var hasStreamingAssistantMessageContent: Bool {
-        guard let streamingAssistantMessageID,
-              let message = messages.first(where: { $0.messageId == streamingAssistantMessageID })
-        else { return false }
-
-        return message.content?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
 
     private func scheduleStreamingScrollTrigger() {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -114174,6 +114174,218 @@
           }
         }
       }
+    },
+    "Working for %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يعمل منذ %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arbeitet seit %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabajando desde hace %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Au travail depuis %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "עובד כבר %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Al lavoro da %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "作業中 %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "작업 중 %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Al %@ aan het werk"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pracuje od %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabalhando há %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Работает уже %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ süredir çalışıyor"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ سے کام جاری ہے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作 %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作 %@"
+          }
+        }
+      }
+    },
+    "Hermes has been working for %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes يعمل منذ %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes arbeitet seit %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes lleva trabajando %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes travaille depuis %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes עובד כבר %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes sta lavorando da %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes は %@ 作業しています"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes가 %@ 동안 작업 중입니다"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes werkt al %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes pracuje od %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes está trabalhando há %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes работает уже %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes %@ süredir çalışıyor"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes %@ سے کام کر رہا ہے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes 已工作 %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes 已工作 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hermes 已工作 %@"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -37,6 +37,31 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testActiveRunStartDateSurvivesSameStreamRestartAndClearsOnFinish() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(streamClient: streamClient, delegate: delegate)
+        XCTAssertNil(coordinator.activeRunStartedAt)
+
+        coordinator.start(streamID: "stream-123")
+        let startedAt = try XCTUnwrap(coordinator.activeRunStartedAt)
+
+        // A foreground reattach restarts the same stream; the counter must not reset.
+        coordinator.suspendActiveStreamConnection()
+        coordinator.start(streamID: "stream-123", replayAfterSeq: 4, recoveryState: .reconnecting)
+        XCTAssertEqual(coordinator.activeRunStartedAt, startedAt)
+
+        streamClient.emit(.streamEnd)
+        XCTAssertNil(coordinator.activeStreamID)
+        XCTAssertNil(coordinator.activeRunStartedAt)
+
+        // A replacement stream is a new run with its own start date.
+        coordinator.start(streamID: "stream-new")
+        XCTAssertNotNil(coordinator.activeRunStartedAt)
+        XCTAssertNotEqual(coordinator.activeRunStartedAt, startedAt)
+    }
+
+    @MainActor
     func testSessionLoadPreparationBelongsOnlyToCapturedStreamRun() {
         let coordinator = makeCoordinator()
 

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -1914,7 +1914,6 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.last?.messageId, liveAssistantID)
         XCTAssertEqual(viewModel.messages.last?.content, "")
         XCTAssertEqual(viewModel.reasoningAnchorMessageID, liveAssistantID)
-        XCTAssertFalse(viewModel.hasStreamingAssistantMessageContent)
 
         streamClient.emit(.toolStarted(ToolStreamEvent(
             eventType: "tool.started",
@@ -1936,7 +1935,6 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(viewModel.streamingAssistantMessageID, liveAssistantID)
         XCTAssertEqual(viewModel.messages.last?.messageId, liveAssistantID)
         XCTAssertEqual(viewModel.messages.last?.content, "Live answer starts now.")
-        XCTAssertTrue(viewModel.hasStreamingAssistantMessageContent)
     }
 
     @MainActor

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -257,56 +257,51 @@ final class TranscriptMessageTests: XCTestCase {
 }
 
 final class ChatTranscriptDisplaySettingsTests: XCTestCase {
-    func testTypingIndicatorStaysHiddenBehindVisibleThinkingAndToolCards() {
-        XCTAssertFalse(ChatTranscriptDisplaySettings.shouldShowAssistantTypingIndicator(
-            hasActiveStream: true,
-            isCancellingStream: false,
-            hasStreamingAssistantMessage: false,
-            liveReasoningText: "Inspecting files",
-            hasLiveToolCalls: false,
-            showsThinkingAndToolCards: true
-        ))
+    func testWorkingRowShowsForActiveRunOnly() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
 
-        XCTAssertFalse(ChatTranscriptDisplaySettings.shouldShowAssistantTypingIndicator(
-            hasActiveStream: true,
+        XCTAssertEqual(
+            ChatWorkingRowPolicy.startedAt(
+                activeRunStartedAt: startedAt,
+                isCancellingStream: false,
+                hasPendingClarificationPrompt: false
+            ),
+            startedAt
+        )
+        XCTAssertNil(ChatWorkingRowPolicy.startedAt(
+            activeRunStartedAt: nil,
             isCancellingStream: false,
-            hasStreamingAssistantMessage: false,
-            liveReasoningText: "",
-            hasLiveToolCalls: true,
-            showsThinkingAndToolCards: true
+            hasPendingClarificationPrompt: false
         ))
     }
 
-    func testTypingIndicatorShowsWhenHiddenCardsAreOnlyLiveActivity() {
-        XCTAssertTrue(ChatTranscriptDisplaySettings.shouldShowAssistantTypingIndicator(
-            hasActiveStream: true,
-            isCancellingStream: false,
-            hasStreamingAssistantMessage: false,
-            liveReasoningText: "Inspecting files",
-            hasLiveToolCalls: true,
-            showsThinkingAndToolCards: false
-        ))
+    func testWorkingRowHidesWhileStoppingOrAwaitingClarification() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
 
-        XCTAssertFalse(ChatTranscriptDisplaySettings.shouldShowAssistantTypingIndicator(
-            hasActiveStream: true,
+        XCTAssertNil(ChatWorkingRowPolicy.startedAt(
+            activeRunStartedAt: startedAt,
+            isCancellingStream: true,
+            hasPendingClarificationPrompt: false
+        ))
+        XCTAssertNil(ChatWorkingRowPolicy.startedAt(
+            activeRunStartedAt: startedAt,
             isCancellingStream: false,
-            hasStreamingAssistantMessage: true,
-            liveReasoningText: "Inspecting files",
-            hasLiveToolCalls: true,
-            showsThinkingAndToolCards: false
+            hasPendingClarificationPrompt: true
         ))
     }
 
-    func testTypingIndicatorHidesBehindPendingClarificationPrompt() {
-        XCTAssertFalse(ChatTranscriptDisplaySettings.shouldShowAssistantTypingIndicator(
-            hasActiveStream: true,
-            isCancellingStream: false,
-            hasStreamingAssistantMessage: false,
-            hasPendingClarificationPrompt: true,
-            liveReasoningText: "",
-            hasLiveToolCalls: false,
-            showsThinkingAndToolCards: false
-        ))
+    func testWorkingElapsedLabelUsesCompactUnits() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+        XCTAssertEqual(ChatWorkingElapsedFormatter.label(startedAt: startedAt, now: startedAt), "0s")
+        XCTAssertEqual(ChatWorkingElapsedFormatter.label(startedAt: startedAt, now: startedAt.addingTimeInterval(5.9)), "5s")
+        XCTAssertEqual(ChatWorkingElapsedFormatter.label(startedAt: startedAt, now: startedAt.addingTimeInterval(64)), "1m 4s")
+        XCTAssertEqual(ChatWorkingElapsedFormatter.label(startedAt: startedAt, now: startedAt.addingTimeInterval(3_723)), "1h 2m 3s")
+        XCTAssertEqual(ChatWorkingElapsedFormatter.label(startedAt: startedAt, now: startedAt.addingTimeInterval(-30)), "0s")
+        XCTAssertEqual(
+            ChatWorkingElapsedFormatter.spokenLabel(startedAt: startedAt, now: startedAt.addingTimeInterval(64)),
+            "1 minute, 4 seconds"
+        )
     }
 
     func testStreamingBubbleRenderingDoesNotMatchNilMessageIDs() {


### PR DESCRIPTION
## Linked issue

No issue. Maintainer-approved transcript polish.

## What changed

While Hermes works, the live edge of the transcript showed a breathing dot until the first token and then nothing, and elapsed time appeared nowhere. The floating status pill only helps once you scroll away.

Now the transcript tail shows a quiet row while a response is active: three static dots and `Working for 1m 4s`, ticking once a second from the moment the stream first became known. It replaces the breathing dot for the whole run and hides while the response is being stopped or the agent is waiting on a clarification answer. The floating pill is unchanged.

Mechanics:
- `ChatStreamCoordinator` records `activeRunStartedAt` keyed to stream identity. A same-stream reattach after backgrounding keeps the date; a stream discovered on session load counts from discovery, since the server does not report when it started.
- `ChatWorkingRowPolicy` decides when the row shows. `ChatWorkingElapsedFormatter` uses Foundation's `Duration` unit formatting (`12s`, `1m 4s`, `1h 2m 3s`) with a spelled-out variant for VoiceOver.
- `ChatWorkingRowView` drives the tick with a `TimelineView` scoped to the row, so message rows are not re-evaluated each second. The dots do not animate, so there is nothing for Reduce Motion to change. The row is one accessibility element and is hidden from VoiceOver whenever the floating pill already announces the run.
- Two new String Catalog keys with `needs_review` translations for every shipped language.

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP `test_sim`: 1793 passed, 0 failed, 2 pre-existing skips.
- New tests: start date survives a same-stream restart and clears on stream end (`ChatStreamCoordinatorTests`); row visibility policy and elapsed formatting (`TranscriptDisplayModelTests`).
- Signed Debug build installed and launched on the simulator via `build_run_sim`.
- Manual simulator pass against a live server pending maintainer review; screenshots to follow.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (no model changes)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no network changes)

Built by Claude Fable 5.1 via Claude Code.