### PR TITLE
fix(chat): keep the reader in place through disclosure toggles

### DIFF
--- a/HermesMobile/Features/Chat/ChatScrollPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatScrollPolicy.swift
@@ -4,12 +4,23 @@ import SwiftUI
 
 /// Pure decision rules for the chat transcript's auto-scroll behavior.
 ///
-/// Auto-follow is an explicit latch driven by scroll gestures rather than a
-/// distance test: touching the transcript switches it off, and only a gesture
-/// that settles at the true bottom, a scroll-to-bottom tap, or a send switches
-/// it back on. Layout growth from streaming tokens never flips the latch on its
-/// own, so a reader parked above the end stays parked. The distance thresholds
-/// below only drive the scroll-to-bottom button and the reading-older chrome.
+/// Auto-follow is an explicit latch rather than a distance test.
+///
+/// Follow switches **off** when a drag begins, when a live gesture moves the
+/// offset, or when a scroll with no gesture carries the reader away from the
+/// bottom (a status-bar tap, VoiceOver, or a hardware-keyboard scroll).
+///
+/// Follow switches **on** when a scroll-to-bottom tap or a send resets it, when
+/// a gesture settles at the true bottom, or when a non-gesture offset change
+/// lands at the true bottom from nearby (a collapse near the end clamping the
+/// offset). Landing at the bottom from far above is a relayout artifact, never
+/// a reason to follow.
+///
+/// Layout growth from streaming tokens and keyboard inset changes never flip
+/// the latch on their own, so a reader parked above the end stays parked. The
+/// distance thresholds below drive the scroll-to-bottom button, the
+/// reading-older chrome, and how far a gesture-free scroll must carry the
+/// reader before it counts as leaving.
 enum ChatScrollPolicy {
     /// Existing transcripts should enter at their latest content as part of the
     /// scroll view's first layout, before the destination becomes visible.
@@ -49,10 +60,19 @@ enum ChatScrollPolicy {
     /// Gap between momentum ticks that means deceleration has stopped.
     static let momentumSettleDelay: TimeInterval = 0.05
 
-    /// How long the bottom size-change anchor stays suspended after a disclosure
-    /// toggle. Covers the disclosure animation plus a frame, since the row's
-    /// height changes on every frame of that animation.
+    /// How long follow scrolls and the bottom size-change anchor stay suspended
+    /// after a disclosure toggle. Covers the disclosure animation plus a frame.
     static let disclosureAnchorSuspension: TimeInterval = 0.25
+
+    /// The offset pin armed by a disclosure toggle releases once the content
+    /// size has been quiet this long. Lazy rows can keep laying out well past
+    /// the animation, and SwiftUI re-applies the bottom anchor on each of those
+    /// size changes after a status-bar scroll, so a fixed window is not enough.
+    static let disclosureHoldQuietPeriod: TimeInterval = 0.3
+
+    /// Upper bound on the pin, so a transcript that never goes quiet (streaming
+    /// tokens) still returns to normal scrolling.
+    static let disclosureHoldMaximum: TimeInterval = 2
 
     /// Scroll-gesture events that drive the follow latch.
     enum FollowEvent: Equatable {
@@ -68,7 +88,40 @@ enum ChatScrollPolicy {
         case userScrollEnd(isAtBottom: Bool)
         /// The content offset changed for any other reason: streaming growth,
         /// keyboard presentation, a programmatic scroll, or a live gesture.
-        case contentScrolled(isAtBottom: Bool, isUserScrolling: Bool)
+        /// `movedAwayFromBottom` marks a scroll with no gesture that carried
+        /// the reader away from the bottom (see `isScrollingAwayFromBottom`);
+        /// `wasNearBottom` is where the previous report left the reader.
+        case contentScrolled(
+            isAtBottom: Bool,
+            isUserScrolling: Bool,
+            movedAwayFromBottom: Bool = false,
+            wasNearBottom: Bool = true
+        )
+    }
+
+    /// The scroll geometry one metrics report is derived from.
+    struct ScrollGeometry: Equatable {
+        var offsetY: CGFloat
+        var contentHeight: CGFloat
+        var visibleHeight: CGFloat
+
+        var distanceFromBottom: CGFloat {
+            max(0, contentHeight - visibleHeight - offsetY)
+        }
+    }
+
+    /// True when a report without a gesture shows the reader farther from the
+    /// bottom than the last one, past the streaming threshold, in the same
+    /// viewport. While follow is on the bottom anchor snaps every size change
+    /// back to zero distance, so only an actual scroll (status-bar tap,
+    /// VoiceOver, hardware keyboard) can move the reader out that far. Keyboard
+    /// insets change the viewport and are excluded; the scroll observer
+    /// suppresses the check while a disclosure pin holds the offset.
+    static func isScrollingAwayFromBottom(previous: ScrollGeometry?, current: ScrollGeometry) -> Bool {
+        guard let previous, previous.visibleHeight == current.visibleHeight else { return false }
+        let distance = current.distanceFromBottom
+        return distance > previous.distanceFromBottom + 0.5
+            && distance > streamingBottomDetectionThreshold
     }
 
     /// The follow latch. `isFollowing` is the answer; the second flag lets an
@@ -94,10 +147,14 @@ enum ChatScrollPolicy {
         case .userScrollEnd(let isAtBottom):
             latch.isFollowing = isAtBottom || current.isFollowing
             latch.ignoresCoastingGesture = false
-        case .contentScrolled(let isAtBottom, let isUserScrolling):
-            if isUserScrolling, !current.ignoresCoastingGesture {
+        case .contentScrolled(let isAtBottom, let isUserScrolling, let movedAwayFromBottom, let wasNearBottom):
+            if isUserScrolling {
+                if !current.ignoresCoastingGesture {
+                    latch.isFollowing = false
+                }
+            } else if movedAwayFromBottom {
                 latch.isFollowing = false
-            } else if isAtBottom {
+            } else if isAtBottom, wasNearBottom {
                 latch.isFollowing = true
             }
         }
@@ -124,9 +181,9 @@ enum ChatScrollPolicy {
     }
 }
 
-/// Transcript disclosure controls (reasoning blocks, tool cards, tool groups)
-/// call this right before they toggle so the transcript can suspend its bottom
-/// anchor and keep the tapped row stationary through the size change.
+/// Transcript disclosure controls (reasoning blocks, tool cards, tool groups,
+/// turn folds) call this right before they toggle so the transcript can pin
+/// the reader's offset and suspend follow scrolls through the size change.
 struct ChatDisclosureToggledKey: EnvironmentKey {
     static let defaultValue: () -> Void = {}
 }

--- a/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
@@ -400,6 +400,10 @@ final class ChatScrollPositionController {
 
     private weak var scrollView: UIScrollView?
     private var mode = Mode.prepend
+    /// Set by `capture()`, cleared by anything that replaces the baseline, so
+    /// a hold armed while the older-message request is in flight cannot be
+    /// mistaken for the prepend capture when the request lands.
+    private var hasPrependCapture = false
     private var baselineContentHeight: CGFloat?
     private var baselineOffsetY: CGFloat?
     private var contentSizeObservation: NSKeyValueObservation?
@@ -442,16 +446,19 @@ final class ChatScrollPositionController {
 
         baselineContentHeight = scrollView.contentSize.height
         baselineOffsetY = scrollView.contentOffset.y
+        hasPrependCapture = true
         return true
     }
 
     /// Arms compensation before SwiftUI performs the prepend layout. Returns
-    /// false when the user moved the scroll view while the request was in flight,
-    /// leaving the caller free to use its coarse fallback instead of overriding
-    /// user-owned movement.
+    /// false when the user moved the scroll view while the request was in
+    /// flight, or a disclosure hold replaced the capture meanwhile, leaving the
+    /// caller free to use its coarse fallback instead of overriding movement it
+    /// does not own.
     @discardableResult
     func restoreAfterPrepend() -> Bool {
-        guard let scrollView,
+        guard hasPrependCapture,
+              let scrollView,
               let baselineOffsetY,
               baselineContentHeight != nil,
               !scrollView.isDragging,
@@ -537,6 +544,8 @@ final class ChatScrollPositionController {
 
     private func beginPreservation(mode: Mode, scrollView: UIScrollView, window: TimeInterval) {
         self.mode = mode
+        completionTask?.cancel()
+        quietReleaseTask?.cancel()
         contentSizeObservation = scrollView.observe(\.contentSize, options: [.new]) { [weak self] scrollView, _ in
             Self.handleObservedContentSizeChange(for: self, scrollView: scrollView)
         }
@@ -557,6 +566,8 @@ final class ChatScrollPositionController {
     }
 
     func cancelPreservation() {
+        mode = .prepend
+        hasPrependCapture = false
         contentSizeObservation = nil
         contentOffsetObservation = nil
         completionTask?.cancel()

--- a/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
@@ -4,6 +4,9 @@ import UIKit
 struct ChatScrollMetrics: Equatable {
     let distanceFromBottom: CGFloat
     let isUserInteracting: Bool
+    /// A scroll with no gesture carried the reader away from the bottom since
+    /// the last delivered report; see `ChatScrollPolicy.isScrollingAwayFromBottom`.
+    let movedAwayFromBottom: Bool
 }
 
 /// Reports the transcript's scroll geometry and the gesture events that drive
@@ -12,18 +15,18 @@ struct ChatScrollMetrics: Equatable {
 /// the gesture, including any momentum, has settled.
 struct ChatScrollObserver: UIViewRepresentable {
     let isStreaming: Bool
-    let prependScrollPositionController: ChatPrependScrollPositionController?
+    let scrollPositionController: ChatScrollPositionController?
     let onFollowEvent: @MainActor (ChatScrollPolicy.FollowEvent) -> Void
     let onMetrics: @MainActor (ChatScrollMetrics) -> Void
 
     init(
         isStreaming: Bool,
-        prependScrollPositionController: ChatPrependScrollPositionController? = nil,
+        scrollPositionController: ChatScrollPositionController? = nil,
         onFollowEvent: @escaping @MainActor (ChatScrollPolicy.FollowEvent) -> Void = { _ in },
         onMetrics: @escaping @MainActor (ChatScrollMetrics) -> Void
     ) {
         self.isStreaming = isStreaming
-        self.prependScrollPositionController = prependScrollPositionController
+        self.scrollPositionController = scrollPositionController
         self.onFollowEvent = onFollowEvent
         self.onMetrics = onMetrics
     }
@@ -35,7 +38,7 @@ struct ChatScrollObserver: UIViewRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(
             metricContext: metricContext,
-            prependScrollPositionController: prependScrollPositionController,
+            scrollPositionController: scrollPositionController,
             onFollowEvent: onFollowEvent,
             onMetrics: onMetrics
         )
@@ -48,7 +51,7 @@ struct ChatScrollObserver: UIViewRepresentable {
     func updateUIView(_ uiView: ObserverView, context: Context) {
         context.coordinator.onMetrics = onMetrics
         context.coordinator.onFollowEvent = onFollowEvent
-        context.coordinator.prependScrollPositionController = prependScrollPositionController
+        context.coordinator.scrollPositionController = scrollPositionController
         uiView.coordinator = context.coordinator
         context.coordinator.updateMetricContext(metricContext)
 
@@ -112,30 +115,35 @@ struct ChatScrollObserver: UIViewRepresentable {
         private var metricContext: MetricContext
         private var lastMetrics: ChatScrollMetrics?
         private var pendingMetrics: ChatScrollMetrics?
+        /// Geometry behind the last report the transcript received. Reports
+        /// coalesce per run loop, so the away-from-bottom check compares
+        /// delivered states, not every intermediate KVO tick.
+        private var deliveredGeometry: ChatScrollPolicy.ScrollGeometry?
+        private var pendingGeometry: ChatScrollPolicy.ScrollGeometry?
         private var hasScheduledMetricDelivery = false
         /// True from the first drag movement until the gesture, including any
         /// momentum, comes to rest. Mirrors the "user scroll session" the follow
         /// latch reasons about.
         private var isUserScrollSessionActive = false
         private var settleWorkItem: DispatchWorkItem?
-        var prependScrollPositionController: ChatPrependScrollPositionController? {
+        var scrollPositionController: ChatScrollPositionController? {
             didSet {
-                guard oldValue !== prependScrollPositionController else { return }
+                guard oldValue !== scrollPositionController else { return }
                 oldValue?.detach()
                 if let scrollView {
-                    prependScrollPositionController?.attach(to: scrollView)
+                    scrollPositionController?.attach(to: scrollView)
                 }
             }
         }
 
         init(
             metricContext: MetricContext,
-            prependScrollPositionController: ChatPrependScrollPositionController?,
+            scrollPositionController: ChatScrollPositionController?,
             onFollowEvent: @escaping @MainActor (ChatScrollPolicy.FollowEvent) -> Void,
             onMetrics: @escaping @MainActor (ChatScrollMetrics) -> Void
         ) {
             self.metricContext = metricContext
-            self.prependScrollPositionController = prependScrollPositionController
+            self.scrollPositionController = scrollPositionController
             self.onFollowEvent = onFollowEvent
             self.onMetrics = onMetrics
         }
@@ -151,16 +159,17 @@ struct ChatScrollObserver: UIViewRepresentable {
             guard let scrollView = enclosingScrollView(for: view) else { return }
 
             guard scrollView !== self.scrollView else {
-                prependScrollPositionController?.attach(to: scrollView)
+                scrollPositionController?.attach(to: scrollView)
                 reportMetrics(delivery: delivery)
                 return
             }
 
             observations.removeAll()
             lastMetrics = nil
+            deliveredGeometry = nil
             endUserScrollSessionSilently()
             self.scrollView = scrollView
-            prependScrollPositionController?.attach(to: scrollView)
+            scrollPositionController?.attach(to: scrollView)
 
             observedPanGesture?.removeTarget(self, action: nil)
             scrollView.panGestureRecognizer.addTarget(self, action: #selector(handlePanGesture(_:)))
@@ -183,9 +192,11 @@ struct ChatScrollObserver: UIViewRepresentable {
             observedPanGesture?.removeTarget(self, action: nil)
             observedPanGesture = nil
             endUserScrollSessionSilently()
-            prependScrollPositionController?.detach()
+            scrollPositionController?.detach()
             lastMetrics = nil
+            deliveredGeometry = nil
             pendingMetrics = nil
+            pendingGeometry = nil
             hasScheduledMetricDelivery = false
             scrollView = nil
         }
@@ -268,24 +279,36 @@ struct ChatScrollObserver: UIViewRepresentable {
             return ChatScrollPolicy.isAtBottom(distanceFromBottom: distance)
         }
 
-        private func distanceFromBottom(of scrollView: UIScrollView) -> CGFloat? {
+        private func geometry(of scrollView: UIScrollView) -> ChatScrollPolicy.ScrollGeometry? {
             let inset = scrollView.adjustedContentInset
             let visibleHeight = scrollView.bounds.height - inset.top - inset.bottom
             guard visibleHeight > 0 else { return nil }
 
-            let currentOffset = scrollView.contentOffset.y + inset.top
-            let maximumOffset = scrollView.contentSize.height - visibleHeight
-            return max(0, maximumOffset - currentOffset)
+            return ChatScrollPolicy.ScrollGeometry(
+                offsetY: scrollView.contentOffset.y + inset.top,
+                contentHeight: scrollView.contentSize.height,
+                visibleHeight: visibleHeight
+            )
+        }
+
+        private func distanceFromBottom(of scrollView: UIScrollView) -> CGFloat? {
+            geometry(of: scrollView)?.distanceFromBottom
         }
 
         func reportMetrics(delivery: MetricDelivery) {
             guard let scrollView else { return }
             trackMomentum(scrollView)
 
-            guard let distanceFromBottom = distanceFromBottom(of: scrollView) else { return }
+            guard let geometry = geometry(of: scrollView) else { return }
+            let isUserInteracting = scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating
+            // While a disclosure pin holds the offset, a toggled row growing
+            // below the reader increases the distance without anyone scrolling.
+            let isPinned = scrollPositionController?.isHoldingPosition == true
             let metrics = ChatScrollMetrics(
-                distanceFromBottom: distanceFromBottom,
-                isUserInteracting: scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating
+                distanceFromBottom: geometry.distanceFromBottom,
+                isUserInteracting: isUserInteracting,
+                movedAwayFromBottom: !isUserInteracting && !isPinned
+                    && ChatScrollPolicy.isScrollingAwayFromBottom(previous: deliveredGeometry, current: geometry)
             )
             guard metrics != lastMetrics else { return }
 
@@ -293,9 +316,11 @@ struct ChatScrollObserver: UIViewRepresentable {
 
             switch delivery {
             case .immediate:
+                deliveredGeometry = geometry
                 onMetrics(metrics)
             case .deferred:
                 pendingMetrics = metrics
+                pendingGeometry = geometry
                 guard !hasScheduledMetricDelivery else { return }
 
                 hasScheduledMetricDelivery = true
@@ -303,9 +328,12 @@ struct ChatScrollObserver: UIViewRepresentable {
                     MainActor.assumeIsolated {
                         guard let self else { return }
                         let metrics = self.pendingMetrics
+                        let geometry = self.pendingGeometry
                         self.pendingMetrics = nil
+                        self.pendingGeometry = nil
                         self.hasScheduledMetricDelivery = false
                         guard let metrics, self.lastMetrics == metrics else { return }
+                        self.deliveredGeometry = geometry
                         self.onMetrics(metrics)
                     }
                 }
@@ -343,24 +371,58 @@ struct ChatScrollObserver: UIViewRepresentable {
     }
 }
 
-/// Keeps the reader's exact vertical position while older transcript rows are
-/// inserted above it. `ScrollViewProxy.scrollTo(_:anchor:)` can only align a row
-/// to a coarse anchor; aligning the previous first row to `.top` loses the gap
-/// formerly occupied by the Load Older button and causes a visible hop.
+/// Keeps the reader's exact vertical position through a layout change SwiftUI
+/// would otherwise move them for. Two cases:
 ///
-/// This controller snapshots the UIKit scroll geometry before the request, then
-/// offsets by the net content-height growth during the following layout pass.
-/// The correction is deliberately non-animated: it preserves an existing
-/// position rather than navigating to a new one.
+/// - **Prepend.** Older rows are inserted above the reader; the offset shifts
+///   by the net content-height growth. `ScrollViewProxy.scrollTo(_:anchor:)`
+///   can only align a row to a coarse anchor, which loses the gap formerly
+///   occupied by the Load Older button and causes a visible hop.
+/// - **Hold.** A disclosure toggle grows or shrinks a row below the reader;
+///   the offset must not move at all. SwiftUI can re-apply a default anchor on
+///   that size change (seen at the exact top after a status-bar scroll); that
+///   shows up as an offset change in the same run-loop turn as a size change
+///   and is put back. Any other offset change is someone scrolling on purpose
+///   (VoiceOver, a hardware keyboard, a follow scroll) and releases the hold.
+///
+/// The controller snapshots the UIKit scroll geometry, then corrects during
+/// the following layout passes for a bounded window. Corrections are
+/// deliberately non-animated: they preserve an existing position rather than
+/// navigating to a new one. Any user movement releases the hold.
 @MainActor
-final class ChatPrependScrollPositionController {
+final class ChatScrollPositionController {
+    private enum Mode {
+        /// Offset follows the net content-height growth.
+        case prepend
+        /// Offset stays put; SwiftUI-driven offset changes are reverted.
+        case hold
+    }
+
     private weak var scrollView: UIScrollView?
+    private var mode = Mode.prepend
     private var baselineContentHeight: CGFloat?
     private var baselineOffsetY: CGFloat?
     private var contentSizeObservation: NSKeyValueObservation?
     private var contentOffsetObservation: NSKeyValueObservation?
     private var completionTask: Task<Void, Never>?
+    private var quietReleaseTask: Task<Void, Never>?
     private var isApplyingCompensation = false
+    /// Set when a hold had to undo an offset SwiftUI applied. SwiftUI's own
+    /// notion of the offset is then stale, and lazy rows it believes are
+    /// off-screen stop hit-testing until a scroll it performed itself resyncs
+    /// it; `resyncAfterHold` is that scroll.
+    private var didRevertSwiftUIOffset = false
+    private var resyncAfterHold: (() -> Void)?
+    /// True from a content-size change until the end of the same run-loop
+    /// turn: an offset change in that window is SwiftUI re-anchoring, not a
+    /// scroll. `lastObservedContentHeight` covers the offset change UIKit
+    /// makes from inside the content-size setter, before that callback runs.
+    private var contentSizeChangedThisTurn = false
+    private var lastObservedContentHeight: CGFloat?
+
+    var isHoldingPosition: Bool {
+        mode == .hold && baselineOffsetY != nil
+    }
 
     func attach(to scrollView: UIScrollView) {
         guard scrollView !== self.scrollView else { return }
@@ -401,23 +463,97 @@ final class ChatPrependScrollPositionController {
             return false
         }
 
-        contentSizeObservation = scrollView.observe(\.contentSize, options: [.new]) { [weak self] _, _ in
-            Self.handleObservedContentSizeChange(for: self)
-        }
-        contentOffsetObservation = scrollView.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, _ in
-            Self.handleObservedUserMovement(for: self, scrollView: scrollView)
-        }
-
         // Text and attachment layout can settle over several run-loop passes.
         // Keep applying the same net-height correction for a short bounded
         // window, then release ownership back to normal scrolling.
-        completionTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(1))
-            guard !Task.isCancelled, let self else { return }
-            self.applyCompensation()
-            self.cancelPreservation()
-        }
+        beginPreservation(mode: .prepend, scrollView: scrollView, window: 1)
         return true
+    }
+
+    /// Pins the current offset: a disclosure toggle is about to change a row's
+    /// height below the reader. The pin releases once the content size has been
+    /// quiet for `ChatScrollPolicy.disclosureHoldQuietPeriod`, or after
+    /// `disclosureHoldMaximum` at the latest. No-op while the user is moving the
+    /// transcript; their gesture owns the position.
+    func holdPosition(resync: @escaping () -> Void) {
+        cancelPreservation()
+        guard let scrollView,
+              !scrollView.isDragging,
+              !scrollView.isTracking,
+              !scrollView.isDecelerating
+        else { return }
+
+        baselineContentHeight = scrollView.contentSize.height
+        baselineOffsetY = scrollView.contentOffset.y
+        lastObservedContentHeight = scrollView.contentSize.height
+        resyncAfterHold = resync
+        beginPreservation(mode: .hold, scrollView: scrollView, window: ChatScrollPolicy.disclosureHoldMaximum)
+        scheduleQuietRelease()
+    }
+
+    /// Hold ran to completion (quiet or capped): let go, then resync SwiftUI
+    /// if the hold had to fight it. A hold ended by a gesture or a deliberate
+    /// scroll needs no resync; that scroll does it.
+    private func finishHold() {
+        applyCompensation()
+        let resync = Self.shouldResync(
+            didRevertSwiftUIOffset: didRevertSwiftUIOffset,
+            heldOffsetY: baselineOffsetY,
+            minimumOffsetY: scrollView.map { -$0.adjustedContentInset.top }
+        ) ? resyncAfterHold : nil
+        cancelPreservation()
+        resync?()
+    }
+
+    /// The resync is a SwiftUI scroll to the transcript's top, so it only
+    /// describes the held position when that position is the top. Anchor
+    /// re-application has only been seen there (after a status-bar scroll);
+    /// anywhere else, leave SwiftUI alone rather than hop.
+    nonisolated static func shouldResync(
+        didRevertSwiftUIOffset: Bool,
+        heldOffsetY: CGFloat?,
+        minimumOffsetY: CGFloat?
+    ) -> Bool {
+        guard didRevertSwiftUIOffset, let heldOffsetY, let minimumOffsetY else { return false }
+        return heldOffsetY <= minimumOffsetY + 0.5
+    }
+
+    /// Ends a disclosure pin early: the transcript is about to scroll on
+    /// purpose (follow, scroll-to-bottom, keyboard). A prepend preservation is
+    /// left alone.
+    func releaseHold() {
+        guard mode == .hold else { return }
+        cancelPreservation()
+    }
+
+    private func scheduleQuietRelease() {
+        quietReleaseTask?.cancel()
+        quietReleaseTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(ChatScrollPolicy.disclosureHoldQuietPeriod))
+            guard !Task.isCancelled, let self else { return }
+            self.finishHold()
+        }
+    }
+
+    private func beginPreservation(mode: Mode, scrollView: UIScrollView, window: TimeInterval) {
+        self.mode = mode
+        contentSizeObservation = scrollView.observe(\.contentSize, options: [.new]) { [weak self] scrollView, _ in
+            Self.handleObservedContentSizeChange(for: self, scrollView: scrollView)
+        }
+        contentOffsetObservation = scrollView.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, _ in
+            Self.handleObservedOffsetChange(for: self, scrollView: scrollView)
+        }
+
+        completionTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(window))
+            guard !Task.isCancelled, let self else { return }
+            if mode == .hold {
+                self.finishHold()
+            } else {
+                self.applyCompensation()
+                self.cancelPreservation()
+            }
+        }
     }
 
     func cancelPreservation() {
@@ -425,70 +561,111 @@ final class ChatPrependScrollPositionController {
         contentOffsetObservation = nil
         completionTask?.cancel()
         completionTask = nil
+        quietReleaseTask?.cancel()
+        quietReleaseTask = nil
+        didRevertSwiftUIOffset = false
+        resyncAfterHold = nil
+        contentSizeChangedThisTurn = false
+        lastObservedContentHeight = nil
         baselineContentHeight = nil
         baselineOffsetY = nil
         isApplyingCompensation = false
     }
 
     nonisolated private static func handleObservedContentSizeChange(
-        for controller: ChatPrependScrollPositionController?
-    ) {
-        guard Thread.isMainThread else {
-            DispatchQueue.main.async { [weak controller] in
-                MainActor.assumeIsolated {
-                    controller?.applyCompensation()
-                }
-            }
-            return
-        }
-
-        MainActor.assumeIsolated {
-            controller?.applyCompensation()
-        }
-    }
-
-    nonisolated private static func handleObservedUserMovement(
-        for controller: ChatPrependScrollPositionController?,
+        for controller: ChatScrollPositionController?,
         scrollView: UIScrollView
     ) {
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak controller, weak scrollView] in
                 MainActor.assumeIsolated {
                     guard let scrollView else { return }
-                    controller?.cancelIfUserIsMoving(scrollView)
+                    controller?.handleContentSizeChange(scrollView)
                 }
             }
             return
         }
 
         MainActor.assumeIsolated {
-            controller?.cancelIfUserIsMoving(scrollView)
+            controller?.handleContentSizeChange(scrollView)
         }
     }
 
-    private func cancelIfUserIsMoving(_ scrollView: UIScrollView) {
-        guard !isApplyingCompensation,
-              scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating
-        else { return }
+    private func handleContentSizeChange(_ scrollView: UIScrollView) {
+        // A callback that outlived a detach must not touch the new attachment.
+        guard scrollView === self.scrollView else { return }
 
-        cancelPreservation()
+        applyCompensation()
+        if mode == .hold {
+            contentSizeChangedThisTurn = true
+            lastObservedContentHeight = scrollView.contentSize.height
+            DispatchQueue.main.async { [weak self] in
+                MainActor.assumeIsolated {
+                    self?.contentSizeChangedThisTurn = false
+                }
+            }
+            scheduleQuietRelease()
+        }
     }
 
-    private func applyCompensation() {
-        guard let scrollView,
-              let baselineContentHeight,
-              let baselineOffsetY
-        else { return }
+    nonisolated private static func handleObservedOffsetChange(
+        for controller: ChatScrollPositionController?,
+        scrollView: UIScrollView
+    ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak controller, weak scrollView] in
+                MainActor.assumeIsolated {
+                    guard let scrollView else { return }
+                    controller?.handleOffsetChange(scrollView)
+                }
+            }
+            return
+        }
 
-        let targetY = Self.compensatedOffsetY(
+        MainActor.assumeIsolated {
+            controller?.handleOffsetChange(scrollView)
+        }
+    }
+
+    /// User movement releases the preservation. In hold mode an offset change
+    /// riding on a size change is SwiftUI re-anchoring and is put back; any
+    /// other offset change is a deliberate scroll and releases the hold.
+    private func handleOffsetChange(_ scrollView: UIScrollView) {
+        guard !isApplyingCompensation, scrollView === self.scrollView else { return }
+
+        if scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating {
+            cancelPreservation()
+        } else if mode == .hold {
+            let sizeIsChanging = contentSizeChangedThisTurn
+                || scrollView.contentSize.height != lastObservedContentHeight
+            if sizeIsChanging {
+                applyCompensation()
+            } else if let targetY = compensatedOffsetY(in: scrollView),
+                      abs(scrollView.contentOffset.y - targetY) > 0.5 {
+                cancelPreservation()
+            }
+        }
+    }
+
+    private func compensatedOffsetY(in scrollView: UIScrollView) -> CGFloat? {
+        guard let baselineContentHeight, let baselineOffsetY else { return nil }
+
+        return Self.compensatedOffsetY(
             baselineOffsetY: baselineOffsetY,
-            contentHeightDelta: scrollView.contentSize.height - baselineContentHeight,
+            contentHeightDelta: mode == .prepend ? scrollView.contentSize.height - baselineContentHeight : 0,
             adjustedInset: scrollView.adjustedContentInset,
             contentSizeHeight: scrollView.contentSize.height,
             boundsHeight: scrollView.bounds.height
         )
+    }
+
+    private func applyCompensation() {
+        guard let scrollView, let targetY = compensatedOffsetY(in: scrollView) else { return }
         guard abs(scrollView.contentOffset.y - targetY) > 0.5 else { return }
 
+        if mode == .hold {
+            didRevertSwiftUIOffset = true
+        }
         isApplyingCompensation = true
         var offset = scrollView.contentOffset
         offset.y = targetY

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct ChatTranscriptView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @State private var prependScrollPositionController = ChatPrependScrollPositionController()
+    @State private var scrollPositionController = ChatScrollPositionController()
 
     let isLoading: Bool
     let errorMessage: String?
@@ -168,7 +168,7 @@ struct ChatTranscriptView: View {
                         ChatScrollToBottomButton(
                             bottomPadding: scrollToBottomButtonBottomPadding,
                             onTap: {
-                                onScrollToBottom(proxy)
+                                releasingHold { onScrollToBottom(proxy) }
                             }
                         )
                         .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
@@ -180,14 +180,14 @@ struct ChatTranscriptView: View {
                     guard isFollowingLatestContent else { return }
 
                     if latestTranscriptMessageRole == "user" {
-                        onScrollToLatestTranscriptMessage(proxy)
+                        releasingHold { onScrollToLatestTranscriptMessage(proxy) }
                     } else {
-                        onScrollToLatestContent(proxy, true)
+                        releasingHold { onScrollToLatestContent(proxy, true) }
                     }
                 }
                 .onChange(of: streamingScrollTrigger) {
                     if isFollowingLatestContent {
-                        onScrollToLatestContent(proxy, true)
+                        releasingHold { onScrollToLatestContent(proxy, true) }
                     }
                 }
                 .onChange(of: cacheFirstReconcileScrollToken) {
@@ -195,17 +195,17 @@ struct ChatTranscriptView: View {
                     // the lighter cached render, so snap back to the bottom (no
                     // animation) unless the reader has scrolled away in the meantime.
                     guard isFollowingLatestContent else { return }
-                    onScrollToLatestContent(proxy, false)
+                    releasingHold { onScrollToLatestContent(proxy, false) }
                 }
                 .onChange(of: clarificationPromptID) {
                     // The bar above the composer just grew the bottom inset; keep
                     // the latest content above it for a reader who was following.
                     guard clarificationPromptID != nil, isFollowingLatestContent else { return }
-                    onScrollToBottom(proxy)
+                    releasingHold { onScrollToBottom(proxy) }
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
                     if isScrolledNearBottom {
-                        onScrollToBottom(proxy)
+                        releasingHold { onScrollToBottom(proxy) }
                     }
                 }
             }
@@ -216,6 +216,28 @@ struct ChatTranscriptView: View {
     /// toggle is mid-animation.
     private var isFollowingLatestContent: Bool {
         shouldFollowLatestMessage && !isDisclosureSettling
+    }
+
+    /// Identifies the whole transcript content so a scroll to its top can be
+    /// expressed through SwiftUI.
+    private let transcriptContentID = "chat-transcript-content"
+
+    /// A tapped row is about to grow or shrink below the reader. Pin the offset
+    /// so a default anchor SwiftUI re-applies on the size change (seen at the
+    /// exact top after a status-bar scroll) cannot move them. If the pin had to
+    /// undo SwiftUI, finish with a SwiftUI-driven scroll to the same place so
+    /// its own offset model, and hit-testing of the visible rows, catch up.
+    private func pinReader(proxy: ScrollViewProxy) {
+        scrollPositionController.holdPosition {
+            proxy.scrollTo(transcriptContentID, anchor: .top)
+        }
+    }
+
+    /// Deliberate scrolls end a disclosure pin first. The pin exists only to
+    /// stop SwiftUI moving the reader on its own after a toggle.
+    private func releasingHold(_ scroll: () -> Void) {
+        scrollPositionController.releaseHold()
+        scroll()
     }
 
     private func transcriptScrollContent(
@@ -254,7 +276,11 @@ struct ChatTranscriptView: View {
                     showsThinkingAndToolCards: showsThinkingAndToolCards,
                     foldState: foldState,
                     isTerminalReply: terminalReplyRenderIDs.contains(transcriptMessage.renderID),
-                    onToggleTurnFold: onToggleTurnFold,
+                    onToggleTurnFold: { turnKey in
+                        // Turn folds toggle in ChatView, so arm the pin here.
+                        pinReader(proxy: proxy)
+                        onToggleTurnFold(turnKey)
+                    },
                     reasoningGroups: reasoningGroups,
                     toolCallGroups: completedToolCallGroupsForAnchor(transcriptMessage.anchorID),
                     liveReasoningText: isReasoningAnchor ? liveReasoningText : "",
@@ -313,12 +339,16 @@ struct ChatTranscriptView: View {
         .padding(.horizontal, transcriptHorizontalPadding)
         .frame(width: viewportWidth, alignment: .leading)
         .clipped()
-        .environment(\.chatDisclosureToggled, onDisclosureToggle)
+        .environment(\.chatDisclosureToggled) {
+            pinReader(proxy: proxy)
+            onDisclosureToggle()
+        }
+        .id(transcriptContentID)
         .background {
             ZStack {
                 ChatScrollObserver(
                     isStreaming: activeStreamID != nil,
-                    prependScrollPositionController: prependScrollPositionController,
+                    scrollPositionController: scrollPositionController,
                     onFollowEvent: onFollowEvent
                 ) { metrics in
                     onUpdateScrollMetrics(metrics)
@@ -363,16 +393,16 @@ struct ChatTranscriptView: View {
     }
 
     private func loadOlderMessagesPreservingPosition(proxy: ScrollViewProxy) async {
-        let capturedExactPosition = prependScrollPositionController.capture()
+        let capturedExactPosition = scrollPositionController.capture()
         let renderID = displayedTranscriptMessages.first?.renderID
         let didLoad = await onLoadOlderMessages()
         guard didLoad else {
-            prependScrollPositionController.cancelPreservation()
+            scrollPositionController.cancelPreservation()
             return
         }
 
         if capturedExactPosition,
-           prependScrollPositionController.restoreAfterPrepend() {
+           scrollPositionController.restoreAfterPrepend() {
             return
         }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -2619,9 +2619,10 @@ struct ChatView: View {
         }
     }
 
-    /// Holds the transcript offset through a disclosure animation so the tapped
-    /// row stays under the finger. The latch itself is untouched, so the next
-    /// streaming trigger catches up once the toggle has settled.
+    /// Suspends follow scrolls and the bottom anchor through a disclosure
+    /// animation; the transcript view pins the offset itself. The latch is
+    /// untouched, so the next streaming trigger catches up once the toggle has
+    /// settled.
     private func handleDisclosureToggle() {
         ChatHaptics.disclosureToggled(isEnabled: isHapticsEnabled)
         suspendBottomAnchorForDisclosure()
@@ -2650,10 +2651,13 @@ struct ChatView: View {
             distanceFromBottom: metrics.distanceFromBottom,
             isStreaming: isStreaming
         )
+        let wasNearBottom = isScrolledNearBottom
         isScrolledNearBottom = isNearBottom
         handleFollowEvent(.contentScrolled(
             isAtBottom: ChatScrollPolicy.isAtBottom(distanceFromBottom: metrics.distanceFromBottom),
-            isUserScrolling: metrics.isUserInteracting
+            isUserScrolling: metrics.isUserInteracting,
+            movedAwayFromBottom: metrics.movedAwayFromBottom,
+            wasNearBottom: wasNearBottom
         ))
 
         if isNearBottom {

--- a/HermesMobileTests/ChatScrollPolicyTests.swift
+++ b/HermesMobileTests/ChatScrollPolicyTests.swift
@@ -137,8 +137,71 @@ final class ChatScrollPolicyTests: XCTestCase {
         XCTAssertTrue(follow(true, .contentScrolled(isAtBottom: false, isUserScrolling: false)))
     }
 
-    func testNonGestureScrollThatLandsAtBottomReArms() {
-        XCTAssertTrue(follow(false, .contentScrolled(isAtBottom: true, isUserScrolling: false)))
+    func testNonGestureScrollThatLandsAtBottomFromNearbyReArms() {
+        // A collapse near the end clamps the offset to the bottom.
+        XCTAssertTrue(follow(false, .contentScrolled(isAtBottom: true, isUserScrolling: false, wasNearBottom: true)))
+    }
+
+    func testTransientBottomFromFarAboveDoesNotReArm() {
+        // A relayout that momentarily reads "at bottom" while the reader was parked
+        // thousands of points up must not switch follow on.
+        XCTAssertFalse(follow(false, .contentScrolled(isAtBottom: true, isUserScrolling: false, wasNearBottom: false)))
+    }
+
+    func testScrollAwayFromBottomWithoutGestureTurnsFollowOff() {
+        // Status-bar tap, VoiceOver, or a hardware-keyboard scroll: no pan gesture,
+        // but the reader is being carried away from the bottom.
+        XCTAssertFalse(follow(true, .contentScrolled(isAtBottom: false, isUserScrolling: false, movedAwayFromBottom: true)))
+    }
+
+    func testExplicitResetSurvivesCoastingMomentumAwayFromBottom() {
+        // Momentum ticks after a reset carry the away flag too; they still belong
+        // to the gesture that predates the reset.
+        let latch = reduce(
+            Latch(),
+            .userScrollBegin,
+            .reset,
+            .contentScrolled(isAtBottom: false, isUserScrolling: true, movedAwayFromBottom: true)
+        )
+        XCTAssertTrue(latch.isFollowing)
+    }
+
+    // MARK: Scroll-away detection
+
+    private typealias Geometry = ChatScrollPolicy.ScrollGeometry
+
+    func testDistanceGrowingPastStreamingThresholdIsAScrollAway() {
+        let atBottom = Geometry(offsetY: 4300, contentHeight: 5000, visibleHeight: 700)
+        // Status-bar scroll: the lazy stack may re-measure on the way, so the
+        // content height is allowed to move as long as the distance grows.
+        let carriedAway = Geometry(offsetY: 3200, contentHeight: 5200, visibleHeight: 700)
+        XCTAssertTrue(ChatScrollPolicy.isScrollingAwayFromBottom(previous: atBottom, current: carriedAway))
+        XCTAssertFalse(ChatScrollPolicy.isScrollingAwayFromBottom(previous: nil, current: carriedAway))
+    }
+
+    func testJitterViewportAndFollowScrollsAreNotScrollAways() {
+        let atBottom = Geometry(offsetY: 4300, contentHeight: 5000, visibleHeight: 700)
+        // Streaming jitter under the loose threshold.
+        XCTAssertFalse(ChatScrollPolicy.isScrollingAwayFromBottom(
+            previous: atBottom,
+            current: Geometry(offsetY: 4300, contentHeight: 5150, visibleHeight: 700)
+        ))
+        // Keyboard inset change: viewport changes.
+        XCTAssertFalse(ChatScrollPolicy.isScrollingAwayFromBottom(
+            previous: atBottom,
+            current: Geometry(offsetY: 4300, contentHeight: 5000, visibleHeight: 400)
+        ))
+        // Follow scroll heading back to the bottom from far away.
+        let farAway = Geometry(offsetY: 1000, contentHeight: 5000, visibleHeight: 700)
+        XCTAssertFalse(ChatScrollPolicy.isScrollingAwayFromBottom(
+            previous: farAway,
+            current: Geometry(offsetY: 2000, contentHeight: 5000, visibleHeight: 700)
+        ))
+        // Size change snapped back to the bottom by the anchor.
+        XCTAssertFalse(ChatScrollPolicy.isScrollingAwayFromBottom(
+            previous: atBottom,
+            current: Geometry(offsetY: 4700, contentHeight: 5400, visibleHeight: 700)
+        ))
     }
 
     func testLiveGestureWinsEvenAtBottom() {

--- a/HermesMobileTests/ChatVerticalScrollAxisGuardTests.swift
+++ b/HermesMobileTests/ChatVerticalScrollAxisGuardTests.swift
@@ -250,6 +250,38 @@ final class ChatScrollPositionControllerTests: XCTestCase {
         ))
     }
 
+    func testFinishedHoldDoesNotFlagTheNextPrependCaptureAsAHold() {
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 240)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        controller.holdPosition {}
+        controller.releaseHold()
+        XCTAssertTrue(controller.capture())
+
+        XCTAssertFalse(controller.isHoldingPosition)
+        XCTAssertTrue(controller.restoreAfterPrepend())
+    }
+
+    func testHoldArmedDuringAnInFlightPrependInvalidatesTheCapture() {
+        // Load Older is awaiting the server when the reader toggles a row. The
+        // hold's baseline must not be mistaken for the prepend capture once the
+        // rows land, or the row's growth would be compensated as prepended
+        // content.
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 240)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        XCTAssertTrue(controller.capture())
+        controller.holdPosition {}
+
+        XCTAssertFalse(controller.restoreAfterPrepend())
+        scrollView.contentSize.height += 640
+        XCTAssertEqual(scrollView.contentOffset.y, 240, accuracy: 0.001)
+    }
+
     func testReleaseHoldLeavesPrependPreservationAlone() {
         let scrollView = makeScrollView()
         scrollView.contentOffset = CGPoint(x: 0, y: 240)

--- a/HermesMobileTests/ChatVerticalScrollAxisGuardTests.swift
+++ b/HermesMobileTests/ChatVerticalScrollAxisGuardTests.swift
@@ -134,11 +134,11 @@ final class ChatVerticalScrollAxisGuardTests: XCTestCase {
 }
 
 @MainActor
-final class ChatPrependScrollPositionControllerTests: XCTestCase {
+final class ChatScrollPositionControllerTests: XCTestCase {
     func testPrependCompensatesByExactContentHeightGrowth() {
         let scrollView = makeScrollView()
         scrollView.contentOffset = CGPoint(x: 0, y: 240)
-        let controller = ChatPrependScrollPositionController()
+        let controller = ChatScrollPositionController()
         controller.attach(to: scrollView)
 
         XCTAssertTrue(controller.capture())
@@ -149,10 +149,125 @@ final class ChatPrependScrollPositionControllerTests: XCTestCase {
         XCTAssertEqual(scrollView.contentOffset.y, 880, accuracy: 0.001)
     }
 
+    func testHoldPutsBackAnAnchorSwiftUIReappliesOnSizeChange() {
+        // Reader parked at the exact top; a disclosure grows a row below them and
+        // SwiftUI re-applies the bottom anchor. The hold restores the top.
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 0)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        controller.holdPosition {}
+        scrollView.contentSize.height += 640
+        scrollView.contentOffset.y = scrollView.contentSize.height - scrollView.bounds.height
+
+        XCTAssertEqual(scrollView.contentOffset.y, 0, accuracy: 0.001)
+    }
+
+    func testHoldClampsWhenARowBelowCollapses() {
+        // Reader at the bottom collapses a row: the content shrinks under them, so
+        // the held offset can only clamp to the new maximum.
+        let scrollView = makeScrollView()
+        let bottom = scrollView.contentSize.height - scrollView.bounds.height
+        scrollView.contentOffset = CGPoint(x: 0, y: bottom)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        controller.holdPosition {}
+        scrollView.contentSize.height -= 200
+
+        XCTAssertEqual(scrollView.contentOffset.y, bottom - 200, accuracy: 0.001)
+    }
+
+    func testReleasedHoldLetsOffsetChangesThrough() {
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 0)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        controller.holdPosition {}
+        controller.releaseHold()
+        scrollView.contentOffset.y = 300
+
+        XCTAssertEqual(scrollView.contentOffset.y, 300, accuracy: 0.001)
+    }
+
+    func testHoldKeepsRevertingAcrossALongRelayout() {
+        // 28 lazy rows settle over many frames; each frame SwiftUI re-applies the
+        // bottom anchor and each time the pin puts the reader back.
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 0)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        controller.holdPosition {}
+        for growth in [640, 400, 220, 90, 40] as [CGFloat] {
+            scrollView.contentSize.height += growth
+            scrollView.contentOffset.y = scrollView.contentSize.height - scrollView.bounds.height
+            XCTAssertEqual(scrollView.contentOffset.y, 0, accuracy: 0.001)
+        }
+    }
+
+    func testHoldResyncsSwiftUIOnlyAfterItHadToRevert() {
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 0)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        let resynced = expectation(description: "resync after revert")
+        controller.holdPosition { resynced.fulfill() }
+        scrollView.contentSize.height += 640
+        scrollView.contentOffset.y = scrollView.contentSize.height - scrollView.bounds.height
+
+        wait(for: [resynced], timeout: 2)
+        XCTAssertEqual(scrollView.contentOffset.y, 0, accuracy: 0.001)
+    }
+
+    func testDeliberateScrollDuringHoldReleasesItInsteadOfReverting() {
+        // VoiceOver or a hardware keyboard moves the offset with no size change in
+        // the same turn: that is a real scroll, and the hold must let it stand.
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 0)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        controller.holdPosition {}
+        scrollView.contentOffset.y = 300
+
+        XCTAssertEqual(scrollView.contentOffset.y, 300, accuracy: 0.001)
+        XCTAssertFalse(controller.isHoldingPosition)
+    }
+
+    func testResyncOnlyDescribesAHeldTop() {
+        XCTAssertTrue(ChatScrollPositionController.shouldResync(
+            didRevertSwiftUIOffset: true, heldOffsetY: -116, minimumOffsetY: -116
+        ))
+        XCTAssertFalse(ChatScrollPositionController.shouldResync(
+            didRevertSwiftUIOffset: true, heldOffsetY: 240, minimumOffsetY: -116
+        ))
+        XCTAssertFalse(ChatScrollPositionController.shouldResync(
+            didRevertSwiftUIOffset: false, heldOffsetY: -116, minimumOffsetY: -116
+        ))
+    }
+
+    func testReleaseHoldLeavesPrependPreservationAlone() {
+        let scrollView = makeScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: 240)
+        let controller = ChatScrollPositionController()
+        controller.attach(to: scrollView)
+
+        XCTAssertTrue(controller.capture())
+        XCTAssertTrue(controller.restoreAfterPrepend())
+        controller.releaseHold()
+        scrollView.contentSize.height += 640
+
+        XCTAssertEqual(scrollView.contentOffset.y, 880, accuracy: 0.001)
+    }
+
     func testCancelledPrependDoesNotMoveScrollPosition() {
         let scrollView = makeScrollView()
         scrollView.contentOffset = CGPoint(x: 0, y: 240)
-        let controller = ChatPrependScrollPositionController()
+        let controller = ChatScrollPositionController()
         controller.attach(to: scrollView)
 
         XCTAssertTrue(controller.capture())
@@ -165,7 +280,7 @@ final class ChatPrependScrollPositionControllerTests: XCTestCase {
     func testPrependDoesNotOverrideMovementWhileRequestIsInFlight() {
         let scrollView = makeScrollView()
         scrollView.contentOffset = CGPoint(x: 0, y: 240)
-        let controller = ChatPrependScrollPositionController()
+        let controller = ChatScrollPositionController()
         controller.attach(to: scrollView)
 
         XCTAssertTrue(controller.capture())
@@ -180,7 +295,7 @@ final class ChatPrependScrollPositionControllerTests: XCTestCase {
         let inset = UIEdgeInsets(top: 12, left: 0, bottom: 20, right: 0)
 
         XCTAssertEqual(
-            ChatPrependScrollPositionController.compensatedOffsetY(
+            ChatScrollPositionController.compensatedOffsetY(
                 baselineOffsetY: -12,
                 contentHeightDelta: -100,
                 adjustedInset: inset,
@@ -191,7 +306,7 @@ final class ChatPrependScrollPositionControllerTests: XCTestCase {
             accuracy: 0.001
         )
         XCTAssertEqual(
-            ChatPrependScrollPositionController.compensatedOffsetY(
+            ChatScrollPositionController.compensatedOffsetY(
                 baselineOffsetY: 700,
                 contentHeightDelta: 500,
                 adjustedInset: inset,


### PR DESCRIPTION
## Linked issue

No linked issue; approved maintainer work on the transcript density pass (follows #355).

## What changed

At the top of a long session, reached with a status-bar tap, tapping "+N previous tool calls", "Show fewer tool calls", a tool row, a thinking row, or a turn fold threw the reader to the bottom of the transcript, and auto-follow re-armed. It was intermittent: it never happened after a real drag on that scroll view.

Frame-by-frame traces on a live session showed three causes, and each gets a small fix:

- **Programmatic scrolls never switched follow off.** Only pan gestures emitted the "user scroll began" event. `ChatScrollObserver` now reports a gesture-free scroll that carries the reader past the streaming threshold in the same viewport (`ChatScrollPolicy.isScrollingAwayFromBottom`), and the latch switches off on it. Streaming growth, keyboard insets, and follow scrolls are excluded by construction.
- **SwiftUI re-applies the bottom anchor on every content-size change after a real status-bar scroll**, until the next drag. The fixed 0.25 s anchor suspension expired while 28 lazy rows were still laying out, and the next size tick moved the reader unopposed. `ChatPrependScrollPositionController` is now `ChatScrollPositionController` with a hold mode: it pins the UIKit offset through the toggle, releases after the content size has been quiet for 0.3 s (2 s cap), and is released early by a gesture or a deliberate scroll (follow, scroll-to-bottom, keyboard). It reverts only an offset change riding on a size change in the same run-loop turn, so a VoiceOver or hardware-keyboard scroll during the hold stands. The turn fold, which toggles in `ChatView`, is routed through the pin as well.
- **Each UIKit-side revert left SwiftUI's own offset model stale**, so lazy rows on screen stopped responding to taps until a real scroll. A hold that had to revert while held at the top ends with a SwiftUI-driven scroll to the transcript's top: nothing moves on screen, SwiftUI's model catches up.

Also, a gesture-free "at bottom" report re-arms follow only when the previous report was already near the bottom, so a relayout artifact from thousands of points up cannot switch follow on.

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP `test_sim`: 1861 passed, 0 failed, 2 pre-existing integration skips.
- `ChatScrollPolicyTests`: gesture-free scroll-away switches follow off; reset survives coasting momentum with the away flag; transient bottom from far above does not re-arm; nearby bottom does; geometry rule cases for jitter, keyboard inset, follow scroll, and anchor-snapped growth.
- `ChatScrollPositionControllerTests`: hold puts back a re-applied anchor, keeps reverting across a multi-frame relayout, clamps when a row below collapses, releases on a deliberate scroll instead of reverting, resyncs only after a revert and only when held at the top, and leaves prepend preservation alone.
- Manual, maintainer, simulator against the live server: fresh session, status bar to top, then fold, "+28 previous tool calls", "Show fewer tool calls", thinking row, tool row: no jump, every row responds on the first tap. Scroll-to-bottom, then expand and collapse a row a screen above the bottom: stays put.
- Pre-PR Codex review: five findings, all addressed before opening (resync scope, hold-aware latch suppression, stale-attachment KVO guards, tests, comment).

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (nothing crosses the wire)

---

Changes made by Claude Fable 5.1 through Claude Code.
