### PR TITLE
feat(chat): put a timestamp and copy button under each message

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */; };
 		C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F02 /* ToolCallLogRowView.swift */; };
 		C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */; };
+		C0AA05000000000000000B01 /* ChatMessageMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA05000000000000000F01 /* ChatMessageMeta.swift */; };
 		C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */; };
 		C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */; };
 		C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12900000000000000000002 /* ChatActiveRunStatusView.swift */; };
@@ -219,6 +220,7 @@
 		C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */; };
 		C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */; };
 		C0AA07000000000000000B07 /* ChatTranscriptRowEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA07000000000000000F07 /* ChatTranscriptRowEntryTests.swift */; };
+		C0AA05000000000000000B02 /* ChatMessageMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA05000000000000000F02 /* ChatMessageMetaTests.swift */; };
 		C03190000000000000B001 /* AttachmentAudioDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F001 /* AttachmentAudioDetection.swift */; };
 		C03190000000000000B002 /* InlineAudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F002 /* InlineAudioPlayerView.swift */; };
 		C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */; };
@@ -533,6 +535,7 @@
 		1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallCardView.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F02 /* ToolCallLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallLogRowView.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFolding.swift; sourceTree = "<group>"; };
+		C0AA05000000000000000F01 /* ChatMessageMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageMeta.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatter.swift; sourceTree = "<group>"; };
 		C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTimelineAccessorySurface.swift; sourceTree = "<group>"; };
 		C12900000000000000000002 /* ChatActiveRunStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatActiveRunStatusView.swift; sourceTree = "<group>"; };
@@ -574,6 +577,7 @@
 		C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatterTests.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFoldingTests.swift; sourceTree = "<group>"; };
 		C0AA07000000000000000F07 /* ChatTranscriptRowEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptRowEntryTests.swift; sourceTree = "<group>"; };
+		C0AA05000000000000000F02 /* ChatMessageMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageMetaTests.swift; sourceTree = "<group>"; };
 		C03190000000000000F001 /* AttachmentAudioDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetection.swift; sourceTree = "<group>"; };
 		C03190000000000000F002 /* InlineAudioPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineAudioPlayerView.swift; sourceTree = "<group>"; };
 		C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentAudioDetectionTests.swift; sourceTree = "<group>"; };
@@ -860,6 +864,7 @@
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */,
 				C0AA07000000000000000F07 /* ChatTranscriptRowEntryTests.swift */,
+				C0AA05000000000000000F02 /* ChatMessageMetaTests.swift */,
 				C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */,
 				C0DE22000000000000000004 /* ChatHapticsTests.swift */,
 				C08800000000000000000004 /* SessionHapticsTests.swift */,
@@ -1068,6 +1073,7 @@
 				1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */,
 				C0AA02000000000000000F02 /* ToolCallLogRowView.swift */,
 				C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */,
+				C0AA05000000000000000F01 /* ChatMessageMeta.swift */,
 				C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */,
 				C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */,
 				C12900000000000000000002 /* ChatActiveRunStatusView.swift */,
@@ -1583,6 +1589,7 @@
 				1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */,
 				C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */,
 				C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */,
+				C0AA05000000000000000B01 /* ChatMessageMeta.swift in Sources */,
 				C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */,
 				C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */,
 				C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */,
@@ -1745,6 +1752,7 @@
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */,
 				C0AA07000000000000000B07 /* ChatTranscriptRowEntryTests.swift in Sources */,
