### PR TITLE
fix(chat): clip transcript row disclosure animation inside the body window

### DIFF
--- a/HermesMobile/Features/Chat/ReasoningBlockView.swift
+++ b/HermesMobile/Features/Chat/ReasoningBlockView.swift
@@ -257,7 +257,7 @@ private struct StreamingReasoningTextView: UIViewRepresentable {
         if uiView.isScrollEnabled != layout.scrolls {
             uiView.isScrollEnabled = layout.scrolls
         }
-        return CGSize(width: width, height: layout.frameHeight ?? 0)
+        return CGSize(width: width, height: layout.frameHeight)
     }
 
     /// A text view that stays scrolled to its last line whenever it scrolls,

--- a/HermesMobile/Features/Chat/TranscriptLogRowView.swift
+++ b/HermesMobile/Features/Chat/TranscriptLogRowView.swift
@@ -96,19 +96,22 @@ struct TranscriptLogRowView<Icon: View, Status: View, ExpandedBody: View>: View 
         VStack(alignment: .leading, spacing: 0) {
             rowLine
 
-            if isExpanded {
-                TranscriptLogRowBodyWindow(content: expandedBody)
-                    .padding(.leading, 12)
-                    .overlay(alignment: .leading) {
-                        Rectangle()
-                            .fill(.quaternary)
-                            .frame(width: 1)
-                    }
-                    .padding(.leading, TranscriptLogRowMetrics.bodyIndent)
-                    .padding(.top, 2)
-                    .padding(.bottom, 6)
-                    .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
+            VStack(alignment: .leading, spacing: 0) {
+                if isExpanded {
+                    TranscriptLogRowBodyWindow(content: expandedBody)
+                        .padding(.leading, 12)
+                        .overlay(alignment: .leading) {
+                            Rectangle()
+                                .fill(.quaternary)
+                                .frame(width: 1)
+                        }
+                        .padding(.leading, TranscriptLogRowMetrics.bodyIndent)
+                        .padding(.top, 2)
+                        .padding(.bottom, 6)
+                        .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
+                }
             }
+            .clipped()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onDisappear { copiedResetTask?.cancel() }

--- a/HermesMobile/Features/Chat/TranscriptLogRowView.swift
+++ b/HermesMobile/Features/Chat/TranscriptLogRowView.swift
@@ -108,7 +108,12 @@ struct TranscriptLogRowView<Icon: View, Status: View, ExpandedBody: View>: View 
                         .padding(.leading, TranscriptLogRowMetrics.bodyIndent)
                         .padding(.top, 2)
                         .padding(.bottom, 6)
-                        .transition(ChatMotion.disclosureTransition(reduceMotion: reduceMotion))
+                        .transition(
+                            .asymmetric(
+                                insertion: .opacity,
+                                removal: ChatMotion.disclosureTransition(reduceMotion: reduceMotion)
+                            )
+                        )
                 }
             }
             .clipped()

--- a/HermesMobile/Features/Chat/TranscriptLogRowView.swift
+++ b/HermesMobile/Features/Chat/TranscriptLogRowView.swift
@@ -16,14 +16,15 @@ enum TranscriptLogRowMetrics {
 /// whether it scrolls, from the measured content height. Shared by the
 /// SwiftUI window and the live thinking text view so both cap alike.
 struct TranscriptLogRowBodyWindowLayout: Equatable {
-    /// `nil` until the content has been measured; the window then sizes to
-    /// whatever the content asks for.
-    let frameHeight: CGFloat?
+    /// Zero until the content has been measured, then the lesser of its
+    /// natural height and the cap. Starting closed prevents one unbounded
+    /// layout pass from moving the transcript before the cap takes effect.
+    let frameHeight: CGFloat
     let scrolls: Bool
 
     static func resolve(contentHeight: CGFloat?, cap: CGFloat) -> Self {
         guard let contentHeight else {
-            return Self(frameHeight: nil, scrolls: false)
+            return Self(frameHeight: 0, scrolls: false)
         }
         return Self(frameHeight: min(contentHeight, cap), scrolls: contentHeight > cap)
     }
@@ -36,6 +37,7 @@ struct TranscriptLogRowBodyWindowLayout: Equatable {
 struct TranscriptLogRowBodyWindow<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var contentHeight: CGFloat?
 
     var body: some View {
@@ -49,12 +51,20 @@ struct TranscriptLogRowBodyWindow<Content: View>: View {
                 .onGeometryChange(for: CGFloat.self) { proxy in
                     proxy.size.height
                 } action: { height in
-                    // The window resizes to its content outside the disclosure
-                    // animation, so a tall body opens straight at the cap.
-                    var transaction = Transaction()
-                    transaction.disablesAnimations = true
-                    withTransaction(transaction) {
-                        contentHeight = height
+                    if contentHeight == nil {
+                        // The first bounded measurement opens the body from
+                        // zero, so rows below only move down toward their final
+                        // positions. Later content changes keep their existing
+                        // non-animated sizing behavior.
+                        withAnimation(ChatMotion.disclosure(reduceMotion: reduceMotion)) {
+                            contentHeight = height
+                        }
+                    } else {
+                        var transaction = Transaction()
+                        transaction.disablesAnimations = true
+                        withTransaction(transaction) {
+                            contentHeight = height
+                        }
                     }
                 }
         }

--- a/HermesMobileTests/TranscriptLogRowBodyWindowTests.swift
+++ b/HermesMobileTests/TranscriptLogRowBodyWindowTests.swift
@@ -4,10 +4,10 @@ import XCTest
 final class TranscriptLogRowBodyWindowTests: XCTestCase {
     private let cap = TranscriptLogRowMetrics.bodyWindowHeight
 
-    func testUnmeasuredContentLeavesTheWindowFreeAndStill() {
+    func testUnmeasuredContentStartsClosed() {
         let layout = TranscriptLogRowBodyWindowLayout.resolve(contentHeight: nil, cap: cap)
 
-        XCTAssertNil(layout.frameHeight)
+        XCTAssertEqual(layout.frameHeight, 0)
         XCTAssertFalse(layout.scrolls)
     }
 


### PR DESCRIPTION
## Linked issue

No linked issue; approved maintainer work on transcript disclosure polish (ticket L39).

## What changed

1. Clip the conditional expanded-body slot in `TranscriptLogRowView.swift`, keeping the disclosure animation inside the row instead of drawing across adjacent content.
2. Use an asymmetric transition: expansion fades in without translating the body, while collapse retains the verified upward slide and fade.
3. Start an unmeasured body window at zero height, then animate it to its measured capped height. This removes the unbounded first layout pass that made downstream transcript content jump up before moving down.
4. Keep the live-thinking `UITextView` on the same nonoptional capped-height sizing rule.

## How it was tested

- Focused red/green test for the unmeasured body-window state.
- Full XCTest suite on iPhone 17: 1,862 passed, 0 failed, 2 simulator-only media tests skipped.
- Slow-motion simulator inspection of a long thinking row: the header stayed fixed and downstream content moved only toward its expanded position.
- `scripts/check-swift-file-sizes` (warning-only; only existing oversized files reported).

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No API or wire-contract changes

---

Changes made by Antigravity (Gemini 3.8 Flash) and Codex (GPT-5) through Synara.
