### PR TITLE
feat(chat): fold settled turns behind one elapsed-time row

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000002 /* ToolActivityGroupView.swift */; };
 		1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */; };
 		C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F02 /* ToolCallLogRowView.swift */; };
+		C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */; };
 		C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */; };
 		C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */; };
 		C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12900000000000000000002 /* ChatActiveRunStatusView.swift */; };
@@ -216,6 +217,7 @@
 		C03180000000000000B007 /* GitTurnChangesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F007 /* GitTurnChangesCard.swift */; };
 		C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */; };
 		C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */; };
+		C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */; };
 		C03190000000000000B001 /* AttachmentAudioDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F001 /* AttachmentAudioDetection.swift */; };
 		C03190000000000000B002 /* InlineAudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F002 /* InlineAudioPlayerView.swift */; };
 		C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */; };
@@ -529,6 +531,7 @@
 		C12800000000000000000002 /* ToolActivityGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityGroupView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallCardView.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F02 /* ToolCallLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallLogRowView.swift; sourceTree = "<group>"; };
+		C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFolding.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatter.swift; sourceTree = "<group>"; };
 		C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTimelineAccessorySurface.swift; sourceTree = "<group>"; };
 		C12900000000000000000002 /* ChatActiveRunStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatActiveRunStatusView.swift; sourceTree = "<group>"; };
@@ -568,6 +571,7 @@
 		C03180000000000000F007 /* GitTurnChangesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTurnChangesCard.swift; sourceTree = "<group>"; };
 		C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeAggregatorTests.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatterTests.swift; sourceTree = "<group>"; };
+		C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFoldingTests.swift; sourceTree = "<group>"; };
 		C03190000000000000F001 /* AttachmentAudioDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetection.swift; sourceTree = "<group>"; };
 		C03190000000000000F002 /* InlineAudioPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineAudioPlayerView.swift; sourceTree = "<group>"; };
 		C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetectionTests.swift; sourceTree = "<group>"; };
@@ -852,6 +856,7 @@
 				C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */,
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
+				C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */,
 				C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */,
 				C0DE22000000000000000004 /* ChatHapticsTests.swift */,
 				C08800000000000000000004 /* SessionHapticsTests.swift */,
@@ -1059,6 +1064,7 @@
 				C12800000000000000000002 /* ToolActivityGroupView.swift */,
 				1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */,
 				C0AA02000000000000000F02 /* ToolCallLogRowView.swift */,
+				C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */,
 				C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */,
 				C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */,
 				C12900000000000000000002 /* ChatActiveRunStatusView.swift */,
@@ -1573,6 +1579,7 @@
 				C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */,
 				1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */,
 				C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */,
+				C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */,
 				C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */,
 				C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */,
 				C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */,
@@ -1733,6 +1740,7 @@
 				C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */,
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
+				C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */,
 				C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */,
 				C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */,
 				C08800000000000000000003 /* SessionHapticsTests.swift in Sources */,

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -213,6 +213,9 @@ enum ChatTranscriptDisplaySettings {
     static let showsAssistantTurnTimestampsKey = "chatTranscript.showsAssistantTurnTimestamps"
     static let showsResponseSpeedKey = "chatTranscript.showsResponseSpeed"
     static let wrapsCodeBlockLinesKey = "chatTranscript.wrapsCodeBlockLines"
+    /// Settings → Chat "Fold Finished Turns": settled turns collapse their
+    /// thinking, tool rows, and interim replies behind one elapsed-time row.
+    static let foldsSettledTurnsKey = "chatTranscript.foldsSettledTurns"
 
     /// Backs the Settings → Chat "Right-to-Left Chat Layout" toggle (issue #259).
     /// Local-only: there is no server settings object to mirror an `rtl` flag
@@ -429,18 +432,29 @@ enum ChatWorkingRowPolicy {
 enum ChatWorkingElapsedFormatter {
     /// Compact elapsed time for the tail row: `12s`, `1m 4s`, `1h 2m 3s`.
     static func label(startedAt: Date, now: Date) -> String {
-        Duration.seconds(elapsedSeconds(startedAt: startedAt, now: now))
-            .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .narrow))
+        label(seconds: now.timeIntervalSince(startedAt))
     }
 
     /// Spelled-out elapsed time for VoiceOver: `1 minute, 4 seconds`.
     static func spokenLabel(startedAt: Date, now: Date) -> String {
-        Duration.seconds(elapsedSeconds(startedAt: startedAt, now: now))
+        spokenLabel(seconds: now.timeIntervalSince(startedAt))
+    }
+
+    /// Compact form of a finished span, shared with the settled-turn fold row.
+    static func label(seconds: TimeInterval) -> String {
+        Duration.seconds(wholeSeconds(seconds))
+            .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .narrow))
+    }
+
+    /// Spelled-out form of a finished span, for VoiceOver.
+    static func spokenLabel(seconds: TimeInterval) -> String {
+        Duration.seconds(wholeSeconds(seconds))
             .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .wide))
     }
 