+				C0AA05000000000000000B02 /* ChatMessageMetaTests.swift in Sources */,
 				C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */,
 				C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */,
 				C08800000000000000000003 /* SessionHapticsTests.swift in Sources */,

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -210,7 +210,7 @@ enum ChatTranscriptDisplaySettings {
     static let thinkingCardsStartExpandedKey = "chatTranscript.thinkingCardsStartExpanded"
     static let toolCardsStartExpandedKey = "chatTranscript.toolCardsStartExpanded"
     static let hidesAttachmentPathsKey = "chatTranscript.hidesAttachmentPaths"
-    /// Settings → Chat "Response Timestamps": the time under each user message
+    /// Settings → Chat "Message Timestamps": the time under each user message
     /// and each finished reply. The key name predates the move under the
     /// message and stays so a stored choice keeps working.
     static let showsAssistantTurnTimestampsKey = "chatTranscript.showsAssistantTurnTimestamps"

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -210,7 +210,11 @@ enum ChatTranscriptDisplaySettings {
     static let thinkingCardsStartExpandedKey = "chatTranscript.thinkingCardsStartExpanded"
     static let toolCardsStartExpandedKey = "chatTranscript.toolCardsStartExpanded"
     static let hidesAttachmentPathsKey = "chatTranscript.hidesAttachmentPaths"
+    /// Settings → Chat "Response Timestamps": the time under each user message
+    /// and each finished reply. The key name predates the move under the
+    /// message and stays so a stored choice keeps working.
     static let showsAssistantTurnTimestampsKey = "chatTranscript.showsAssistantTurnTimestamps"
+    static let defaultShowsTimestamps = true
     static let showsResponseSpeedKey = "chatTranscript.showsResponseSpeed"
     static let wrapsCodeBlockLinesKey = "chatTranscript.wrapsCodeBlockLines"
     /// Settings → Chat "Fold Finished Turns": settled turns collapse their
@@ -269,18 +273,19 @@ enum ChatTranscriptDisplaySettings {
             messageID == streamingAssistantMessageID
     }
 
-    /// Whether to draw the per-turn `glyph + timestamp` header above an assistant
-    /// turn. The header is a turn *separator*, not an identity, so it is limited
-    /// to real assistant turns that carry visible text — never user bubbles,
+    /// Whether to draw the `glyph + speed` header above an assistant reply. It
+    /// only exists to carry Response Speed, so it is limited to real assistant
+    /// turns with visible text and a measured speed — never user bubbles,
     /// system/marker cards, tool-call cards, or empty/tool-only assistant rows.
+    /// The reply's time lives under the message (`ChatMessageMetaRow`).
     static func showsAssistantTurnHeader(
         role: String?,
         hasTextContent: Bool,
-        isEnabled: Bool,
-        showsResponseSpeed: Bool = false,
-        hasResponseSpeed: Bool = false
+        showsResponseSpeed: Bool,
+        hasResponseSpeed: Bool
     ) -> Bool {
-        (isEnabled || (showsResponseSpeed && hasResponseSpeed)) &&
+        showsResponseSpeed &&
+            hasResponseSpeed &&
             role == "assistant" &&
             hasTextContent
     }

--- a/HermesMobile/Features/Chat/ChatMessageMeta.swift
+++ b/HermesMobile/Features/Chat/ChatMessageMeta.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+/// Which transcript rows draw the `time · copy` row under their bubble. Every
+/// user message gets one. An assistant row gets one only as the reply that
+/// closes a settled turn: mid-turn replies, the turn a stream is still
+/// answering, and the message that is streaming show nothing, so the row only
+/// ever sits under text the user can act on.
+enum TranscriptMessageMetaPolicy {
+    /// Render IDs of the last bubble-bearing reply of each settled assistant turn.
+    static func terminalReplyRenderIDs(
+        transcriptMessages: [TranscriptMessage],
+        messages: [ChatMessage],
+        messageOffset: Int?,
+        rendersBubble: (ChatMessage) -> Bool,
+        isStreamActive: Bool,
+        streamingAssistantMessageID: String?
+    ) -> Set<String> {
+        let turnKeyByAnchorID = TranscriptTurnClassifier.assistantTurnKeysByAnchorID(
+            messages,
+            messageOffset: messageOffset
+        )
+        let unsettledTurnKey = isStreamActive
+            ? TranscriptTurnClassifier.latestTurnKey(in: messages, messageOffset: messageOffset)
+            : nil
+        let streamingTurnKey = streamingAssistantMessageID.flatMap { turnKeyByAnchorID[$0] }
+
+        var lastReplyByTurnKey: [String: String] = [:]
+        for transcriptMessage in transcriptMessages
+        where transcriptMessage.message.role == "assistant" && rendersBubble(transcriptMessage.message) {
+            guard let turnKey = turnKeyByAnchorID[transcriptMessage.anchorID],
+                  turnKey != unsettledTurnKey,
+                  turnKey != streamingTurnKey
+            else { continue }
+            lastReplyByTurnKey[turnKey] = transcriptMessage.renderID
+        }
+
+        return Set(lastReplyByTurnKey.values)
+    }
+}
+
+/// The row under a message bubble: the time it was sent and a copy button.
+/// User rows read `[time][copy]` against the trailing edge, assistant rows
+/// `[copy][time]` against the leading edge, so the button always sits at the
+/// outer edge and RTL mirrors both through the semantic alignments.
+struct ChatMessageMetaRow: View {
+    let isUserMessage: Bool
+    let timeText: String?
+    let onCopy: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if isUserMessage {
+                time
+                copyButton
+            } else {
+                copyButton
+                time
+            }
+        }
+        .padding(.horizontal, 2)
+        .frame(maxWidth: .infinity, alignment: isUserMessage ? .trailing : .leading)
+    }
+
+    @ViewBuilder
+    private var time: some View {
+        if let timeText {
+            Text(timeText)
+                .font(AppFont.caption(weight: .medium).monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var copyButton: some View {
+        if let onCopy {
+            ChatCopyButton(action: onCopy)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+/// A copy button that answers with a checkmark for `feedbackDuration` after
+/// each tap. The caller writes the pasteboard and fires the haptic; this only
+/// owns the feedback state, and SwiftUI cancels the reset with the view.
+struct ChatCopyButton: View {
+    static let feedbackDuration: Duration = .milliseconds(1200)
+
+    var label = String(localized: "Copy")
+    var copiedLabel = String(localized: "Copied")
+    var size: CGFloat = 28
+    var glyphSize: CGFloat = 13
+    var glyphWeight: Font.Weight = .medium
+    let action: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var showsCopied = false
+    @State private var copyCount = 0
+
+    var body: some View {
+        Button {
+            action()
+            showsCopied = true
+            copyCount += 1
+        } label: {
+            Image(systemName: showsCopied ? "checkmark" : "doc.on.doc")
+                .font(.system(size: glyphSize, weight: glyphWeight))
+                .frame(width: size, height: size)
+                .contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
+                .chatMinimumHitTarget(
+                    horizontalPadding: max(0, (44 - size) / 2),
+                    verticalPadding: max(0, (44 - size) / 2),
+                    in: Rectangle()
+                )
+        }
+        .buttonStyle(.chatTactile(.icon))
+        .accessibilityLabel(showsCopied ? copiedLabel : label)
+        .task(id: copyCount) {
+            guard copyCount > 0 else { return }
+            try? await Task.sleep(for: Self.feedbackDuration)
+            guard !Task.isCancelled else { return }
+            showsCopied = false
+        }
+    }
+}
+
+// MARK: - Timestamp formatting
+
+/// Formats a message's unix `timestamp` as a short, locale-/24h-aware time
+/// (e.g. `2:14 PM` or `14:14`). Returns `nil` for a missing or non-finite
+/// timestamp so the meta row simply omits the time.
+enum ChatMessageTimestampFormatter {
+    private static let sharedFormatter: DateFormatter = makeFormatter(
+        locale: .autoupdatingCurrent,
+        timeZone: .autoupdatingCurrent
+    )
+
+    static func shortTime(forUnixTimestamp timestamp: Double?) -> String? {
+        format(timestamp, with: sharedFormatter)
+    }
+
+    /// Test seam: format against an explicit locale/time zone so 12h/24h
+    /// assertions stay deterministic regardless of host device settings.
+    static func shortTime(
+        forUnixTimestamp timestamp: Double?,
+        locale: Locale,
+        timeZone: TimeZone
+    ) -> String? {
+        format(timestamp, with: makeFormatter(locale: locale, timeZone: timeZone))
+    }
+
+    private static func makeFormatter(locale: Locale, timeZone: TimeZone) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.timeZone = timeZone
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }
+
+    private static func format(_ timestamp: Double?, with formatter: DateFormatter) -> String? {
+        guard let timestamp, timestamp.isFinite else { return nil }
+        return formatter.string(from: Date(timeIntervalSince1970: timestamp))
+    }
+}

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -63,6 +63,8 @@ struct ChatTranscriptView: View {
     let onDisclosureToggle: () -> Void
     /// Settled-turn folds derived by the owner; `.none` when folding is off.
     let turnFolds: TranscriptTurnFolds
+    /// Rows that close a settled turn and so carry the time + copy row.
+    let terminalReplyRenderIDs: Set<String>
     let expandedTurnKeys: Set<String>
     let onToggleTurnFold: (String) -> Void
     let onDismissKeyboard: () -> Void
@@ -251,6 +253,7 @@ struct ChatTranscriptView: View {
                     transcriptSpacing: transcriptSpacing,
                     showsThinkingAndToolCards: showsThinkingAndToolCards,
                     foldState: foldState,
+                    isTerminalReply: terminalReplyRenderIDs.contains(transcriptMessage.renderID),
                     onToggleTurnFold: onToggleTurnFold,
                     reasoningGroups: reasoningGroups,
                     toolCallGroups: completedToolCallGroupsForAnchor(transcriptMessage.anchorID),
@@ -505,6 +508,8 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     /// Nil outside a settled-turn fold. Otherwise says whether this row draws
     /// the fold row and which of its parts are hidden right now.
     let foldState: TranscriptTurnFoldRowState?
+    /// Whether this row is the reply that closes a settled turn.
+    let isTerminalReply: Bool
     let onToggleTurnFold: (String) -> Void
     let reasoningGroups: [ReasoningGroup]
     let toolCallGroups: [ToolCallGroup]
@@ -548,6 +553,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
             lhs.transcriptSpacing == rhs.transcriptSpacing &&
             lhs.showsThinkingAndToolCards == rhs.showsThinkingAndToolCards &&
             lhs.foldState == rhs.foldState &&
+            lhs.isTerminalReply == rhs.isTerminalReply &&
             lhs.reasoningGroups == rhs.reasoningGroups &&
             lhs.toolCallGroups == rhs.toolCallGroups &&
             lhs.liveReasoningText == rhs.liveReasoningText &&
@@ -628,6 +634,7 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                     message: transcriptMessage.message,
                     visibleIndex: transcriptMessage.loadedIndex,
                     actionContext: actionContext(transcriptMessage.message, transcriptMessage.loadedIndex),
+                    isTerminalReply: isTerminalReply,
                     localAttachmentPreviews: localAttachmentPreviews,
                     listeningMessageID: listeningMessageID,
                     isViewingCachedData: isViewingCachedData,
@@ -715,9 +722,12 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
 }
 
 private struct ChatTranscriptMessageRow: View {
+    @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsTimestamps = ChatTranscriptDisplaySettings.defaultShowsTimestamps
+
     let message: ChatMessage
     let visibleIndex: Int
     let actionContext: MessageActionContext?
+    let isTerminalReply: Bool
     let localAttachmentPreviews: [String: Data]?
     let listeningMessageID: String?
     let isViewingCachedData: Bool
@@ -747,28 +757,58 @@ private struct ChatTranscriptMessageRow: View {
         // don't apply to system-emitted markers.
         if let markerKind = ChatMarkerMessageClassifier.classify(message) {
             MarkerMessageCardView(kind: markerKind, content: message.content)
-        } else if let actionContext {
-            bubble
-                .contextMenu {
-                    ChatMessageActionMenu(
-                        context: actionContext,
-                        listeningMessageID: listeningMessageID,
-                        isViewingCachedData: isViewingCachedData,
-                        hasActiveStream: hasActiveStream,
-                        isRegeneratingMessage: isRegeneratingMessage,
-                        isEditingMessage: isEditingMessage,
-                        isForkingMessage: isForkingMessage,
-                        onToggleListening: onToggleListening,
-                        onSelectText: onSelectText,
-                        onRegenerate: onRegenerate,
-                        onEdit: onEdit,
-                        onFork: onFork,
-                        onCopy: onCopy
+        } else {
+            VStack(alignment: isUserMessage ? .trailing : .leading, spacing: 4) {
+                if let actionContext {
+                    bubble
+                        .contextMenu {
+                            ChatMessageActionMenu(
+                                context: actionContext,
+                                listeningMessageID: listeningMessageID,
+                                isViewingCachedData: isViewingCachedData,
+                                hasActiveStream: hasActiveStream,
+                                isRegeneratingMessage: isRegeneratingMessage,
+                                isEditingMessage: isEditingMessage,
+                                isForkingMessage: isForkingMessage,
+                                onToggleListening: onToggleListening,
+                                onSelectText: onSelectText,
+                                onRegenerate: onRegenerate,
+                                onEdit: onEdit,
+                                onFork: onFork,
+                                onCopy: onCopy
+                            )
+                        }
+                } else {
+                    bubble
+                }
+
+                if showsMetaRow {
+                    ChatMessageMetaRow(
+                        isUserMessage: isUserMessage,
+                        timeText: metaTimeText,
+                        onCopy: actionContext.map { context -> () -> Void in
+                            { onCopy(context) }
+                        }
                     )
                 }
-        } else {
-            bubble
+            }
         }
+    }
+
+    private var isUserMessage: Bool {
+        message.role == "user"
+    }
+
+    /// Every user message carries the row; an assistant row only as the reply
+    /// that closes a settled turn, and never while it is still streaming.
+    private var showsMetaRow: Bool {
+        guard metaTimeText != nil || actionContext != nil else { return false }
+        return isUserMessage || (isTerminalReply && !isStreaming)
+    }
+
+    private var metaTimeText: String? {
+        guard showsTimestamps else { return nil }
+        return ChatMessageTimestampFormatter.shortTime(forUnixTimestamp: message.timestamp)
     }
 
     private var bubble: some View {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1228,6 +1228,7 @@ struct ChatView: View {
             onFollowEvent: handleFollowEvent,
             onDisclosureToggle: handleDisclosureToggle,
             turnFolds: turnFolds(reasoningGroups: reasoningGroups),
+            terminalReplyRenderIDs: terminalReplyRenderIDs,
             expandedTurnKeys: expandedTurnKeys,
             onToggleTurnFold: toggleTurnFold,
             onDismissKeyboard: dismissKeyboard,
@@ -1431,6 +1432,18 @@ struct ChatView: View {
             isStreamActive: viewModel.activeStreamID != nil,
             streamingAssistantMessageID: viewModel.streamingAssistantMessageID,
             latestRunOutcome: viewModel.latestRunOutcome
+        )
+    }
+
+    /// Rows that get the time + copy row as the reply closing a settled turn.
+    private var terminalReplyRenderIDs: Set<String> {
+        TranscriptMessageMetaPolicy.terminalReplyRenderIDs(
+            transcriptMessages: transcriptMessages,
+            messages: viewModel.messages,
+            messageOffset: viewModel.messagesOffset,
+            rendersBubble: shouldRenderMessageRow,
+            isStreamActive: viewModel.activeStreamID != nil,
+            streamingAssistantMessageID: viewModel.streamingAssistantMessageID
         )
     }
 

--- a/HermesMobile/Features/Chat/MarkdownRenderer.swift
+++ b/HermesMobile/Features/Chat/MarkdownRenderer.swift
@@ -416,7 +416,6 @@ private struct ChatCodeBlock: View {
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage(ChatTranscriptDisplaySettings.wrapsCodeBlockLinesKey) private var wrapsCodeBlockLines = false
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
-    @State private var didCopy = false
     @State private var highlightedCode: NSAttributedString?
 
     private let logger = Logger.hermesMarkdownRendering
@@ -437,23 +436,21 @@ private struct ChatCodeBlock: View {
                         .frame(width: 36, height: 36)
                         .contentTransition(.symbolEffect(.replace))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.chatTactile(.icon))
                 .foregroundStyle(SwiftUI.Color.primary)
                 .accessibilityLabel(wrapsCodeBlockLines ? "Disable code line wrapping" : "Enable code line wrapping")
 
-                Button {
+                ChatCopyButton(
+                    label: String(localized: "Copy code"),
+                    copiedLabel: String(localized: "Copied code"),
+                    size: 36,
+                    glyphSize: 18,
+                    glyphWeight: .semibold
+                ) {
                     UIPasteboard.general.string = content
-                    didCopy = true
                     ChatHaptics.copied(isEnabled: isHapticsEnabled)
-                } label: {
-                    Image(systemName: didCopy ? "checkmark" : "square.on.square")
-                        .font(.system(size: 18, weight: .semibold))
-                    .frame(width: 36, height: 36)
-                    .contentTransition(.symbolEffect(.replace))
                 }
-                .buttonStyle(.plain)
                 .foregroundStyle(SwiftUI.Color.primary)
-                .accessibilityLabel(didCopy ? "Copied code" : "Copy code")
             }
             .padding(.leading, 16)
             .padding(.trailing, 10)
@@ -474,9 +471,6 @@ private struct ChatCodeBlock: View {
         .overlay {
             RoundedRectangle(cornerRadius: 24, style: .continuous)
                 .stroke(SwiftUI.Color(.separator).opacity(0.35), lineWidth: 1)
-        }
-        .onChange(of: content) { _, _ in
-            didCopy = false
         }
         .task(id: highlightRequest) {
             await updateHighlightedCode(for: highlightRequest)

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -5,7 +5,6 @@ struct MessageBubbleView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
-    @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsAssistantTurnTimestamps = false
     @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
 
     let message: ChatMessage
@@ -117,20 +116,15 @@ struct MessageBubbleView: View {
 
     // MARK: - Assistant turn header (issue #258)
 
-    /// A compact, generic `glyph + time` marker drawn above each assistant text
-    /// turn so back-to-back responses are visually separable. Deliberately carries
-    /// no model/profile/agent identity — only the message's own timestamp, which
-    /// is the single per-message-accurate datum available.
+    /// A compact `glyph + speed` marker drawn above an assistant reply while
+    /// Response Speed is on. Deliberately carries no model/profile/agent
+    /// identity. The reply's time is not here: it sits under the message in
+    /// `ChatMessageMetaRow`, next to the copy button.
     private var assistantTurnHeader: some View {
         HStack(spacing: 5) {
             Image(systemName: "sparkle")
                 .foregroundStyle(Color.accentColor)
                 .accessibilityHidden(true)
-
-            if let time = assistantTurnTimeText {
-                Text(time)
-                    .foregroundStyle(.secondary)
-            }
 
             if let speed = assistantResponseSpeedText {
                 Text(speed)
@@ -146,7 +140,6 @@ struct MessageBubbleView: View {
         ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
             role: message.role,
             hasTextContent: hasVisibleAssistantText,
-            isEnabled: showsAssistantTurnTimestamps,
             showsResponseSpeed: showsResponseSpeed,
             hasResponseSpeed: assistantResponseSpeedText != nil
         )
@@ -160,23 +153,16 @@ struct MessageBubbleView: View {
         return !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private var assistantTurnTimeText: String? {
-        guard showsAssistantTurnTimestamps else { return nil }
-        return AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: message.timestamp)
-    }
-
     private var assistantResponseSpeedText: String? {
         guard showsResponseSpeed else { return nil }
         return ResponseSpeedFormatter.compactText(isStreaming ? liveTokensPerSecond : message.turnTps)
     }
 
     private var assistantTurnHeaderAccessibilityLabel: String {
-        let details = [
-            assistantTurnTimeText,
-            assistantResponseSpeedAccessibilityText
-        ].compactMap { $0 }
-        guard !details.isEmpty else { return String(localized: "Assistant") }
-        return String(localized: "Assistant, \(details.joined(separator: ", "))")
+        guard let speed = assistantResponseSpeedAccessibilityText else {
+            return String(localized: "Assistant")
+        }
+        return String(localized: "Assistant, \(speed)")
     }
 
     private var assistantResponseSpeedAccessibilityText: String? {
@@ -699,46 +685,6 @@ private actor AttachmentImageCache {
             cache[path] = image
         }
         return image
-    }
-}
-
-// MARK: - Assistant turn timestamp formatting
-
-/// Formats an assistant turn's unix `timestamp` as a short, locale-/24h-aware
-/// time (e.g. `2:14 PM` or `14:14`). Returns `nil` for a missing or non-finite
-/// timestamp so the per-turn header falls back to glyph-only.
-enum AssistantTurnTimestampFormatter {
-    private static let sharedFormatter: DateFormatter = makeFormatter(
-        locale: .autoupdatingCurrent,
-        timeZone: .autoupdatingCurrent
-    )
-
-    static func shortTime(forUnixTimestamp timestamp: Double?) -> String? {
-        format(timestamp, with: sharedFormatter)
-    }
-
-    /// Test seam: format against an explicit locale/time zone so 12h/24h
-    /// assertions stay deterministic regardless of host device settings.
-    static func shortTime(
-        forUnixTimestamp timestamp: Double?,
-        locale: Locale,
-        timeZone: TimeZone
-    ) -> String? {
-        format(timestamp, with: makeFormatter(locale: locale, timeZone: timeZone))
-    }
-
-    private static func makeFormatter(locale: Locale, timeZone: TimeZone) -> DateFormatter {
-        let formatter = DateFormatter()
-        formatter.locale = locale
-        formatter.timeZone = timeZone
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }
-
-    private static func format(_ timestamp: Double?, with formatter: DateFormatter) -> String? {
-        guard let timestamp, timestamp.isFinite else { return nil }
-        return formatter.string(from: Date(timeIntervalSince1970: timestamp))
     }
 }
 

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -259,7 +259,7 @@ struct SettingsView: View {
                     SettingsDivider()
 
                     SettingsToggleRow(
-                        title: String(localized: "Response Timestamps"),
+                        title: String(localized: "Message Timestamps"),
                         systemImage: "clock",
                         isOn: $showsAssistantTurnTimestamps
                     )

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -76,7 +76,7 @@ struct SettingsView: View {
     @AppStorage(ChatTranscriptDisplaySettings.toolCardsStartExpandedKey) private var toolCardsStartExpanded = false
     @AppStorage(ChatTranscriptDisplaySettings.foldsSettledTurnsKey) private var foldsSettledTurns = true
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
-    @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsAssistantTurnTimestamps = false
+    @AppStorage(ChatTranscriptDisplaySettings.showsAssistantTurnTimestampsKey) private var showsAssistantTurnTimestamps = ChatTranscriptDisplaySettings.defaultShowsTimestamps
     @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
     @AppStorage(ChatTranscriptDisplaySettings.wrapsCodeBlockLinesKey) private var wrapsCodeBlockLines = false
     @AppStorage(ChatTranscriptDisplaySettings.rtlChatLayoutEnabledKey) private var rtlChatLayoutEnabled = ChatTranscriptDisplaySettings.rtlChatLayoutDefaultEnabled
@@ -264,7 +264,7 @@ struct SettingsView: View {
                         isOn: $showsAssistantTurnTimestamps
                     )
 
-                    SettingsFootnote(String(localized: "Adds a small marker and the time above each response so back-to-back replies are easier to tell apart."))
+                    SettingsFootnote(String(localized: "Shows the time under your messages and under each finished response."))
 
                     SettingsDivider()
 

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -64167,108 +64167,108 @@
         }
       }
     },
-    "Response Timestamps" : {
+    "Message Timestamps" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "الطوابع الزمنية للردّ"
+            "value" : "الطوابع الزمنية للرسائل"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Antwort-Zeitstempel"
+            "value" : "Nachrichten-Zeitstempel"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Marcas de tiempo de respuesta"
+            "value" : "Marcas de tiempo de mensajes"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Horodatages des réponses"
+            "value" : "Horodatages des messages"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "חותמות זמן של תשובות"
+            "value" : "חותמות זמן של הודעות"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Timestamp risposta"
+            "value" : "Timestamp messaggi"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "応答のタイムスタンプ"
+            "value" : "メッセージのタイムスタンプ"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "응답 타임스탬프"
+            "value" : "메시지 타임스탬프"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Tijdstempels van antwoorden"
+            "value" : "Tijdstempels van berichten"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Znaczniki czasu odpowiedzi"
+            "value" : "Znaczniki czasu wiadomości"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Carimbos de data/hora das respostas"
+            "value" : "Carimbos de data/hora das mensagens"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Метки времени ответа"
+            "value" : "Метки времени сообщений"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Yanıt Zaman Damgaları"
+            "value" : "Mesaj Zaman Damgaları"
           }
         },
         "ur" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "جواب کے ٹائم اسٹیمپس"
+            "value" : "پیغام کے ٹائم اسٹیمپس"
           }
         },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "回應時間戳記"
+            "value" : "訊息時間戳記"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "回复时间戳"
+            "value" : "消息时间戳"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "回覆時間戳記"
+            "value" : "訊息時間戳記"
           }
         }
       }

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -10308,112 +10308,6 @@
         }
       }
     },
-    "Adds a small marker and the time above each response so back-to-back replies are easier to tell apart." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "يضيف علامة صغيرة والوقت أعلى كل رد ليسهل التمييز بين الردود المتتالية."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Fügt über jeder Antwort eine kleine Markierung und die Uhrzeit hinzu, damit aufeinanderfolgende Antworten leichter auseinanderzuhalten sind."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Añade un marcador pequeño y la hora sobre cada respuesta para distinguir las réplicas consecutivas más fácilmente."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Affiche un indicateur et l'heure au-dessus de chaque réponse pour distinguer facilement les réponses successives."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "מוסיף סימן קטן ואת השעה מעל כל תגובה כדי שיהיה קל יותר להבחין בין תשובות עוקבות."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Aggiunge un indicatore e l'orario sopra ogni risposta per distinguere facilmente le risposte consecutive."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "各応答の上に小さなマーカーと時刻を表示し、連続した返信を見分けやすくします。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "각 응답 위에 작은 표시와 시간을 추가해 연속된 답변을 더 쉽게 구분할 수 있어요."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Voegt een kleine markering en de tijd boven elk antwoord toe, zodat opeenvolgende antwoorden gemakkelijker te onderscheiden zijn."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Dodaje mały znacznik i godzinę nad każdą odpowiedzią, aby kolejne odpowiedzi były łatwiejsze do rozróżnienia."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Adiciona um pequeno marcador e o horário acima de cada resposta para facilitar a distinção entre respostas consecutivas."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Добавляет небольшой маркер и время над каждым ответом, чтобы было легче различать ответы, идущие подряд."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Art arda gelen yanıtların birbirinden daha kolay ayırt edilebilmesi için her yanıtın üstüne küçük bir işaret ve saat ekler."
-          }
-        },
-        "ur" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ہر جواب کے اوپر ایک چھوٹا نشان اور وقت شامل کرتا ہے تاکہ یکے بعد دیگرے جوابات میں فرق کرنا آسان ہو۔"
-          }
-        },
-        "zh-HK" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "在每則回覆上方加入小標記和時間，方便區分連續的回覆。"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "在每条回复上方添加小标记和时间，便于区分连续的回复。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "在每則回覆上方加上小標記和時間，方便區分連續的回覆。"
-          }
-        }
-      }
-    },
     "Adds another Hermes server." : {
       "localizations" : {
         "ar" : {
@@ -117219,6 +117113,112 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "你已停止此回覆"
+          }
+        }
+      }
+    },
+    "Shows the time under your messages and under each finished response." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يعرض الوقت أسفل رسائلك وأسفل كل رد مكتمل."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zeigt die Uhrzeit unter deinen Nachrichten und unter jeder fertigen Antwort."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Muestra la hora debajo de tus mensajes y de cada respuesta terminada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Affiche l’heure sous vos messages et sous chaque réponse terminée."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מציג את השעה מתחת להודעות שלך ומתחת לכל תשובה שהושלמה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra l’ora sotto i tuoi messaggi e sotto ogni risposta completata."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "メッセージと完了した各返答の下に時刻を表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "내 메시지와 완료된 각 응답 아래에 시간을 표시합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toont de tijd onder je berichten en onder elk voltooid antwoord."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pokazuje godzinę pod Twoimi wiadomościami i pod każdą zakończoną odpowiedzią."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra a hora abaixo das suas mensagens e de cada resposta concluída."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показывает время под вашими сообщениями и под каждым завершённым ответом."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mesajlarının ve tamamlanan her yanıtın altında saati gösterir."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آپ کے پیغامات اور ہر مکمل جواب کے نیچے وقت دکھاتا ہے۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在你的訊息和每則已完成的回覆下方顯示時間。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在你的消息和每条已完成的回复下方显示时间。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在你的訊息和每則已完成的回覆下方顯示時間。"
           }
         }
       }

