### PR TITLE
feat(chat): render thinking as a log row

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -177,6 +177,9 @@
 		C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000002 /* ToolActivityGroupView.swift */; };
 		1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */; };
 		C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F02 /* ToolCallLogRowView.swift */; };
+		C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */; };
+		C0AA020000000000000000B11 /* ReasoningSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F11 /* ReasoningSummaryFormatter.swift */; };
+		C0AA020000000000000000B10 /* TranscriptLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F10 /* TranscriptLogRowView.swift */; };
 		C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */; };
 		C0AA05000000000000000B01 /* ChatMessageMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA05000000000000000F01 /* ChatMessageMeta.swift */; };
 		C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */; };
@@ -534,6 +537,9 @@
 		C12800000000000000000002 /* ToolActivityGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityGroupView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallCardView.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F02 /* ToolCallLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallLogRowView.swift; sourceTree = "<group>"; };
+		C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningSummaryFormatterTests.swift; sourceTree = "<group>"; };
+		C0AA020000000000000000F11 /* ReasoningSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningSummaryFormatter.swift; sourceTree = "<group>"; };
+		C0AA020000000000000000F10 /* TranscriptLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLogRowView.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFolding.swift; sourceTree = "<group>"; };
 		C0AA05000000000000000F01 /* ChatMessageMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageMeta.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatter.swift; sourceTree = "<group>"; };
@@ -862,6 +868,7 @@
 				C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */,
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
+				C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */,
 				C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */,
 				C0AA07000000000000000F07 /* ChatTranscriptRowEntryTests.swift */,
 				C0AA05000000000000000F02 /* ChatMessageMetaTests.swift */,
@@ -1072,6 +1079,8 @@
 				C12800000000000000000002 /* ToolActivityGroupView.swift */,
 				1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */,
 				C0AA02000000000000000F02 /* ToolCallLogRowView.swift */,
+				C0AA020000000000000000F11 /* ReasoningSummaryFormatter.swift */,
+				C0AA020000000000000000F10 /* TranscriptLogRowView.swift */,
 				C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */,
 				C0AA05000000000000000F01 /* ChatMessageMeta.swift */,
 				C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */,
@@ -1588,6 +1597,8 @@
 				C12800000000000000000001 /* ToolActivityGroupView.swift in Sources */,
 				1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */,
 				C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */,
+				C0AA020000000000000000B11 /* ReasoningSummaryFormatter.swift in Sources */,
+				C0AA020000000000000000B10 /* TranscriptLogRowView.swift in Sources */,
 				C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */,
 				C0AA05000000000000000B01 /* ChatMessageMeta.swift in Sources */,
 				C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */,
