### PR TITLE
feat(chat): cap expanded row bodies at a scrollable window

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		1A2B3C4D5E6F7000000000E0 /* ToolCallCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */; };
 		C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F02 /* ToolCallLogRowView.swift */; };
 		C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */; };
+		C0AA020000000000000000B13 /* TranscriptLogRowBodyWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F13 /* TranscriptLogRowBodyWindowTests.swift */; };
 		C0AA020000000000000000B11 /* ReasoningSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F11 /* ReasoningSummaryFormatter.swift */; };
 		C0AA020000000000000000B10 /* TranscriptLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F10 /* TranscriptLogRowView.swift */; };
 		C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */; };
@@ -538,6 +539,7 @@
 		1A2B3C4D5E6F7000000000E1 /* ToolCallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallCardView.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F02 /* ToolCallLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallLogRowView.swift; sourceTree = "<group>"; };
 		C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningSummaryFormatterTests.swift; sourceTree = "<group>"; };
+		C0AA020000000000000000F13 /* TranscriptLogRowBodyWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLogRowBodyWindowTests.swift; sourceTree = "<group>"; };
 		C0AA020000000000000000F11 /* ReasoningSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningSummaryFormatter.swift; sourceTree = "<group>"; };
 		C0AA020000000000000000F10 /* TranscriptLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLogRowView.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFolding.swift; sourceTree = "<group>"; };
@@ -869,6 +871,7 @@
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */,
+				C0AA020000000000000000F13 /* TranscriptLogRowBodyWindowTests.swift */,
 				C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */,
 				C0AA07000000000000000F07 /* ChatTranscriptRowEntryTests.swift */,
 				C0AA05000000000000000F02 /* ChatMessageMetaTests.swift */,