-    private static func elapsedSeconds(startedAt: Date, now: Date) -> Int {
-        max(0, Int(now.timeIntervalSince(startedAt).rounded(.down)))
+    private static func wholeSeconds(_ seconds: TimeInterval) -> Int {
+        guard seconds.isFinite else { return 0 }
+        return max(0, Int(seconds.rounded(.down)))
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -41,6 +41,13 @@ struct ChatStreamSnapshotRestoreResult: Equatable {
     )
 }
 
+/// Span of a finished run and how it ended; the view model keys it to a turn.
+struct ChatRunEnding: Equatable {
+    let startedAt: Date
+    let endedAt: Date
+    let ending: TranscriptTurnRunOutcome.Ending
+}
+
 @MainActor
 protocol ChatStreamCoordinatorDelegate: AnyObject {
     var streamCoordinatorSessionID: String? { get }
@@ -110,6 +117,9 @@ final class ChatStreamCoordinator {
     /// on session load counts from discovery, since the server does not report
     /// when it started.
     private(set) var activeRunStartedAt: Date?
+    /// The last run's span and how it ended, set by `finishStream` before the
+    /// active stream clears so the delegate can key it to a turn.
+    private(set) var latestRunEnding: ChatRunEnding?
     private(set) var recoveryState: ActiveStreamRecoveryState = .idle
     private(set) var isConnectionSuspended = false
     private(set) var hasCompletedCurrentResponse = false
@@ -234,7 +244,7 @@ final class ChatStreamCoordinator {
         guard response.ok != false else { return response }
 
         liveActivityManager.end(status: .cancelled, activity: String(localized: "Response cancelled"), errorSummary: nil)
-        finishStream()
+        finishStream(ending: .cancelled)
         return response
     }
 
@@ -718,13 +728,13 @@ final class ChatStreamCoordinator {
             finishStream()
         case .cancelled:
             liveActivityManager.end(status: .cancelled, activity: String(localized: "Response cancelled"), errorSummary: nil)
-            finishStream()
+            finishStream(ending: .cancelled)
         case .error(let message):
             if !hasCompletedCurrentResponse {
                 delegate?.streamCoordinatorDidReceiveErrorMessage(message)
             }
             liveActivityManager.end(status: .failed, activity: String(localized: "Response failed"), errorSummary: nil)
-            finishStream()
+            finishStream(ending: .failed)
         case .transportError(let message):
             handleTransportError(message)
         case .heartbeat:
@@ -747,7 +757,7 @@ final class ChatStreamCoordinator {
             if !hasCompletedCurrentResponse {
                 delegate?.streamCoordinatorDidReceiveErrorMessage(message)
             }
-            finishStream()
+            finishStream(ending: hasCompletedCurrentResponse ? .completed : .failed)
             return
         }
 
@@ -902,17 +912,20 @@ final class ChatStreamCoordinator {
             completeResponseFromRefreshedTranscriptAndFinishStream(streamID: streamID)
         } else {
             liveActivityManager.end(status: .failed, activity: String(localized: "Response failed"), errorSummary: nil)
-            finishStream()
+            finishStream(ending: .failed)
         }
     }
 
-    private func finishStream() {
+    private func finishStream(ending: TranscriptTurnRunOutcome.Ending = .completed) {
         guard !isTransportFinished else { return }
         isTransportFinished = true
         runGeneration &+= 1
         invalidateReconnectTask()
         let completedNormally = hasCompletedCurrentResponse
         let finishedStreamID = activeStreamID
+        if let activeRunStartedAt {
+            latestRunEnding = ChatRunEnding(startedAt: activeRunStartedAt, endedAt: Date(), ending: ending)
+        }
         streamClient.stop()
         delegate?.streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: true)
         delegate?.streamCoordinatorFlushPinnedLocalNoticesToTranscript()

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -110,6 +110,9 @@ final class ChatStreamCoordinator {
         didSet {
             guard activeStreamID != oldValue else { return }
             activeRunStartedAt = activeStreamID == nil ? nil : Date()
+            if activeStreamID != nil {
+                latestRunEnding = nil
+            }
         }
     }
     /// When the current stream first became known here. Keyed to stream
@@ -117,8 +120,9 @@ final class ChatStreamCoordinator {
     /// on session load counts from discovery, since the server does not report
     /// when it started.
     private(set) var activeRunStartedAt: Date?
-    /// The last run's span and how it ended, set by `finishStream` before the
-    /// active stream clears so the delegate can key it to a turn.
+    /// The last run's span and how it ended, recorded the moment the run stops
+    /// counting (`done` or teardown) so the delegate can key it to a turn.
+    /// Cleared when the next run starts, so a stale ending never outlives it.
     private(set) var latestRunEnding: ChatRunEnding?
     private(set) var recoveryState: ActiveStreamRecoveryState = .idle
     private(set) var isConnectionSuspended = false
@@ -868,6 +872,7 @@ final class ChatStreamCoordinator {
         liveActivityManager.end(status: .complete, activity: String(localized: "Response complete"), errorSummary: nil)
         delegate?.streamCoordinatorRemoveSnapshot(streamID: activeStreamID)
         delegate?.streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: true)
+        recordRunEndingIfRunning(.completed)
         activeStreamID = nil
         hasInMemorySnapshotForActiveStream = false
         lastEventID = nil
@@ -923,9 +928,7 @@ final class ChatStreamCoordinator {
         invalidateReconnectTask()
         let completedNormally = hasCompletedCurrentResponse
         let finishedStreamID = activeStreamID
-        if let activeRunStartedAt {
-            latestRunEnding = ChatRunEnding(startedAt: activeRunStartedAt, endedAt: Date(), ending: ending)
-        }
+        recordRunEndingIfRunning(ending)
         streamClient.stop()
         delegate?.streamCoordinatorStopAuxiliaryMonitoring(clearPrompt: true)
         delegate?.streamCoordinatorFlushPinnedLocalNoticesToTranscript()
@@ -943,6 +946,14 @@ final class ChatStreamCoordinator {
         if completedNormally {
             delegate?.streamCoordinatorRefreshCompletedResponseTitleIfNeeded()
         }
+    }
+
+    /// Records the run's span once. `completeCurrentResponse` already cleared
+    /// the run start for a normal completion, so a later teardown event (a
+    /// `streamEnd` or `cancelled` after `done`) cannot overwrite that ending.
+    private func recordRunEndingIfRunning(_ ending: TranscriptTurnRunOutcome.Ending) {
+        guard let activeRunStartedAt else { return }
+        latestRunEnding = ChatRunEnding(startedAt: activeRunStartedAt, endedAt: Date(), ending: ending)
     }
 
     private func markConnectionStarted(

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -61,6 +61,10 @@ struct ChatTranscriptView: View {
     let onUpdateScrollMetrics: (ChatScrollMetrics) -> Void
     let onFollowEvent: (ChatScrollPolicy.FollowEvent) -> Void
     let onDisclosureToggle: () -> Void
+    /// Settled-turn folds derived by the owner; `.none` when folding is off.
+    let turnFolds: TranscriptTurnFolds
+    let expandedTurnKeys: Set<String>
+    let onToggleTurnFold: (String) -> Void
     let onDismissKeyboard: () -> Void
     let onScrollToBottom: (ScrollViewProxy) -> Void
     let onScrollToLatestTranscriptMessage: (ScrollViewProxy) -> Void
@@ -234,11 +238,17 @@ struct ChatTranscriptView: View {
                 let isToolCallAnchor = toolCallAnchorMessageID == transcriptMessage.anchorID
                 let isStreamingRow = streamingAssistantMessageID != nil
                     && transcriptMessage.message.messageId == streamingAssistantMessageID
+                let foldState = turnFolds.rowState(
+                    for: transcriptMessage.renderID,
+                    expandedTurnKeys: expandedTurnKeys
+                )
 
                 ChatTranscriptMessageBlock(
                     transcriptMessage: transcriptMessage,
                     transcriptSpacing: transcriptSpacing,
                     showsThinkingAndToolCards: showsThinkingAndToolCards,
+                    foldState: foldState,
+                    onToggleTurnFold: onToggleTurnFold,
                     reasoningGroups: reasoningGroups,
                     toolCallGroups: completedToolCallGroupsForAnchor(transcriptMessage.anchorID),
                     liveReasoningText: isReasoningAnchor ? liveReasoningText : "",
@@ -472,9 +482,15 @@ struct ChatTranscriptView: View {
 }
 
 private struct ChatTranscriptMessageBlock: View, Equatable {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let transcriptMessage: TranscriptMessage
     let transcriptSpacing: CGFloat
     let showsThinkingAndToolCards: Bool
+    /// Nil outside a settled-turn fold. Otherwise says whether this row draws
+    /// the fold row and which of its parts are hidden right now.
+    let foldState: TranscriptTurnFoldRowState?
+    let onToggleTurnFold: (String) -> Void
     let reasoningGroups: [ReasoningGroup]
     let toolCallGroups: [ToolCallGroup]
     let liveReasoningText: String
@@ -516,6 +532,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
         lhs.transcriptMessage == rhs.transcriptMessage &&
             lhs.transcriptSpacing == rhs.transcriptSpacing &&
             lhs.showsThinkingAndToolCards == rhs.showsThinkingAndToolCards &&
+            lhs.foldState == rhs.foldState &&
             lhs.reasoningGroups == rhs.reasoningGroups &&
             lhs.toolCallGroups == rhs.toolCallGroups &&
             lhs.liveReasoningText == rhs.liveReasoningText &&
@@ -536,13 +553,62 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: transcriptSpacing) {
-            reasoningBlocks
-            liveReasoningBlock
-            toolActivityGroups
-            liveToolActivityGroup
+        // Yield nothing when every part is folded away, so the outer stack adds
+        // no spacing for an empty row.
+        if hasVisibleContent {
+            VStack(alignment: .leading, spacing: transcriptSpacing) {
+                if let fold = foldState?.fold {
+                    TranscriptTurnFoldRowView(
+                        fold: fold,
+                        isExpanded: foldState?.isExpanded == true,
+                        onToggle: { onToggleTurnFold(fold.turnKey) }
+                    )
+                }
 
-            if shouldRenderMessageRow(transcriptMessage.message) {
+                if showsActivity {
+                    Group {
+                        reasoningBlocks
+                        liveReasoningBlock
+                        toolActivityGroups
+                        liveToolActivityGroup
+                    }
+                    .transition(foldTransition)
+                }
+
+                if showsBubble {
+                    messageRow
+                        .transition(foldTransition)
+                }
+            }
+        }
+    }
+
+    /// Only folded rows animate in and out; ordinary rows keep no transition
+    /// so streaming appends stay instant.
+    private var foldTransition: AnyTransition {
+        foldState == nil ? .identity : ChatMotion.disclosureTransition(reduceMotion: reduceMotion)
+    }
+
+    private var showsActivity: Bool {
+        foldState?.hidesActivity != true
+    }
+
+    private var showsBubble: Bool {
+        foldState?.hidesBubble != true && shouldRenderMessageRow(transcriptMessage.message)
+    }
+
+    private var rendersActivity: Bool {
+        let hasArchivedActivity = showsThinkingAndToolCards
+            && (!toolCallGroups.isEmpty
+                || reasoningGroups.contains { $0.anchorMessageID == transcriptMessage.anchorID })
+        return hasArchivedActivity || shouldRenderLiveReasoningBlock || shouldRenderLiveToolActivityGroup
+    }
+
+    private var hasVisibleContent: Bool {
+        foldState?.fold != nil || (showsActivity && rendersActivity) || showsBubble
+    }
+
+    private var messageRow: some View {
                 ChatTranscriptMessageRow(
                     message: transcriptMessage.message,
                     visibleIndex: transcriptMessage.loadedIndex,
@@ -575,8 +641,6 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                     onFork: onFork,
                     onCopy: onCopy
                 )
-            }
-        }
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -270,6 +270,7 @@ struct ChatView: View {
     @AppStorage(ResponseCompletionNotifications.isEnabledKey) private var isResponseCompletionNotificationsEnabled = false
     @AppStorage(AgentRunLiveActivityPrivacy.showsResponseExcerptsKey) private var showsLiveActivityResponseExcerpts = false
     @AppStorage(ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey) private var showsThinkingAndToolCards = true
+    @AppStorage(ChatTranscriptDisplaySettings.foldsSettledTurnsKey) private var foldsSettledTurns = true
     @AppStorage(ChatTranscriptDisplaySettings.rtlChatLayoutEnabledKey) private var rtlChatLayoutEnabled = ChatTranscriptDisplaySettings.rtlChatLayoutDefaultEnabled
     @AppStorage(SectionVisibilitySettings.chatFilesKey) private var showsFilesButton = true
     @AppStorage(SectionVisibilitySettings.chatGitKey) private var showsGitControls = true
@@ -301,6 +302,9 @@ struct ChatView: View {
     /// scrolls are suspended so a disclosure toggle grows or shrinks in place.
     @State private var isDisclosureSettling = false
     @State private var disclosureSettleGeneration = 0
+    /// Settled turns the user has opened, plus failed or stopped turns, which
+    /// start open. Keyed by turn so paging older messages in does not shift them.
+    @State private var expandedTurnKeys: Set<String> = []
     /// While set and in the future, auto-follow scrolls snap instead of animating, so
     /// the cache-first → network reconcile re-pins to the bottom without a jump (#289).
     @State private var cacheFirstSnapUntil: Date?
@@ -1153,13 +1157,14 @@ struct ChatView: View {
 
     @ViewBuilder
     private var messageContent: some View {
+        let reasoningGroups = viewModel.displayedReasoningGroups
         ChatTranscriptView(
             isLoading: viewModel.isLoading,
             errorMessage: viewModel.errorMessage,
             messages: viewModel.messages,
             displayedTranscriptMessages: displayedTranscriptMessages,
             compressionReferenceCard: viewModel.compressionReferenceCard,
-            reasoningGroups: viewModel.displayedReasoningGroups,
+            reasoningGroups: reasoningGroups,
             completedToolCallGroupsForAnchor: { anchorMessageID in
                 viewModel.completedToolCallGroupsForAnchor(anchorMessageID)
             },
@@ -1222,6 +1227,9 @@ struct ChatView: View {
             onUpdateScrollMetrics: updateScrollMetrics,
             onFollowEvent: handleFollowEvent,
             onDisclosureToggle: handleDisclosureToggle,
+            turnFolds: turnFolds(reasoningGroups: reasoningGroups),
+            expandedTurnKeys: expandedTurnKeys,
+            onToggleTurnFold: toggleTurnFold,
             onDismissKeyboard: dismissKeyboard,
             onScrollToBottom: scrollToBottom,
             onScrollToLatestTranscriptMessage: { proxy in
@@ -1273,6 +1281,10 @@ struct ChatView: View {
                 turnDiffPresentation = .file(file)
             }
         )
+        // Off the main body chain, which is at the type-checker's limit.
+        .onChange(of: viewModel.latestRunOutcome) {
+            handleLatestRunOutcomeChange(viewModel.latestRunOutcome)
+        }
     }
 
     /// The chat-canvas layout direction. Driven by the manual Settings → Chat
@@ -1397,6 +1409,44 @@ struct ChatView: View {
 
     private var displayedTranscriptMessages: [TranscriptMessage] {
         transcriptMessages
+    }
+
+    /// Settled-turn folds for the current transcript. Activity anchors count
+    /// only while thinking and tool cards are shown, so a turn with nothing
+    /// visible to hide gets no row.
+    private func turnFolds(reasoningGroups: [ReasoningGroup]) -> TranscriptTurnFolds {
+        guard foldsSettledTurns else { return .none }
+
+        let activityAnchorIDs: Set<String> = showsThinkingAndToolCards
+            ? Set(reasoningGroups.compactMap(\.anchorMessageID))
+                .union(viewModel.completedToolCallGroups.compactMap(\.anchorMessageID))
+            : []
+
+        return TranscriptTurnFolds.derive(
+            transcriptMessages: transcriptMessages,
+            messages: viewModel.messages,
+            messageOffset: viewModel.messagesOffset,
+            activityAnchorIDs: activityAnchorIDs,
+            rendersBubble: shouldRenderMessageRow,
+            isStreamActive: viewModel.activeStreamID != nil,
+            streamingAssistantMessageID: viewModel.streamingAssistantMessageID,
+            latestRunOutcome: viewModel.latestRunOutcome
+        )
+    }
+
+    private func toggleTurnFold(_ turnKey: String) {
+        handleDisclosureToggle()
+        withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
+            if !expandedTurnKeys.insert(turnKey).inserted {
+                expandedTurnKeys.remove(turnKey)
+            }
+        }
+    }
+
+    /// Failed or stopped turns start open so the work that went wrong is in view.
+    private func handleLatestRunOutcomeChange(_ outcome: TranscriptTurnRunOutcome?) {
+        guard let outcome, outcome.ending != .completed else { return }
+        expandedTurnKeys.insert(outcome.turnKey)
     }
 
     private var latestTranscriptMessageID: String? {
@@ -2276,6 +2326,12 @@ struct ChatView: View {
             // so it also detects a repo the agent just created (git init/clone) mid-turn.
             Task { await gitAvailabilityViewModel.refreshAfterExternalMutation() }
             return
+        }
+
+        // A new turn starting folds the previous one, even one that opened
+        // itself after failing or being stopped.
+        if let previousTurnKey = viewModel.latestRunOutcome?.turnKey {
+            expandedTurnKeys.remove(previousTurnKey)
         }
 
         startActiveStreamStatusRefreshTask(streamID: activeStreamID)

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -221,6 +221,9 @@ final class ChatViewModel {
     private(set) var isViewingCachedData = false
     var activeStreamID: String? { streamCoordinator.activeStreamID }
     var activeRunStartedAt: Date? { streamCoordinator.activeRunStartedAt }
+    /// How the latest run ended, keyed to the turn it answered. Drives the
+    /// settled-turn fold label and which turns start expanded.
+    private(set) var latestRunOutcome: TranscriptTurnRunOutcome?
     var activeStreamRecoveryState: ActiveStreamRecoveryState { streamCoordinator.recoveryState }
     var liveTokensPerSecond: Double? { streamCoordinator.liveTokensPerSecond }
     private(set) var errorMessage: String?
@@ -5308,6 +5311,14 @@ extension ChatViewModel: ChatStreamCoordinatorDelegate {
         flushPendingStreamingContent()
         dismissSteeringConfirmation()
         responseCompletionNeedsTranscriptRefresh = false
+        if let ending = streamCoordinator.latestRunEnding {
+            latestRunOutcome = TranscriptTurnRunOutcome(
+                turnKey: TranscriptTurnClassifier.latestTurnKey(in: messages, messageOffset: messagesOffset),
+                startedAt: ending.startedAt,
+                endedAt: ending.endedAt,
+                ending: ending.ending
+            )
+        }
     }
 
     func streamCoordinatorDidReceiveErrorMessage(_ message: String) {

--- a/HermesMobile/Features/Chat/TranscriptTurnFolding.swift
+++ b/HermesMobile/Features/Chat/TranscriptTurnFolding.swift
@@ -1,0 +1,272 @@
+import SwiftUI
+
+/// How the most recent response run ended, keyed to the turn it answered. The
+/// view model records one when a stream finishes so the settled turn's fold
+/// row can read "You stopped after 8s" and failed or stopped turns start open.
+struct TranscriptTurnRunOutcome: Equatable {
+    enum Ending: Equatable {
+        case completed
+        case cancelled
+        case failed
+    }
+
+    let turnKey: String
+    let startedAt: Date
+    let endedAt: Date
+    let ending: Ending
+
+    var elapsed: TimeInterval {
+        max(0, endedAt.timeIntervalSince(startedAt))
+    }
+}
+
+/// One settled turn collapsed behind a single row.
+struct TranscriptTurnFold: Equatable, Identifiable {
+    enum Label: Equatable {
+        case worked(elapsed: String?)
+        case stopped(elapsed: String?)
+
+        var title: String {
+            switch self {
+            case .worked(let elapsed?):
+                String(localized: "Worked for \(elapsed)")
+            case .worked(nil):
+                String(localized: "Worked")
+            case .stopped(let elapsed?):
+                String(localized: "You stopped after \(elapsed)")
+            case .stopped(nil):
+                String(localized: "You stopped this response")
+            }
+        }
+    }
+
+    let turnKey: String
+    /// Transcript row that draws the fold row above its content: the first row
+    /// of the turn with something to hide.
+    let hostRenderID: String
+    let label: Label
+
+    var id: String { turnKey }
+}
+
+/// What one transcript row does about folding, resolved against the set of
+/// turns the user has expanded.
+struct TranscriptTurnFoldRowState: Equatable {
+    /// Non-nil on the host row, which draws the fold row.
+    let fold: TranscriptTurnFold?
+    let isExpanded: Bool
+    let hidesBubble: Bool
+    let hidesActivity: Bool
+}
+
+/// Folding of settled turns: a pure presentation layer over the displayed
+/// transcript. A turn keeps its first and last text reply visible; every other
+/// entry (reasoning, tool rows, interim replies) hides behind one row labelled
+/// with the elapsed time. The turn a stream is answering, and any turn holding
+/// the streaming message, never folds. Cache, message actions, and stream
+/// recovery see none of this.
+struct TranscriptTurnFolds: Equatable {
+    private struct Membership: Equatable {
+        let foldIndex: Int
+        let isHost: Bool
+        let foldsBubble: Bool
+        let foldsActivity: Bool
+    }
+
+    private(set) var folds: [TranscriptTurnFold] = []
+    private var membershipByRenderID: [String: Membership] = [:]
+
+    static let none = TranscriptTurnFolds()
+
+    /// - Parameters:
+    ///   - activityAnchorIDs: anchors whose reasoning or tool groups are rendered.
+    ///     Pass an empty set when thinking and tool cards are hidden, so a turn
+    ///     with nothing visible to hide gets no row.
+    ///   - rendersBubble: whether a transcript message draws a bubble at all;
+    ///     activity-only assistant shells do not.
+    static func derive(
+        transcriptMessages: [TranscriptMessage],
+        messages: [ChatMessage],
+        messageOffset: Int?,
+        activityAnchorIDs: Set<String>,
+        rendersBubble: (ChatMessage) -> Bool,
+        isStreamActive: Bool,
+        streamingAssistantMessageID: String?,
+        latestRunOutcome: TranscriptTurnRunOutcome?
+    ) -> TranscriptTurnFolds {
+        let offset = max(0, messageOffset ?? 0)
+        let turnKeyByAnchorID = TranscriptTurnClassifier.assistantTurnKeysByAnchorID(
+            messages,
+            messageOffset: messageOffset
+        )
+
+        var startTimestampByTurnKey: [String: Double] = [:]
+        for (index, message) in messages.enumerated()
+        where TranscriptTurnClassifier.isUserTurnBoundary(message) {
+            startTimestampByTurnKey[TranscriptTurnClassifier.userTurnKey(absoluteIndex: offset + index)] = message.timestamp
+        }
+
+        let unsettledTurnKey = isStreamActive
+            ? TranscriptTurnClassifier.latestTurnKey(in: messages, messageOffset: messageOffset)
+            : nil
+        let streamingTurnKey = streamingAssistantMessageID.flatMap { turnKeyByAnchorID[$0] }
+
+        struct Row {
+            let renderID: String
+            let message: ChatMessage
+            let hasActivity: Bool
+            let hasBubble: Bool
+        }
+
+        var turnKeys: [String] = []
+        var rowsByTurnKey: [String: [Row]] = [:]
+        for transcriptMessage in transcriptMessages where transcriptMessage.message.role == "assistant" {
+            guard let turnKey = turnKeyByAnchorID[transcriptMessage.anchorID] else { continue }
+            if rowsByTurnKey[turnKey] == nil {
+                turnKeys.append(turnKey)
+                rowsByTurnKey[turnKey] = []
+            }
+            rowsByTurnKey[turnKey]?.append(Row(
+                renderID: transcriptMessage.renderID,
+                message: transcriptMessage.message,
+                hasActivity: activityAnchorIDs.contains(transcriptMessage.anchorID),
+                hasBubble: rendersBubble(transcriptMessage.message)
+            ))
+        }
+
+        var result = TranscriptTurnFolds()
+        for turnKey in turnKeys {
+            guard turnKey != unsettledTurnKey, turnKey != streamingTurnKey,
+                  let rows = rowsByTurnKey[turnKey]
+            else { continue }
+
+            let bubbleRows = rows.filter(\.hasBubble)
+            let firstBubbleID = bubbleRows.first?.renderID
+            let lastBubbleID = bubbleRows.last?.renderID
+
+            var memberships: [(renderID: String, foldsBubble: Bool, foldsActivity: Bool)] = []
+            for row in rows {
+                let foldsBubble = row.hasBubble
+                    && row.renderID != firstBubbleID
+                    && row.renderID != lastBubbleID
+                memberships.append((row.renderID, foldsBubble, row.hasActivity))
+            }
+
+            guard let host = memberships.first(where: { $0.foldsBubble || $0.foldsActivity }) else {
+                continue
+            }
+
+            let outcome = latestRunOutcome?.turnKey == turnKey ? latestRunOutcome : nil
+            let elapsed = elapsedSeconds(
+                rows: rows.map(\.message),
+                startTimestamp: startTimestampByTurnKey[turnKey],
+                outcome: outcome
+            )
+            let elapsedLabel = elapsed.map(ChatWorkingElapsedFormatter.label(seconds:))
+            let label: TranscriptTurnFold.Label = outcome?.ending == .cancelled
+                ? .stopped(elapsed: elapsedLabel)
+                : .worked(elapsed: elapsedLabel)
+
+            let foldIndex = result.folds.count
+            result.folds.append(TranscriptTurnFold(
+                turnKey: turnKey,
+                hostRenderID: host.renderID,
+                label: label
+            ))
+            for membership in memberships {
+                result.membershipByRenderID[membership.renderID] = Membership(
+                    foldIndex: foldIndex,
+                    isHost: membership.renderID == host.renderID,
+                    foldsBubble: membership.foldsBubble,
+                    foldsActivity: membership.foldsActivity
+                )
+            }
+        }
+
+        return result
+    }
+
+    /// Nil for rows outside any fold.
+    func rowState(for renderID: String, expandedTurnKeys: Set<String>) -> TranscriptTurnFoldRowState? {
+        guard let membership = membershipByRenderID[renderID] else { return nil }
+
+        let fold = folds[membership.foldIndex]
+        let isExpanded = expandedTurnKeys.contains(fold.turnKey)
+        return TranscriptTurnFoldRowState(
+            fold: membership.isHost ? fold : nil,
+            isExpanded: isExpanded,
+            hidesBubble: membership.foldsBubble && !isExpanded,
+            hidesActivity: membership.foldsActivity && !isExpanded
+        )
+    }
+
+    /// Server-measured `_turnDuration` first; the client-measured run for the
+    /// turn that just finished next; the gap from the user message to the
+    /// turn's last message last. Nil when none of those exist.
+    private static func elapsedSeconds(
+        rows: [ChatMessage],
+        startTimestamp: Double?,
+        outcome: TranscriptTurnRunOutcome?
+    ) -> TimeInterval? {
+        if let duration = rows.reversed().lazy.compactMap(\.turnDuration).first, duration >= 0 {
+            return duration
+        }
+
+        if let outcome {
+            return outcome.elapsed
+        }
+
+        guard let startTimestamp,
+              let endTimestamp = rows.compactMap(\.timestamp).max(),
+              endTimestamp >= startTimestamp
+        else {
+            return nil
+        }
+
+        return endTimestamp - startTimestamp
+    }
+}
+
+/// The 44 pt row a settled turn folds behind: elapsed label in monospaced
+/// digits, a chevron, and a bottom hairline. Tapping toggles the turn through
+/// the transcript's disclosure handler so the row stays put while it animates.
+struct TranscriptTurnFoldRowView: View {
+    let fold: TranscriptTurnFold
+    let isExpanded: Bool
+    let onToggle: () -> Void
+
+    static let minimumHeight: CGFloat = 44
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 8) {
+                Text(fold.label.title)
+                    .font(AppFont.subheadline(weight: .medium).monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .frame(minHeight: Self.minimumHeight)
+            .contentShape(Rectangle())
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(Color(.separator).opacity(0.5))
+                    .frame(height: 0.5)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(fold.label.title)
+        .accessibilityValue(isExpanded ? String(localized: "Expanded") : String(localized: "Collapsed"))
+        .accessibilityHint(
+            isExpanded
+                ? String(localized: "Double tap to hide this turn's work.")
+                : String(localized: "Double tap to show this turn's work.")
+        )
+    }
+}

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -74,6 +74,7 @@ struct SettingsView: View {
     @AppStorage(ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey) private var showsThinkingAndToolCards = true
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var thinkingCardsStartExpanded = false
     @AppStorage(ChatTranscriptDisplaySettings.toolCardsStartExpandedKey) private var toolCardsStartExpanded = false
+    @AppStorage(ChatTranscriptDisplaySettings.foldsSettledTurnsKey) private var foldsSettledTurns = true
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsAssistantTurnTimestamps = false
     @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
@@ -234,6 +235,16 @@ struct SettingsView: View {
                     )
 
                     SettingsFootnote(String(localized: "Thinking and Tool cards start expanded instead of collapsed. Tapping a card still toggles it."))
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        title: String(localized: "Fold Finished Turns"),
+                        systemImage: "rectangle.compress.vertical",
+                        isOn: $foldsSettledTurns
+                    )
+
+                    SettingsFootnote(String(localized: "Collapses a finished turn's thinking, tool calls, and interim replies behind one row that shows how long it took. Tap the row to expand it."))
 
                     SettingsDivider()
 

--- a/HermesMobile/Models/ChatMessage.swift
+++ b/HermesMobile/Models/ChatMessage.swift
@@ -17,6 +17,9 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
     let reasoning: String?
     let attachments: [MessageAttachment]?
     let turnTps: Double?
+    /// Server-measured wall-clock seconds for the whole turn, set on its final
+    /// assistant message (`_turnDuration`). Absent on older transcripts.
+    let turnDuration: Double?
 
     init(
         role: String?,
@@ -30,7 +33,8 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         contentParts: [JSONValue]? = nil,
         reasoning: String? = nil,
         attachments: [MessageAttachment]? = nil,
-        turnTps: Double? = nil
+        turnTps: Double? = nil,
+        turnDuration: Double? = nil
     ) {
         self.role = role
         self.content = content
@@ -44,6 +48,7 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         self.reasoning = reasoning
         self.attachments = attachments
         self.turnTps = turnTps
+        self.turnDuration = turnDuration
     }
 
     enum CodingKeys: String, CodingKey {
@@ -58,6 +63,7 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         case reasoning
         case attachments
         case turnTps = "_turnTps"
+        case turnDuration = "_turnDuration"
         case underscoredTimestamp = "_ts"
     }
 
@@ -78,6 +84,7 @@ struct ChatMessage: Decodable, Equatable, Identifiable {
         let decodedAttachments = Self.decodeAttachmentsTolerantly(from: container)
         attachments = Self.attachments(decodedAttachments, enrichedByMarkerIn: content)
         turnTps = container.decodeLossyDoubleIfPresent(forKey: .turnTps)
+        turnDuration = container.decodeLossyDoubleIfPresent(forKey: .turnDuration)
     }
 
     private static func attachments(
@@ -218,13 +225,29 @@ enum TranscriptTurnClassifier {
         message.role == "user" && !hasVisibleUserContent(message)
     }
 
+    /// Turn key for messages before the first user boundary of the loaded page.
+    static let initialTurnKey = "turn:start"
+
+    /// Key shared by every assistant message answering the user message at
+    /// `absoluteIndex` (loaded index plus page offset), so turn-scoped state
+    /// survives paging older messages in.
+    static func userTurnKey(absoluteIndex: Int) -> String {
+        "turn:user:\(absoluteIndex)"
+    }
+
+    /// Key of the latest turn: the last user boundary's, or `initialTurnKey`.
+    static func latestTurnKey(in messages: [ChatMessage], messageOffset: Int? = nil) -> String {
+        guard let index = messages.lastIndex(where: isUserTurnBoundary) else { return initialTurnKey }
+        return userTurnKey(absoluteIndex: max(0, messageOffset ?? 0) + index)
+    }
+
     static func assistantTurnKeysByAnchorID(_ messages: [ChatMessage], messageOffset: Int? = nil) -> [String: String] {
         var keysByMessageID: [String: String] = [:]
-        var currentTurnKey = "turn:start"
+        var currentTurnKey = initialTurnKey
 
         for (messageIndex, message) in messages.enumerated() {
             if isUserTurnBoundary(message) {
-                currentTurnKey = "turn:user:\(max(0, messageOffset ?? 0) + messageIndex)"
+                currentTurnKey = userTurnKey(absoluteIndex: max(0, messageOffset ?? 0) + messageIndex)
             }
 
             if message.role == "assistant" {

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -358,7 +358,8 @@ private extension ChatMessage {
             contentParts: contentParts,
             reasoning: cachedMessage.reasoning,
             attachments: attachments,
-            turnTps: cachedMessage.turnTps
+            turnTps: cachedMessage.turnTps,
+            turnDuration: cachedMessage.turnDuration
         )
     }
 }

--- a/HermesMobile/Persistence/CachedMessage.swift
+++ b/HermesMobile/Persistence/CachedMessage.swift
@@ -19,6 +19,7 @@ final class CachedMessage {
     var reasoning: String?
     var attachmentsData: Data?
     var turnTps: Double?
+    var turnDuration: Double?
     var cachedAt: Date
     var expiresAt: Date
 
@@ -74,6 +75,7 @@ final class CachedMessage {
         }
         reasoning = message.reasoning
         turnTps = message.turnTps
+        turnDuration = message.turnDuration
         if let attachments = message.attachments, !attachments.isEmpty {
             attachmentsData = try? JSONEncoder().encode(attachments)
         } else {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -116162,6 +116162,1066 @@
           }
         }
       }
+    },
+    "Collapsed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مطويّ"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eingeklappt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Plegado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Replié"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מכווץ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compresso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "折りたたみ済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "접힘"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ingevouwen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zwinięte"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recolhido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Свёрнуто"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kapalı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سمٹا ہوا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已摺疊"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已折叠"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已摺疊"
+          }
+        }
+      }
+    },
+    "Collapses a finished turn's thinking, tool calls, and interim replies behind one row that shows how long it took. Tap the row to expand it." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يطوي تفكير الدور المنتهي واستدعاءات الأدوات والردود المؤقتة خلف صف واحد يعرض المدة المستغرقة. اضغط على الصف لتوسيعه."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Blendet Denken, Tool-Aufrufe und Zwischenantworten einer abgeschlossenen Runde hinter einer Zeile aus, die die benötigte Zeit zeigt. Tippe auf die Zeile, um sie auszuklappen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oculta el razonamiento, las llamadas a herramientas y las respuestas intermedias de un turno terminado tras una fila que muestra cuánto tardó. Toca la fila para desplegarla."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Masque la réflexion, les appels d'outils et les réponses intermédiaires d'un tour terminé derrière une ligne indiquant sa durée. Touchez la ligne pour la déplier."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מסתיר את החשיבה, קריאות הכלים והתשובות הביניים של סבב שהסתיים מאחורי שורה אחת שמציגה כמה זמן זה לקח. הקישו על השורה כדי להרחיב."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nasconde ragionamento, chiamate agli strumenti e risposte intermedie di un turno concluso dietro una riga che mostra quanto tempo ha richiesto. Tocca la riga per espanderla."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "完了したターンの思考、ツール呼び出し、途中の返答を、所要時間を示す1行の後ろに折りたたみます。行をタップすると展開します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "완료된 턴의 사고, 도구 호출, 중간 답변을 소요 시간을 표시하는 한 줄 뒤로 접습니다. 줄을 탭하면 펼쳐집니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verbergt het denken, de toolaanroepen en tussentijdse antwoorden van een voltooide beurt achter één rij die de duur toont. Tik op de rij om uit te vouwen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zwija myślenie, wywołania narzędzi i odpowiedzi pośrednie zakończonej tury za jednym wierszem pokazującym, ile to trwało. Stuknij wiersz, aby rozwinąć."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recolhe o raciocínio, as chamadas de ferramentas e as respostas intermediárias de um turno concluído atrás de uma linha que mostra quanto tempo levou. Toque na linha para expandir."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сворачивает размышления, вызовы инструментов и промежуточные ответы завершённого хода в одну строку с затраченным временем. Коснитесь строки, чтобы развернуть."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Biten bir turun düşünme, araç çağrıları ve ara yanıtlarını ne kadar sürdüğünü gösteren tek bir satırın arkasına katlar. Açmak için satıra dokunun."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مکمل شدہ باری کی سوچ، ٹول کالز اور عبوری جوابات کو ایک قطار کے پیچھے سمیٹ دیتا ہے جو بتاتی ہے کہ کتنا وقت لگا۔ کھولنے کے لیے قطار پر ٹیپ کریں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "將已完成回合的思考、工具呼叫和中途回覆摺疊到一行之後，並顯示所花時間。點一下該行即可展開。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "将已完成回合的思考、工具调用和中间回复折叠到一行之后，并显示所用时间。轻点该行即可展开。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "將已完成回合的思考、工具呼叫和中途回覆摺疊到一行之後，並顯示所花時間。點一下該行即可展開。"
+          }
+        }
+      }
+    },
+    "Double tap to hide this turn's work." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اضغط مرتين لإخفاء عمل هذا الدور."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Doppeltippen, um die Arbeit dieser Runde auszublenden."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toca dos veces para ocultar el trabajo de este turno."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Touchez deux fois pour masquer le travail de ce tour."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הקישו פעמיים כדי להסתיר את העבודה של סבב זה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tocca due volte per nascondere il lavoro di questo turno."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ダブルタップでこのターンの作業を隠します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "두 번 탭하여 이 턴의 작업을 숨깁니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dubbeltik om het werk van deze beurt te verbergen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Stuknij dwukrotnie, aby ukryć pracę tej tury."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque duas vezes para ocultar o trabalho deste turno."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Дважды коснитесь, чтобы скрыть работу этого хода."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu turun çalışmasını gizlemek için iki kez dokunun."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اس باری کا کام چھپانے کے لیے دو بار ٹیپ کریں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下以隱藏此回合的工作。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "轻点两下以隐藏此回合的工作。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下以隱藏此回合的工作。"
+          }
+        }
+      }
+    },
+    "Double tap to show this turn's work." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اضغط مرتين لعرض عمل هذا الدور."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Doppeltippen, um die Arbeit dieser Runde anzuzeigen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toca dos veces para mostrar el trabajo de este turno."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Touchez deux fois pour afficher le travail de ce tour."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הקישו פעמיים כדי להציג את העבודה של סבב זה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tocca due volte per mostrare il lavoro di questo turno."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ダブルタップでこのターンの作業を表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "두 번 탭하여 이 턴의 작업을 표시합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dubbeltik om het werk van deze beurt te tonen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Stuknij dwukrotnie, aby pokazać pracę tej tury."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque duas vezes para mostrar o trabalho deste turno."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Дважды коснитесь, чтобы показать работу этого хода."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu turun çalışmasını göstermek için iki kez dokunun."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اس باری کا کام دکھانے کے لیے دو بار ٹیپ کریں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下以顯示此回合的工作。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "轻点两下以显示此回合的工作。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下以顯示此回合的工作。"
+          }
+        }
+      }
+    },
+    "Expanded" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "موسّع"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ausgeklappt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desplegado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Déplié"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מורחב"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Espanso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "展開済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "펼침"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitgevouwen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rozwinięte"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Expandido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Развёрнуто"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Açık"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کھلا ہوا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已展開"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已展开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已展開"
+          }
+        }
+      }
+    },
+    "Fold Finished Turns" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "طيّ الأدوار المنتهية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abgeschlossene Runden einklappen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Plegar turnos terminados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Replier les tours terminés"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "קיפול סבבים שהסתיימו"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Comprimi i turni conclusi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "完了したターンを折りたたむ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "완료된 턴 접기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Voltooide beurten invouwen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zwijaj zakończone tury"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recolher turnos concluídos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сворачивать завершённые ходы"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Biten turları katla"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مکمل شدہ باریاں سمیٹیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "摺疊已完成的回合"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "折叠已完成的回合"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "摺疊已完成的回合"
+          }
+        }
+      }
+    },
+    "Worked" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "عمل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gearbeitet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabajó"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A travaillé"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "עבד"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ha lavorato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "作業しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "작업함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gewerkt"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pracował"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabalhou"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Работал"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalıştı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کام کیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作"
+          }
+        }
+      }
+    },
+    "Worked for %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "عمل لمدة %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ gearbeitet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabajó durante %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A travaillé pendant %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "עבד במשך %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ha lavorato per %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ 作業しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ 동안 작업함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ gewerkt"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pracował przez %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabalhou por %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Работал %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ çalıştı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ تک کام کیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作 %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已工作 %@"
+          }
+        }
+      }
+    },
+    "You stopped after %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "أوقفت بعد %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nach %@ gestoppt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detuviste tras %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arrêté après %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "עצרת אחרי %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hai interrotto dopo %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ 後に停止しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ 후 중지함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gestopt na %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zatrzymano po %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você interrompeu após %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Остановлено через %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ sonra durdurdunuz"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آپ نے %@ بعد روک دیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "你在 %@ 後停止"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "你在 %@ 后停止"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "你在 %@ 後停止"
+          }
+        }
+      }
+    },
+    "You stopped this response" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "أوقفت هذا الرد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Du hast diese Antwort gestoppt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detuviste esta respuesta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vous avez arrêté cette réponse"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "עצרת את התשובה הזו"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hai interrotto questa risposta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "この応答を停止しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 응답을 중지했습니다"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Je hebt dit antwoord gestopt"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zatrzymano tę odpowiedź"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você interrompeu esta resposta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Вы остановили этот ответ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu yanıtı durdurdunuz"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آپ نے یہ جواب روک دیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "你已停止此回覆"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "你已停止此回复"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "你已停止此回覆"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -1382,6 +1382,38 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testRunEndingRecordsEachRunAndNeverLeaksAStopIntoTheNextCompletion() async throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(
+            streamClient: streamClient,
+            liveActivityManager: liveActivityManager,
+            delegate: delegate
+        ) { request in
+            apiTestJSONResponse(#"{"ok": true}"#, for: request)
+        }
+
+        coordinator.start(streamID: "stream-cancel")
+        _ = try await coordinator.cancelActiveStream()
+        XCTAssertEqual(coordinator.latestRunEnding?.ending, .cancelled)
+
+        // A normal completion clears the run start on `done`, before the
+        // trailing `streamEnd` teardown; the ending must still be recorded as
+        // completed rather than inheriting the previous stop.
+        coordinator.start(streamID: "stream-complete")
+        XCTAssertNil(coordinator.latestRunEnding, "A new run clears the previous ending")
+        streamClient.emit(.done(DoneStreamEvent()))
+        XCTAssertEqual(coordinator.latestRunEnding?.ending, .completed)
+        streamClient.emit(.streamEnd)
+        XCTAssertEqual(coordinator.latestRunEnding?.ending, .completed)
+
+        coordinator.start(streamID: "stream-error")
+        streamClient.emit(.error("server failed"))
+        XCTAssertEqual(coordinator.latestRunEnding?.ending, .failed)
+    }
+
+    @MainActor
     func testLiveResponseSpeedAcceptsOnlyCurrentSessionExactReadingsAndClearsOnLifecycleChanges() {
         let streamClient = CoordinatorSpySSEStreamingClient()
         let delegate = CoordinatorDelegateSpy()

--- a/HermesMobileTests/TranscriptTurnFoldingTests.swift
+++ b/HermesMobileTests/TranscriptTurnFoldingTests.swift
@@ -1,0 +1,284 @@
+import XCTest
+@testable import HermesMobile
+
+final class TranscriptTurnFoldingTests: XCTestCase {
+    private let firstTurnKey = TranscriptTurnClassifier.userTurnKey(absoluteIndex: 0)
+
+    // MARK: - Settled vs active
+
+    func testSettledTurnFoldsActivityBehindTheFinalReply() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Done.", timestamp: 172.7, turnDuration: 72.3)
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"])
+
+        XCTAssertEqual(folds.folds.count, 1)
+        let fold = folds.folds[0]
+        XCTAssertEqual(fold.turnKey, firstTurnKey)
+        XCTAssertEqual(fold.hostRenderID, "transcript:1")
+        XCTAssertEqual(fold.label, .worked(elapsed: "1m 12s"))
+        XCTAssertEqual(fold.label.title, "Worked for 1m 12s")
+
+        XCTAssertNil(folds.rowState(for: "transcript:0", expandedTurnKeys: []))
+
+        let hostState = folds.rowState(for: "transcript:1", expandedTurnKeys: [])
+        XCTAssertEqual(hostState?.fold, fold)
+        XCTAssertEqual(hostState?.hidesActivity, true)
+        XCTAssertEqual(hostState?.hidesBubble, false)
+        XCTAssertEqual(hostState?.isExpanded, false)
+
+        let replyState = folds.rowState(for: "transcript:2", expandedTurnKeys: [])
+        XCTAssertNil(replyState?.fold)
+        XCTAssertEqual(replyState?.hidesBubble, false)
+        XCTAssertEqual(replyState?.hidesActivity, false)
+    }
+
+    func testActiveTurnNeverFoldsWhileEarlierTurnsDo() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Done.", timestamp: 160),
+            user("u2", timestamp: 200),
+            assistantWithTools("a3", timestamp: 205),
+            assistant("a4", text: "Working on it.", timestamp: 210)
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: ["a1", "a3"], isStreamActive: true)
+
+        XCTAssertEqual(folds.folds.map(\.turnKey), [firstTurnKey])
+        XCTAssertNil(folds.rowState(for: "transcript:4", expandedTurnKeys: []))
+    }
+
+    func testTurnHoldingTheStreamingMessageNeverFolds() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Partial", timestamp: 110)
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"], streamingAssistantMessageID: "a2")
+
+        XCTAssertTrue(folds.folds.isEmpty)
+    }
+
+    // MARK: - Interruption and expansion
+
+    func testStoppedTurnReadsYouStoppedAndOpensWhenExpanded() {
+        let messages = [
+            user("u1", timestamp: nil),
+            assistantWithTools("a1", timestamp: nil),
+            assistant("a2", text: "I was about to", timestamp: nil)
+        ]
+        let outcome = TranscriptTurnRunOutcome(
+            turnKey: firstTurnKey,
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: 8.4),
+            ending: .cancelled
+        )
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"], outcome: outcome)
+
+        XCTAssertEqual(folds.folds.first?.label, .stopped(elapsed: "8s"))
+        XCTAssertEqual(folds.folds.first?.label.title, "You stopped after 8s")
+
+        let expanded = folds.rowState(for: "transcript:1", expandedTurnKeys: [firstTurnKey])
+        XCTAssertEqual(expanded?.isExpanded, true)
+        XCTAssertEqual(expanded?.hidesActivity, false)
+        XCTAssertNotNil(expanded?.fold, "The host row keeps its fold row while expanded")
+    }
+
+    func testOutcomeForAnotherTurnDoesNotRelabelThisOne() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Done.", timestamp: 130)
+        ]
+        let outcome = TranscriptTurnRunOutcome(
+            turnKey: TranscriptTurnClassifier.userTurnKey(absoluteIndex: 9),
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: 3),
+            ending: .cancelled
+        )
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"], outcome: outcome)
+
+        XCTAssertEqual(folds.folds.first?.label, .worked(elapsed: "30s"))
+    }
+
+    // MARK: - Elapsed sources
+
+    func testMissingTimestampsFallBackToPlainWorked() {
+        let messages = [
+            user("u1", timestamp: nil),
+            assistantWithTools("a1", timestamp: nil),
+            assistant("a2", text: "Done.", timestamp: nil)
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"])
+
+        XCTAssertEqual(folds.folds.first?.label, .worked(elapsed: nil))
+        XCTAssertEqual(folds.folds.first?.label.title, "Worked")
+    }
+
+    func testElapsedFallsBackToTheGapFromTheUserMessage() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Done.", timestamp: 160)
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"])
+
+        XCTAssertEqual(folds.folds.first?.label, .worked(elapsed: "1m"))
+    }
+
+    func testServerTurnDurationWinsOverTheClientMeasuredRun() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Done.", timestamp: 160, turnDuration: 45)
+        ]
+        let outcome = TranscriptTurnRunOutcome(
+            turnKey: firstTurnKey,
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: 20),
+            ending: .completed
+        )
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"], outcome: outcome)
+
+        XCTAssertEqual(folds.folds.first?.label, .worked(elapsed: "45s"))
+    }
+
+    func testTurnDurationDecodesFromUnderscoredKey() throws {
+        let json = #"{"role":"assistant","content":"Done.","timestamp":172.7,"_turnDuration":72.863}"#
+        let message = try JSONDecoder().decode(ChatMessage.self, from: Data(json.utf8))
+
+        XCTAssertEqual(message.turnDuration, 72.863)
+    }
+
+    // MARK: - Shape of the turn
+
+    func testSingleReplyWithNothingToHideGetsNoFold() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistant("a1", text: "Done.", timestamp: 110)
+        ]
+
+        XCTAssertTrue(derive(messages, activityAnchorIDs: []).folds.isEmpty)
+    }
+
+    func testSingleReplyWithReasoningFoldsOnlyTheReasoning() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistant("a1", text: "Done.", timestamp: 110, reasoning: "Thinking it through")
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"])
+
+        XCTAssertEqual(folds.folds.first?.hostRenderID, "transcript:1")
+        let state = folds.rowState(for: "transcript:1", expandedTurnKeys: [])
+        XCTAssertNotNil(state?.fold)
+        XCTAssertEqual(state?.hidesActivity, true)
+        XCTAssertEqual(state?.hidesBubble, false)
+    }
+
+    func testHiddenActivityDoesNotCountWhenCardsAreOff() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistant("a1", text: "Done.", timestamp: 110, reasoning: "Thinking it through")
+        ]
+
+        XCTAssertTrue(derive(messages, activityAnchorIDs: []).folds.isEmpty)
+    }
+
+    func testInterimRepliesFoldBetweenFirstAndLast() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistant("a1", text: "Looking.", timestamp: 105),
+            assistant("a2", text: "Still looking.", timestamp: 110),
+            assistant("a3", text: "Done.", timestamp: 120)
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: [])
+
+        XCTAssertEqual(folds.folds.first?.hostRenderID, "transcript:2")
+        XCTAssertEqual(folds.rowState(for: "transcript:1", expandedTurnKeys: [])?.hidesBubble, false)
+        XCTAssertEqual(folds.rowState(for: "transcript:2", expandedTurnKeys: [])?.hidesBubble, true)
+        XCTAssertEqual(folds.rowState(for: "transcript:3", expandedTurnKeys: [])?.hidesBubble, false)
+    }
+
+    func testTurnKeysUseAbsoluteIndicesAcrossPagedOffsets() {
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Done.", timestamp: 130)
+        ]
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"], messageOffset: 40)
+
+        XCTAssertEqual(folds.folds.first?.turnKey, TranscriptTurnClassifier.userTurnKey(absoluteIndex: 40))
+        XCTAssertEqual(folds.folds.first?.hostRenderID, "transcript:41")
+    }
+
+    // MARK: - Helpers
+
+    private func derive(
+        _ messages: [ChatMessage],
+        activityAnchorIDs: Set<String>,
+        messageOffset: Int? = nil,
+        isStreamActive: Bool = false,
+        streamingAssistantMessageID: String? = nil,
+        outcome: TranscriptTurnRunOutcome? = nil
+    ) -> TranscriptTurnFolds {
+        let transcript = ChatViewModel.transcriptMessages(
+            from: messages,
+            messageOffset: messageOffset,
+            renderedActivityAnchorIDs: activityAnchorIDs
+        )
+        return TranscriptTurnFolds.derive(
+            transcriptMessages: transcript,
+            messages: messages,
+            messageOffset: messageOffset,
+            activityAnchorIDs: activityAnchorIDs,
+            rendersBubble: { $0.content?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false },
+            isStreamActive: isStreamActive,
+            streamingAssistantMessageID: streamingAssistantMessageID,
+            latestRunOutcome: outcome
+        )
+    }
+
+    private func user(_ id: String, timestamp: Double?) -> ChatMessage {
+        ChatMessage(role: "user", content: "Do the thing", timestamp: timestamp, messageId: id)
+    }
+
+    private func assistant(
+        _ id: String,
+        text: String?,
+        timestamp: Double?,
+        reasoning: String? = nil,
+        turnDuration: Double? = nil
+    ) -> ChatMessage {
+        ChatMessage(
+            role: "assistant",
+            content: text,
+            timestamp: timestamp,
+            messageId: id,
+            reasoning: reasoning,
+            turnDuration: turnDuration
+        )
+    }
+
+    private func assistantWithTools(_ id: String, timestamp: Double?) -> ChatMessage {
+        ChatMessage(
+            role: "assistant",
+            content: "",
+            timestamp: timestamp,
+            messageId: id,
+            toolCalls: [.object(["id": .string("call-\(id)"), "function": .object(["name": .string("terminal")])])]
+        )
+    }
+}