--- a/HermesMobileTests/ChatMessageMetaTests.swift
+++ b/HermesMobileTests/ChatMessageMetaTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import HermesMobile
+
+final class ChatMessageMetaTests: XCTestCase {
+    func testOnlyTheLastReplyOfASettledTurnIsTerminal() {
+        let messages = [
+            user("u1"),
+            assistant("a1", text: "Looking."),
+            assistant("a2", text: "Still looking."),
+            assistant("a3", text: "Done.")
+        ]
+
+        XCTAssertEqual(terminalIDs(messages), ["transcript:3"])
+    }
+
+    func testActivityOnlyShellAfterTheReplyDoesNotTakeTerminal() {
+        let messages = [
+            user("u1"),
+            assistant("a1", text: "Done."),
+            assistant("a2", text: nil)
+        ]
+
+        XCTAssertEqual(terminalIDs(messages), ["transcript:1"])
+    }
+
+    func testTheTurnBeingAnsweredHasNoTerminalReplyWhileItStreams() {
+        let messages = [
+            user("u1"),
+            assistant("a1", text: "First answer."),
+            user("u2"),
+            assistant("a2", text: "Partial")
+        ]
+
+        XCTAssertEqual(
+            terminalIDs(messages, isStreamActive: true, streamingAssistantMessageID: "a2"),
+            ["transcript:1"]
+        )
+        XCTAssertEqual(terminalIDs(messages), ["transcript:1", "transcript:3"])
+    }
+
+    func testTurnHoldingTheStreamingMessageIsNotTerminal() {
+        let messages = [
+            user("u1"),
+            assistant("a1", text: "Regenerating"),
+            user("u2"),
+            assistant("a2", text: "Second answer.")
+        ]
+
+        XCTAssertEqual(
+            terminalIDs(messages, isStreamActive: true, streamingAssistantMessageID: "a1"),
+            []
+        )
+    }
+
+    func testRepliesBeforeTheFirstUserBoundaryFormTheirOwnTurn() {
+        let messages = [
+            assistant("a0", text: "Earlier page tail."),
+            user("u1"),
+            assistant("a1", text: "Done.")
+        ]
+
+        XCTAssertEqual(terminalIDs(messages), ["transcript:0", "transcript:2"])
+    }
+
+    func testRenderIDsFollowPagedOffsets() {
+        let messages = [
+            user("u1"),
+            assistant("a1", text: "Done.")
+        ]
+
+        XCTAssertEqual(terminalIDs(messages, messageOffset: 40), ["transcript:41"])
+    }
+
+    // MARK: - Helpers
+
+    private func terminalIDs(
+        _ messages: [ChatMessage],
+        messageOffset: Int? = nil,
+        isStreamActive: Bool = false,
+        streamingAssistantMessageID: String? = nil
+    ) -> Set<String> {
+        let transcript = ChatViewModel.transcriptMessages(
+            from: messages,
+            messageOffset: messageOffset,
+            renderedActivityAnchorIDs: []
+        )
+        return TranscriptMessageMetaPolicy.terminalReplyRenderIDs(
+            transcriptMessages: transcript,
+            messages: messages,
+            messageOffset: messageOffset,
+            rendersBubble: { $0.content?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false },
+            isStreamActive: isStreamActive,
+            streamingAssistantMessageID: streamingAssistantMessageID
+        )
+    }
+
+    private func user(_ id: String) -> ChatMessage {
+        ChatMessage(role: "user", content: "Do the thing", timestamp: 100, messageId: id)
+    }
+
+    private func assistant(_ id: String, text: String?) -> ChatMessage {
+        ChatMessage(role: "assistant", content: text, timestamp: 110, messageId: id)
+    }
+}

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -394,33 +394,21 @@ final class ChatTranscriptDisplaySettingsTests: XCTestCase {
         )
     }
 
