### PR TITLE
feat(chat): pin the clarification card above the composer

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -124,7 +124,7 @@
 		A04200000000000000000001 /* Approval.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04200000000000000000002 /* Approval.swift */; };
 		A04200000000000000000003 /* ApprovalRequestOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04200000000000000000004 /* ApprovalRequestOverlay.swift */; };
 		C1A042000000000000000001 /* Clarification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000002 /* Clarification.swift */; };
-		C1A042000000000000000003 /* ClarificationRequestOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000004 /* ClarificationRequestOverlay.swift */; };
+		C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000004 /* ClarificationRequestCard.swift */; };
 		C1A042000000000000000005 /* ClarificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000006 /* ClarificationTests.swift */; };
 		A02400000000000000000001 /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02400000000000000000002 /* Goal.swift */; };
 		C04600000000000000000001 /* ChatStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04600000000000000000002 /* ChatStreamCoordinator.swift */; };
@@ -481,7 +481,7 @@
 		A04200000000000000000002 /* Approval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Approval.swift; sourceTree = "<group>"; };
 		A04200000000000000000004 /* ApprovalRequestOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequestOverlay.swift; sourceTree = "<group>"; };
 		C1A042000000000000000002 /* Clarification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clarification.swift; sourceTree = "<group>"; };
-		C1A042000000000000000004 /* ClarificationRequestOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationRequestOverlay.swift; sourceTree = "<group>"; };
+		C1A042000000000000000004 /* ClarificationRequestCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationRequestCard.swift; sourceTree = "<group>"; };
 		C1A042000000000000000006 /* ClarificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationTests.swift; sourceTree = "<group>"; };
 		A02400000000000000000002 /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
 		C04600000000000000000002 /* ChatStreamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinator.swift; sourceTree = "<group>"; };
@@ -1065,7 +1065,7 @@
 				C0DE22000000000000000002 /* ChatHaptics.swift */,
 				105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */,
 				A04200000000000000000004 /* ApprovalRequestOverlay.swift */,
-				C1A042000000000000000004 /* ClarificationRequestOverlay.swift */,
+				C1A042000000000000000004 /* ClarificationRequestCard.swift */,
 				1A2B3C4D5E6F7000000000D9 /* MessageBubbleView.swift */,
 				C03190000000000000F002 /* InlineAudioPlayerView.swift */,
 				BEEF02400000000000000002 /* ChatAttachmentPreviewView.swift */,
@@ -1649,7 +1649,7 @@
 				A04200000000000000000001 /* Approval.swift in Sources */,
 				A04200000000000000000003 /* ApprovalRequestOverlay.swift in Sources */,
 				C1A042000000000000000001 /* Clarification.swift in Sources */,
-				C1A042000000000000000003 /* ClarificationRequestOverlay.swift in Sources */,
+				C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */,
 				A02400000000000000000001 /* Goal.swift in Sources */,
 				3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */,
 				3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatMotion.swift
+++ b/HermesMobile/Features/Chat/ChatMotion.swift
@@ -29,6 +29,13 @@ enum ChatMotion {
         reduceMotion ? nil : .easeOut(duration: 0.15)
     }
 