### PR DESCRIPTION
## Linked issue

Transcript density polish; no tracking issue.

## What changed

A finished turn kept its thinking block, tool rows, and interim replies on screen forever. A turn with a handful of tool calls was a screen of history above a two-line answer.

A settled turn now shows only its first and last reply. Everything in between (reasoning, tool rows, interim replies) sits behind one 44 pt row labelled with the elapsed time: `Worked for 1m 12s`, or `You stopped after 8s` for a stopped run. Tap the row to expand it in place; it goes through the shared disclosure handler so the transcript's bottom anchor is suspended and the row stays put.

- The turn a stream is answering, and any turn holding the streaming message, never folds.
- Stopped or failed turns start open. A new turn starting folds the previous one.
- Elapsed comes from the server's `_turnDuration` on the final reply (verified on a live server: seconds, matching the user-to-reply gap), then the client-measured run, then the gap between the user message and the turn's last message. With none of those the row reads `Worked`.
- Settings → Chat gains a **Fold Finished Turns** toggle, on by default. With Thinking and Tool Cards off, only interim replies fold, so a turn with nothing visible to hide gets no row.

Folding is a pure derivation (`TranscriptTurnFolds`) over the displayed transcript, keyed by turn so paging older messages in does not shift it. Cache, message actions, and stream recovery are untouched. `ChatMessage` decodes `_turnDuration` tolerantly and the cache stores it. `ChatStreamCoordinator` records how each run ended (completed, cancelled, failed) so the view model can key it to a turn.

## How it was tested

- `TranscriptTurnFoldingTests` (14): settled vs active turn, streaming message, interruption label and expansion, missing timestamps, elapsed source precedence, `_turnDuration` decoding, single-reply turns, interim replies, paged offsets.
- `LocalizationCatalogTests` (7) for the new String Catalog entries.
- Manual on the iPhone 17 simulator and on a physical iPhone via the Hermex Branch TestFlight build (202609020128): fold rows above finished turns, tap to open in place, live turn stays unfolded until it settles, stopped turn reads `You stopped after …` and folds after the next send, Settings toggle restores full expansion.
- Full XCTest suite: running on the final head; result posted below.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

---

Built by Claude Fable 5.1 in Claude Code.