-    func testTimestampAndResponseSpeedTogglesAreIndependent() {
+    func testTimestampsDefaultOn() {
+        XCTAssertTrue(ChatTranscriptDisplaySettings.defaultShowsTimestamps)
+    }
+
+    func testAssistantTurnHeaderIsOnlyTheResponseSpeedMarker() {
+        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
+            role: "assistant",
+            hasTextContent: true,
+            showsResponseSpeed: true,
+            hasResponseSpeed: true
+        ))
         XCTAssertFalse(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
             role: "assistant",
             hasTextContent: true,
-            isEnabled: false,
             showsResponseSpeed: false,
-            hasResponseSpeed: true
-        ))
-        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
-            role: "assistant",
-            hasTextContent: true,
-            isEnabled: true,
-            showsResponseSpeed: false,
-            hasResponseSpeed: true
-        ))
-        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
-            role: "assistant",
-            hasTextContent: true,
-            isEnabled: false,
-            showsResponseSpeed: true,
-            hasResponseSpeed: true
-        ))
-        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
-            role: "assistant",
-            hasTextContent: true,
-            isEnabled: true,
-            showsResponseSpeed: true,
             hasResponseSpeed: true
         ))
     }
@@ -429,25 +417,8 @@ final class ChatTranscriptDisplaySettingsTests: XCTestCase {
         XCTAssertFalse(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
             role: "assistant",
             hasTextContent: true,
-            isEnabled: false,
             showsResponseSpeed: true,
             hasResponseSpeed: false
-        ))
-    }
-
-    func testAssistantTurnHeaderShowsForAssistantTextTurnWhenEnabled() {
-        XCTAssertTrue(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
-            role: "assistant",
-            hasTextContent: true,
-            isEnabled: true
-        ))
-    }
-
-    func testAssistantTurnHeaderHiddenWhenToggleOff() {
-        XCTAssertFalse(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
-            role: "assistant",
-            hasTextContent: true,
-            isEnabled: false
         ))
     }
 