+    /// Expanding or collapsing the clarification card above the composer. The
+    /// card slides its own height past the bar's bottom edge on one ease-out
+    /// clock, sized like the keyboard's; Reduce Motion snaps.
+    static func clarificationToggle(reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : .easeOut(duration: 0.22)
+    }
+
     static func bottomOverlayTransition(reduceMotion: Bool) -> AnyTransition {
         reduceMotion ? .opacity : .move(edge: .bottom).combined(with: .opacity)
     }

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -20,9 +20,9 @@ struct ChatTranscriptView: View {
     let streamingAssistantMessageID: String?
     let liveTokensPerSecond: Double?
     let activeStreamRecoveryState: ActiveStreamRecoveryState
-    let clarificationPrompt: ClarificationPromptState?
-    let isRespondingToClarification: Bool
-    let clarificationErrorMessage: String?
+    /// The pending clarification's id. The card itself is pinned above the
+    /// composer by `ChatView`; the transcript only follows its arrival.
+    let clarificationPromptID: String?
     let hidesRunStatusAccessibility: Bool
     let showsThinkingAndToolCards: Bool
     /// Start date for the "Working for" tail row; nil hides the row.
@@ -74,7 +74,6 @@ struct ChatTranscriptView: View {
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
     let onPreviewTranscriptMedia: (TranscriptMediaReference) -> Void
     let onToggleListening: (MessageActionContext) -> Void
-    let onSubmitClarification: (String) -> Void
     let onSelectText: (MessageActionContext) -> Void
     let onRegenerate: (MessageActionContext) -> Void
     let onEdit: (MessageActionContext) -> Void
@@ -91,10 +90,10 @@ struct ChatTranscriptView: View {
     var onOpenTurnFileDiff: (GitFile) -> Void = { _ in }
 
     var body: some View {
-        if isLoading && messages.isEmpty && clarificationPrompt == nil {
+        if isLoading && messages.isEmpty {
             ChatTranscriptLoadingSkeletonView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let errorMessage, messages.isEmpty, clarificationPrompt == nil {
+        } else if let errorMessage, messages.isEmpty {
             ContentUnavailableView {
                 Label("Could Not Load Messages", systemImage: "exclamationmark.triangle")
             } description: {
@@ -104,7 +103,7 @@ struct ChatTranscriptView: View {
                     Task { await onLoadMessages() }
                 }
             }
-        } else if messages.isEmpty && clarificationPrompt == nil {
+        } else if messages.isEmpty {
             ContentUnavailableView {
                 Image(systemName: "bubble.left.and.bubble.right")
             } description: {
@@ -161,7 +160,6 @@ struct ChatTranscriptView: View {
                     .adaptiveSoftScrollEdges()
                     .simultaneousGesture(
                         TapGesture().onEnded {
-                            guard clarificationPrompt == nil else { return }
                             onDismissKeyboard()
                         }
                     )
@@ -199,8 +197,10 @@ struct ChatTranscriptView: View {
                     guard isFollowingLatestContent else { return }
                     onScrollToLatestContent(proxy, false)
                 }
-                .onChange(of: clarificationPrompt?.id) {
-                    guard clarificationPrompt != nil, isFollowingLatestContent else { return }
+                .onChange(of: clarificationPromptID) {
+                    // The bar above the composer just grew the bottom inset; keep
+                    // the latest content above it for a reader who was following.
+                    guard clarificationPromptID != nil, isFollowingLatestContent else { return }
                     onScrollToBottom(proxy)
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
@@ -299,7 +299,6 @@ struct ChatTranscriptView: View {
 
             transcriptLooseBlocks
             liveResponseBlocks
-            inlineClarificationCard
             workingRow
             turnChangesCard
             inlineCommitButton
@@ -419,21 +418,6 @@ struct ChatTranscriptView: View {
                     .accessibilityHidden(hidesRunStatusAccessibility)
                     .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
             }
-        }
-    }
-
-    @ViewBuilder
-    private var inlineClarificationCard: some View {
-        if let clarificationPrompt {
-            ClarificationRequestCard(
-                prompt: clarificationPrompt,
-                isResponding: isRespondingToClarification,
-                errorMessage: clarificationErrorMessage,
-                onSubmit: onSubmitClarification
-            )
-            .id(clarificationPrompt.id)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
         }
     }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -329,6 +329,9 @@ struct ChatView: View {
     @State private var gitToastState = GitActionToastState()
     @State private var gitAlert: GitChatAlert?
     @State private var composerHeight: CGFloat = 52
+    /// Measured height of the collapsed clarification bar, the request's only
+    /// layout footprint; the expanded card overlays the transcript instead.
+    @State private var clarificationBarHeight: CGFloat = 0
     @State private var composerIsFocused = false
     @State private var didHydrateDraft = false
     /// True from the moment hydration finds persisted attachment records until
@@ -610,6 +613,8 @@ struct ChatView: View {
             BottomComposerMaterialFade(composerHeight: composerHeight)
 
             composerAccessoryStack
+
+            clarificationInset
 
             messageComposer
 
@@ -1125,6 +1130,43 @@ struct ChatView: View {
         }
     }
 
+    /// The pending clarification, pinned above the composer. Sits in the same
+    /// bottom stack as the composer so it rides the keyboard with it.
+    private var clarificationInset: some View {
+        ZStack(alignment: .bottom) {
+            if let clarificationPrompt = viewModel.clarificationPrompt {
+                ClarificationRequestInset(
+                    prompt: clarificationPrompt,
+                    isResponding: viewModel.isRespondingToClarification,
+                    isStopping: viewModel.isCancellingStream,
+                    errorMessage: viewModel.clarificationErrorMessage,
+                    isHapticsEnabled: isHapticsEnabled,
+                    onSubmit: { response in
+                        Task {
+                            let didRespond = await viewModel.respondToClarification(response)
+                            if didRespond {
+                                ChatHaptics.clarificationSubmitted(isEnabled: isHapticsEnabled)
+                            }
+                        }
+                    },
+                    onStop: {
+                        Task { await cancelStream() }
+                    },
+                    onDismissKeyboard: dismissKeyboard,
+                    onFootprintChange: { height in
+                        clarificationBarHeight = height
+                    }
+                )
+                .id(clarificationPrompt.id)
+                .padding(.horizontal, 16)
+                .padding(.bottom, composerHeight + 8)
+                .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
+            }
+        }
+        .zIndex(9)
+        .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: viewModel.clarificationPrompt?.id)
+    }
+
     @ViewBuilder
     private var composerAccessoryStack: some View {
         if composerAccessoryVisibleItemCount > 0 {
@@ -1145,7 +1187,7 @@ struct ChatView: View {
                 }
             }
             .padding(.horizontal)
-            .padding(.bottom, composerHeight + 8)
+            .padding(.bottom, composerHeight + 8 + clarificationFootprintHeight)
             .allowsHitTesting(false)
             .zIndex(8)
             .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: composerAccessoryVisibleItemCount)
@@ -1175,9 +1217,7 @@ struct ChatView: View {
             streamingAssistantMessageID: viewModel.streamingAssistantMessageID,
             liveTokensPerSecond: viewModel.liveTokensPerSecond,
             activeStreamRecoveryState: viewModel.activeStreamRecoveryState,
-            clarificationPrompt: viewModel.clarificationPrompt,
-            isRespondingToClarification: viewModel.isRespondingToClarification,
-            clarificationErrorMessage: viewModel.clarificationErrorMessage,
+            clarificationPromptID: viewModel.clarificationPrompt?.id,
             hidesRunStatusAccessibility: activeRunStatusPresentation != nil,
             showsThinkingAndToolCards: showsThinkingAndToolCards,
             workingRowStartedAt: workingRowStartedAt,
@@ -1250,14 +1290,6 @@ struct ChatView: View {
             onToggleListening: { context in
                 viewModel.toggleListening(to: context)
             },
-            onSubmitClarification: { response in
-                Task {
-                    let didRespond = await viewModel.respondToClarification(response)
-                    if didRespond {
-                        ChatHaptics.clarificationSubmitted(isEnabled: isHapticsEnabled)
-                    }
-                }
-            },
             onSelectText: { context in
                 selectableResponseText = SelectableTextPresentation(context: context)
             },
@@ -1322,11 +1354,18 @@ struct ChatView: View {
     }
 
     private var transcriptBottomInsetHeight: CGFloat {
-        max(96, composerHeight + 44 + composerAccessorySpacerHeight)
+        max(96, composerHeight + 44 + composerAccessorySpacerHeight + clarificationFootprintHeight)
     }
 
     private var scrollToBottomButtonBottomPadding: CGFloat {
-        composerHeight + 12 + composerAccessorySpacerHeight
+        composerHeight + 12 + composerAccessorySpacerHeight + clarificationFootprintHeight
+    }
+
+    /// Bar height plus its gap above the composer while a clarification is
+    /// pending. Constant across expand and collapse, so the transcript never
+    /// moves while the card animates.
+    private var clarificationFootprintHeight: CGFloat {
+        viewModel.clarificationPrompt == nil ? 0 : clarificationBarHeight + 8
     }
 
     private var pinnedNoticeSpacerHeight: CGFloat {

--- a/HermesMobile/Features/Chat/ClarificationRequestCard.swift
+++ b/HermesMobile/Features/Chat/ClarificationRequestCard.swift
@@ -1,30 +1,156 @@
 import SwiftUI
+import UIKit
 
-struct ClarificationRequestOverlay: View {
+/// The clarification request pinned above the composer while the agent waits
+/// for an answer. The collapsed bar is the permanent footprint: its measured
+/// height feeds the transcript's bottom inset. The expanded card is an overlay
+/// that rises from the bar's bottom edge, so opening or closing it never moves
+/// the transcript. A new request always arrives expanded.
+struct ClarificationRequestInset: View {
     let prompt: ClarificationPromptState
     let isResponding: Bool
+    let isStopping: Bool
     let errorMessage: String?
-    let bottomPadding: CGFloat
+    let isHapticsEnabled: Bool
     let onSubmit: (String) -> Void
+    let onStop: () -> Void
+    /// Collapsing hides the response field, so the keyboard goes with it.
+    let onDismissKeyboard: () -> Void
+    /// The bar's height, the only part of this view that takes layout space.
+    let onFootprintChange: (CGFloat) -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.colorScheme) private var colorScheme
+    @State private var isExpanded = true
+    // Lives here rather than in the card so a typed answer survives collapse.
+    @State private var draftResponse = ""
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            Color.black.opacity(colorScheme == .dark ? 0.24 : 0.18)
-                .ignoresSafeArea()
-
-            ClarificationRequestCard(
-                prompt: prompt,
-                isResponding: isResponding,
-                errorMessage: errorMessage,
-                onSubmit: onSubmit
-            )
-                .padding(.horizontal, 16)
-                .padding(.bottom, bottomPadding)
-                .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
+        ClarificationRequestBar(
+            prompt: prompt,
+            isStopping: isStopping,
+            onExpand: { setExpanded(true) },
+            onStop: onStop
+        )
+        .accessibilityHidden(isExpanded)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            onFootprintChange(height)
         }
+        .overlay(alignment: .bottom) {
+            // Clip window with its bottom edge on the bar's bottom edge: the
+            // opaque card slides its own height down through it, revealing the
+            // transcript and then the bar only where it has physically left.
+            // No crossfade, and nothing is drawn over the composer below.
+            ZStack(alignment: .bottom) {
+                if isExpanded {
+                    ClarificationRequestCard(
+                        prompt: prompt,
+                        isResponding: isResponding,
+                        errorMessage: errorMessage,
+                        draftResponse: $draftResponse,
+                        onSubmit: onSubmit,
+                        onCollapse: { setExpanded(false) }
+                    )
+                    .transition(.move(edge: .bottom))
+                }
+            }
+            .clipped()
+        }
+        .onChange(of: prompt.id, initial: true) {
+            announceRequest()
+        }
+    }
+
+    private func setExpanded(_ expanded: Bool) {
+        guard expanded != isExpanded else { return }
+        if !expanded {
+            onDismissKeyboard()
+        }
+        ChatHaptics.disclosureToggled(isEnabled: isHapticsEnabled)
+        withAnimation(ChatMotion.clarificationToggle(reduceMotion: reduceMotion)) {
+            isExpanded = expanded
+        }
+    }
+
+    /// One announcement per request; re-renders and toggles stay silent.
+    private func announceRequest() {
+        guard UIAccessibility.isVoiceOverRunning else { return }
+        let announcement = String(localized: "Input needed: \(ClarificationRequestBar.summary(for: prompt.question))")
+        AccessibilityNotification.Announcement(announcement).post()
+    }
+}
+
+/// One-line footprint of a pending clarification: what is being asked, a way
+/// back into the card, and Stop for when the run should end instead.
+struct ClarificationRequestBar: View {
+    let prompt: ClarificationPromptState
+    let isStopping: Bool
+    let onExpand: () -> Void
+    let onStop: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @ScaledMetric(relativeTo: .body) private var stopButtonSize: CGFloat = 32
+
+    /// The first non-empty line of a question, so a multi-line prompt reads
+    /// as one line on the bar.
+    static func summary(for question: String) -> String {
+        question
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { !$0.isEmpty } ?? ""
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: onExpand) {
+                HStack(spacing: 10) {
+                    Image(systemName: "questionmark.circle")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Input needed")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                        Text(Self.summary(for: prompt.question))
+                            .font(.subheadline)
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 8)
+
+                    Image(systemName: "chevron.up")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Expand clarification")
+            .accessibilityValue(Self.summary(for: prompt.question))
+
+            Button(action: onStop) {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: stopButtonSize, height: stopButtonSize)
+                    .background(Color.red.opacity(colorScheme == .dark ? 0.22 : 0.12))
+                    .foregroundStyle(.red)
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.chatTactile(.icon))
+            .disabled(isStopping)
+            .accessibilityLabel("Stop response")
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 8)
+        .padding(.vertical, 8)
+        .frame(maxWidth: 560)
+        .clarificationSurface(cornerRadius: 22)
         .accessibilityElement(children: .contain)
     }
 }
@@ -33,42 +159,28 @@ struct ClarificationRequestCard: View {
     let prompt: ClarificationPromptState
     let isResponding: Bool
     let errorMessage: String?
+    @Binding var draftResponse: String
     let onSubmit: (String) -> Void
+    let onCollapse: () -> Void
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorScheme) private var colorScheme
     @ScaledMetric(relativeTo: .body) private var submitButtonSize: CGFloat = 40
-    @State private var draftResponse = ""
+    @ScaledMetric(relativeTo: .body) private var collapseButtonSize: CGFloat = 28
+    @State private var bodyContentHeight: CGFloat?
+
+    /// Beyond this the question and choices scroll inside the card, so a long
+    /// prompt cannot push the response field off screen. Sized to fit a short
+    /// question with four choices without scrolling.
+    private let bodyHeightCap: CGFloat = 300
 
     var body: some View {
-        card
+        cardContent
+            .frame(maxWidth: 560, alignment: .leading)
+            .clarificationSurface(cornerRadius: 24)
+            // Ideal height regardless of what the bar-sized overlay proposes.
+            .fixedSize(horizontal: false, vertical: true)
             .accessibilityElement(children: .contain)
-    }
-
-    private var card: some View {
-        cardSurface
-            .shadow(color: .black.opacity(colorScheme == .dark ? 0.22 : 0.12), radius: 18, x: 0, y: 12)
-    }
-
-    @ViewBuilder
-    private var cardSurface: some View {
-        if reduceTransparency {
-            cardContent
-                .background(
-                    Color(.secondarySystemBackground),
-                    in: RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-                )
-                .overlay(cardBorder)
-        } else if #available(iOS 26.0, *) {
-            GlassEffectContainer(spacing: 14) {
-                cardContent
-                    .glassEffect(.regular.tint(cardTint), in: .rect(cornerRadius: cardCornerRadius))
-            }
-        } else {
-            cardContent
-                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous))
-                .overlay(cardBorder)
-        }
     }
 
     private var header: some View {
@@ -92,7 +204,22 @@ struct ClarificationRequestCard: View {
             Spacer(minLength: 8)
 
             expirationView
+
+            collapseButton
         }
+    }
+
+    private var collapseButton: some View {
+        Button(action: onCollapse) {
+            Image(systemName: "chevron.down")
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: collapseButtonSize, height: collapseButtonSize)
+                .background(.primary.opacity(0.08))
+                .foregroundStyle(.secondary)
+                .clipShape(Circle())
+        }
+        .buttonStyle(.chatTactile(.icon))
+        .accessibilityLabel("Collapse clarification")
     }
 
     private var question: some View {
@@ -114,6 +241,32 @@ struct ClarificationRequestCard: View {
             ForEach(prompt.choices, id: \.self) { choice in
                 choiceButton(choice)
             }
+        }
+    }
+
+    /// Question plus choices, scrolling only once they outgrow the cap.
+    @ViewBuilder
+    private var scrollableBody: some View {
+        let content = VStack(alignment: .leading, spacing: 14) {
+            question
+
+            if !prompt.choices.isEmpty {
+                choicesList
+            }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            bodyContentHeight = height
+        }
+
+        if let bodyContentHeight, bodyContentHeight > bodyHeightCap {
+            ScrollView {
+                content
+            }
+            .frame(height: bodyHeightCap)
+        } else {
+            content
         }
     }
 
@@ -194,17 +347,11 @@ struct ClarificationRequestCard: View {
     private var cardContent: some View {
         VStack(alignment: .leading, spacing: 14) {
             header
-            question
-
-            if !prompt.choices.isEmpty {
-                choicesList
-            }
-
+            scrollableBody
             responseField
             footer
         }
         .padding(16)
-        .frame(maxWidth: 560, alignment: .leading)
     }
 
     @ViewBuilder
@@ -271,19 +418,6 @@ struct ClarificationRequestCard: View {
         colorScheme == .dark ? Color.white.opacity(0.72) : Color.black.opacity(0.58)
     }
 
-    private var cardTint: Color {
-        colorScheme == .dark ? Color.white.opacity(0.035) : Color.white.opacity(0.16)
-    }
-
-    private var cardCornerRadius: CGFloat {
-        24
-    }
-
-    private var cardBorder: some View {
-        RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-            .stroke(.primary.opacity(0.10), lineWidth: 1)
-    }
-
     private func submitDraft() {
         let value = trimmedDraft
         guard !value.isEmpty else { return }
@@ -338,6 +472,20 @@ struct ClarificationRequestCard: View {
 }
 
 private extension View {
+    /// Opaque on purpose: the bar and card float over live transcript text,
+    /// and a translucent surface would render the question on top of whatever
+    /// message happens to sit underneath.
+    func clarificationSurface(cornerRadius: CGFloat) -> some View {
+        background(
+            Color(.secondarySystemBackground),
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .stroke(.primary.opacity(0.10), lineWidth: 1)
+        )
+    }
+
     @ViewBuilder
     func choiceButtonSurface(reduceTransparency: Bool) -> some View {
         if reduceTransparency {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -117222,6 +117222,430 @@
           }
         }
       }
+    },
+    "Input needed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مطلوب إدخال"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eingabe erforderlich"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Respuesta necesaria"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Réponse requise"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נדרש קלט"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Risposta richiesta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "入力が必要です"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "입력 필요"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Invoer nodig"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wymagana odpowiedź"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resposta necessária"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Требуется ответ"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yanıt gerekli"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "جواب درکار ہے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要輸入"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要输入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要輸入"
+          }
+        }
+      }
+    },
+    "Input needed: %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مطلوب إدخال: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eingabe erforderlich: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Respuesta necesaria: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Réponse requise : %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נדרש קלט: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Risposta richiesta: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "入力が必要です: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "입력 필요: %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Invoer nodig: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wymagana odpowiedź: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resposta necessária: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Требуется ответ: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yanıt gerekli: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "جواب درکار ہے: %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要輸入：%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要输入：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要輸入：%@"
+          }
+        }
+      }
+    },
+    "Expand clarification" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "توسيع التوضيح"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rückfrage ausklappen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Expandir aclaración"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Développer la clarification"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הרחב את ההבהרה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Espandi chiarimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "確認内容を展開"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "설명 요청 펼치기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verduidelijking uitvouwen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rozwiń pytanie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Expandir esclarecimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Развернуть уточнение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Açıklamayı genişlet"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "وضاحت پھیلائیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "展開澄清請求"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "展开澄清请求"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "展開澄清請求"
+          }
+        }
+      }
+    },
+    "Collapse clarification" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "طي التوضيح"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rückfrage einklappen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Contraer aclaración"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Réduire la clarification"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "כווץ את ההבהרה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Comprimi chiarimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "確認内容を折りたたむ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "설명 요청 접기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verduidelijking invouwen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zwiń pytanie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recolher esclarecimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Свернуть уточнение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Açıklamayı daralt"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "وضاحت سمیٹیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "收合澄清請求"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "折叠澄清请求"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "收合澄清請求"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/TranscriptDisplayModelTests.swift
+++ b/HermesMobileTests/TranscriptDisplayModelTests.swift
@@ -3,6 +3,7 @@ import AVFoundation
 import ImageIO
 import SwiftData
 import UIKit
