### PR TITLE
feat(chat): render settled tool calls as one-line log rows

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -176,6 +176,8 @@
 		1A2B3C4D5E6F7000000000DE /* ToolCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000DF /* ToolCall.swift */; };
 		C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000002 /* ToolActivityGroupView.swift */; };
 		1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */; };
+		C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F02 /* ToolCallLogRowView.swift */; };
+		C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */; };
 		C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */; };
 		C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12900000000000000000002 /* ChatActiveRunStatusView.swift */; };
 		C06000000000000000000001 /* ToolCallDisplayFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06000000000000000000002 /* ToolCallDisplayFormatter.swift */; };
@@ -213,6 +215,7 @@
 		C03180000000000000B005 /* TurnFileChangeSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F005 /* TurnFileChangeSummary.swift */; };
 		C03180000000000000B007 /* GitTurnChangesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F007 /* GitTurnChangesCard.swift */; };
 		C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */; };
+		C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */; };
 		C03190000000000000B001 /* AttachmentAudioDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F001 /* AttachmentAudioDetection.swift */; };
 		C03190000000000000B002 /* InlineAudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F002 /* InlineAudioPlayerView.swift */; };
 		C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */; };
@@ -525,6 +528,8 @@
 		1A2B3C4D5E6F7000000000DF /* ToolCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCall.swift; sourceTree = "<group>"; };
 		C12800000000000000000002 /* ToolActivityGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityGroupView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallCardView.swift; sourceTree = "<group>"; };
+		C0AA02000000000000000F02 /* ToolCallLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallLogRowView.swift; sourceTree = "<group>"; };
+		C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatter.swift; sourceTree = "<group>"; };
 		C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTimelineAccessorySurface.swift; sourceTree = "<group>"; };
 		C12900000000000000000002 /* ChatActiveRunStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatActiveRunStatusView.swift; sourceTree = "<group>"; };
 		C06000000000000000000002 /* ToolCallDisplayFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallDisplayFormatter.swift; sourceTree = "<group>"; };
@@ -562,6 +567,7 @@
 		C03180000000000000F005 /* TurnFileChangeSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeSummary.swift; sourceTree = "<group>"; };
 		C03180000000000000F007 /* GitTurnChangesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTurnChangesCard.swift; sourceTree = "<group>"; };
 		C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeAggregatorTests.swift; sourceTree = "<group>"; };
+		C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatterTests.swift; sourceTree = "<group>"; };
 		C03190000000000000F001 /* AttachmentAudioDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetection.swift; sourceTree = "<group>"; };
 		C03190000000000000F002 /* InlineAudioPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineAudioPlayerView.swift; sourceTree = "<group>"; };
 		C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetectionTests.swift; sourceTree = "<group>"; };
@@ -845,6 +851,7 @@
 				C03120000000000000F006 /* APIClientGitTests.swift */,
 				C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */,
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
+				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */,
 				C0DE22000000000000000004 /* ChatHapticsTests.swift */,
 				C08800000000000000000004 /* SessionHapticsTests.swift */,
@@ -1051,6 +1058,8 @@
 				BEEF02400000000000000002 /* ChatAttachmentPreviewView.swift */,
 				C12800000000000000000002 /* ToolActivityGroupView.swift */,
 				1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */,
+				C0AA02000000000000000F02 /* ToolCallLogRowView.swift */,
+				C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */,
 				C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */,
 				C12900000000000000000002 /* ChatActiveRunStatusView.swift */,
 				C06000000000000000000002 /* ToolCallDisplayFormatter.swift */,
@@ -1563,6 +1572,8 @@
 				BEEF02400000000000000001 /* ChatAttachmentPreviewView.swift in Sources */,
 				C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */,
 				1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */,
+				C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */,
+				C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */,
 				C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */,
 				C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */,
 				C06000000000000000000001 /* ToolCallDisplayFormatter.swift in Sources */,