@@ -455,7 +426,8 @@ final class ChatTranscriptDisplaySettingsTests: XCTestCase {
         XCTAssertFalse(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
             role: "assistant",
             hasTextContent: false,
-            isEnabled: true
+            showsResponseSpeed: true,
+            hasResponseSpeed: true
         ))
     }
 
@@ -465,7 +437,8 @@ final class ChatTranscriptDisplaySettingsTests: XCTestCase {
                 ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
                     role: role,
                     hasTextContent: true,
-                    isEnabled: true
+                    showsResponseSpeed: true,
+                    hasResponseSpeed: true
                 ),
                 "Header must not render for role \(role)"
             )
@@ -474,7 +447,8 @@ final class ChatTranscriptDisplaySettingsTests: XCTestCase {
         XCTAssertFalse(ChatTranscriptDisplaySettings.showsAssistantTurnHeader(
             role: nil,
             hasTextContent: true,
-            isEnabled: true
+            showsResponseSpeed: true,
+            hasResponseSpeed: true
         ))
     }
 
@@ -586,13 +560,13 @@ final class ChatActiveRunStatusPolicyTests: XCTestCase {
     }
 }
 
-final class AssistantTurnTimestampFormatterTests: XCTestCase {
+final class ChatMessageTimestampFormatterTests: XCTestCase {
     // 2021-01-01 14:14:00 UTC
     private let fixedTimestamp: Double = 1_609_510_440
     private let utc = TimeZone(identifier: "UTC")!
 
     func testFormatsTwelveHourLocaleAsShortTime() {
-        let result = AssistantTurnTimestampFormatter.shortTime(
+        let result = ChatMessageTimestampFormatter.shortTime(
             forUnixTimestamp: fixedTimestamp,
             locale: Locale(identifier: "en_US"),
             timeZone: utc
@@ -604,7 +578,7 @@ final class AssistantTurnTimestampFormatterTests: XCTestCase {
     }
 
     func testFormatsTwentyFourHourLocaleAsShortTime() {
-        let result = AssistantTurnTimestampFormatter.shortTime(
+        let result = ChatMessageTimestampFormatter.shortTime(
             forUnixTimestamp: fixedTimestamp,
             locale: Locale(identifier: "en_GB"),
             timeZone: utc
@@ -616,8 +590,8 @@ final class AssistantTurnTimestampFormatterTests: XCTestCase {
     }
 
     func testReturnsNilForNilTimestamp() {
-        XCTAssertNil(AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: nil))
-        XCTAssertNil(AssistantTurnTimestampFormatter.shortTime(
+        XCTAssertNil(ChatMessageTimestampFormatter.shortTime(forUnixTimestamp: nil))
+        XCTAssertNil(ChatMessageTimestampFormatter.shortTime(
             forUnixTimestamp: nil,
             locale: Locale(identifier: "en_US"),
             timeZone: utc
@@ -625,12 +599,12 @@ final class AssistantTurnTimestampFormatterTests: XCTestCase {
     }
 
     func testReturnsNilForNonFiniteTimestamp() {
-        XCTAssertNil(AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: .nan))
-        XCTAssertNil(AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: .infinity))
+        XCTAssertNil(ChatMessageTimestampFormatter.shortTime(forUnixTimestamp: .nan))
+        XCTAssertNil(ChatMessageTimestampFormatter.shortTime(forUnixTimestamp: .infinity))
     }
 
     func testCurrentLocaleOverloadFormatsFiniteTimestamp() {
-        XCTAssertNotNil(AssistantTurnTimestampFormatter.shortTime(forUnixTimestamp: fixedTimestamp))
+        XCTAssertNotNil(ChatMessageTimestampFormatter.shortTime(forUnixTimestamp: fixedTimestamp))
     }
 }
 


### PR DESCRIPTION
## Linked issue

None — local follow-up to the micro-haptics work in #342.

## What changed

Copying a message meant long-pressing and finding it in the menu, and the only timestamp was an off-by-default sparkle row above each response. Now every message you sent and every finished reply carries a small row underneath: the time it was sent and a copy button. Copy flips to a checkmark for 1.2 s with a light haptic, and VoiceOver reads "Copied" while it does. Code blocks get the same feedback in their header button.

How it works:

- `TranscriptMessageMetaPolicy` picks which rows get the row: every user message, and the last reply of a turn that has settled. Mid-turn replies, the turn a stream is still answering, and the streaming message show nothing.
- `ChatCopyButton` owns the 1.2 s checkmark state (`.task(id:)`, so SwiftUI cancels the reset with the view); the caller keeps the existing pasteboard + haptic path. The code-block header now uses it too, so its checkmark resets instead of sticking.
- The time moved out of the above-reply header into the row. The header stays only as the Response Speed marker.
- "Response Timestamps" now defaults on; an explicit choice is kept. The Settings footnote and its 17 translations describe the new placement.
- User rows read `[time][copy]` on the trailing edge, assistant rows `[copy][time]` on the leading edge; RTL mirrors through the semantic alignments. Times use the locale's short style with monospaced digits.

Decisions taken (say the word if you want a different one):

1. Keep the sparkle+time header above replies? No — the time lives under the message now; the header only carries Response Speed. Two timestamps per reply read as noise.
2. Flip the timestamp default on for users who never touched it? Yes; a stored choice is honored.
3. Code-block VoiceOver labels stay "Copy code" / "Copied code" (already translated) rather than plain "Copied".

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP `test_sim`: 1832 passed, 0 failed, 2 skipped (pre-existing skips).
- New `ChatMessageMetaTests` cover the policy: last reply of a settled turn only, activity-only shells after the reply, the streaming/unsettled turn, replies before the first user boundary, and paged offsets. Header tests updated for the speed-only marker; timestamp formatter tests renamed with it.
- Signed Debug build launched on the simulator against the live server (read-only): rows render under user messages and terminal replies; tapping copy put the reply text on the simulator pasteboard (`simctl pbpaste`).

| Before | After | 
| --- | --- |
| <img src="https://gist.githubusercontent.com/uzairansaruzi/2644e15bc4a595e86d2ecf673dff7b9c/raw/before-chat.jpg" width="300" alt="Before: user bubble, fold row, and reply with no timestamp or copy button"> | <img src="https://gist.githubusercontent.com/uzairansaruzi/2644e15bc4a595e86d2ecf673dff7b9c/raw/after-chat.jpg" width="300" alt="After: time and copy button under the user bubble and under the finished reply"> |

Code block header with the shared copy button:

<img src="https://gist.githubusercontent.com/uzairansaruzi/2644e15bc4a595e86d2ecf673dff7b9c/raw/after-code.jpg" width="300" alt="After: code block header with wrap and copy buttons, meta row under the reply">

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no wire changes)

---

Made with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