+import SwiftUI
 import UniformTypeIdentifiers
 @testable import HermesMobile
 
@@ -625,5 +626,21 @@ final class ResponseSpeedFormatterTests: XCTestCase {
         XCTAssertNil(ResponseSpeedFormatter.compactText(-1))
         XCTAssertNil(ResponseSpeedFormatter.compactText(.infinity))
         XCTAssertNil(ResponseSpeedFormatter.compactText(.nan))
+    }
+}
+
+final class ClarificationRequestPresentationTests: XCTestCase {
+    func testBarSummaryIsFirstNonEmptyLineOfQuestion() {
+        XCTAssertEqual(ClarificationRequestBar.summary(for: "Which branch?"), "Which branch?")
+        XCTAssertEqual(
+            ClarificationRequestBar.summary(for: "\n  Which branch should I use?  \n1. main\n2. release"),
+            "Which branch should I use?"
+        )
+        XCTAssertEqual(ClarificationRequestBar.summary(for: "   "), "")
+    }
+
+    func testToggleCurveIsOneEaseOutClockAndSnapsUnderReduceMotion() {
+        XCTAssertEqual(ChatMotion.clarificationToggle(reduceMotion: false), .easeOut(duration: 0.22))
+        XCTAssertNil(ChatMotion.clarificationToggle(reduceMotion: true))
     }
 }


