### PR TITLE
feat(tasks): show per-task run history with tap-through full run output on Task Detail

### DIFF
--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -8,6 +8,7 @@ struct TaskDetailView: View {
     @State private var viewModel: TaskDetailViewModel
     @State private var isPresentingEditTask = false
     @State private var isConfirmingDelete = false
+    @State private var selectedRun: CronRunEntry?
     @Environment(\.dismiss) private var dismiss
 
     init(
@@ -29,6 +30,7 @@ struct TaskDetailView: View {
                 headerSection
                 actionStatusSection
                 metadataSection
+                runHistorySection
 
                 if viewModel.isLoading && viewModel.outputs.isEmpty {
                     ProgressView("Loading output...")
@@ -123,6 +125,22 @@ struct TaskDetailView: View {
                 return didUpdate
             }
         }
+        .sheet(item: $selectedRun, onDismiss: { viewModel.clearRunDetail() }) { run in
+            CronRunDetailSheet(
+                run: run,
+                isLoading: viewModel.isLoadingRunDetail,
+                detail: viewModel.loadedRunDetail,
+                errorMessage: viewModel.runDetailErrorMessage,
+                onRetry: {
+                    Task {
+                        await viewModel.loadRunDetail(filename: run.filename ?? "")
+                    }
+                }
+            )
+            .task(id: run.id) {
+                await viewModel.loadRunDetail(filename: run.filename ?? "")
+            }
+        }
         .alert("Delete Task?", isPresented: $isConfirmingDelete) {
             Button("Delete", role: .destructive) {
                 Task { await deleteTask() }
@@ -133,6 +151,7 @@ struct TaskDetailView: View {
         }
         .task {
             await loadOutput()
+            await loadRunHistory()
         }
     }
 
@@ -233,6 +252,73 @@ struct TaskDetailView: View {
             }
         }
         .font(.footnote)
+    }
+
+    @ViewBuilder
+    private var runHistorySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Run History")
+                    .font(.headline)
+                Spacer()
+                if let total = viewModel.runHistoryTotal {
+                    Text("\(total) total")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if viewModel.isLoadingHistory && viewModel.runHistory.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 12)
+            } else if let historyError = viewModel.historyErrorMessage, viewModel.runHistory.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(historyError)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Button("Try Again") {
+                        Task { await loadRunHistory() }
+                    }
+                    .font(.footnote)
+                }
+            } else if viewModel.runHistory.isEmpty {
+                Text("No Past Runs")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(viewModel.runHistory) { run in
+                    Button {
+                        selectedRun = run
+                    } label: {
+                        CronRunHistoryRow(run: run)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if viewModel.canLoadMoreRunHistory {
+                    Button {
+                        Task { _ = await viewModel.loadMoreRunHistory() }
+                    } label: {
+                        HStack(spacing: 8) {
+                            if viewModel.isLoadingHistory {
+                                ProgressView()
+                            }
+                            Text("Load More")
+                        }
+                        .font(.footnote.weight(.medium))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 6)
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(viewModel.isLoadingHistory)
+                }
+            }
+        }
+    }
+
+    private func loadRunHistory() async {
+        await viewModel.loadRunHistory()
     }
 
     @ViewBuilder
@@ -350,5 +436,124 @@ struct TaskDetailView: View {
         }
 
         onMutation(mutation)