@@ -1762,6 +1765,7 @@
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */,
+				C0AA020000000000000000B13 /* TranscriptLogRowBodyWindowTests.swift in Sources */,
 				C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */,
 				C0AA07000000000000000B07 /* ChatTranscriptRowEntryTests.swift in Sources */,
 				C0AA05000000000000000B02 /* ChatMessageMetaTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ReasoningBlockView.swift
+++ b/HermesMobile/Features/Chat/ReasoningBlockView.swift
@@ -209,10 +209,11 @@ private struct StreamingReasoningTextView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+        let textView = TailPinnedTextView()
         textView.isEditable = false
         textView.isSelectable = false
         textView.isScrollEnabled = false
+        textView.showsVerticalScrollIndicator = true
         textView.backgroundColor = .clear
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
@@ -237,6 +238,9 @@ private struct StreamingReasoningTextView: UIViewRepresentable {
         textView.accessibilityLabel = state.sourceText
     }
 
+    /// Reports at most the row body cap. Past it the text view scrolls itself
+    /// and `TailPinnedTextView` keeps the newest chunk in view, so the SwiftUI
+    /// window around it never needs to scroll for live thinking.
     func sizeThatFits(
         _ proposal: ProposedViewSize,
         uiView: UITextView,
@@ -246,7 +250,29 @@ private struct StreamingReasoningTextView: UIViewRepresentable {
         let size = uiView.sizeThatFits(
             CGSize(width: width, height: .greatestFiniteMagnitude)
         )
-        return CGSize(width: width, height: ceil(size.height))
+        let layout = TranscriptLogRowBodyWindowLayout.resolve(
+            contentHeight: ceil(size.height),
+            cap: TranscriptLogRowMetrics.bodyWindowHeight
+        )
+        if uiView.isScrollEnabled != layout.scrolls {
+            uiView.isScrollEnabled = layout.scrolls
+        }
+        return CGSize(width: width, height: layout.frameHeight ?? 0)
+    }
+
+    /// A text view that stays scrolled to its last line whenever it scrolls,
+    /// so streaming thinking shows the newest text. It is never interactive
+    /// while live, so there is no user offset to respect.
+    final class TailPinnedTextView: UITextView {
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            guard isScrollEnabled else { return }
+
+            let tailOffset = max(0, contentSize.height + adjustedContentInset.bottom - bounds.height)
+            if abs(contentOffset.y - tailOffset) > 0.5 {
+                contentOffset = CGPoint(x: contentOffset.x, y: tailOffset)
+            }
+        }
     }
 
     @MainActor

--- a/HermesMobile/Features/Chat/TranscriptLogRowView.swift
+++ b/HermesMobile/Features/Chat/TranscriptLogRowView.swift
@@ -7,13 +7,69 @@ enum TranscriptLogRowMetrics {
     static let minimumHeight: CGFloat = 32
     /// Icon column width plus the gap, so the expanded body indents under the text.
     static let bodyIndent: CGFloat = 26
+    /// Tallest an expanded body gets before it scrolls inside its own window.
+    /// Fixed at every Dynamic Type size so a long result never owns the screen.
+    static let bodyWindowHeight: CGFloat = 240
+}
+
+/// Pure sizing rule for an expanded body window: the frame it takes and
+/// whether it scrolls, from the measured content height. Shared by the
+/// SwiftUI window and the live thinking text view so both cap alike.
+struct TranscriptLogRowBodyWindowLayout: Equatable {
+    /// `nil` until the content has been measured; the window then sizes to
+    /// whatever the content asks for.
+    let frameHeight: CGFloat?
+    let scrolls: Bool
+
+    static func resolve(contentHeight: CGFloat?, cap: CGFloat) -> Self {
+        guard let contentHeight else {
+            return Self(frameHeight: nil, scrolls: false)
+        }
+        return Self(frameHeight: min(contentHeight, cap), scrolls: contentHeight > cap)
+    }
+}
+
+/// Clips an expanded body at `TranscriptLogRowMetrics.bodyWindowHeight` and
+/// scrolls the overflow inside the window. Shorter content takes its natural
+/// height and cannot scroll. The measurement lives only here, so collapsed
+/// rows in the lazy transcript pay nothing for it.
+struct TranscriptLogRowBodyWindow<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    @State private var contentHeight: CGFloat?
+
+    var body: some View {
+        let layout = TranscriptLogRowBodyWindowLayout.resolve(
+            contentHeight: contentHeight,
+            cap: TranscriptLogRowMetrics.bodyWindowHeight
+        )
+
+        ScrollView(.vertical) {
+            content()
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { height in
+                    // The window resizes to its content outside the disclosure
+                    // animation, so a tall body opens straight at the cap.
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        contentHeight = height
+                    }
+                }
+        }
+        .scrollDisabled(!layout.scrolls)
+        .scrollBounceBehavior(.basedOnSize)
+        .frame(height: layout.frameHeight)
+    }
 }
 
 /// The dense log row settled tool calls and thinking share: a 20 pt icon
 /// column, bold summary, dim one-line detail, `Copied` badge, chevron slot, and
 /// a fixed status slot so labels align across rows. Tap toggles the owner's
-/// expansion state and reveals `expandedBody` under the text behind a hairline;
-/// long-press copies `copyText` with a haptic and a short "Copied" badge.
+/// expansion state and reveals `expandedBody` under the text behind a hairline,
+/// inside a `TranscriptLogRowBodyWindow` that scrolls once the body outgrows
+/// the cap; long-press copies `copyText` with a haptic and a short "Copied" badge.
 struct TranscriptLogRowView<Icon: View, Status: View, ExpandedBody: View>: View {
     let summary: String
     let detail: String?
@@ -41,7 +97,7 @@ struct TranscriptLogRowView<Icon: View, Status: View, ExpandedBody: View>: View 
             rowLine
 
             if isExpanded {
-                expandedBody()
+                TranscriptLogRowBodyWindow(content: expandedBody)
                     .padding(.leading, 12)
                     .overlay(alignment: .leading) {
                         Rectangle()

--- a/HermesMobileTests/TranscriptLogRowBodyWindowTests.swift
+++ b/HermesMobileTests/TranscriptLogRowBodyWindowTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import HermesMobile
+
+final class TranscriptLogRowBodyWindowTests: XCTestCase {
+    private let cap = TranscriptLogRowMetrics.bodyWindowHeight
+
+    func testUnmeasuredContentLeavesTheWindowFreeAndStill() {
+        let layout = TranscriptLogRowBodyWindowLayout.resolve(contentHeight: nil, cap: cap)
+
+        XCTAssertNil(layout.frameHeight)
+        XCTAssertFalse(layout.scrolls)
+    }
+
+    func testContentBelowTheCapTakesItsNaturalHeightWithoutScrolling() {
+        let layout = TranscriptLogRowBodyWindowLayout.resolve(contentHeight: 96, cap: cap)
+
+        XCTAssertEqual(layout.frameHeight, 96)
+        XCTAssertFalse(layout.scrolls)
+    }
+
+    func testContentAtTheCapFillsTheWindowWithoutScrolling() {
+        let layout = TranscriptLogRowBodyWindowLayout.resolve(contentHeight: cap, cap: cap)
+
+        XCTAssertEqual(layout.frameHeight, cap)
+        XCTAssertFalse(layout.scrolls)
+    }
+
+    func testContentAboveTheCapClipsToTheWindowAndScrolls() {
+        let layout = TranscriptLogRowBodyWindowLayout.resolve(contentHeight: 1_800, cap: cap)
+
+        XCTAssertEqual(layout.frameHeight, cap)
+        XCTAssertTrue(layout.scrolls)
+    }
+
+    func testTheCapIsTwoHundredFortyPoints() {
+        XCTAssertEqual(cap, 240)
+    }
+}


### PR DESCRIPTION
## Linked issue

No linked issue; approved maintainer work on the transcript density pass (follows #354).

## What changed

Expanding a tool row or thinking row with a long body pushed the whole transcript down by the full height of the text, so one big result meant pages of scrolling to get past a single row.

Expanded bodies now open inside a window that stops growing at 240 pt and scrolls on its own behind the row's left hairline. Shorter bodies keep their natural height and cannot scroll. The cap is fixed at every Dynamic Type size.

- `TranscriptLogRowBodyWindow` wraps the expanded body inside `TranscriptLogRowView`, so tool rows and thinking rows share one container. It measures its content with `onGeometryChange`, so the measurement exists only inside expanded bodies; collapsed rows in the lazy transcript gain nothing.
- `TranscriptLogRowBodyWindowLayout` is the pure rule `(contentHeight, cap) → (frameHeight, scrolls)`. The measured height is applied outside the disclosure animation so a tall body opens straight at the cap.
- Live thinking keeps its `UITextView`. Its `sizeThatFits` now reports at most the cap through the same layout rule, turns on the text view's own scrolling only once the content exceeds it, and `TailPinnedTextView` keeps the newest chunk visible on each layout. It stays non-interactive while streaming, so the outer window never scrolls for it and no user offset needs respecting.
- The inner scroller is a separate `UIScrollView`, so the transcript's follow latch and bottom anchor never see it. Expanding and collapsing still run through the existing anchor suspension.

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP `test_sim`: 1848 passed, 0 failed, 2 pre-existing integration skips.
- New `TranscriptLogRowBodyWindowTests` cover the layout rule for unmeasured, below-cap, at-cap, and above-cap content, plus the 240 pt cap.
- Manual simulator pass to follow: expand a long tool result and a long thinking row, confirm both clip at the cap and scroll inside, confirm a short body does not scroll, and scroll inside an expanded body during a live stream to check the transcript's follow state stays put.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (nothing crosses the wire)

---

Changes made by Claude Fable 5.1 through Claude Code.