### PR DESCRIPTION
## Linked issue

Chat feel polish; no tracking issue.

## What changed

When the agent asks a clarifying question, the card lived inside the transcript. Scroll up to re-read what led to the question and the card, its choices, and its answer field leave the screen; nothing on the way back says input is waiting, and the only Stop is the composer slot.

The request is now pinned above the composer:

- A one-line bar (**Input needed**, the first line of the question, a chevron, and **Stop**) is the permanent footprint. Its measured height is the only thing added to the transcript's bottom inset, and that inset is the same whether the card is open or closed, so the transcript never moves while the card animates.
- The full card (question, choices, answer field, expiry, errors) opens over the transcript from the bar's bottom edge and slides back down behind it: an opaque surface with no crossfade, clipped at the bar so nothing draws over the composer. The transcript stays scrollable underneath.
- Expand and collapse share one 0.22 s ease-out curve (`ChatMotion.clarificationToggle`); Reduce Motion snaps. Toggles get the same selection haptic as other disclosures.
- A typed answer survives collapse (the draft lives in the pinned container, not the card), collapse releases the keyboard, and the composer below is untouched, so its draft survives too.
- VoiceOver announces each new request once (`Input needed: <question>`); the bar is hidden from VoiceOver while the card covers it.
- Long questions or many choices scroll inside the card past 300 pt, so the answer field stays reachable above the keyboard.
- Submit is still disabled until the field has text; choices still submit on tap; the error footer, the `1 of N pending` count, and the expiry countdown are unchanged.