+    }
+}
+
+/// One row in the Run History list: filename, date, size, and usage chips.
+struct CronRunHistoryRow: View {
+    let run: CronRunEntry
+
+    private static let byteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(run.filename ?? String(localized: "Untitled"))
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            HStack(spacing: 6) {
+                if let date = run.modified?.date {
+                    Text(date, style: .date)
+                    Text(date, style: .time)
+                }
+
+                if let size = run.size {
+                    Text(Self.byteFormatter.string(fromByteCount: Int64(size)))
+                }
+
+                if let usage = run.usage {
+                    if !usage.chipText.isEmpty {
+                        Text(usage.chipText)
+                    }
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+    }
+}
+
+extension CronRunUsage {
+    /// Compact one-line summary for the history row chips ("model · 2.3s · $0.0123").
+    var chipText: String {
+        var parts: [String] = []
+        if let durationSeconds, durationSeconds > 0 {
+            if durationSeconds < 60 {
+                parts.append(String(format: "%.1fs", durationSeconds))
+            } else {
+                parts.append(String(format: "%.1fm", durationSeconds / 60))
+            }
+        }
+        if let estimatedCostUsd {
+            parts.append(String(format: "$%.4f", estimatedCostUsd))
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+/// Tap-through from a history row: full output of one past run.
+struct CronRunDetailSheet: View {
+    let run: CronRunEntry
+    let isLoading: Bool
+    let detail: CronRunDetailResponse?
+    let errorMessage: String?
+    let onRetry: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView(String(localized: "Loading run..."))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let errorMessage, detail == nil {
+                    ContentUnavailableView {
+                        Label("Could Not Load Run", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(errorMessage)
+                    } actions: {
+                        Button("Try Again") {
+                            onRetry()
+                        }
+                    }
+                } else if let detail {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 12) {
+                            if let content = detail.content, !content.isEmpty {
+                                Text(content)
+                                    .font(.system(.body, design: .monospaced))
+                                    .textSelection(.enabled)
+                                    .padding(12)
+                                    .background(Color(.secondarySystemBackground))
+                                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            } else {
+                                Text("Empty output")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding()
+                    }
+                }
+            }
+            .navigationTitle(Text(run.filename ?? String(localized: "Untitled")))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
     }
 }

--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -288,12 +288,18 @@ struct TaskDetailView: View {
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(viewModel.runHistory) { run in
-                    Button {
-                        selectedRun = run
-                    } label: {
+                    if run.addressable {
+                        Button {
+                            selectedRun = run
+                        } label: {
+                            CronRunHistoryRow(run: run)
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        // No filename means the server cannot serve this
+                        // run's content, so the row is display-only.
                         CronRunHistoryRow(run: run)
                     }
-                    .buttonStyle(.plain)
                 }
 
                 if viewModel.canLoadMoreRunHistory {
@@ -478,6 +484,15 @@ struct CronRunHistoryRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 6)
         .contentShape(Rectangle())
+    }
+}
+
+extension CronRunEntry {
+    /// Whether this run can be opened: a filename is required to fetch its
+    /// content, so filename-less rows render display-only instead of opening
+    /// a detail sheet that can never load.
+    var addressable: Bool {
+        !(filename?.isEmpty ?? true)
     }
 }
 

--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -492,7 +492,8 @@ extension CronRunEntry {
     /// content, so filename-less rows render display-only instead of opening
     /// a detail sheet that can never load.
     var addressable: Bool {
-        !(filename?.isEmpty ?? true)
+        guard let filename else { return false }
+        return !filename.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 

--- a/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
@@ -8,6 +8,13 @@ final class TaskDetailViewModel {
     private(set) var runningElapsed: Double?
 
     private(set) var outputs: [CronOutputItem] = []
+    private(set) var runHistory: [CronRunEntry] = []
+    private(set) var runHistoryTotal: Int?
+    private(set) var isLoadingHistory = false
+    private(set) var historyErrorMessage: String?
+    private(set) var loadedRunDetail: CronRunDetailResponse?
+    private(set) var isLoadingRunDetail = false
+    private(set) var runDetailErrorMessage: String?
     /// Server-provided deliver targets; `nil` while unknown or when the
     /// endpoint is unavailable (the editor then falls back to free text).
     private(set) var deliveryOptions: [CronDeliveryOption]?
@@ -19,6 +26,8 @@ final class TaskDetailViewModel {
     private(set) var lastMutation: CronJobListMutation?
 
     private let client: APIClient
+
+    private static let runHistoryPageSize = 50
 
     init(job: CronJob, runningElapsed: Double?, server: URL, client: APIClient? = nil) {
         self.job = job
@@ -50,6 +59,86 @@ final class TaskDetailViewModel {
         }
 
         deliveryOptions = await deliveryOptionsResponse?.platforms
+    }
+
+    /// Loads the first page of run history. History is an optional enhancement:
+    /// a failure never blocks the detail screen (the recent-output section is
+    /// the primary content), it only shows a small inline error.
+    func loadRunHistory() async {
+        guard let jobID = job.jobId else { return }
+
+        isLoadingHistory = true
+        historyErrorMessage = nil
+        defer { isLoadingHistory = false }
+
+        do {
+            let response = try await client.cronRunHistory(jobID: jobID, offset: 0, limit: Self.runHistoryPageSize)
+            runHistory = response.runs ?? []
+            runHistoryTotal = response.total
+        } catch {
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// Appends the next page of runs; `true` when a request was made.
+    func loadMoreRunHistory() async -> Bool {
+        guard let jobID = job.jobId else { return false }
+
+        let nextOffset = runHistory.count
+        guard canLoadMoreRunHistory, nextOffset > 0 else { return false }
+
+        isLoadingHistory = true
+        defer { isLoadingHistory = false }
+
+        do {
+            let response = try await client.cronRunHistory(jobID: jobID, offset: nextOffset, limit: Self.runHistoryPageSize)
+            runHistory.append(contentsOf: response.runs ?? [])
+            runHistory = deduplicatedRunHistory()
+            runHistoryTotal = response.total
+            return true
+        } catch {
+            historyErrorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    var canLoadMoreRunHistory: Bool {
+        guard let total = runHistoryTotal else { return false }
+        return runHistory.count < total
+    }
+
+    /// Server returns runs newest-first; dedupe defensively by filename so a
+    /// page boundary can never render a row twice.
+    private func deduplicatedRunHistory() -> [CronRunEntry] {
+        var seen = Set<String>()
+        return runHistory.filter { entry in
+            let key = entry.filename ?? entry.id
+            return seen.insert(key).inserted
+        }
+    }
+
+    /// Loads the full content of one past run for the detail sheet.
+    func loadRunDetail(filename: String) async {
+        guard let jobID = job.jobId, !filename.isEmpty else {
+            runDetailErrorMessage = String(localized: "Missing run identifier.")
+            return
+        }
+
+        isLoadingRunDetail = true
+        loadedRunDetail = nil
+        runDetailErrorMessage = nil
+        defer { isLoadingRunDetail = false }
+
+        do {
+            loadedRunDetail = try await client.cronRunDetail(jobID: jobID, filename: filename)
+        } catch {
+            runDetailErrorMessage = error.localizedDescription
+        }
+    }
+
+    func clearRunDetail() {
+        loadedRunDetail = nil
+        runDetailErrorMessage = nil
     }
 
     func clearActionError() {

--- a/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
@@ -10,11 +10,20 @@ final class TaskDetailViewModel {
     private(set) var outputs: [CronOutputItem] = []
     private(set) var runHistory: [CronRunEntry] = []
     private(set) var runHistoryTotal: Int?
+    /// Number of server records already consumed across pages. Server paging
+    /// is positional, so the next request's offset must track fetched records —
+    /// not the deduplicated display list, or a repeated filename across a page
+    /// boundary would re-request an earlier offset forever.
+    private(set) var consumedRunCount = 0
     private(set) var isLoadingHistory = false
     private(set) var historyErrorMessage: String?
     private(set) var loadedRunDetail: CronRunDetailResponse?
     private(set) var isLoadingRunDetail = false
     private(set) var runDetailErrorMessage: String?
+    /// The run whose detail request is currently in flight; responses (and
+    /// errors) for any other run are discarded so a slow earlier request can
+    /// never overwrite a newer selection.
+    private var inFlightRunDetailFilename: String?
     /// Server-provided deliver targets; `nil` while unknown or when the
     /// endpoint is unavailable (the editor then falls back to free text).
     private(set) var deliveryOptions: [CronDeliveryOption]?
@@ -74,17 +83,20 @@ final class TaskDetailViewModel {
         do {
             let response = try await client.cronRunHistory(jobID: jobID, offset: 0, limit: Self.runHistoryPageSize)
             runHistory = response.runs ?? []
+            consumedRunCount = runHistory.count
             runHistoryTotal = response.total
         } catch {
             historyErrorMessage = error.localizedDescription
         }
     }
 
-    /// Appends the next page of runs; `true` when a request was made.
+    /// Appends the next page of runs; `true` when a request was made. The
+    /// paging offset counts server records consumed (including duplicates the
+    /// display list drops), so it always advances past the last fetched page.
     func loadMoreRunHistory() async -> Bool {
         guard let jobID = job.jobId else { return false }
 
-        let nextOffset = runHistory.count
+        let nextOffset = consumedRunCount
         guard canLoadMoreRunHistory, nextOffset > 0 else { return false }
 
         isLoadingHistory = true
@@ -93,6 +105,7 @@ final class TaskDetailViewModel {
         do {
             let response = try await client.cronRunHistory(jobID: jobID, offset: nextOffset, limit: Self.runHistoryPageSize)
             runHistory.append(contentsOf: response.runs ?? [])
+            consumedRunCount = nextOffset + (response.runs?.count ?? 0)
             runHistory = deduplicatedRunHistory()
             runHistoryTotal = response.total
             return true
@@ -104,7 +117,7 @@ final class TaskDetailViewModel {
 
     var canLoadMoreRunHistory: Bool {
         guard let total = runHistoryTotal else { return false }
-        return runHistory.count < total
+        return consumedRunCount < total
     }
 
     /// Server returns runs newest-first; dedupe defensively by filename so a
@@ -117,7 +130,10 @@ final class TaskDetailViewModel {
         }
     }
 
-    /// Loads the full content of one past run for the detail sheet.
+    /// Loads the full content of one past run for the detail sheet. Tracks the
+    /// in-flight filename so a slow response for an earlier selection (or an
+    /// error arriving after the user moved on) can never clobber the newer
+    /// selection's state. Cancellation is not a user-facing failure.
     func loadRunDetail(filename: String) async {
         guard let jobID = job.jobId, !filename.isEmpty else {
             runDetailErrorMessage = String(localized: "Missing run identifier.")
@@ -127,16 +143,23 @@ final class TaskDetailViewModel {
         isLoadingRunDetail = true
         loadedRunDetail = nil
         runDetailErrorMessage = nil
+        inFlightRunDetailFilename = filename
         defer { isLoadingRunDetail = false }
 
         do {
-            loadedRunDetail = try await client.cronRunDetail(jobID: jobID, filename: filename)
+            let response = try await client.cronRunDetail(jobID: jobID, filename: filename)
+            guard inFlightRunDetailFilename == filename else { return }
+            loadedRunDetail = response
+        } catch is CancellationError {
+            return
         } catch {
+            guard inFlightRunDetailFilename == filename else { return }
             runDetailErrorMessage = error.localizedDescription
         }
     }
 
     func clearRunDetail() {
+        inFlightRunDetailFilename = nil
         loadedRunDetail = nil
         runDetailErrorMessage = nil
     }

--- a/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
@@ -144,7 +144,15 @@ final class TaskDetailViewModel {
         loadedRunDetail = nil
         runDetailErrorMessage = nil
         inFlightRunDetailFilename = filename
-        defer { isLoadingRunDetail = false }
+
+        defer {
+            // Only wind down the loading flag if this request is still the
+            // active one; a superseded request finishing late must not clear
+            // the newer request's spinner.
+            if inFlightRunDetailFilename == filename {
+                isLoadingRunDetail = false
+            }
+        }
 
         do {
             let response = try await client.cronRunDetail(jobID: jobID, filename: filename)
@@ -160,6 +168,7 @@ final class TaskDetailViewModel {
 
     func clearRunDetail() {
         inFlightRunDetailFilename = nil
+        isLoadingRunDetail = false
         loadedRunDetail = nil
         runDetailErrorMessage = nil
     }

--- a/HermesMobile/Models/Cron.swift
+++ b/HermesMobile/Models/Cron.swift
@@ -243,7 +243,10 @@ struct CronOutputItem: Decodable, Equatable, Identifiable {
 /// One past run of a cron job from `/api/crons/history` (metadata only — the
 /// server lists run files without content; full content comes from `/api/crons/run`).
 struct CronRunEntry: Decodable, Equatable, Identifiable {
-    var id: String { filename ?? UUID().uuidString }
+    /// Stable identity captured once at decode: a missing filename falls back
+    /// to a fallback captured here, so repeated `id` access never yields a new
+    /// UUID (which would destroy SwiftUI row identity and restart sheet tasks).
+    let id: String
 
     let filename: String?
     let size: Int?
@@ -260,6 +263,7 @@ struct CronRunEntry: Decodable, Equatable, Identifiable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         filename = container.decodeLossyStringIfPresent(forKey: .filename)
+        id = filename ?? "run-\(UUID().uuidString)"
         size = ((try? container.decodeFlexibleDoubleIfPresent(forKey: .size)) ?? nil).map(Int.init)
         modified = (try? container.decodeIfPresent(CronDateValue.self, forKey: .modified)) ?? nil
         usage = (try? container.decodeIfPresent(CronRunUsage.self, forKey: .usage)) ?? nil

--- a/HermesMobile/Models/Cron.swift
+++ b/HermesMobile/Models/Cron.swift
@@ -240,6 +240,117 @@ struct CronOutputItem: Decodable, Equatable, Identifiable {
     }
 }
 
+/// One past run of a cron job from `/api/crons/history` (metadata only — the
+/// server lists run files without content; full content comes from `/api/crons/run`).
+struct CronRunEntry: Decodable, Equatable, Identifiable {
+    var id: String { filename ?? UUID().uuidString }
+
+    let filename: String?
+    let size: Int?
+    let modified: CronDateValue?
+    let usage: CronRunUsage?
+
+    enum CodingKeys: String, CodingKey {
+        case filename
+        case size
+        case modified
+        case usage
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        filename = container.decodeLossyStringIfPresent(forKey: .filename)
+        size = ((try? container.decodeFlexibleDoubleIfPresent(forKey: .size)) ?? nil).map(Int.init)
+        modified = (try? container.decodeIfPresent(CronDateValue.self, forKey: .modified)) ?? nil
+        usage = (try? container.decodeIfPresent(CronRunUsage.self, forKey: .usage)) ?? nil
+    }
+}
+
+/// Token/cost metadata the server parses out of a cron run's output header.
+/// Every field is optional: the server only emits what it can find.
+struct CronRunUsage: Decodable, Equatable {
+    let model: String?
+    let provider: String?
+    let estimatedCostUsd: Double?
+    let durationSeconds: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case provider
+        case estimatedCostUsd
+        case durationSeconds
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = container.decodeLossyStringIfPresent(forKey: .model)
+        provider = container.decodeLossyStringIfPresent(forKey: .provider)
+        estimatedCostUsd = (try? container.decodeFlexibleDoubleIfPresent(forKey: .estimatedCostUsd)) ?? nil
+        durationSeconds = (try? container.decodeFlexibleDoubleIfPresent(forKey: .durationSeconds)) ?? nil
+    }
+}
+
+struct CronRunHistoryResponse: Decodable, Equatable {
+    let jobId: String?
+    let runs: [CronRunEntry]?
+    let total: Int?
+    let offset: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case jobId
+        case runs
+        case total
+        case offset
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jobId = try container.decodeIfPresent(String.self, forKey: .jobId)
+        runs = (try? container.decodeIfPresent([CronRunEntry].self, forKey: .runs)) ?? nil
+        total = ((try? container.decodeFlexibleDoubleIfPresent(forKey: .total)) ?? nil).map(Int.init)
+        offset = ((try? container.decodeFlexibleDoubleIfPresent(forKey: .offset)) ?? nil).map(Int.init)
+    }
+}
+
+struct CronRunDetailResponse: Decodable, Equatable {
+    let jobId: String?
+    let filename: String?
+    let content: String?
+    let snippet: String?
+    let usage: CronRunUsage?
+
+    enum CodingKeys: String, CodingKey {
+        case jobId
+        case filename
+        case content
+        case snippet
+        case usage
+    }
+
+    init(
+        jobId: String?,
+        filename: String?,
+        content: String?,
+        snippet: String?,
+        usage: CronRunUsage?
+    ) {
+        self.jobId = jobId
+        self.filename = filename
+        self.content = content
+        self.snippet = snippet
+        self.usage = usage
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jobId = try container.decodeIfPresent(String.self, forKey: .jobId)
+        filename = try container.decodeIfPresent(String.self, forKey: .filename)
+        content = try container.decodeIfPresent(String.self, forKey: .content)
+        snippet = try container.decodeIfPresent(String.self, forKey: .snippet)
+        usage = (try? container.decodeIfPresent(CronRunUsage.self, forKey: .usage)) ?? nil
+    }
+}
+
 struct CronDeliveryOptionsResponse: Decodable, Equatable {
     let platforms: [CronDeliveryOption]?
 

--- a/HermesMobile/Networking/APIClient+Cron.swift
+++ b/HermesMobile/Networking/APIClient+Cron.swift
@@ -106,6 +106,16 @@ extension APIClient {
     func cronOutput(jobID: String, limit: Int? = 5) async throws -> CronOutputResponse {
         try await send(endpoint: .cronOutput(jobID: jobID, limit: limit), method: "GET")
     }
+
+    /// Past runs of a job (metadata only), from `/api/crons/history`.
+    func cronRunHistory(jobID: String, offset: Int = 0, limit: Int = 50) async throws -> CronRunHistoryResponse {
+        try await send(endpoint: .cronRunHistory(jobID: jobID, offset: offset, limit: limit), method: "GET")
+    }
+
+    /// Full content of one past run, from `/api/crons/run`.
+    func cronRunDetail(jobID: String, filename: String) async throws -> CronRunDetailResponse {
+        try await send(endpoint: .cronRunDetail(jobID: jobID, filename: filename), method: "GET")
+    }
 }
 
 private struct CronCreateRequest: Encodable {

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -96,6 +96,8 @@ enum Endpoint {
     case cronResume
     case cronStatus(jobID: String?)
     case cronOutput(jobID: String, limit: Int?)
+    case cronRunHistory(jobID: String, offset: Int, limit: Int)
+    case cronRunDetail(jobID: String, filename: String)
     case cronDeliveryOptions
     case kanbanConfig
     case kanbanBoards
@@ -317,6 +319,10 @@ enum Endpoint {
             return "/api/crons/status"
         case .cronOutput:
             return "/api/crons/output"
+        case .cronRunHistory:
+            return "/api/crons/history"
+        case .cronRunDetail:
+            return "/api/crons/run"
         case .cronDeliveryOptions:
             return "/api/crons/delivery-options"
         case .kanbanConfig:
@@ -483,6 +489,17 @@ enum Endpoint {
                 items.append(URLQueryItem(name: "limit", value: "\(limit)"))
             }
             return items
+        case let .cronRunHistory(jobID, offset, limit):
+            return [
+                URLQueryItem(name: "job_id", value: jobID),
+                URLQueryItem(name: "offset", value: "\(offset)"),
+                URLQueryItem(name: "limit", value: "\(limit)"),
+            ]
+        case let .cronRunDetail(jobID, filename):
+            return [
+                URLQueryItem(name: "job_id", value: jobID),
+                URLQueryItem(name: "filename", value: filename),
+            ]
         case let .kanbanBoard(request):
             return request.queryItems
         case let .kanbanDispatch(request):

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -117222,6 +117222,642 @@
           }
         }
       }
+    },
+    "Run History" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سجل التشغيلات"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ausführungsverlauf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historial de ejecuciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historique des exécutions"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "היסטוריית הרצות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cronologia delle esecuzioni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行履歴"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행 기록"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitvoeringsgeschiedenis"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historia uruchomień"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico de execuções"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "История запусков"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalıştırma geçmişi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رن ہسٹری"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行歷史"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "运行历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行歷史"
+          }
+        }
+      }
+    },
+    "No Past Runs" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لا توجد تشغيلات سابقة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine bisherigen Ausführungen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sin ejecuciones anteriores"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aucune exécution passée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "אין הרצות קודמות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nessuna esecuzione precedente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "過去の実行はありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "과거 실행 없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geen eerdere uitvoeringen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brak poprzednich uruchomień"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma execução anterior"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Прошлых запусков нет"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geçmiş çalıştırma yok"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کوئی سابقہ رن نہیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "暫無歷史執行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "暂无历史运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "暫無歷史執行"
+          }
+        }
+      }
+    },
+    "Load More" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تحميل المزيد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mehr laden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cargar más"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Charger plus"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "טען עוד"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carica altro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "さらに読み込む"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "더 불러오기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meer laden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wczytaj więcej"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregar mais"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загрузить ещё"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Daha fazla yükle"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مزید لوڈ کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "載入更多"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "加载更多"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "載入更多"
+          }
+        }
+      }
+    },
+    "Loading run..." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "جارٍ تحميل التشغيل..."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ausführung wird geladen..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cargando ejecución..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chargement de l'exécution…"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "טוען הרצה..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Caricamento esecuzione..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行を読み込み中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행 불러오는 중..."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitvoering laden..."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wczytywanie uruchomienia..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando execução..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загрузка запуска..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalıştırma yükleniyor..."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رن لوڈ ہو رہا ہے..."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在載入執行..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在加载运行..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在載入執行..."
+          }
+        }
+      }
+    },
+    "Could Not Load Run" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تعذر تحميل التشغيل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ausführung konnte nicht geladen werden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No se pudo cargar la ejecución"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossible de charger l'exécution"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא ניתן לטעון את ההרצה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossibile caricare l'esecuzione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行を読み込めませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행을 불러올 수 없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kan uitvoering niet laden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nie udało się wczytać uruchomienia"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não foi possível carregar a execução"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Не удалось загрузить запуск"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalıştırma yüklenemedi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رن لوڈ نہیں ہو سکا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法載入執行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法加载运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法載入執行"
+          }
+        }
+      }
+    },
+    "%lld total" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld إجمالاً"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld gesamt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld en total"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld au total"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld סה״כ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld in totale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "合計 %lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "총 %lld개"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld totaal"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "łącznie %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld no total"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "всего %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "toplam %lld"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کل %lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "共 %lld 條"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "共 %lld 条"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "共 %lld 條"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/APIClientCronEndpointTests.swift
+++ b/HermesMobileTests/APIClientCronEndpointTests.swift
@@ -397,4 +397,128 @@ final class APIClientCronEndpointTests: APIClientTestCase {
         let response = try await client.cronOutput(jobID: "job456", limit: nil)
         XCTAssertEqual(response.outputs?.count, 0)
     }
+
+    func testCronRunHistoryBuildsExpectedPathAndQueryAndDecodesRuns() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/crons/history")
+            XCTAssertEqual(request.httpMethod, "GET")
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            XCTAssertEqual(query["job_id"], "job123")
+            XCTAssertEqual(query["offset"], "0")
+            XCTAssertEqual(query["limit"], "50")
+
+            return apiTestJSONResponse("""
+            {
+              "job_id": "job123",
+              "runs": [
+                {
+                  "filename": "2026-09-01T07-05.md",
+                  "size": 1234,
+                  "modified": 1788300000.5,
+                  "usage": {
+                    "model": "MiniMax M3",
+                    "provider": "minimax",
+                    "estimated_cost_usd": 0.0123,
+                    "duration_seconds": 42.7,
+                    "unknown_future_field": true
+                  }
+                },
+                {
+                  "filename": "2026-08-31T07-05.md",
+                  "size": 996,
+                  "modified": 1788213600
+                }
+              ],
+              "total": 137,
+              "offset": 0,
+              "unknown_top_level": {"nested": 1}
+            }
+            """, for: request)
+        }
+
+        let response = try await client.cronRunHistory(jobID: "job123")
+        let first = try XCTUnwrap(response.runs?.first)
+        let second = try XCTUnwrap(response.runs?.last)
+
+        XCTAssertEqual(response.jobId, "job123")
+        XCTAssertEqual(response.total, 137)
+        XCTAssertEqual(response.offset, 0)
+
+        XCTAssertEqual(first.filename, "2026-09-01T07-05.md")
+        XCTAssertEqual(first.size, 1234)
+        let modified = try XCTUnwrap(first.modified)
+        XCTAssertEqual(modified.date.timeIntervalSince1970, 1_788_300_000.5, accuracy: 0.1)
+        let usage = try XCTUnwrap(first.usage)
+        XCTAssertEqual(usage.model, "MiniMax M3")
+        XCTAssertEqual(usage.provider, "minimax")
+        XCTAssertEqual(usage.estimatedCostUsd ?? 0, 0.0123, accuracy: 0.0001)
+        XCTAssertEqual(usage.durationSeconds ?? 0, 42.7, accuracy: 0.1)
+
+        XCTAssertEqual(second.filename, "2026-08-31T07-05.md")
+        XCTAssertEqual(second.size, 996)
+        XCTAssertNil(second.usage)
+    }
+
+    func testCronRunDetailBuildsExpectedPathAndDecodesContent() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/crons/run")
+            XCTAssertEqual(request.httpMethod, "GET")
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            XCTAssertEqual(query["job_id"], "job123")
+            XCTAssertEqual(query["filename"], "run 1.md")
+
+            return apiTestJSONResponse("""
+            {
+              "job_id": "job123",
+              "filename": "run 1.md",
+              "content": "# Cron Run\\n\\nMorning message body.",
+              "snippet": "Morning message body",
+              "usage": {"duration_seconds": 12, "estimated_cost_usd": 0.004},
+              "unknown_field": [1, 2, 3]
+            }
+            """, for: request)
+        }
+
+        let response = try await client.cronRunDetail(jobID: "job123", filename: "run 1.md")
+
+        XCTAssertEqual(response.filename, "run 1.md")
+        XCTAssertEqual(response.content, "# Cron Run\n\nMorning message body.")
+        XCTAssertEqual(response.snippet, "Morning message body")
+        let usage = try XCTUnwrap(response.usage)
+        XCTAssertEqual(usage.durationSeconds ?? 0, 12, accuracy: 0.1)
+        XCTAssertEqual(usage.estimatedCostUsd ?? 0, 0.004, accuracy: 0.0001)
+    }
+
+    func testCronRunHistoryToleratesNullAndMissingFields() async throws {
+        let client = makeClient { request in
+            return apiTestJSONResponse("""
+            {
+              "job_id": "job123",
+              "runs": [
+                {"filename": null, "size": null, "modified": null, "usage": null},
+                {"size": "2048", "modified": "2026-09-01T07:05:00Z", "usage": {"estimated_cost_usd": "0.5"}}
+              ],
+              "total": null,
+              "offset": null
+            }
+            """, for: request)
+        }
+
+        let response = try await client.cronRunHistory(jobID: "job123", offset: 10, limit: 20)
+        let first = try XCTUnwrap(response.runs?.first)
+        let second = try XCTUnwrap(response.runs?.last)
+
+        XCTAssertNil(first.filename)
+        XCTAssertNil(first.size)
+        XCTAssertNil(first.modified)
+        XCTAssertNil(first.usage)
+
+        XCTAssertEqual(second.size, 2048)
+        XCTAssertNotNil(second.modified)
+        XCTAssertEqual(second.usage?.estimatedCostUsd ?? 0, 0.5, accuracy: 0.0001)
+        XCTAssertNil(response.total)
+        XCTAssertNil(response.offset)
+    }
 }