@@ -1750,6 +1761,7 @@
 				C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */,
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
+				C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */,
 				C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */,
 				C0AA07000000000000000B07 /* ChatTranscriptRowEntryTests.swift in Sources */,
 				C0AA05000000000000000B02 /* ChatMessageMetaTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ReasoningBlockView.swift
+++ b/HermesMobile/Features/Chat/ReasoningBlockView.swift
@@ -1,13 +1,15 @@
 import SwiftUI
 import UIKit
 
+/// A turn's reasoning as the same dense log row tool calls use: brain icon,
+/// bold `Thinking`, dim one-line summary, chevron, and an empty status slot so
+/// the labels line up. Tap reveals the reasoning under the row; long-press
+/// copies it. Live thinking streams through `LiveReasoningTextView`; settled
+/// text is selectable. "Expand Thinking by Default" decides the initial state.
 struct ReasoningBlockView: View {
     let text: String
     let liveStreamID: String?
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
     @AppStorage(ChatTranscriptDisplaySettings.thinkingCardsStartExpandedKey) private var startsExpanded = false
     @State private var userToggledExpansion: Bool?
 
@@ -25,74 +27,27 @@ struct ReasoningBlockView: View {
 
     var body: some View {
         if let displayText = ReasoningBlockContent.displayText(from: text) {
-            let summary = summary(for: displayText)
+            let summary = ReasoningSummaryFormatter.summary(for: displayText)
 
-            VStack(alignment: .leading, spacing: isExpanded ? 8 : 0) {
-                Button {
-                    chatDisclosureToggled()
-                    withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
-                        userToggledExpansion = !isExpanded
-                    }
-                } label: {
-                    header(summary: summary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(localized: "Thinking, \(summary)"))
-                .accessibilityHint(isExpanded ? "Double tap to collapse details." : "Double tap to expand details.")
-
-                if isExpanded {
-                    reasoningText(displayText)
-                        .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
-                }
+            TranscriptLogRowView(
+                summary: String(localized: "Thinking"),
+                detail: summary,
+                isExpanded: isExpanded,
+                accessibilityLabel: String(localized: "Thinking, \(summary)"),
+                copyText: { displayText },
+                toggleExpansion: { userToggledExpansion = !isExpanded }
+            ) {
+                Image("LucideBrain")
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14, height: 14)
+            } status: {
+                EmptyView()
+            } expandedBody: {
+                reasoningText(displayText)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 9)
-            .chatTimelineAccessorySurface(
-                fallbackMaterial: .thinMaterial,
-                cornerRadius: 10
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-
-    private var usesStackedHeader: Bool {
-        dynamicTypeSize.isAccessibilitySize
-    }
-
-    private func header(summary: String) -> some View {
-        HStack(alignment: usesStackedHeader ? .top : .center, spacing: 8) {
-            Image("LucideBrain")
-                .resizable()
-                .scaledToFit()
-                .foregroundStyle(.secondary)
-                .frame(width: 18, height: 18)
-
-            if usesStackedHeader {
-                VStack(alignment: .leading, spacing: 1) {
-                    titleText
-                    summaryText(summary, lineLimit: 2)
-                }
-            } else {
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    titleText
-                    summaryText(summary, lineLimit: 1)
-                }
-            }
-
-            Spacer(minLength: 6)
-
-            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-        }
-        .contentShape(Rectangle())
-    }
-
-    private var titleText: some View {
-        Text("Thinking")
-            .font(AppFont.caption(weight: .semibold))
-            .foregroundStyle(.primary)
-            .lineLimit(1)
     }
 
     @ViewBuilder
@@ -107,25 +62,6 @@ struct ReasoningBlockView: View {
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-
-    private func summaryText(_ value: String, lineLimit: Int) -> some View {
-        Text(value)
-            .font(AppFont.caption())
-            .foregroundStyle(.secondary)
-            .lineLimit(lineLimit)
-    }
-
-    private func summary(for value: String) -> String {
-        let oneLine = value
-            .replacingOccurrences(of: "\n", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        if oneLine.count <= 80 {
-            return oneLine
-        }
-
-        return "\(oneLine.prefix(80))..."
     }
 }
 

--- a/HermesMobile/Features/Chat/ReasoningSummaryFormatter.swift
+++ b/HermesMobile/Features/Chat/ReasoningSummaryFormatter.swift
@@ -4,16 +4,19 @@ import Foundation
 /// shows. Pure so the cut rules are unit-testable.
 enum ReasoningSummaryFormatter {
     static let characterLimit = 80
+    /// Newlines never count toward the limit, so a hard cap on characters read
+    /// keeps a newline-heavy block from being rescanned in full on every chunk.
+    static let scanLimit = characterLimit * 4
 
     /// Newline runs collapse to a single space and anything past the limit is
-    /// cut with an ellipsis. Scans only as far as the limit so summarising a
-    /// long live stream on every chunk stays cheap.
+    /// cut with an ellipsis. Reads at most `scanLimit` characters so summarising
+    /// a long live stream on every chunk stays cheap.
     static func summary(for text: String) -> String {
         var result = ""
         var count = 0
         var pendingSpace = false
 
-        for character in text {
+        for character in text.prefix(scanLimit) {
             if character.isNewline {
                 pendingSpace = !result.isEmpty
                 continue

--- a/HermesMobile/Features/Chat/ReasoningSummaryFormatter.swift
+++ b/HermesMobile/Features/Chat/ReasoningSummaryFormatter.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Reduces a reasoning block to the one-line preview its collapsed log row
+/// shows. Pure so the cut rules are unit-testable.
+enum ReasoningSummaryFormatter {
+    static let characterLimit = 80
+
+    /// Newline runs collapse to a single space and anything past the limit is
+    /// cut with an ellipsis. Scans only as far as the limit so summarising a
+    /// long live stream on every chunk stays cheap.
+    static func summary(for text: String) -> String {
+        var result = ""
+        var count = 0
+        var pendingSpace = false
+
+        for character in text {
+            if character.isNewline {
+                pendingSpace = !result.isEmpty
+                continue
+            }
+
+            if pendingSpace {
+                result.append(" ")
+                count += 1
+                pendingSpace = false
+            }
+
+            result.append(character)
+            count += 1
+
+            if count > characterLimit {
+                return String(result.prefix(characterLimit)) + "..."
+            }
+        }
+
+        return result.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/HermesMobile/Features/Chat/ToolActivityGroupView.swift
+++ b/HermesMobile/Features/Chat/ToolActivityGroupView.swift
@@ -82,7 +82,7 @@ struct ToolActivityGroupView: View {
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, 2)
-            .frame(minHeight: ToolCallLogRowView.minimumHeight)
+            .frame(minHeight: TranscriptLogRowMetrics.minimumHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/HermesMobile/Features/Chat/ToolCallLogRowView.swift
+++ b/HermesMobile/Features/Chat/ToolCallLogRowView.swift
@@ -1,121 +1,36 @@
 import SwiftUI
-import UIKit
 
 /// One settled tool call as a dense log line: icon column, bold verb, dim
-/// one-line detail, chevron, and a fixed status-glyph slot. Tap expands the
-/// same Arguments/Result body the live card shows; long-press copies it.
+/// one-line detail, chevron, and a status glyph. Tap expands the same
+/// Arguments/Result body the live card shows; long-press copies it.
 struct ToolCallLogRowView: View {
     let entry: ToolCallLogEntry
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
-    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
     @State private var isExpanded = false
-    @State private var isPressed = false
-    @State private var showsCopied = false
-    @State private var copiedResetTask: Task<Void, Never>?
-
-    /// Row height at the default text size; text grows the row at larger sizes.
-    static let minimumHeight: CGFloat = 32
-    /// Icon column width plus the gap, so the expanded body indents under the text.
-    private static let bodyIndent: CGFloat = 26
 
     private var row: ToolCallLogRow { entry.row }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            rowLine
-
-            if isExpanded {
-                expandedBody
-                    .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        // Commands, paths, and results are code-like and stay left-to-right
-        // inside an RTL transcript (#259), like the live card.
-        .forcedLeftToRight()
-        .onDisappear { copiedResetTask?.cancel() }
-    }
-
-    private var rowLine: some View {
-        HStack(alignment: usesStackedLabel ? .top : .center, spacing: 6) {
+        TranscriptLogRowView(
+            summary: row.summary,
+            detail: row.detail,
+            isFailure: row.isFailure,
+            isExpanded: isExpanded,
+            accessibilityLabel: accessibilityLabel,
+            copyText: { ToolCallSummaryFormatter.copyText(for: entry.toolCall) },
+            toggleExpansion: { isExpanded.toggle() }
+        ) {
             Image(systemName: row.icon)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(row.isFailure ? Color.red : Color.secondary)
-                .frame(width: 20, height: 18)
-
-            label
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack(spacing: 1) {
-                if showsCopied {
-                    Text("Copied")
-                        .font(AppFont.caption2(weight: .semibold))
-                        .foregroundStyle(.green)
-                        .padding(.trailing, 4)
-                }
-
-                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 16, height: 16)
-
-                statusGlyph
-                    .frame(width: 16, height: 16)
-            }
+        } status: {
+            statusGlyph
+        } expandedBody: {
+            ToolCallDetailBodyView(toolCall: entry.toolCall)
         }
-        .padding(.horizontal, 2)
-        .frame(minHeight: Self.minimumHeight)
-        .background(
-            Color.primary.opacity(isPressed ? 0.06 : 0),
-            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture(perform: toggleExpansion)
-        .onLongPressGesture(minimumDuration: 0.45, perform: copy) { pressing in
-            isPressed = pressing
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityAddTraits(.isButton)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint("Double tap to show details. Long press to copy.")
-        .accessibilityAction { toggleExpansion() }
-        .accessibilityAction(named: Text("Copy")) { copy() }
-    }
-
-    private var usesStackedLabel: Bool {
-        dynamicTypeSize.isAccessibilitySize
-    }
-
-    @ViewBuilder
-    private var label: some View {
-        if usesStackedLabel {
-            VStack(alignment: .leading, spacing: 2) {
-                summaryText
-                if let detail = row.detail {
-                    detailText(detail).lineLimit(2)
-                }
-            }
-        } else if let detail = row.detail {
-            (summaryText + Text(" ") + detailText(detail))
-                .lineLimit(1)
-        } else {
-            summaryText.lineLimit(1)
-        }
-    }
-
-    private var summaryText: Text {
-        Text(row.summary)
-            .font(AppFont.caption(weight: .semibold))
-            .foregroundStyle(row.isFailure ? Color.red : Color.primary)
-    }
-
-    private func detailText(_ detail: String) -> Text {
-        Text(detail)
-            .font(AppFont.caption())
-            .foregroundStyle(.secondary)
+        // Commands, paths, and results are code-like and stay left-to-right
+        // inside an RTL transcript (#259), like the live card.
+        .forcedLeftToRight()
     }
 
     @ViewBuilder
@@ -136,51 +51,9 @@ struct ToolCallLogRowView: View {
         }
     }
 
-    private var expandedBody: some View {
-        ToolCallDetailBodyView(toolCall: entry.toolCall)
-            .padding(.leading, 12)
-            .overlay(alignment: .leading) {
-                Rectangle()
-                    .fill(.quaternary)
-                    .frame(width: 1)
-            }
-            .padding(.leading, Self.bodyIndent)
-            .padding(.top, 2)
-            .padding(.bottom, 6)
-    }
-
     private var accessibilityLabel: String {
         [row.summary, row.detail, row.statusText]
             .compactMap { $0 }
             .joined(separator: ", ")
-    }
-
-    private func toggleExpansion() {
-        chatDisclosureToggled()
-        withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
-            isExpanded.toggle()
-        }
-    }
-
-    /// Copies the row and its body, then shows "Copied" for a moment. The reset
-    /// task is cancelled when the row leaves the screen so it never mutates a
-    /// row that is gone.
-    private func copy() {
-        isPressed = false
-        UIPasteboard.general.string = ToolCallSummaryFormatter.copyText(for: entry.toolCall)
-        ChatHaptics.copied(isEnabled: isHapticsEnabled)
-
-        withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
-            showsCopied = true
-        }
-
-        copiedResetTask?.cancel()
-        copiedResetTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(1.2))
-            guard !Task.isCancelled else { return }
-            withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
-                showsCopied = false
-            }
-        }
     }
 }

--- a/HermesMobile/Features/Chat/TranscriptLogRowView.swift
+++ b/HermesMobile/Features/Chat/TranscriptLogRowView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+import UIKit
+
+/// Geometry shared by every log row so the group toggle and the rows line up.
+enum TranscriptLogRowMetrics {
+    /// Row height at the default text size; text grows the row at larger sizes.
+    static let minimumHeight: CGFloat = 32
+    /// Icon column width plus the gap, so the expanded body indents under the text.
+    static let bodyIndent: CGFloat = 26
+}
+
+/// The dense log row settled tool calls and thinking share: a 20 pt icon
+/// column, bold summary, dim one-line detail, `Copied` badge, chevron slot, and
+/// a fixed status slot so labels align across rows. Tap toggles the owner's
+/// expansion state and reveals `expandedBody` under the text behind a hairline;
+/// long-press copies `copyText` with a haptic and a short "Copied" badge.
+struct TranscriptLogRowView<Icon: View, Status: View, ExpandedBody: View>: View {
+    let summary: String
+    let detail: String?
+    var isFailure = false
+    let isExpanded: Bool
+    let accessibilityLabel: String
+    let copyText: () -> String
+    /// Flips the owner's expansion state; the row wraps it in the disclosure
+    /// animation and suspends the transcript's scroll anchor around it.
+    let toggleExpansion: () -> Void
+    @ViewBuilder let icon: () -> Icon
+    @ViewBuilder let status: () -> Status
+    @ViewBuilder let expandedBody: () -> ExpandedBody
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.chatDisclosureToggled) private var chatDisclosureToggled
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @State private var isPressed = false
+    @State private var showsCopied = false
+    @State private var copiedResetTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            rowLine
+
+            if isExpanded {
+                expandedBody()
+                    .padding(.leading, 12)
+                    .overlay(alignment: .leading) {
+                        Rectangle()
+                            .fill(.quaternary)
+                            .frame(width: 1)
+                    }
+                    .padding(.leading, TranscriptLogRowMetrics.bodyIndent)
+                    .padding(.top, 2)
+                    .padding(.bottom, 6)
+                    .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onDisappear { copiedResetTask?.cancel() }
+    }
+
+    private var rowLine: some View {
+        HStack(alignment: usesStackedLabel ? .top : .center, spacing: 6) {
+            icon()
+                .frame(width: 20, height: 18)
+
+            label
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 1) {
+                if showsCopied {
+                    Text("Copied")
+                        .font(AppFont.caption2(weight: .semibold))
+                        .foregroundStyle(.green)
+                        .padding(.trailing, 4)
+                }
+
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16, height: 16)
+
+                status()
+                    .frame(width: 16, height: 16)
+            }
+        }
+        .padding(.horizontal, 2)
+        .frame(minHeight: TranscriptLogRowMetrics.minimumHeight)
+        .background(
+            Color.primary.opacity(isPressed ? 0.06 : 0),
+            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: toggle)
+        .onLongPressGesture(minimumDuration: 0.45, perform: copy) { pressing in
+            isPressed = pressing
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Double tap to show details. Long press to copy.")
+        .accessibilityAction { toggle() }
+        .accessibilityAction(named: Text("Copy")) { copy() }
+    }
+
+    private var usesStackedLabel: Bool {
+        dynamicTypeSize.isAccessibilitySize
+    }
+
+    @ViewBuilder
+    private var label: some View {
+        if usesStackedLabel {
+            VStack(alignment: .leading, spacing: 2) {
+                summaryText
+                if let detail {
+                    detailText(detail).lineLimit(2)
+                }
+            }
+        } else if let detail {
+            (summaryText + Text(" ") + detailText(detail))
+                .lineLimit(1)
+        } else {
+            summaryText.lineLimit(1)
+        }
+    }
+
+    private var summaryText: Text {
+        Text(summary)
+            .font(AppFont.caption(weight: .semibold))
+            .foregroundStyle(isFailure ? Color.red : Color.primary)
+    }
+
+    private func detailText(_ detail: String) -> Text {
+        Text(detail)
+            .font(AppFont.caption())
+            .foregroundStyle(.secondary)
+    }
+
+    private func toggle() {
+        chatDisclosureToggled()
+        withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
+            toggleExpansion()
+        }
+    }
+
+    /// Copies the row's text, then shows "Copied" for a moment. The reset task
+    /// is cancelled when the row leaves the screen so it never mutates a row
+    /// that is gone.
+    private func copy() {
+        isPressed = false
+        UIPasteboard.general.string = copyText()
+        ChatHaptics.copied(isEnabled: isHapticsEnabled)
+
+        withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
+            showsCopied = true
+        }
+
+        copiedResetTask?.cancel()
+        copiedResetTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.2))
+            guard !Task.isCancelled else { return }
+            withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
+                showsCopied = false
+            }
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/TranscriptLogRowView.swift
+++ b/HermesMobile/Features/Chat/TranscriptLogRowView.swift
@@ -97,7 +97,11 @@ struct TranscriptLogRowView<Icon: View, Status: View, ExpandedBody: View>: View 
         .accessibilityElement(children: .ignore)
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint("Double tap to show details. Long press to copy.")
+        .accessibilityHint(
+            isExpanded
+                ? "Double tap to hide details. Long press to copy."
+                : "Double tap to show details. Long press to copy."
+        )
         .accessibilityAction { toggle() }
         .accessibilityAction(named: Text("Copy")) { copy() }
     }

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -117646,6 +117646,112 @@
           }
         }
       }
+    },
+    "Double tap to hide details. Long press to copy." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "انقر مرتين لإخفاء التفاصيل. اضغط مطولًا للنسخ."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Doppeltippen, um Details auszublenden. Gedrückt halten, um zu kopieren."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toca dos veces para ocultar los detalles. Mantén pulsado para copiar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Touchez deux fois pour masquer les détails. Appuyez longuement pour copier."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הקש פעמיים להסתרת פרטים. לחיצה ארוכה להעתקה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tocca due volte per nascondere i dettagli. Tieni premuto per copiare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ダブルタップで詳細を隠します。長押しでコピーします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "두 번 탭하여 세부 정보를 숨깁니다. 길게 눌러 복사합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dubbeltik om details te verbergen. Houd ingedrukt om te kopiëren."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Stuknij dwukrotnie, aby ukryć szczegóły. Przytrzymaj, aby skopiować."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque duas vezes para ocultar os detalhes. Toque e segure para copiar."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Дважды коснитесь, чтобы скрыть детали. Удерживайте, чтобы скопировать."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ayrıntıları gizlemek için iki kez dokunun. Kopyalamak için basılı tutun."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تفصیلات چھپانے کے لیے دو بار ٹیپ کریں۔ کاپی کرنے کے لیے دیر تک دبائیں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下隱藏詳細資料。長按以複製。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "轻点两下隐藏详情。长按以复制。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點兩下隱藏詳細資訊。長按以拷貝。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ReasoningSummaryFormatterTests.swift
+++ b/HermesMobileTests/ReasoningSummaryFormatterTests.swift
@@ -25,4 +25,9 @@ final class ReasoningSummaryFormatterTests: XCTestCase {
     func testTrimsSurroundingWhitespace() {
         XCTAssertEqual(ReasoningSummaryFormatter.summary(for: "  \nplan  \n"), "plan")
     }
+
+    func testStopsReadingAtTheScanLimitEvenAcrossNewlines() {
+        let text = "a" + String(repeating: "\n", count: ReasoningSummaryFormatter.scanLimit) + "b"
+        XCTAssertEqual(ReasoningSummaryFormatter.summary(for: text), "a")
+    }
 }

--- a/HermesMobileTests/ReasoningSummaryFormatterTests.swift
+++ b/HermesMobileTests/ReasoningSummaryFormatterTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import HermesMobile
+
+final class ReasoningSummaryFormatterTests: XCTestCase {
+    func testCollapsesNewlineRunsToOneSpace() {
+        XCTAssertEqual(
+            ReasoningSummaryFormatter.summary(for: "First line\n\nSecond line\r\nThird"),
+            "First line Second line Third"
+        )
+    }
+
+    func testKeepsTextAtTheLimitIntact() {
+        let text = String(repeating: "a", count: ReasoningSummaryFormatter.characterLimit)
+        XCTAssertEqual(ReasoningSummaryFormatter.summary(for: text), text)
+    }
+
+    func testCutsTextPastTheLimitWithAnEllipsis() {
+        let text = String(repeating: "b", count: ReasoningSummaryFormatter.characterLimit + 1)
+        XCTAssertEqual(
+            ReasoningSummaryFormatter.summary(for: text),
+            String(repeating: "b", count: ReasoningSummaryFormatter.characterLimit) + "..."
+        )
+    }
+
+    func testTrimsSurroundingWhitespace() {
+        XCTAssertEqual(ReasoningSummaryFormatter.summary(for: "  \nplan  \n"), "plan")
+    }
+}


### PR DESCRIPTION
## Linked issue

No linked issue; approved maintainer work on the transcript density pass (follows #344 and #345).

## What changed

Tool calls settle into dense 32 pt log rows, but "Thinking" still sat in a padded material card, so a settled turn mixed two visual languages. Thinking now renders through the same row: brain icon in the icon column, bold `Thinking`, dim one-line summary, chevron, and an empty status slot so labels align with tool rows. Tap expands the reasoning under the row behind the same hairline; long-press copies it with the `Copied` badge and haptic. Live thinking uses the same row and keeps its streaming text view.

- New `TranscriptLogRowView` owns the row chrome (icon column, label, copied badge, chevron and status slots, press highlight, min height, expanded-body indent). `ToolCallLogRowView` and `ReasoningBlockView` are thin users of it, so the geometry exists once.
- `ReasoningSummaryFormatter` derives the one-line summary (newline runs collapse, 80-character cut) and scans only as far as the limit, so summarising a long live stream on every chunk stays cheap.
- "Expand Thinking by Default", the disclosure scroll-anchor suspension, Reduce Motion, and turn folding are untouched. Tool rows keep their forced left-to-right layout; reasoning text follows the transcript direction because it is prose.

## How it was tested

- Full XCTest suite on iPhone 17 simulator via XcodeBuildMCP `test_sim`: 1842 passed, 0 failed, 2 pre-existing skips.
- New `ReasoningSummaryFormatterTests` cover newline collapse, the exact-limit boundary, the ellipsis cut, and whitespace trimming.
- `TranscriptTurnFoldingTests` unchanged and passing.
- Before/after screenshots will come from the maintainer's simulator pass against a live session.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no networking changes)

Built by Claude Fable 5.1 via Claude Code.