Approvals keep their modal overlay for now. `ClarificationRequestOverlay.swift` (the old dimmed overlay, no longer referenced) becomes `ClarificationRequestCard.swift`, which holds the pinned container, the bar, and the card.

Two calls made along the way, open to a different answer:

1. **Stop on the bar even though the composer's send slot also shows Stop during a run.** Kept it: typing a steer flips the composer slot to Send, so the bar's Stop is the one that stays put.
2. **Opaque surface instead of the previous glass.** The card now floats over live transcript text, and a translucent surface renders the question on top of whatever message sits underneath.

### Before / after

| Before (in the transcript) | After, expanded | After, collapsed |
| --- | --- | --- |
| ![before](https://gist.githubusercontent.com/uzairansaruzi/f9c6ddd5a534b00c510ffcb5558ef315/raw/before-master.jpg) | ![after expanded](https://gist.githubusercontent.com/uzairansaruzi/f9c6ddd5a534b00c510ffcb5558ef315/raw/after-expanded.jpg) | ![after collapsed](https://gist.githubusercontent.com/uzairansaruzi/f9c6ddd5a534b00c510ffcb5558ef315/raw/after-collapsed.jpg) |

Motion (collapse, then expand; the transcript behind stays put): [clarification-toggle.mp4](https://gist.githubusercontent.com/uzairansaruzi/f9c6ddd5a534b00c510ffcb5558ef315/raw/clarification-toggle.mp4)

## How it was tested

- `ClarificationRequestPresentationTests` (2): the bar's one-line summary of a multi-line question, and the toggle curve (0.22 s ease-out, nil under Reduce Motion).
- `LocalizationCatalogTests` (7) for the four new String Catalog keys, translated in every shipped language.
- Manual on the iPhone 17 simulator against a live server, in a disposable session that asked a real `clarify` question: card arrives expanded above the composer; collapse to the bar and the transcript does not shift; expand again; type an answer, collapse, expand and the draft is still there; tap a choice and the card clears and the run continues; Stop on the bar ends the run (`You stopped after …`). Session deleted afterwards.
- Full XCTest suite on `bd2b703` via XcodeBuildMCP `test_sim` (iPhone 17): 1829 passed, 0 failed, 2 skipped (the pre-existing photo-library integration skips).

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename) — no model changes
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server) — no endpoint changes

---

Built by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