--- a/HermesMobileTests/CronManagementTests.swift
+++ b/HermesMobileTests/CronManagementTests.swift
@@ -376,6 +376,150 @@ final class CronManagementViewModelTests: XCTestCase {
         return APIClient(baseURL: URL(string: "https://example.test")!, session: session)
     }
 
+    @MainActor
+    func testTaskDetailViewModelLoadsRunHistoryAndStopsAtTotal() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons/history":
+                return apiTestJSONResponse("""
+                {
+                  "job_id": "job123",
+                  "runs": [{"filename": "run-1.md", "size": 100, "modified": 1788300000}],
+                  "total": 1,
+                  "offset": 0
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TaskDetailViewModel(
+            job: try decodeCronJob(#"{"id": "job123", "name": "Digest"}"#),
+            runningElapsed: nil,
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.loadRunHistory()
+
+        XCTAssertEqual(viewModel.runHistory.map(\.filename), ["run-1.md"])
+        XCTAssertEqual(viewModel.runHistoryTotal, 1)
+        XCTAssertFalse(viewModel.canLoadMoreRunHistory)
+        XCTAssertNil(viewModel.historyErrorMessage)
+    }
+
+    @MainActor
+    func testTaskDetailViewModelLoadMoreRunHistoryAppendsNextPage() async throws {
+        final class OffsetBox: @unchecked Sendable {
+            var offsets: [String] = []
+        }
+        let box = OffsetBox()
+
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons/history":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                box.offsets.append(query["offset"] ?? "nil")
+                if query["offset"] == "0" {
+                    return apiTestJSONResponse("""
+                    {"job_id": "job123", "runs": [{"filename": "run-1.md"}, {"filename": "run-2.md"}], "total": 3, "offset": 0}
+                    """, for: request)
+                }
+                return apiTestJSONResponse("""
+                {"job_id": "job123", "runs": [{"filename": "run-3.md"}], "total": 3, "offset": 2}
+                """, for: request)
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TaskDetailViewModel(
+            job: try decodeCronJob(#"{"id": "job123", "name": "Digest"}"#),
+            runningElapsed: nil,
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.loadRunHistory()
+        let didLoadMore = await viewModel.loadMoreRunHistory()
+
+        XCTAssertTrue(didLoadMore)
+        XCTAssertEqual(viewModel.runHistory.map(\.filename), ["run-1.md", "run-2.md", "run-3.md"])
+        XCTAssertEqual(box.offsets, ["0", "2"])
+        XCTAssertFalse(viewModel.canLoadMoreRunHistory)
+    }
+
+    @MainActor
+    func testTaskDetailViewModelHistoryFailureKeepsPrimaryContentUsable() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons/history":
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 500,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (response, Data(#"{"error": "boom"}"#.utf8))
+            case "/api/crons/output":
+                return apiTestJSONResponse("""
+                {"job_id": "job123", "outputs": [{"filename": "out.md", "content": "hello"}]}
+                """, for: request)
+            case "/api/crons/delivery-options":
+                return apiTestJSONResponse("{}", for: request)
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TaskDetailViewModel(
+            job: try decodeCronJob(#"{"id": "job123", "name": "Digest"}"#),
+            runningElapsed: nil,
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.load()
+        await viewModel.loadRunHistory()
+
+        XCTAssertNotNil(viewModel.historyErrorMessage)
+        XCTAssertTrue(viewModel.runHistory.isEmpty, "History failure must not fabricate runs.")
+        XCTAssertEqual(viewModel.outputs.first?.filename, "out.md", "Primary recent-output content must stay intact.")
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testTaskDetailViewModelLoadRunDetailFetchesContentAndClears() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/crons/run")
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            XCTAssertEqual(query["job_id"], "job123")
+            XCTAssertEqual(query["filename"], "run-1.md")
+
+            return apiTestJSONResponse("""
+            {"job_id": "job123", "filename": "run-1.md", "content": "Full run body", "snippet": "Full run body"}
+            """, for: request)
+        }
+        let viewModel = TaskDetailViewModel(
+            job: try decodeCronJob(#"{"id": "job123", "name": "Digest"}"#),
+            runningElapsed: nil,
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.loadRunDetail(filename: "run-1.md")
+
+        XCTAssertEqual(viewModel.loadedRunDetail?.content, "Full run body")
+        XCTAssertNil(viewModel.runDetailErrorMessage)
+
+        viewModel.clearRunDetail()
+        XCTAssertNil(viewModel.loadedRunDetail)
+        XCTAssertNil(viewModel.runDetailErrorMessage)
+    }
+
     private func decodeCronJob(_ json: String) throws -> CronJob {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/HermesMobileTests/CronManagementTests.swift
+++ b/HermesMobileTests/CronManagementTests.swift
@@ -88,6 +88,37 @@ final class CronManagementModelTests: XCTestCase {
         XCTAssertEqual(draft.provider, "openai")
     }
 
+    func testCronRunEntryKeepsStableIdentityWithoutFilename() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let entry = try decoder.decode(
+            CronRunEntry.self,
+            from: Data(#"{"size": 10, "modified": 1788300000}"#.utf8)
+        )
+
+        XCTAssertEqual(entry.id, entry.id, "Repeated id access must not mint a new UUID.")
+        XCTAssertFalse(entry.addressable)
+        XCTAssertNil(entry.filename)
+
+        let named = try decoder.decode(
+            CronRunEntry.self,
+            from: Data(#"{"filename": "run-1.md", "size": 10}"#.utf8)
+        )
+        XCTAssertEqual(named.id, "run-1.md")
+        XCTAssertTrue(named.addressable)
+    }
+
+    func testCronRunEntryTreatsBlankFilenameAsUnaddressable() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let entry = try decoder.decode(
+            CronRunEntry.self,
+            from: Data(#"{"filename": "   ", "size": 10}"#.utf8)
+        )
+
+        XCTAssertFalse(entry.addressable, "A blank filename cannot address the run endpoint.")
+    }
+
     func testCronDeliverPickerFallsBackWithoutUsableOptions() {
         XCTAssertNil(CronDeliverPicker.options(serverOptions: nil, currentValue: "local"))
         XCTAssertNil(CronDeliverPicker.options(serverOptions: [], currentValue: "local"))
@@ -517,6 +548,115 @@ final class CronManagementViewModelTests: XCTestCase {
 
         viewModel.clearRunDetail()
         XCTAssertNil(viewModel.loadedRunDetail)
+        XCTAssertNil(viewModel.runDetailErrorMessage)
+    }
+
+    @MainActor
+    func testTaskDetailViewModelLoadMorePagingOffsetCountsServerRecordsNotDisplayList() async throws {
+        final class OffsetBox: @unchecked Sendable {
+            var offsets: [String] = []
+        }
+        let box = OffsetBox()
+
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons/history":
+                let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+                let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+                box.offsets.append(query["offset"] ?? "nil")
+                if query["offset"] == "0" {
+                    return apiTestJSONResponse(
+                        #"{"job_id": "job123", "runs": [{"filename": "run-1.md"}, {"filename": "run-2.md"}], "total": 4, "offset": 0}"#,
+                        for: request
+                    )
+                }
+                if query["offset"] == "2" {
+                    // Page boundary repeats run-2.md; the display list dedupes
+                    // it, but the next offset must still advance by records.
+                    return apiTestJSONResponse(
+                        #"{"job_id": "job123", "runs": [{"filename": "run-2.md"}, {"filename": "run-3.md"}], "total": 4, "offset": 2}"#,
+                        for: request
+                    )
+                }
+                return apiTestJSONResponse(
+                    #"{"job_id": "job123", "runs": [{"filename": "run-4.md"}], "total": 4, "offset": 3}"#,
+                    for: request
+                )
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TaskDetailViewModel(
+            job: try decodeCronJob(#"{"id": "job123", "name": "Digest"}"#),
+            runningElapsed: nil,
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        await viewModel.loadRunHistory()
+        XCTAssertTrue(await viewModel.loadMoreRunHistory())
+        XCTAssertTrue(await viewModel.loadMoreRunHistory())
+
+        XCTAssertEqual(
+            box.offsets,
+            ["0", "2", "3"],
+            "Offsets must track consumed server records (including cross-page duplicates), not the deduped list."
+        )
+        XCTAssertEqual(viewModel.runHistory.map(\.filename), ["run-1.md", "run-2.md", "run-3.md", "run-4.md"])
+        XCTAssertFalse(viewModel.canLoadMoreRunHistory)
+    }
+
+    @MainActor
+    func testTaskDetailViewModelStaleRunDetailResponseDoesNotOverwriteNewerSelection() async throws {
+        final class Gate: @unchecked Sendable {
+            let releaseSlowResponse = DispatchSemaphore(value: 0)
+        }
+        let gate = Gate()
+
+        let client = makeClient { request in
+            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+            let query = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+
+            if query["filename"] == "slow.md" {
+                // Park the slow response until the test has already selected
+                // and completed a newer run, then deliver the stale body.
+                _ = gate.releaseSlowResponse.wait(timeout: .now() + 10)
+                return apiTestJSONResponse(
+                    #"{"job_id": "job123", "filename": "slow.md", "content": "STALE BODY"}"#,
+                    for: request
+                )
+            }
+            return apiTestJSONResponse(
+                #"{"job_id": "job123", "filename": "fast.md", "content": "fresh body"}"#,
+                for: request
+            )
+        }
+        let viewModel = TaskDetailViewModel(
+            job: try decodeCronJob(#"{"id": "job123", "name": "Digest"}"#),
+            runningElapsed: nil,
+            server: try XCTUnwrap(URL(string: "https://example.test")),
+            client: client
+        )
+
+        let slowTask = Task { await viewModel.loadRunDetail(filename: "slow.md") }
+        // Give the slow request a beat to capture in-flight state.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let fastTask = Task { await viewModel.loadRunDetail(filename: "fast.md") }
+        await fastTask.value
+        XCTAssertEqual(viewModel.loadedRunDetail?.content, "fresh body", "Newer selection loads normally.")
+
+        // Now release the stale response; it must be discarded.
+        gate.releaseSlowResponse.signal()
+        await slowTask.value
+
+        XCTAssertEqual(
+            viewModel.loadedRunDetail?.filename,
+            "fast.md",
+            "A late response for the earlier selection must not replace the newer selection."
+        )
+        XCTAssertEqual(viewModel.loadedRunDetail?.content, "fresh body")
         XCTAssertNil(viewModel.runDetailErrorMessage)
     }
 

--- a/HermesMobileTests/CronManagementTests.swift
+++ b/HermesMobileTests/CronManagementTests.swift
@@ -566,7 +566,7 @@ final class CronManagementViewModelTests: XCTestCase {
                 box.offsets.append(query["offset"] ?? "nil")
                 if query["offset"] == "0" {
                     return apiTestJSONResponse(
-                        #"{"job_id": "job123", "runs": [{"filename": "run-1.md"}, {"filename": "run-2.md"}], "total": 4, "offset": 0}"#,
+                        #"{"job_id": "job123", "runs": [{"filename": "run-1.md"}, {"filename": "run-2.md"}], "total": 5, "offset": 0}"#,
                         for: request
                     )
                 }
@@ -574,12 +574,19 @@ final class CronManagementViewModelTests: XCTestCase {
                     // Page boundary repeats run-2.md; the display list dedupes
                     // it, but the next offset must still advance by records.
                     return apiTestJSONResponse(
-                        #"{"job_id": "job123", "runs": [{"filename": "run-2.md"}, {"filename": "run-3.md"}], "total": 4, "offset": 2}"#,
+                        #"{"job_id": "job123", "runs": [{"filename": "run-2.md"}, {"filename": "run-3.md"}], "total": 5, "offset": 2}"#,
                         for: request
                     )
                 }
+                if query["offset"] == "4" {
+                    return apiTestJSONResponse(
+                        #"{"job_id": "job123", "runs": [{"filename": "run-4.md"}, {"filename": "run-5.md"}], "total": 5, "offset": 4}"#,
+                        for: request
+                    )
+                }
+                XCTFail("Unexpected offset: \(query["offset"] ?? "nil") — the deduped display list must not rewind paging.")
                 return apiTestJSONResponse(
-                    #"{"job_id": "job123", "runs": [{"filename": "run-4.md"}], "total": 4, "offset": 3}"#,
+                    #"{"job_id": "job123", "runs": [], "total": 5, "offset": 0}"#,
                     for: request
                 )
             default:
@@ -597,20 +604,21 @@ final class CronManagementViewModelTests: XCTestCase {
         await viewModel.loadRunHistory()
         XCTAssertTrue(await viewModel.loadMoreRunHistory())
         XCTAssertTrue(await viewModel.loadMoreRunHistory())
+        XCTAssertFalse(viewModel.canLoadMoreRunHistory)
 
         XCTAssertEqual(
             box.offsets,
-            ["0", "2", "3"],
+            ["0", "2", "4"],
             "Offsets must track consumed server records (including cross-page duplicates), not the deduped list."
         )
-        XCTAssertEqual(viewModel.runHistory.map(\.filename), ["run-1.md", "run-2.md", "run-3.md", "run-4.md"])
-        XCTAssertFalse(viewModel.canLoadMoreRunHistory)
+        XCTAssertEqual(viewModel.runHistory.map(\.filename), ["run-1.md", "run-2.md", "run-3.md", "run-4.md", "run-5.md"])
     }
 
     @MainActor
     func testTaskDetailViewModelStaleRunDetailResponseDoesNotOverwriteNewerSelection() async throws {
         final class Gate: @unchecked Sendable {
             let releaseSlowResponse = DispatchSemaphore(value: 0)
+            let releaseFastResponse = DispatchSemaphore(value: 0)
         }
         let gate = Gate()
 
@@ -620,13 +628,15 @@ final class CronManagementViewModelTests: XCTestCase {
 
             if query["filename"] == "slow.md" {
                 // Park the slow response until the test has already selected
-                // and completed a newer run, then deliver the stale body.
+                // a newer run, then deliver the stale body while the newer
+                // request is still in flight.
                 _ = gate.releaseSlowResponse.wait(timeout: .now() + 10)
                 return apiTestJSONResponse(
                     #"{"job_id": "job123", "filename": "slow.md", "content": "STALE BODY"}"#,
                     for: request
                 )
             }
+            _ = gate.releaseFastResponse.wait(timeout: .now() + 10)
             return apiTestJSONResponse(
                 #"{"job_id": "job123", "filename": "fast.md", "content": "fresh body"}"#,
                 for: request
@@ -644,19 +654,26 @@ final class CronManagementViewModelTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000)
 
         let fastTask = Task { await viewModel.loadRunDetail(filename: "fast.md") }
-        await fastTask.value
-        XCTAssertEqual(viewModel.loadedRunDetail?.content, "fresh body", "Newer selection loads normally.")
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(viewModel.isLoadingRunDetail, "Newer request owns the loading flag.")
 
-        // Now release the stale response; it must be discarded.
+        // Release the stale response while the newer request is still parked.
         gate.releaseSlowResponse.signal()
         await slowTask.value
 
-        XCTAssertEqual(
-            viewModel.loadedRunDetail?.filename,
-            "fast.md",
-            "A late response for the earlier selection must not replace the newer selection."
+        XCTAssertNil(viewModel.loadedRunDetail, "Stale body must not populate the sheet.")
+        XCTAssertNil(viewModel.runDetailErrorMessage, "Stale errors must not surface either.")
+        XCTAssertTrue(
+            viewModel.isLoadingRunDetail,
+            "The superseded request finishing late must not clear the newer request's loading flag."
         )
+
+        gate.releaseFastResponse.signal()
+        await fastTask.value
+
+        XCTAssertEqual(viewModel.loadedRunDetail?.filename, "fast.md")
         XCTAssertEqual(viewModel.loadedRunDetail?.content, "fresh body")
+        XCTAssertFalse(viewModel.isLoadingRunDetail)
         XCTAssertNil(viewModel.runDetailErrorMessage)
     }
 


### PR DESCRIPTION
Fixes #350

## What changed

Task Detail gains a **Run History** section (between metadata and recent output) backed by two existing read-only server endpoints:

- `GET /api/crons/history?job_id=&offset=&limit=` — paginated past-run list (filename, modified, size, server-parsed usage metadata).
- `GET /api/crons/run?job_id=&filename=` — full content of one past run.

On screen: newest-first rows with date, size, and cost/duration chips, a "%lld total" count, load-more paging at 50 per page, and a sheet showing the full run output as selectable monospaced text. History is an optional enhancement — failures show an inline error with retry and never block the recent-output section.

Implementation follows the existing architecture: new `Endpoint` cases (`cronRunHistory`, `cronRunDetail`) with query items, `APIClient+Cron` extension methods, tolerant `Codable` models (`CronRunEntry`, `CronRunUsage`, `CronRunHistoryResponse`, `CronRunDetailResponse` — every field optional, flexible numbers, lossy strings, unknown fields ignored), `@Observable` view-model state on `TaskDetailViewModel`, and 7 new user-facing keys added to the String Catalog for all 17 shipped languages via the repo's `add_localization_keys.py` flow (needs_review state).

## How it was tested

- **Windows dev box (no Swift toolchain):** `python scripts-local/swift_syntax_check.py` — 7/7 files parse clean; localization catalog round-trip verified zero changes to pre-existing keys (parsed-subtree equality).
- **Contract check:** endpoint paths, query names (`job_id`, `offset`, `limit`, `filename`), and JSON field shapes verified line-by-line against upstream `hermes-webui` `api/routes.py` (`_handle_cron_history`, `_handle_cron_run_detail`) at the pinned upstream commit; snake_case→camelCase noted for `estimated_cost_usd` → `estimatedCostUsd`.
- **New tests:** `APIClientCronEndpointTests` + `CronManagementTests` extended with endpoint-path assertions and tolerant-decode fixtures (ISO strings, epoch numbers, missing/odd fields, duplicate pages).
- **Full suite:** not run locally — Windows has no Xcode. Relying on this repo's PR CI (build + 1,771-test XCTest suite, signing disabled) to be the real gate. Will fix anything CI reports.

Two self-review catches fixed before commit: the run sheet now re-fetches on reopen via `.task(id:)`, and the snake_case cost field decodes as `estimatedCostUsd` (not `estimatedCostUSD`) so cost chips never silently nil.

## Checklist

- [ ] The full test suite passes locally — **not runnable on Windows; PR CI is the gate** (see above)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

---
Built with Hermes Agent (Rei, automated daily-feature workflow) — AI-assisted, disclosed per CONTRIBUTING.md.