@@ -1721,6 +1732,7 @@
 				C03120000000000000B006 /* APIClientGitTests.swift in Sources */,
 				C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */,
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,
+				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */,
 				C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */,
 				C08800000000000000000003 /* SessionHapticsTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -379,7 +379,8 @@ struct ChatTranscriptView: View {
                         group: ToolCallGroup.live(
                             anchorMessageID: toolCallAnchorMessageID,
                             toolCalls: liveToolCalls
-                        )
+                        ),
+                        isLive: true
                     )
                 }
             }
@@ -613,7 +614,8 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                 group: ToolCallGroup.live(
                     anchorMessageID: toolCallAnchorMessageID,
                     toolCalls: liveToolCalls
-                )
+                ),
+                isLive: true
             )
         }
     }

--- a/HermesMobile/Features/Chat/ToolActivityGroupView.swift
+++ b/HermesMobile/Features/Chat/ToolActivityGroupView.swift
@@ -1,13 +1,21 @@
 import SwiftUI
 
+/// A turn's tool calls. While the response streams (`isLive`) the group is the
+/// familiar material card of per-call cards, so a running call keeps its
+/// status pill. Once the group settles it becomes a dense log: only the last
+/// call's row, with the earlier rows behind a `+N previous tool calls` toggle.
 struct ToolActivityGroupView: View {
     let group: ToolCallGroup
+    var isLive = false
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
     @AppStorage(ChatTranscriptDisplaySettings.toolCardsStartExpandedKey) private var startsExpanded = false
     @State private var userToggledExpansion: Bool?
 
+    /// Live: whether the card lists its calls. Settled: whether the previous
+    /// rows are shown. Both follow "Expand Tools by Default" until tapped.
     private var isExpanded: Bool {
         ChatTranscriptDisplaySettings.isCardExpanded(
             userToggled: userToggledExpansion,
@@ -16,14 +24,83 @@ struct ToolActivityGroupView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
-            Button {
-                chatDisclosureToggled()
-                withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
-                    userToggledExpansion = !isExpanded
+        if isLive {
+            liveCard
+        } else {
+            settledLog
+        }
+    }
+
+    private func toggleExpansion() {
+        chatDisclosureToggled()
+        withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
+            userToggledExpansion = !isExpanded
+        }
+    }
+
+    // MARK: - Settled log
+
+    @ViewBuilder
+    private var settledLog: some View {
+        let entries = ToolCallSummaryFormatter.entries(for: group.toolCalls)
+
+        if let lastEntry = entries.last {
+            let previousEntries = Array(entries.dropLast())
+
+            VStack(alignment: .leading, spacing: 1) {
+                if !previousEntries.isEmpty {
+                    previousRowsToggle(hiddenCount: previousEntries.count)
+
+                    if isExpanded {
+                        ForEach(previousEntries) { entry in
+                            ToolCallLogRowView(entry: entry)
+                        }
+                        .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
+                    }
                 }
-            } label: {
-                header
+
+                ToolCallLogRowView(entry: lastEntry)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    private func previousRowsToggle(hiddenCount: Int) -> some View {
+        Button(action: toggleExpansion) {
+            HStack(spacing: 6) {
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 18)
+
+                Text(previousRowsToggleTitle(hiddenCount: hiddenCount))
+                    .font(AppFont.caption(weight: .medium))
+                    .foregroundStyle(.primary.opacity(0.8))
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 2)
+            .frame(minHeight: ToolCallLogRowView.minimumHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(previousRowsToggleTitle(hiddenCount: hiddenCount))
+    }
+
+    private func previousRowsToggleTitle(hiddenCount: Int) -> String {
+        isExpanded
+            ? String(localized: "Show fewer tool calls")
+            : String(localized: "+\(hiddenCount) previous tool calls")
+    }
+
+    // MARK: - Live card
+
+    private var liveCard: some View {
+        VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
+            Button(action: toggleExpansion) {
+                liveHeader
             }
             .buttonStyle(.plain)
             .accessibilityLabel(activityAccessibilityLabel)
@@ -52,7 +129,7 @@ struct ToolActivityGroupView: View {
         dynamicTypeSize.isAccessibilitySize
     }
 
-    private var header: some View {
+    private var liveHeader: some View {
         HStack(alignment: usesStackedHeader ? .top : .center, spacing: 8) {
             Image(systemName: activityIcon)
                 .font(.system(size: 14, weight: .semibold))

--- a/HermesMobile/Features/Chat/ToolCallCardView.swift
+++ b/HermesMobile/Features/Chat/ToolCallCardView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+/// The per-call material card shown while a response is still streaming. Once
+/// the group settles, `ToolCallLogRowView` shows the same call as a log line.
 struct ToolCallCardView: View {
     let toolCall: ToolCall
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -32,7 +34,7 @@ struct ToolCallCardView: View {
             .accessibilityHint(isExpanded ? "Double tap to collapse details." : "Double tap to expand details.")
 
             if isExpanded {
-                expandedContent(statusDisplay: statusDisplay)
+                ToolCallDetailBodyView(toolCall: toolCall)
                     .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
             }
         }
@@ -47,24 +49,6 @@ struct ToolCallCardView: View {
         // content that must stay left-to-right inside an RTL message (#259). The
         // group's summary header above (ToolActivityGroupView) still mirrors.
         .forcedLeftToRight()
-    }
-
-    private func expandedContent(statusDisplay: ToolCallStatusDisplay) -> some View {
-        let displayContent = ToolCallDisplayFormatter.content(for: toolCall)
-
-        return VStack(alignment: .leading, spacing: 7) {
-            if !displayContent.argumentRows.isEmpty {
-                argumentsSection(displayContent.argumentRows)
-            }
-
-            if let result = displayContent.result {
-                resultSection(result)
-            }
-
-            if shouldShowStatusDetail(displayContent: displayContent) {
-                statusDetail(statusDisplay.detailText)
-            }
-        }
     }
 
     private var usesStackedHeader: Bool {
@@ -125,6 +109,40 @@ struct ToolCallCardView: View {
 
         return .secondary
     }
+}
+
+/// The Arguments, Result, and Status sections of a tool call. Shared by the
+/// live card and the settled log row so expanding either shows the same body.
+struct ToolCallDetailBodyView: View {
+    let toolCall: ToolCall
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        let statusDisplay = ToolCallStatusDisplay(toolCall: toolCall)
+        let displayContent = ToolCallDisplayFormatter.content(for: toolCall)
+
+        VStack(alignment: .leading, spacing: 7) {
+            if !displayContent.argumentRows.isEmpty {
+                argumentsSection(displayContent.argumentRows)
+            }
+
+            if let result = displayContent.result {
+                resultSection(result)
+            }
+
+            if shouldShowStatusDetail(displayContent: displayContent) {
+                statusDetail(statusDisplay.detailText)
+            }
+        }
+    }
+
+    private var usesStackedRows: Bool {
+        dynamicTypeSize.isAccessibilitySize
+    }
+
+    private var statusColor: Color {
+        toolCall.isError == true ? .red : .secondary
+    }
 
     private func shouldShowStatusDetail(displayContent: ToolCallDisplayContent) -> Bool {
         let hasPrimaryContent = !displayContent.argumentRows.isEmpty || displayContent.result != nil
@@ -178,7 +196,7 @@ struct ToolCallCardView: View {
 
     @ViewBuilder
     private func argumentRow(_ row: ToolCallArgumentDisplay) -> some View {
-        if usesStackedHeader {
+        if usesStackedRows {
             VStack(alignment: .leading, spacing: 2) {
                 argumentKey(row.key)
                 argumentValue(row.value)

--- a/HermesMobile/Features/Chat/ToolCallDisplayFormatter.swift
+++ b/HermesMobile/Features/Chat/ToolCallDisplayFormatter.swift
@@ -26,6 +26,25 @@ enum ToolCallDisplayFormatter {
         )
     }
 
+    /// Whether a JSON result envelope reports failure: an `error` value, or a
+    /// non-zero `exit_code`. `false` when the envelope has neither signal or a
+    /// zero exit code; `nil` when the preview is not an object envelope at all.
+    static func envelopeReportsFailure(preview: String?) -> Bool? {
+        guard let preview = nonEmpty(preview),
+              case .object(let object)? = parsedJSONValue(from: preview)
+        else {
+            return nil
+        }
+
+        if errorText(from: object["error"]) != nil {
+            return true
+        }
+        if let exitCode = exitCode(from: object["exit_code"] ?? object["exitCode"]) {
+            return exitCode != 0
+        }
+        return false
+    }
+
     static func argumentRows(from args: [String: JSONValue]?) -> [ToolCallArgumentDisplay] {
         (args ?? [:])
             .sorted { $0.key < $1.key }

--- a/HermesMobile/Features/Chat/ToolCallLogRowView.swift
+++ b/HermesMobile/Features/Chat/ToolCallLogRowView.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+import UIKit
+
+/// One settled tool call as a dense log line: icon column, bold verb, dim
+/// one-line detail, chevron, and a fixed status-glyph slot. Tap expands the
+/// same Arguments/Result body the live card shows; long-press copies it.
+struct ToolCallLogRowView: View {
+    let entry: ToolCallLogEntry
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @State private var isExpanded = false
+    @State private var isPressed = false
+    @State private var showsCopied = false
+    @State private var copiedResetTask: Task<Void, Never>?
+
+    /// Row height at the default text size; text grows the row at larger sizes.
+    static let minimumHeight: CGFloat = 32
+    /// Icon column width plus the gap, so the expanded body indents under the text.
+    private static let bodyIndent: CGFloat = 26
+
+    private var row: ToolCallLogRow { entry.row }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            rowLine
+
+            if isExpanded {
+                expandedBody
+                    .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        // Commands, paths, and results are code-like and stay left-to-right
+        // inside an RTL transcript (#259), like the live card.
+        .forcedLeftToRight()
+        .onDisappear { copiedResetTask?.cancel() }
+    }
+
+    private var rowLine: some View {
+        HStack(alignment: usesStackedLabel ? .top : .center, spacing: 6) {
+            Image(systemName: row.icon)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(row.isFailure ? Color.red : Color.secondary)
+                .frame(width: 20, height: 18)
+
+            label
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 1) {
+                if showsCopied {
+                    Text("Copied")
+                        .font(AppFont.caption2(weight: .semibold))
+                        .foregroundStyle(.green)
+                        .padding(.trailing, 4)
+                }
+
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16, height: 16)
+
+                statusGlyph
+                    .frame(width: 16, height: 16)
+            }
+        }
+        .padding(.horizontal, 2)
+        .frame(minHeight: Self.minimumHeight)
+        .background(
+            Color.primary.opacity(isPressed ? 0.06 : 0),
+            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: toggleExpansion)
+        .onLongPressGesture(minimumDuration: 0.45, perform: copy) { pressing in
+            isPressed = pressing
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Double tap to show details. Long press to copy.")
+        .accessibilityAction { toggleExpansion() }
+        .accessibilityAction(named: Text("Copy")) { copy() }
+    }
+
+    private var usesStackedLabel: Bool {
+        dynamicTypeSize.isAccessibilitySize
+    }
+
+    @ViewBuilder
+    private var label: some View {
+        if usesStackedLabel {
+            VStack(alignment: .leading, spacing: 2) {
+                summaryText
+                if let detail = row.detail {
+                    detailText(detail).lineLimit(2)
+                }
+            }
+        } else if let detail = row.detail {
+            (summaryText + Text(" ") + detailText(detail))
+                .lineLimit(1)
+        } else {
+            summaryText.lineLimit(1)
+        }
+    }
+
+    private var summaryText: Text {
+        Text(row.summary)
+            .font(AppFont.caption(weight: .semibold))
+            .foregroundStyle(row.isFailure ? Color.red : Color.primary)
+    }
+
+    private func detailText(_ detail: String) -> Text {
+        Text(detail)
+            .font(AppFont.caption())
+            .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder
+    private var statusGlyph: some View {
+        switch row.status {
+        case .success:
+            Image(systemName: "checkmark")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+        case .failure:
+            Image(systemName: "xmark")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.red)
+        case .interrupted:
+            Image(systemName: "minus")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var expandedBody: some View {
+        ToolCallDetailBodyView(toolCall: entry.toolCall)
+            .padding(.leading, 12)
+            .overlay(alignment: .leading) {
+                Rectangle()
+                    .fill(.quaternary)
+                    .frame(width: 1)
+            }
+            .padding(.leading, Self.bodyIndent)
+            .padding(.top, 2)
+            .padding(.bottom, 6)
+    }
+
+    private var accessibilityLabel: String {
+        [row.summary, row.detail, row.statusText]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+    }
+
+    private func toggleExpansion() {
+        chatDisclosureToggled()
+        withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
+            isExpanded.toggle()
+        }
+    }
+
+    /// Copies the row and its body, then shows "Copied" for a moment. The reset
+    /// task is cancelled when the row leaves the screen so it never mutates a
+    /// row that is gone.
+    private func copy() {
+        isPressed = false
+        UIPasteboard.general.string = ToolCallSummaryFormatter.copyText(for: entry.toolCall)
+        ChatHaptics.copied(isEnabled: isHapticsEnabled)
+
+        withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
+            showsCopied = true
+        }
+
+        copiedResetTask?.cancel()
+        copiedResetTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.2))
+            guard !Task.isCancelled else { return }
+            withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
+                showsCopied = false
+            }
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/ToolCallSummaryFormatter.swift
+++ b/HermesMobile/Features/Chat/ToolCallSummaryFormatter.swift
@@ -61,7 +61,7 @@ enum ToolCallSummaryFormatter {
         let name = nonEmpty(toolCall.name)
         let toolKind = kind(forToolNamed: name)
         let resultText = resultText(for: toolCall)
-        let rowStatus = status(for: toolCall, resultText: resultText)
+        let rowStatus = status(for: toolCall, kind: toolKind, resultText: resultText)
         let detail = targetDetail(kind: toolKind, name: name, args: toolCall.args)
             ?? resultText.flatMap(firstLine)
 
@@ -302,13 +302,23 @@ enum ToolCallSummaryFormatter {
 
     // MARK: - Status
 
-    private static func status(for toolCall: ToolCall, resultText: String?) -> ToolCallLogRow.Status {
-        if toolCall.isError == true { return .failure }
-        if let resultText {
-            if let exitCode = strippingTrailingExitCode(resultText).exitCode, exitCode != 0 {
+    /// The server's `is_error` verdict wins whenever the call carries one
+    /// (every live completion, and persisted transcripts that store it). A call
+    /// with no verdict falls back to its result: the JSON envelope's `error` /
+    /// `exit_code` first, then the text heuristics. Search and web results are
+    /// never judged by text, since their output is whatever the query matched.
+    private static func status(for toolCall: ToolCall, kind: Kind, resultText: String?) -> ToolCallLogRow.Status {
+        switch toolCall.isError {
+        case true?:
+            return .failure
+        case false?:
+            break
+        case nil:
+            if let envelopeFailure = ToolCallDisplayFormatter.envelopeReportsFailure(preview: toolCall.preview) {
+                if envelopeFailure { return .failure }
+            } else if let resultText, kind != .search, kind != .web, looksLikeFailure(resultText) {
                 return .failure
             }
-            if looksLikeFailure(resultText) { return .failure }
         }
         return toolCall.isCompleted ? .success : .interrupted
     }
@@ -329,30 +339,38 @@ enum ToolCallSummaryFormatter {
         return (nonEmpty(output), Int(trimmed[codeRange]))
     }
 
-    /// Text-only failure signals for tools that report success but printed an
-    /// error. Covers the formatter's own `Error:` / `Exit code:` envelope lines
-    /// (a denied command reports exit code -1) and the upstream text heuristics.
+    /// Text-only failure signals for a call with no server verdict and no JSON
+    /// envelope. A trailing `<exited with exit code N>` marker is decisive either
+    /// way. Otherwise only the first line of output is read, which is where
+    /// shells and file tools put their error, so a call that merely mentions
+    /// "not found" further down its output stays green.
     static func looksLikeFailure(_ text: String) -> Bool {
-        let normalized = text.lowercased()
-        if normalized.hasPrefix("error:") { return true }
+        let stripped = strippingTrailingExitCode(text)
+        if let exitCode = stripped.exitCode {
+            return exitCode != 0
+        }
+
+        guard let firstLine = (stripped.output ?? "")
+            .split(whereSeparator: \.isNewline)
+            .first?
+            .trimmingCharacters(in: .whitespaces)
+            .lowercased()
+        else {
+            return false
+        }
+
+        if firstLine.hasPrefix("error:") { return true }
+
         let phrases = [
             "file not found", "no files found", "enoent", "no such file or directory", "no such file",
             "commandnotfoundexception", "command not found",
             "is not recognized as the name of a cmdlet",
             "a parameter cannot be found that matches parameter name"
         ]
-        if phrases.contains(where: { normalized.contains($0) }) { return true }
-        if normalized.contains("cannot find path"), normalized.contains("because it does not exist") { return true }
-        if normalized.contains("is not recognized"), normalized.contains("the term '") { return true }
-
-        let patterns = [
-            #"<exited with exit code\s+[1-9]\d*\s*>"#,
-            #"exit(?:ed)? with exit code\s+[1-9]\d*"#,
-            #"exit code\s*[:\s]\s*-?[1-9]\d*\b"#
-        ]
-        return patterns.contains { pattern in
-            text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
-        }
+        if phrases.contains(where: { firstLine.contains($0) }) { return true }
+        if firstLine.contains("cannot find path"), firstLine.contains("because it does not exist") { return true }
+        if firstLine.contains("is not recognized"), firstLine.contains("the term '") { return true }
+        return false
     }
 
     // MARK: - Helpers

--- a/HermesMobile/Features/Chat/ToolCallSummaryFormatter.swift
+++ b/HermesMobile/Features/Chat/ToolCallSummaryFormatter.swift
@@ -1,0 +1,436 @@
+import Foundation
+
+/// One settled tool call reduced to a log line: icon, bold verb, dim one-line
+/// detail, and a status glyph. Built by `ToolCallSummaryFormatter`.
+struct ToolCallLogRow: Equatable {
+    enum Status: Equatable {
+        case success
+        case failure
+        /// The group settled before the call ever reported completion.
+        case interrupted
+    }
+
+    /// SF Symbol for the leading icon column.
+    let icon: String
+    /// The verb ("Ran", "Read", …) or, for unrecognised tools, the short tool name.
+    let summary: String
+    /// The call's target (command, file, query, skill) or the first result line.
+    let detail: String?
+    let status: Status
+
+    var isFailure: Bool { status == .failure }
+
+    var statusText: String {
+        switch status {
+        case .success: String(localized: "Completed")
+        case .failure: String(localized: "Failed")
+        case .interrupted: String(localized: "Interrupted")
+        }
+    }
+}
+
+/// A tool call paired with its log row, keyed by the call's id for `ForEach`.
+struct ToolCallLogEntry: Identifiable, Equatable {
+    let toolCall: ToolCall
+    let row: ToolCallLogRow
+
+    var id: String { toolCall.id }
+}
+
+/// Turns settled tool calls into one-line log rows. The rules mirror the upstream
+/// web UI's compact tool labels (`_toolActionKind` / `_toolTargetLabel` in
+/// `static/ui.js`) so a call reads the same on the phone and in the browser.
+/// Pure and stateless so every rule is unit-testable.
+enum ToolCallSummaryFormatter {
+    enum Kind: Equatable {
+        case shell, read, write, search, web, list, skill, memory, delegate, unknown
+    }
+
+    private static let detailLimit = 160
+
+    /// Rows for a settled group, in call order. Calls with nothing to say (no
+    /// name, target, or result) are dropped; failures are never dropped.
+    static func entries(for toolCalls: [ToolCall]) -> [ToolCallLogEntry] {
+        toolCalls.compactMap { toolCall in
+            row(for: toolCall).map { ToolCallLogEntry(toolCall: toolCall, row: $0) }
+        }
+    }
+
+    /// The log row for one call, or `nil` when the call carries no signal.
+    static func row(for toolCall: ToolCall) -> ToolCallLogRow? {
+        let name = nonEmpty(toolCall.name)
+        let toolKind = kind(forToolNamed: name)
+        let resultText = resultText(for: toolCall)
+        let rowStatus = status(for: toolCall, resultText: resultText)
+        let detail = targetDetail(kind: toolKind, name: name, args: toolCall.args)
+            ?? resultText.flatMap(firstLine)
+
+        guard rowStatus == .failure || name != nil || detail != nil else {
+            return nil
+        }
+
+        return ToolCallLogRow(
+            icon: icon(kind: toolKind, name: name),
+            summary: summary(kind: toolKind, name: name),
+            detail: detail,
+            status: rowStatus
+        )
+    }
+
+    /// Everything a long-press puts on the pasteboard: the row line, then the
+    /// same arguments and result the expanded body shows.
+    static func copyText(for toolCall: ToolCall) -> String {
+        var lines: [String] = []
+        if let row = row(for: toolCall) {
+            lines.append([row.summary, row.detail].compactMap { $0 }.joined(separator: " "))
+        }
+
+        let content = ToolCallDisplayFormatter.content(for: toolCall)
+        lines += content.argumentRows.map { "\($0.key): \($0.value)" }
+        if let result = content.result {
+            lines.append(result.text)
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Kind and presentation
+
+    static func kind(forToolNamed rawName: String?) -> Kind {
+        let name = normalizedName(rawName)
+        guard !name.isEmpty else { return .unknown }
+
+        if name == "subagent_progress" || name == "delegate_task" { return .delegate }
+        if name.contains("skill") { return .skill }
+        if name.contains("memory") { return .memory }
+        if name.contains("terminal") || name.contains("shell") || name.contains("command")
+            || name.contains("process") || name == "execute_code" {
+            return .shell
+        }
+        if name.contains("read") || name.contains("view") || name.contains("open") || name == "vision_analyze" {
+            return .read
+        }
+        if name.contains("list") || name == "todo" { return .list }
+        if name.contains("web") || name.contains("fetch") || name.contains("curl")
+            || name.contains("extract") || name.contains("browse") || name.contains("navigate") {
+            return .web
+        }
+        if name.contains("search") || name.contains("grep") || name.contains("find") { return .search }
+        if name.contains("write") || name.contains("patch") || name.contains("edit") { return .write }
+        return .unknown
+    }
+
+    private static func summary(kind: Kind, name: String?) -> String {
+        switch kind {
+        case .shell: String(localized: "Ran")
+        case .read: String(localized: "Read")
+        case .write: String(localized: "Updated")
+        case .search: String(localized: "Searched")
+        case .web: String(localized: "Checked")
+        case .list: String(localized: "Listed")
+        case .skill: String(localized: "Loaded")
+        case .memory: String(localized: "Saved")
+        case .delegate: String(localized: "Delegated")
+        case .unknown: shortToolName(name)
+        }
+    }
+
+    private static func icon(kind: Kind, name: String?) -> String {
+        let normalized = normalizedName(name)
+        if normalized.hasPrefix("mcp_") { return "powerplug" }
+
+        switch normalized {
+        case "execute_code": return "play"
+        case "todo": return "checklist"
+        case "cronjob": return "clock"
+        case "send_message": return "bubble.left"
+        case "vision_analyze": return "eye"
+        default: break
+        }
+
+        switch kind {
+        case .shell: return "terminal"
+        case .read: return "doc.text"
+        case .write: return "pencil.line"
+        case .search: return "magnifyingglass"
+        case .web: return "globe"
+        case .list: return "list.bullet"
+        case .skill: return "book"
+        case .memory: return "brain"
+        case .delegate: return "arrow.triangle.branch"
+        case .unknown: return "wrench"
+        }
+    }
+
+    /// `mcp__server__tool` reads as `server/tool`; anything else is the raw name.
+    static func shortToolName(_ rawName: String?) -> String {
+        guard let name = nonEmpty(rawName) else { return String(localized: "Tool") }
+
+        if name.hasPrefix("mcp__") {
+            let parts = name.split(separator: "__").map(String.init).filter { !$0.isEmpty }
+            if parts.count > 1 { return parts.dropFirst().joined(separator: "/") }
+        }
+        if name.hasPrefix("mcp.") {
+            let parts = name.split(separator: ".").map(String.init).filter { !$0.isEmpty }
+            if parts.count > 1 { return parts.dropFirst().joined(separator: "/") }
+        }
+        return name
+    }
+
+    // MARK: - Detail
+
+    private static func targetDetail(kind: Kind, name: String?, args: [String: JSONValue]?) -> String? {
+        guard let args, !args.isEmpty else { return nil }
+
+        switch kind {
+        case .shell:
+            return firstString(in: args, keys: ["cmd", "command"])
+                .map(unwrappingShellWrapper)
+                .flatMap(compacted)
+        case .skill:
+            return firstString(in: args, keys: ["name", "skill"]).flatMap(compacted)
+        case .memory:
+            return firstString(in: args, keys: ["target", "name", "action"]).flatMap(compacted)
+        case .read:
+            guard let path = firstString(in: args, keys: ["path", "file_path", "file", "target", "name"]) else {
+                return nil
+            }
+            let fileName = basename(path)
+            if normalizedName(name) == "read_file", let range = readRange(args: args) {
+                return compacted("\(range) · \(fileName)")
+            }
+            return compacted(fileName)
+        case .write:
+            return changedFilesPreview(args: args)
+        case .search, .web:
+            return firstString(in: args, keys: ["query", "pattern", "url", "uri"]).flatMap(compacted)
+        case .list, .delegate, .unknown:
+            return firstString(
+                in: args,
+                keys: ["cmd", "command", "path", "file_path", "file", "uri", "url", "query", "pattern", "dir", "task", "name"]
+            )
+            .flatMap(compacted)
+        }
+    }
+
+    /// `L12-40 · File.swift` style range for `read_file` offset/limit arguments.
+    private static func readRange(args: [String: JSONValue]) -> String? {
+        guard let offset = integer(args["offset"]), offset > 0 else { return nil }
+        guard let limitValue = args["limit"] else { return "L\(offset)" }
+        guard let limit = integer(limitValue), limit > 0 else { return nil }
+        guard limit > 1 else { return "L\(offset)" }
+        let (end, overflow) = offset.addingReportingOverflow(limit - 1)
+        return overflow ? nil : "L\(offset)-\(end)"
+    }
+
+    /// First changed file plus `+N more`, from the same path arguments the
+    /// per-turn file recap reads (`path`, `paths[]`, `edits[].path`, …).
+    static func changedFilesPreview(args: [String: JSONValue]) -> String? {
+        var paths: [String] = []
+        func append(_ value: JSONValue?) {
+            if let string = string(value), !paths.contains(string) {
+                paths.append(string)
+            }
+        }
+
+        for key in ["path", "file_path", "file", "target", "destination", "name"] {
+            append(args[key])
+        }
+        if case .array(let items)? = args["paths"] {
+            items.forEach(append)
+        }
+        if case .array(let edits)? = args["edits"] {
+            for edit in edits {
+                if case .object(let object) = edit {
+                    append(object["path"])
+                }
+            }
+        }
+
+        guard let first = paths.first else { return nil }
+        let remaining = paths.count - 1
+        guard remaining > 0 else { return compacted(basename(first)) }
+        return compacted("\(basename(first)) \(String(localized: "+\(remaining) more"))")
+    }
+
+    /// `bash -lc "git status"`, `pwsh -Command "…"`, and `cmd /c …` read as the
+    /// inner command. Anything else is returned untouched.
+    static func unwrappingShellWrapper(_ command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let split = trimmed.firstIndex(where: \.isWhitespace) else { return command }
+
+        let executable = executableBasename(String(trimmed[..<split]))
+        let rest = trimmed[split...].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rest.isEmpty else { return command }
+
+        let flagPattern: String
+        switch executable {
+        case "pwsh", "powershell": flagPattern = #"(?:^|\s)-command\s+"#
+        case "cmd": flagPattern = #"(?:^|\s)/c\s+"#
+        case "bash", "sh", "zsh": flagPattern = #"(?:^|\s)-(?:l)?c\s+"#
+        default: return command
+        }
+
+        guard let regex = try? NSRegularExpression(pattern: flagPattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: rest, range: NSRange(rest.startIndex..., in: rest)),
+              let matchRange = Range(match.range, in: rest)
+        else {
+            return command
+        }
+
+        let inner = rest[matchRange.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !inner.isEmpty else { return command }
+        let unquoted = trimmingMatchingOuterQuotes(inner)
+        return unquoted.isEmpty ? command : unquoted
+    }
+
+    private static func executableBasename(_ executable: String) -> String {
+        var name = executable.split(whereSeparator: { $0 == "/" || $0 == "\\" }).last.map(String.init) ?? executable
+        name = name.lowercased()
+        if name.hasSuffix(".exe") { name.removeLast(4) }
+        return name
+    }
+
+    private static func trimmingMatchingOuterQuotes(_ value: String) -> String {
+        guard value.count >= 2, let first = value.first, let last = value.last,
+              first == last, first == "\"" || first == "'"
+        else {
+            return value
+        }
+        return String(value.dropFirst().dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Status
+
+    private static func status(for toolCall: ToolCall, resultText: String?) -> ToolCallLogRow.Status {
+        if toolCall.isError == true { return .failure }
+        if let resultText {
+            if let exitCode = strippingTrailingExitCode(resultText).exitCode, exitCode != 0 {
+                return .failure
+            }
+            if looksLikeFailure(resultText) { return .failure }
+        }
+        return toolCall.isCompleted ? .success : .interrupted
+    }
+
+    /// Splits a trailing `<exited with exit code N>` marker off tool output.
+    static func strippingTrailingExitCode(_ text: String) -> (output: String?, exitCode: Int?) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pattern = #"^([\s\S]*?)(?:\s*<exited with exit code (\d+)>)\s*$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed)),
+              let outputRange = Range(match.range(at: 1), in: trimmed),
+              let codeRange = Range(match.range(at: 2), in: trimmed)
+        else {
+            return (nonEmpty(trimmed), nil)
+        }
+
+        let output = trimmed[outputRange].trimmingCharacters(in: .whitespacesAndNewlines)
+        return (nonEmpty(output), Int(trimmed[codeRange]))
+    }
+
+    /// Text-only failure signals for tools that report success but printed an
+    /// error. Covers the formatter's own `Error:` / `Exit code:` envelope lines
+    /// (a denied command reports exit code -1) and the upstream text heuristics.
+    static func looksLikeFailure(_ text: String) -> Bool {
+        let normalized = text.lowercased()
+        if normalized.hasPrefix("error:") { return true }
+        let phrases = [
+            "file not found", "no files found", "enoent", "no such file or directory", "no such file",
+            "commandnotfoundexception", "command not found",
+            "is not recognized as the name of a cmdlet",
+            "a parameter cannot be found that matches parameter name"
+        ]
+        if phrases.contains(where: { normalized.contains($0) }) { return true }
+        if normalized.contains("cannot find path"), normalized.contains("because it does not exist") { return true }
+        if normalized.contains("is not recognized"), normalized.contains("the term '") { return true }
+
+        let patterns = [
+            #"<exited with exit code\s+[1-9]\d*\s*>"#,
+            #"exit(?:ed)? with exit code\s+[1-9]\d*"#,
+            #"exit code\s*[:\s]\s*-?[1-9]\d*\b"#
+        ]
+        return patterns.contains { pattern in
+            text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// The unwrapped result the expanded body shows, minus the exit-code marker.
+    private static func resultText(for toolCall: ToolCall) -> String? {
+        guard let display = ToolCallDisplayFormatter.resultDisplay(preview: toolCall.preview, toolName: toolCall.name) else {
+            return nil
+        }
+        return display.text
+    }
+
+    private static func firstLine(_ text: String) -> String? {
+        let stripped = strippingTrailingExitCode(text).output ?? text
+        for line in stripped.split(whereSeparator: \.isNewline) {
+            if let compactLine = compacted(String(line)) { return compactLine }
+        }
+        return nil
+    }
+
+    /// Collapses whitespace to single spaces and caps the length for one line.
+    private static func compacted(_ text: String) -> String? {
+        let collapsed = text
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > detailLimit else { return collapsed }
+        return String(collapsed.prefix(detailLimit - 1)) + "…"
+    }
+
+    private static func basename(_ path: String) -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        let components = trimmed.split(whereSeparator: { $0 == "/" || $0 == "\\" })
+        return components.last.map(String.init) ?? trimmed
+    }
+
+    private static func normalizedName(_ rawName: String?) -> String {
+        let lowered = (rawName ?? "").lowercased()
+        var result = ""
+        var pendingUnderscore = false
+        for scalar in lowered.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar), scalar.isASCII {
+                if pendingUnderscore, !result.isEmpty { result.append("_") }
+                pendingUnderscore = false
+                result.unicodeScalars.append(scalar)
+            } else {
+                pendingUnderscore = true
+            }
+        }
+        return result
+    }
+
+    private static func firstString(in args: [String: JSONValue], keys: [String]) -> String? {
+        for key in keys {
+            if let value = string(args[key]) { return value }
+        }
+        return nil
+    }
+
+    private static func string(_ value: JSONValue?) -> String? {
+        guard case .string(let string)? = value else { return nil }
+        return nonEmpty(string)
+    }
+
+    private static func integer(_ value: JSONValue?) -> Int? {
+        switch value {
+        case .number(let number)?:
+            guard number.isFinite, number == number.rounded(.towardZero) else { return nil }
+            return Int(exactly: number)
+        case .string(let string)?:
+            return Int(string.trimmingCharacters(in: .whitespacesAndNewlines))
+        default:
+            return nil
+        }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}

--- a/HermesMobile/Models/ToolCall.swift
+++ b/HermesMobile/Models/ToolCall.swift
@@ -45,6 +45,10 @@ struct PersistedToolCall: Decodable, Equatable {
     let tid: String?
     let assistantMsgIdx: Int?
     let args: [String: JSONValue]?
+    /// The server's verdict for the call, when the transcript carries one.
+    /// `nil` on older transcripts; the settled log then falls back to the result text.
+    let isError: Bool?
+    let duration: Double?
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -53,6 +57,8 @@ struct PersistedToolCall: Decodable, Equatable {
         case assistantMsgIdx
         case assistantMsgIdxSnake = "assistant_msg_idx"
         case args
+        case isError = "is_error"
+        case duration
     }
 
     init(
@@ -60,13 +66,17 @@ struct PersistedToolCall: Decodable, Equatable {
         snippet: String?,
         tid: String?,
         assistantMsgIdx: Int?,
-        args: [String: JSONValue]?
+        args: [String: JSONValue]?,
+        isError: Bool? = nil,
+        duration: Double? = nil
     ) {
         self.name = name
         self.snippet = snippet
         self.tid = tid
         self.assistantMsgIdx = assistantMsgIdx
         self.args = args
+        self.isError = isError
+        self.duration = duration
     }
 
     init(from decoder: Decoder) throws {
@@ -77,6 +87,8 @@ struct PersistedToolCall: Decodable, Equatable {
         assistantMsgIdx = container.decodeLossyIntIfPresent(forKey: .assistantMsgIdx)
             ?? container.decodeLossyIntIfPresent(forKey: .assistantMsgIdxSnake)
         args = try? container.decodeIfPresent([String: JSONValue].self, forKey: .args)
+        isError = container.decodeLossyBoolIfPresent(forKey: .isError)
+        duration = container.decodeLossyDoubleIfPresent(forKey: .duration)
     }
 
     func toolCall(fallbackIndex: Int) -> ToolCall {
@@ -93,6 +105,8 @@ struct PersistedToolCall: Decodable, Equatable {
             name: name,
             preview: snippet,
             args: args,
+            duration: duration,
+            isError: isError,
             isCompleted: true
         )
     }

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -114386,6 +114386,1782 @@
           }
         }
       }
+    },
+    "Ran" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم التشغيل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ausgeführt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ejecutado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exécuté"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הורץ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eseguito"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitgevoerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uruchomiono"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Executado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Выполнено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalıştırıldı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "چلایا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已執行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已執行"
+          }
+        }
+      }
+    },
+    "Read" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تمت القراءة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gelesen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Leído"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lu"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נקרא"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Letto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "読み取り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "읽음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gelezen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Odczytano"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Прочитано"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Okundu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "پڑھا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已讀取"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已读取"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已讀取"
+          }
+        }
+      }
+    },
+    "Searched" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم البحث"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gesucht"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Buscado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recherché"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בוצע חיפוש"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cercato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gezocht"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wyszukano"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pesquisado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Выполнен поиск"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arandı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تلاش کیا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已搜尋"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已搜索"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已搜尋"
+          }
+        }
+      }
+    },
+    "Checked" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم الفحص"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geprüft"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Consultado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Consulté"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נבדק"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Consultato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "확인함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gecontroleerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sprawdzono"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Consultado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Проверено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kontrol edildi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "چیک کیا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已查看"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已查看"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已查看"
+          }
+        }
+      }
+    },
+    "Listed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم الإدراج"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aufgelistet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Listado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Listé"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הוצג ברשימה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Elencato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一覧表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "나열함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Weergegeven"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wylistowano"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Listado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Список получен"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Listelendi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فہرست بنائی گئی"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已列出"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已列出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已列出"
+          }
+        }
+      }
+    },
+    "Loaded" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم التحميل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geladen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cargado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chargé"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נטען"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Caricato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "読み込み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "불러옴"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geladen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wczytano"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загружено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yüklendi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لوڈ کیا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已載入"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已加载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已載入"
+          }
+        }
+      }
+    },
+    "Delegated" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم التفويض"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Delegiert"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Delegado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Délégué"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הואצל"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Delegato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "委任"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "위임함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gedelegeerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Delegowano"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Delegado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Делегировано"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Devredildi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سونپا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已委派"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已委派"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已委派"
+          }
+        }
+      }
+    },
+    "Interrupted" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تمت المقاطعة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Unterbrochen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Interrumpido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Interrompu"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הופסק"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Interrotto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "中断"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "중단됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Onderbroken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Przerwano"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Interrompido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Прервано"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kesildi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "روک دیا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已中斷"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已中断"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已中斷"
+          }
+        }
+      }
+    },
+    "Show fewer tool calls" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "إظهار عدد أقل من استدعاءات الأدوات"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Weniger Tool-Aufrufe anzeigen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar menos llamadas a herramientas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Afficher moins d'appels d'outils"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הצג פחות קריאות לכלים"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra meno chiamate agli strumenti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ツール呼び出しを減らして表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "도구 호출 접기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Minder toolaanroepen tonen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pokaż mniej wywołań narzędzi"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar menos chamadas de ferramentas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показать меньше вызовов инструментов"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Daha az araç çağrısı göster"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کم ٹول کالز دکھائیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "收合工具呼叫"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "收起工具调用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "收合工具呼叫"
+          }
+        }
+      }
+    },
+    "Double tap to show details. Long press to copy." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "انقر مرتين لإظهار التفاصيل. اضغط مطولًا للنسخ."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Doppeltippen, um Details anzuzeigen. Gedrückt halten, um zu kopieren."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toca dos veces para mostrar los detalles. Mantén pulsado para copiar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Touchez deux fois pour afficher les détails. Appuyez longuement pour copier."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הקש פעמיים להצגת פרטים. לחיצה ארוכה להעתקה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tocca due volte per mostrare i dettagli. Tieni premuto per copiare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ダブルタップで詳細を表示します。長押しでコピーします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "두 번 탭하여 세부 정보를 표시합니다. 길게 눌러 복사합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dubbeltik om details te tonen. Houd ingedrukt om te kopiëren."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Stuknij dwukrotnie, aby pokazać szczegóły. Przytrzymaj, aby skopiować."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque duas vezes para mostrar os detalhes. Toque e segure para copiar."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Дважды коснитесь, чтобы показать детали. Удерживайте, чтобы скопировать."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ayrıntıları göstermek için iki kez dokunun. Kopyalamak için basılı tutun."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تفصیلات دکھانے کے لیے دو بار ٹیپ کریں۔ کاپی کرنے کے لیے دیر تک دبائیں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下顯示詳細資料。長按以複製。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "轻点两下显示详情。长按以复制。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下顯示詳細資訊。長按以拷貝。"
+          }
+        }
+      }
+    },
+    "+%lld more" : {
+      "localizations" : {
+        "ar" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld أخرى"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld أخرى"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld أخرى"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld أخرى"
+                }
+              },
+              "two" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld أخرى"
+                }
+              },
+              "zero" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld أخرى"
+                }
+              }
+            }
+          }
+        },
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld weitere"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld weitere"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "+%lld more"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "+%lld more"
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld más"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld más"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld autre"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld autres"
+                }
+              }
+            }
+          }
+        },
+        "he" : {
+          "variations" : {
+            "plural" : {
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld נוספים"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld נוסף"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld נוספים"
+                }
+              },
+              "two" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld נוספים"
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld altro"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld altri"
+                }
+              }
+            }
+          }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld件"
+                }
+              }
+            }
+          }
+        },
+        "ko" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld개"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld meer"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld meer"
+                }
+              }
+            }
+          }
+        },
+        "pl" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld więcej"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld więcej"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld więcej"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld więcej"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld mais"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld mais"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+ещё %lld"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+ещё %lld"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+ещё %lld"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+ещё %lld"
+                }
+              }
+            }
+          }
+        },
+        "tr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld daha"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld daha"
+                }
+              }
+            }
+          }
+        },
+        "ur" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld مزید"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld مزید"
+                }
+              }
+            }
+          }
+        },
+        "zh-HK" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld 個"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld 个"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hant" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld 個"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "+%lld previous tool calls" : {
+      "localizations" : {
+        "ar" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld استدعاءات أدوات سابقة"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld استدعاء أداة سابقًا"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld استدعاء أداة سابق"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld استدعاء أداة سابق"
+                }
+              },
+              "two" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld استدعاءا أداة سابقان"
+                }
+              },
+              "zero" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld استدعاءات أدوات سابقة"
+                }
+              }
+            }
+          }
+        },
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld vorheriger Tool-Aufruf"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld vorherige Tool-Aufrufe"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "+%lld previous tool call"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "+%lld previous tool calls"
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld llamada a herramienta anterior"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld llamadas a herramientas anteriores"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld appel d'outil précédent"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld appels d'outils précédents"
+                }
+              }
+            }
+          }
+        },
+        "he" : {
+          "variations" : {
+            "plural" : {
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld קריאות קודמות לכלים"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld קריאה קודמת לכלי"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld קריאות קודמות לכלים"
+                }
+              },
+              "two" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld קריאות קודמות לכלים"
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld chiamata precedente"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld chiamate precedenti"
+                }
+              }
+            }
+          }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld件の以前のツール呼び出し"
+                }
+              }
+            }
+          }
+        },
+        "ko" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld개의 이전 도구 호출"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld eerdere toolaanroep"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld eerdere toolaanroepen"
+                }
+              }
+            }
+          }
+        },
+        "pl" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld poprzednie wywołania narzędzi"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld poprzednich wywołań narzędzi"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld poprzednie wywołanie narzędzia"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld poprzednich wywołań narzędzi"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld chamada de ferramenta anterior"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld chamadas de ferramentas anteriores"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld предыдущих вызова инструментов"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld предыдущих вызовов инструментов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld предыдущий вызов инструмента"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld предыдущих вызовов инструментов"
+                }
+              }
+            }
+          }
+        },
+        "tr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld önceki araç çağrısı"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld önceki araç çağrısı"
+                }
+              }
+            }
+          }
+        },
+        "ur" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld پچھلی ٹول کال"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld پچھلی ٹول کالز"
+                }
+              }
+            }
+          }
+        },
+        "zh-HK" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld 個先前的工具呼叫"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld 个之前的工具调用"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hant" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "+%lld 個先前的工具呼叫"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ToolCallSummaryFormatterTests.swift
+++ b/HermesMobileTests/ToolCallSummaryFormatterTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import HermesMobile
+
+final class ToolCallSummaryFormatterTests: XCTestCase {
+    // MARK: - Shell wrapper unwrap
+
+    func testUnwrapsKnownShellWrappers() {
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper(#"bash -lc "git status""#), "git status")
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper("/bin/zsh -c 'ls -la'"), "ls -la")
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper("sh -c make test"), "make test")
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper("pwsh -Command 'Get-ChildItem'"), "Get-ChildItem")
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper("cmd.exe /c dir"), "dir")
+    }
+
+    func testLeavesPlainCommandsAlone() {
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper("git status"), "git status")
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper("bash -lc"), "bash -lc")
+        XCTAssertEqual(ToolCallSummaryFormatter.unwrappingShellWrapper("bash script.sh"), "bash script.sh")
+    }
+
+    // MARK: - Exit code
+
+    func testStripsTrailingExitCodeMarker() {
+        let stripped = ToolCallSummaryFormatter.strippingTrailingExitCode("hello\n<exited with exit code 2>")
+        XCTAssertEqual(stripped.output, "hello")
+        XCTAssertEqual(stripped.exitCode, 2)
+
+        let markerOnly = ToolCallSummaryFormatter.strippingTrailingExitCode("<exited with exit code 0>")
+        XCTAssertNil(markerOnly.output)
+        XCTAssertEqual(markerOnly.exitCode, 0)
+
+        let plain = ToolCallSummaryFormatter.strippingTrailingExitCode("  done  ")
+        XCTAssertEqual(plain.output, "done")
+        XCTAssertNil(plain.exitCode)
+    }
+
+    func testShellRowUsesUnwrappedCommandAndNonZeroExitCodeFails() throws {
+        let toolCall = ToolCall(
+            name: "terminal",
+            preview: "make: *** No rule\n<exited with exit code 2>",
+            args: ["command": .string("bash -lc 'make test'"), "workdir": .string("/tmp")],
+            isCompleted: true
+        )
+
+        let row = try XCTUnwrap(ToolCallSummaryFormatter.row(for: toolCall))
+        XCTAssertEqual(row.icon, "terminal")
+        XCTAssertEqual(row.summary, "Ran")
+        XCTAssertEqual(row.detail, "make test")
+        XCTAssertEqual(row.status, .failure)
+    }
+
+    // MARK: - Changed files and read ranges
+
+    func testChangedFilePreviewShowsFirstFileAndRemainder() throws {
+        let patch = ToolCall(
+            name: "patch",
+            preview: nil,
+            args: [
+                "edits": .array([
+                    .object(["path": .string("Sources/App/One.swift")]),
+                    .object(["path": .string("Sources/App/Two.swift")]),
+                    .object(["path": .string("Sources/App/Three.swift")])
+                ])
+            ],
+            isCompleted: true
+        )
+        let patchRow = try XCTUnwrap(ToolCallSummaryFormatter.row(for: patch))
+        XCTAssertEqual(patchRow.summary, "Updated")
+        XCTAssertEqual(patchRow.detail, "One.swift +2 more")
+
+        let write = ToolCall(
+            name: "write_file",
+            preview: nil,
+            args: ["path": .string("~/project/Notes.md"), "content": .string("secret body")],
+            isCompleted: true
+        )
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: write)?.detail, "Notes.md")
+    }
+
+    func testReadRowShowsLineRangeAndBasename() throws {
+        let toolCall = ToolCall(
+            name: "read_file",
+            preview: "line 12",
+            args: ["path": .string("/repo/Sources/File.swift"), "offset": .number(12), "limit": .number(20)],
+            isCompleted: true
+        )
+
+        let row = try XCTUnwrap(ToolCallSummaryFormatter.row(for: toolCall))
+        XCTAssertEqual(row.icon, "doc.text")
+        XCTAssertEqual(row.summary, "Read")
+        XCTAssertEqual(row.detail, "L12-31 · File.swift")
+        XCTAssertEqual(row.status, .success)
+    }
+
+    // MARK: - Failure heuristics
+
+    func testFailureTextHeuristics() {
+        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("zsh: command not found: foo"))
+        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Error: ENOENT: no such file"))
+        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Exit code: 3"))
+        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Exit code: -1"))
+        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Error: BLOCKED: Command denied by user."))
+        XCTAssertFalse(ToolCallSummaryFormatter.looksLikeFailure("Exit code: 0"))
+        XCTAssertFalse(ToolCallSummaryFormatter.looksLikeFailure("Successfully wrote 3 files"))
+    }
+
+    func testDeniedCommandEnvelopeFailsTheRow() {
+        let toolCall = ToolCall(
+            name: "terminal",
+            preview: #"{"error":"BLOCKED: Command denied by user.","exit_code":-1}"#,
+            args: ["command": .string("rm -rf /tmp/x")],
+            isCompleted: true
+        )
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: toolCall)?.status, .failure)
+    }
+
+    func testResultTextCanFailACompletedCall() {
+        let toolCall = ToolCall(
+            name: "read_file",
+            preview: "No such file or directory: missing.txt",
+            args: ["path": .string("missing.txt")],
+            isCompleted: true
+        )
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: toolCall)?.status, .failure)
+    }
+
+    func testNeverCompletedCallIsInterrupted() {
+        let toolCall = ToolCall(name: "terminal", preview: nil, args: ["command": .string("sleep 60")])
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: toolCall)?.status, .interrupted)
+    }
+
+    // MARK: - Drop rule and fallbacks
+
+    func testDropsRowsWithoutSignalButKeepsFailures() {
+        let empty = ToolCall(name: nil, preview: nil, args: nil, isCompleted: true)
+        let failed = ToolCall(name: nil, preview: nil, args: nil, isError: true, isCompleted: true)
+        let named = ToolCall(name: "terminal", preview: nil, args: nil, isCompleted: true)
+
+        let entries = ToolCallSummaryFormatter.entries(for: [empty, failed, named])
+        XCTAssertEqual(entries.map(\.toolCall.id), [failed.id, named.id])
+        XCTAssertEqual(entries.first?.row.status, .failure)
+    }
+
+    func testDetailFallsBackToFirstResultLineWhenThereIsNoTarget() throws {
+        let toolCall = ToolCall(
+            name: "terminal",
+            preview: "  12 files   changed\nmore output\n<exited with exit code 0>",
+            args: ["workdir": .string("/tmp")],
+            isCompleted: true
+        )
+
+        let row = try XCTUnwrap(ToolCallSummaryFormatter.row(for: toolCall))
+        XCTAssertEqual(row.detail, "12 files changed")
+        XCTAssertEqual(row.status, .success)
+    }
+
+    func testUnknownToolsUseTheirShortName() throws {
+        let mcp = ToolCall(name: "mcp__slack__post", preview: nil, args: ["channel": .string("#ops")], isCompleted: true)
+        let mcpRow = try XCTUnwrap(ToolCallSummaryFormatter.row(for: mcp))
+        XCTAssertEqual(mcpRow.summary, "slack/post")
+        XCTAssertEqual(mcpRow.icon, "powerplug")
+        XCTAssertNil(mcpRow.detail)
+
+        let clarify = ToolCall(name: "clarify", preview: nil, args: ["question": .string("Which?")], isCompleted: true)
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: clarify)?.summary, "clarify")
+    }
+
+    func testSearchAndWebRowsShowTheQuery() {
+        let search = ToolCall(name: "search_files", preview: nil, args: ["pattern": .string("TODO")], isCompleted: true)
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: search)?.summary, "Searched")
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: search)?.detail, "TODO")
+
+        let web = ToolCall(name: "web_search", preview: nil, args: ["query": .string("swift  regex")], isCompleted: true)
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: web)?.summary, "Checked")
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: web)?.detail, "swift regex")
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: web)?.icon, "globe")
+    }
+
+    func testCopyTextIncludesRowArgumentsAndResult() {
+        let toolCall = ToolCall(
+            name: "terminal",
+            preview: "ok",
+            args: ["command": .string("ls")],
+            isCompleted: true
+        )
+
+        XCTAssertEqual(ToolCallSummaryFormatter.copyText(for: toolCall), "Ran ls\ncommand: ls\nok")
+    }
+}

--- a/HermesMobileTests/ToolCallSummaryFormatterTests.swift
+++ b/HermesMobileTests/ToolCallSummaryFormatterTests.swift
@@ -94,14 +94,67 @@ final class ToolCallSummaryFormatterTests: XCTestCase {
 
     // MARK: - Failure heuristics
 
-    func testFailureTextHeuristics() {
+    func testFailureTextHeuristicsReadTheFirstLineAndTheExitMarker() {
         XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("zsh: command not found: foo"))
         XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Error: ENOENT: no such file"))
-        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Exit code: 3"))
-        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Exit code: -1"))
         XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("Error: BLOCKED: Command denied by user."))
-        XCTAssertFalse(ToolCallSummaryFormatter.looksLikeFailure("Exit code: 0"))
+        XCTAssertTrue(ToolCallSummaryFormatter.looksLikeFailure("make: *** No rule\n<exited with exit code 2>"))
+        XCTAssertFalse(ToolCallSummaryFormatter.looksLikeFailure("grep: 3 lines mention 'file not found'\n<exited with exit code 0>"))
         XCTAssertFalse(ToolCallSummaryFormatter.looksLikeFailure("Successfully wrote 3 files"))
+        XCTAssertFalse(ToolCallSummaryFormatter.looksLikeFailure("ok\nlater output says no such file"))
+    }
+
+    func testServerVerdictBeatsResultText() {
+        let succeeded = ToolCall(
+            name: "terminal",
+            preview: "zsh: command not found: foo",
+            args: ["command": .string("foo")],
+            isError: false,
+            isCompleted: true
+        )
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: succeeded)?.status, .success)
+
+        let failed = ToolCall(
+            name: "terminal",
+            preview: "all good",
+            args: ["command": .string("foo")],
+            isError: true,
+            isCompleted: true
+        )
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: failed)?.status, .failure)
+    }
+
+    func testEnvelopeExitCodeZeroKeepsScaryOutputGreen() {
+        let toolCall = ToolCall(
+            name: "terminal",
+            preview: #"{"output":"grep: file not found handler matched 3 lines","exit_code":0}"#,
+            args: ["command": .string("grep -rn 'file not found' src")],
+            isCompleted: true
+        )
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: toolCall)?.status, .success)
+    }
+
+    func testSearchResultsAreNeverJudgedByText() {
+        let toolCall = ToolCall(
+            name: "search_files",
+            preview: "src/errors.swift:12: throw FileError(\"file not found\")\nsrc/io.swift:4: // ENOENT",
+            args: ["pattern": .string("file not found")],
+            isCompleted: true
+        )
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: toolCall)?.status, .success)
+    }
+
+    func testPersistedToolCallCarriesTheServerVerdict() throws {
+        let json = #"{"name":"terminal","snippet":"boom","tid":"t1","assistant_msg_idx":2,"args":{"command":"x"},"is_error":true,"duration":1.5}"#
+        let persisted = try JSONDecoder().decode(PersistedToolCall.self, from: Data(json.utf8))
+        let toolCall = persisted.toolCall(fallbackIndex: 0)
+
+        XCTAssertEqual(toolCall.isError, true)
+        XCTAssertEqual(toolCall.duration, 1.5)
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: toolCall)?.status, .failure)
+
+        let legacy = try JSONDecoder().decode(PersistedToolCall.self, from: Data(#"{"name":"terminal","snippet":"ok","tid":"t2"}"#.utf8))
+        XCTAssertNil(legacy.isError)
     }
 
     func testDeniedCommandEnvelopeFailsTheRow() {


### PR DESCRIPTION
## Linked issue

Transcript density polish; no tracking issue.

## What changed

A finished turn's tool calls were a stack of material cards, each with its own header, status pill, and Arguments/Result body, nested inside another card. A turn with a handful of calls filled the screen and buried the answer.

A settled group is now a dense log:

- Only the **last** call shows, as a 32 pt row: 20 pt icon column, bold verb (`Ran`, `Read`, `Updated`, `Searched`, …, or the short tool name for anything unrecognised), dim one-line detail, chevron, and a fixed 16×16 status glyph. 1 pt gaps, no material.
- Earlier calls sit behind a `+N previous tool calls` / `Show fewer tool calls` toggle. "Expand Tools by Default" now means the previous rows start shown; bodies stay closed.
- Tap opens the same Arguments/Result body the card showed (extracted into `ToolCallDetailBodyView` so both presentations share it). Long-press copies the row line plus that body, with the existing copy haptic and a 1.2 s "Copied".
- Row taps and the group toggle go through the shared disclosure handler, so the transcript's bottom anchor is suspended and the tapped row stays put.
- Failures are red with an ✕ and are never dropped. A row is dropped only when the call has no name, no target, and no result.
- Live groups keep the current card and per-call status pills until the group settles.

`ToolCallSummaryFormatter` is pure and mirrors the web UI's compact tool labels (`_toolActionKind` / `_toolTargetLabel`): kind cascade by tool name, target detail per kind (command, file basename with `L12-31` read ranges, first changed file `+N more`, query, skill, memory target), `bash/sh/zsh -lc` / `pwsh -Command` / `cmd /c` unwrap with outer-quote trimming, trailing `<exited with exit code N>` stripping, and the failure heuristics (`command not found`, `ENOENT`, non-zero exit codes, and the formatter's own `Error:` / `Exit code:` envelope, which is how a denied command reports exit code -1). When a call has no target, the detail falls back to the first line of the unwrapped result.

12 new catalog keys are translated for all 17 shipped languages, including the two plural forms.

## How it was tested

- Full XCTest suite on the iPhone 17 simulator via XcodeBuildMCP `test_sim`: 1808 passed, 0 failed, 2 pre-existing skips.
- New `ToolCallSummaryFormatterTests` (15 tests): shell wrapper unwrap and pass-through, exit-code stripping, changed-file preview, read ranges, failure heuristics, the denied-command envelope, interrupted status, the drop rule, result-line fallback, MCP short names, query rows, and copy text.
- `LocalizationCatalogTests` covers the new keys in every shipped language.
- Driven on the simulator with XcodeBuildMCP UI automation against a live server: settled row + toggle, toggle open/close, row expand/collapse, long-press copy (pasteboard verified), a slow `sleep 10` command showing the live card mid-stream then settling into a row, and the Expand Tools by Default setting. Screenshots in the review handoff.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no networking changes)

Built by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
