### PR TITLE
fix(chat): open the message menu without lifting the bubble

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -179,10 +179,12 @@
 		C0AA02000000000000000B02 /* ToolCallLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F02 /* ToolCallLogRowView.swift */; };
 		C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */; };
 		C0AA020000000000000000B13 /* TranscriptLogRowBodyWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F13 /* TranscriptLogRowBodyWindowTests.swift */; };
+		C0AA0208000000000000B002 /* ChatMessageActionMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA0208000000000000F002 /* ChatMessageActionMenuTests.swift */; };
 		C0AA020000000000000000B11 /* ReasoningSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F11 /* ReasoningSummaryFormatter.swift */; };
 		C0AA020000000000000000B10 /* TranscriptLogRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA020000000000000000F10 /* TranscriptLogRowView.swift */; };
 		C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */; };
 		C0AA05000000000000000B01 /* ChatMessageMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA05000000000000000F01 /* ChatMessageMeta.swift */; };
+		C0AA0208000000000000B001 /* ChatMessageContextMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA0208000000000000F001 /* ChatMessageContextMenuView.swift */; };
 		C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */; };
 		C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */; };
 		C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12900000000000000000002 /* ChatActiveRunStatusView.swift */; };
@@ -540,10 +542,12 @@
 		C0AA02000000000000000F02 /* ToolCallLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallLogRowView.swift; sourceTree = "<group>"; };
 		C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningSummaryFormatterTests.swift; sourceTree = "<group>"; };
 		C0AA020000000000000000F13 /* TranscriptLogRowBodyWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLogRowBodyWindowTests.swift; sourceTree = "<group>"; };
+		C0AA0208000000000000F002 /* ChatMessageActionMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageActionMenuTests.swift; sourceTree = "<group>"; };
 		C0AA020000000000000000F11 /* ReasoningSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningSummaryFormatter.swift; sourceTree = "<group>"; };
 		C0AA020000000000000000F10 /* TranscriptLogRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLogRowView.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFolding.swift; sourceTree = "<group>"; };
 		C0AA05000000000000000F01 /* ChatMessageMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageMeta.swift; sourceTree = "<group>"; };
+		C0AA0208000000000000F001 /* ChatMessageContextMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageContextMenuView.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatter.swift; sourceTree = "<group>"; };
 		C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTimelineAccessorySurface.swift; sourceTree = "<group>"; };
 		C12900000000000000000002 /* ChatActiveRunStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatActiveRunStatusView.swift; sourceTree = "<group>"; };
@@ -872,6 +876,7 @@
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */,
 				C0AA020000000000000000F13 /* TranscriptLogRowBodyWindowTests.swift */,
+				C0AA0208000000000000F002 /* ChatMessageActionMenuTests.swift */,
 				C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */,
 				C0AA07000000000000000F07 /* ChatTranscriptRowEntryTests.swift */,
 				C0AA05000000000000000F02 /* ChatMessageMetaTests.swift */,
@@ -1086,6 +1091,7 @@
 				C0AA020000000000000000F10 /* TranscriptLogRowView.swift */,
 				C0AA03000000000000000F01 /* TranscriptTurnFolding.swift */,
 				C0AA05000000000000000F01 /* ChatMessageMeta.swift */,
+				C0AA0208000000000000F001 /* ChatMessageContextMenuView.swift */,
 				C0AA02000000000000000F01 /* ToolCallSummaryFormatter.swift */,
 				C12800000000000000000004 /* ChatTimelineAccessorySurface.swift */,
 				C12900000000000000000002 /* ChatActiveRunStatusView.swift */,
@@ -1604,6 +1610,7 @@
 				C0AA020000000000000000B10 /* TranscriptLogRowView.swift in Sources */,
 				C0AA03000000000000000B01 /* TranscriptTurnFolding.swift in Sources */,
 				C0AA05000000000000000B01 /* ChatMessageMeta.swift in Sources */,
+				C0AA0208000000000000B001 /* ChatMessageContextMenuView.swift in Sources */,
 				C0AA02000000000000000B01 /* ToolCallSummaryFormatter.swift in Sources */,
 				C12800000000000000000003 /* ChatTimelineAccessorySurface.swift in Sources */,
 				C12900000000000000000001 /* ChatActiveRunStatusView.swift in Sources */,
@@ -1766,6 +1773,7 @@
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B13 /* TranscriptLogRowBodyWindowTests.swift in Sources */,
+				C0AA0208000000000000B002 /* ChatMessageActionMenuTests.swift in Sources */,
 				C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */,
 				C0AA07000000000000000B07 /* ChatTranscriptRowEntryTests.swift in Sources */,
 				C0AA05000000000000000B02 /* ChatMessageMetaTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatMessageActions.swift
+++ b/HermesMobile/Features/Chat/ChatMessageActions.swift
@@ -15,6 +15,27 @@ struct SelectableTextPresentation: Identifiable, Equatable {
     }
 }
 
+/// One entry of the message action menu. The SwiftUI menu and the UIKit
+/// context-menu interaction both build from this list so they never drift.
+struct ChatMessageActionItem: Identifiable {
+    enum Kind: String {
+        case listen
+        case selectText
+        case regenerate
+        case edit
+        case fork
+        case copy
+    }
+
+    let kind: Kind
+    let title: String
+    let systemImage: String
+    let isEnabled: Bool
+    let perform: () -> Void
+
+    var id: Kind { kind }
+}
+
 struct ChatMessageActionMenu: View {
     let context: MessageActionContext
     let listeningMessageID: String?
@@ -31,51 +52,87 @@ struct ChatMessageActionMenu: View {
     let onCopy: (MessageActionContext) -> Void
 
     var body: some View {
+        ForEach(items) { item in
+            Button {
+                item.perform()
+            } label: {
+                Label(item.title, systemImage: item.systemImage)
+            }
+            .disabled(!item.isEnabled)
+        }
+    }
+
+    /// The actions for this message in display order. Mutating actions are
+    /// disabled while the transcript is cached or a stream is active.
+    var items: [ChatMessageActionItem] {
+        var items: [ChatMessageActionItem] = []
+
         if context.role == .assistant {
-            Button {
-                onToggleListening(context)
-            } label: {
-                Label(
-                    isListening ? "Stop Listening" : "Listen",
-                    systemImage: isListening ? "speaker.slash" : "speaker.wave.2"
-                )
-            }
-
-            Button {
-                onSelectText(context)
-            } label: {
-                Label("Select Text", systemImage: "text.cursor")
-            }
-
-            Button {
-                onRegenerate(context)
-            } label: {
-                Label("Regenerate Response", systemImage: "arrow.clockwise")
-            }
-            .disabled(isViewingCachedData || hasActiveStream || isRegeneratingMessage)
+            items.append(ChatMessageActionItem(
+                kind: .listen,
+                title: isListening ? String(localized: "Stop Listening") : String(localized: "Listen"),
+                systemImage: isListening ? "speaker.slash" : "speaker.wave.2",
+                isEnabled: true,
+                perform: { onToggleListening(context) }
+            ))
+            items.append(ChatMessageActionItem(
+                kind: .selectText,
+                title: String(localized: "Select Text"),
+                systemImage: "text.cursor",
+                isEnabled: true,
+                perform: { onSelectText(context) }
+            ))
+            items.append(ChatMessageActionItem(
+                kind: .regenerate,
+                title: String(localized: "Regenerate Response"),
+                systemImage: "arrow.clockwise",
+                isEnabled: !(isViewingCachedData || hasActiveStream || isRegeneratingMessage),
+                perform: { onRegenerate(context) }
+            ))
         }
 
         if context.role == .user {
-            Button {
-                onEdit(context)
-            } label: {
-                Label("Edit Message", systemImage: "pencil")
+            items.append(ChatMessageActionItem(
+                kind: .edit,
+                title: String(localized: "Edit Message"),
+                systemImage: "pencil",
+                isEnabled: !(isViewingCachedData || hasActiveStream || isEditingMessage),
+                perform: { onEdit(context) }
+            ))
+        }
+
+        items.append(ChatMessageActionItem(
+            kind: .fork,
+            title: String(localized: "Fork From Here"),
+            systemImage: "arrow.triangle.branch",
+            isEnabled: !(isViewingCachedData || hasActiveStream || isForkingMessage),
+            perform: { onFork(context) }
+        ))
+        items.append(ChatMessageActionItem(
+            kind: .copy,
+            title: String(localized: "Copy"),
+            systemImage: "doc.on.doc",
+            isEnabled: true,
+            perform: { onCopy(context) }
+        ))
+
+        return items
+    }
+
+    /// The same actions as a UIKit menu, for `ChatMessageContextMenuView`.
+    func uiMenu() -> UIMenu {
+        UIMenu(children: items.map { item in
+            let action = UIAction(
+                title: item.title,
+                image: UIImage(systemName: item.systemImage)
+            ) { _ in
+                item.perform()
             }
-            .disabled(isViewingCachedData || hasActiveStream || isEditingMessage)
-        }
-
-        Button {
-            onFork(context)
-        } label: {
-            Label("Fork From Here", systemImage: "arrow.triangle.branch")
-        }
-        .disabled(isViewingCachedData || hasActiveStream || isForkingMessage)
-
-        Button {
-            onCopy(context)
-        } label: {
-            Label("Copy", systemImage: "doc.on.doc")
-        }
+            if !item.isEnabled {
+                action.attributes = .disabled
+            }
+            return action
+        })
     }
 
     private var isListening: Bool {

--- a/HermesMobile/Features/Chat/ChatMessageContextMenuView.swift
+++ b/HermesMobile/Features/Chat/ChatMessageContextMenuView.swift
@@ -10,15 +10,23 @@ import UIKit
 /// makes room. Here nothing is lifted: the transcript dims and the menu opens
 /// beside the press in one motion, whatever the reply's length (issue #208).
 extension View {
-    func chatMessageContextMenu(_ menu: ChatMessageActionMenu) -> some View {
-        background(ChatMessageContextMenuHost(menu: menu))
-            .accessibilityActions {
-                ForEach(menu.items.filter(\.isEnabled)) { item in
-                    Button(item.title) {
-                        item.perform()
+    /// Attach to the message content itself, not the full-width row, so the
+    /// menu opens only where there is something to act on. A nil menu leaves
+    /// the view untouched.
+    @ViewBuilder
+    func chatMessageContextMenu(_ menu: ChatMessageActionMenu?) -> some View {
+        if let menu {
+            background(ChatMessageContextMenuHost(menu: menu))
+                .accessibilityActions {
+                    ForEach(menu.items.filter(\.isEnabled)) { item in
+                        Button(item.title) {
+                            item.perform()
+                        }
                     }
                 }
-            }
+        } else {
+            self
+        }
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatMessageContextMenuView.swift
+++ b/HermesMobile/Features/Chat/ChatMessageContextMenuView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+import UIKit
+
+/// Attaches the message action menu to a transcript bubble through UIKit's
+/// `UIContextMenuInteraction` instead of SwiftUI's `.contextMenu`.
+///
+/// SwiftUI lifts a snapshot of the whole bubble before it can show the menu.
+/// On a multi-screen reply that snapshot is slow and taller than the screen,
+/// so the menu lands over the undimmed transcript and then jumps as UIKit
+/// makes room. Here nothing is lifted: the transcript dims and the menu opens
+/// beside the press in one motion, whatever the reply's length (issue #208).
+extension View {
+    func chatMessageContextMenu(_ menu: ChatMessageActionMenu) -> some View {
+        background(ChatMessageContextMenuHost(menu: menu))
+            .accessibilityActions {
+                ForEach(menu.items.filter(\.isEnabled)) { item in
+                    Button(item.title) {
+                        item.perform()
+                    }
+                }
+            }
+    }
+}
+
+private struct ChatMessageContextMenuHost: UIViewRepresentable {
+    let menu: ChatMessageActionMenu
+
+    func makeUIView(context: Context) -> ChatMessageContextMenuView {
+        let view = ChatMessageContextMenuView()
+        view.menu = menu
+        return view
+    }
+
+    func updateUIView(_ view: ChatMessageContextMenuView, context: Context) {
+        view.menu = menu
+    }
+}
+
+/// A clear, touch-transparent view behind one bubble. It only marks the
+/// bubble's frame and menu for the coordinator on the transcript's scroll view.
+///
+/// The interaction cannot live here: SwiftUI's text-selection long-press on
+/// the hosting view outranks recognizers on child platform views, so a menu
+/// attached to this view never fires. On the scroll view it wins, as it does
+/// in a collection view.
+final class ChatMessageContextMenuView: UIView {
+    var menu: ChatMessageActionMenu?
+
+    private weak var coordinator: ChatMessageContextMenuCoordinator?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        isOpaque = false
+        isUserInteractionEnabled = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        coordinator?.unregister(self)
+        coordinator = nil
+        guard window != nil, let scrollView = enclosingScrollView else { return }
+        let coordinator = ChatMessageContextMenuCoordinator.coordinator(for: scrollView)
+        coordinator.register(self)
+        self.coordinator = coordinator
+    }
+
+    private var enclosingScrollView: UIScrollView? {
+        var ancestor = superview
+        while let view = ancestor {
+            if let scrollView = view as? UIScrollView { return scrollView }
+            ancestor = view.superview
+        }
+        return nil
+    }
+}
+
+/// One context-menu interaction per transcript scroll view. Rows register
+/// while on screen; a long-press resolves to the row under the touch.
+@MainActor
+final class ChatMessageContextMenuCoordinator: NSObject, UIContextMenuInteractionDelegate {
+    private static let coordinators = NSMapTable<UIScrollView, ChatMessageContextMenuCoordinator>(
+        keyOptions: .weakMemory,
+        valueOptions: .strongMemory
+    )
+
+    static func coordinator(for scrollView: UIScrollView) -> ChatMessageContextMenuCoordinator {
+        if let existing = coordinators.object(forKey: scrollView) {
+            return existing
+        }
+        let coordinator = ChatMessageContextMenuCoordinator(scrollView: scrollView)
+        coordinators.setObject(coordinator, forKey: scrollView)
+        return coordinator
+    }
+
+    private weak var scrollView: UIScrollView?
+    private let rows = NSHashTable<ChatMessageContextMenuView>.weakObjects()
+
+    /// The row being presented and the press point inside it, which anchors
+    /// the menu.
+    private weak var activeRow: ChatMessageContextMenuView?
+    private var pressInRow: CGPoint = .zero
+
+    private init(scrollView: UIScrollView) {
+        self.scrollView = scrollView
+        super.init()
+        scrollView.addInteraction(UIContextMenuInteraction(delegate: self))
+    }
+
+    func register(_ row: ChatMessageContextMenuView) {
+        rows.add(row)
+    }
+
+    func unregister(_ row: ChatMessageContextMenuView) {
+        rows.remove(row)
+    }
+
+    private func row(at location: CGPoint) -> ChatMessageContextMenuView? {
+        guard let scrollView else { return nil }
+        return rows.allObjects.first { row in
+            row.window != nil
+                && row.menu != nil
+                && row.convert(row.bounds, to: scrollView).contains(location)
+        }
+    }
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let scrollView, let row = row(at: location) else { return nil }
+        activeRow = row
+        pressInRow = row.convert(location, from: scrollView)
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak row] _ in
+            row?.menu?.uiMenu()
+        }
+    }
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        previewForHighlightingMenuWithConfiguration configuration: UIContextMenuConfiguration
+    ) -> UITargetedPreview? {
+        anchorPreview()
+    }
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        previewForDismissingMenuWithConfiguration configuration: UIContextMenuConfiguration
+    ) -> UITargetedPreview? {
+        anchorPreview()
+    }
+
+    /// An invisible preview at the press point. It gives UIKit something to
+    /// anchor the menu to without lifting any of the bubble; the bubble stays
+    /// in place under the dim like the rest of the transcript.
+    private func anchorPreview() -> UITargetedPreview? {
+        guard let activeRow else { return nil }
+        let anchor = UIView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        anchor.backgroundColor = .clear
+        let parameters = UIPreviewParameters()
+        parameters.backgroundColor = .clear
+        parameters.shadowPath = UIBezierPath()
+        let target = UIPreviewTarget(container: activeRow, center: pressInRow)
+        return UITargetedPreview(view: anchor, parameters: parameters, target: target)
+    }
+}

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -773,28 +773,7 @@ private struct ChatTranscriptMessageRow: View {
             MarkerMessageCardView(kind: markerKind, content: message.content)
         } else {
             VStack(alignment: isUserMessage ? .trailing : .leading, spacing: 4) {
-                if let actionContext {
-                    bubble
-                        .chatMessageContextMenu(
-                            ChatMessageActionMenu(
-                                context: actionContext,
-                                listeningMessageID: listeningMessageID,
-                                isViewingCachedData: isViewingCachedData,
-                                hasActiveStream: hasActiveStream,
-                                isRegeneratingMessage: isRegeneratingMessage,
-                                isEditingMessage: isEditingMessage,
-                                isForkingMessage: isForkingMessage,
-                                onToggleListening: onToggleListening,
-                                onSelectText: onSelectText,
-                                onRegenerate: onRegenerate,
-                                onEdit: onEdit,
-                                onFork: onFork,
-                                onCopy: onCopy
-                            )
-                        )
-                } else {
-                    bubble
-                }
+                bubble
 
                 if showsMetaRow {
                     ChatMessageMetaRow(
@@ -837,7 +816,27 @@ private struct ChatTranscriptMessageRow: View {
             onPreviewAttachment: onPreviewAttachment,
             onPreviewTranscriptMedia: onPreviewTranscriptMedia,
             isStreaming: isStreaming,
-            liveTokensPerSecond: liveTokensPerSecond
+            liveTokensPerSecond: liveTokensPerSecond,
+            contextMenu: actionMenu
+        )
+    }
+
+    private var actionMenu: ChatMessageActionMenu? {
+        guard let actionContext else { return nil }
+        return ChatMessageActionMenu(
+            context: actionContext,
+            listeningMessageID: listeningMessageID,
+            isViewingCachedData: isViewingCachedData,
+            hasActiveStream: hasActiveStream,
+            isRegeneratingMessage: isRegeneratingMessage,
+            isEditingMessage: isEditingMessage,
+            isForkingMessage: isForkingMessage,
+            onToggleListening: onToggleListening,
+            onSelectText: onSelectText,
+            onRegenerate: onRegenerate,
+            onEdit: onEdit,
+            onFork: onFork,
+            onCopy: onCopy
         )
     }
 }

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -775,7 +775,7 @@ private struct ChatTranscriptMessageRow: View {
             VStack(alignment: isUserMessage ? .trailing : .leading, spacing: 4) {
                 if let actionContext {
                     bubble
-                        .contextMenu {
+                        .chatMessageContextMenu(
                             ChatMessageActionMenu(
                                 context: actionContext,
                                 listeningMessageID: listeningMessageID,
@@ -791,7 +791,7 @@ private struct ChatTranscriptMessageRow: View {
                                 onFork: onFork,
                                 onCopy: onCopy
                             )
-                        }
+                        )
                 } else {
                     bubble
                 }

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -18,6 +18,9 @@ struct MessageBubbleView: View {
     let onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)?
     let isStreaming: Bool
     let liveTokensPerSecond: Double?
+    /// Long-press actions, attached to the message content only so the empty
+    /// gutter beside a user bubble does not open its menu.
+    let contextMenu: ChatMessageActionMenu?
 
     init(
         message: ChatMessage,
@@ -30,7 +33,8 @@ struct MessageBubbleView: View {
         onPreviewAttachment: ((MessageAttachment, Data?) -> Void)? = nil,
         onPreviewTranscriptMedia: ((TranscriptMediaReference) -> Void)? = nil,
         isStreaming: Bool = false,
-        liveTokensPerSecond: Double? = nil
+        liveTokensPerSecond: Double? = nil,
+        contextMenu: ChatMessageActionMenu? = nil
     ) {
         self.message = message
         self.loadAttachmentImage = loadAttachmentImage
@@ -43,6 +47,7 @@ struct MessageBubbleView: View {
         self.onPreviewTranscriptMedia = onPreviewTranscriptMedia
         self.isStreaming = isStreaming
         self.liveTokensPerSecond = liveTokensPerSecond
+        self.contextMenu = contextMenu
     }
 
     var body: some View {
@@ -61,6 +66,7 @@ struct MessageBubbleView: View {
         VStack(alignment: .trailing, spacing: 8) {
             if let attachments = message.attachments, !attachments.isEmpty {
                 attachmentPreviews
+                    .chatMessageContextMenu(contextMenu)
             }
 
             // When the attachment-path line is hidden, an attachment-only
@@ -75,6 +81,7 @@ struct MessageBubbleView: View {
                         }
                         linkPreview
                     }
+                    .chatMessageContextMenu(contextMenu)
                 }
             }
         }
@@ -104,6 +111,7 @@ struct MessageBubbleView: View {
 
             linkPreview
         }
+        .chatMessageContextMenu(contextMenu)
         .frame(maxWidth: .infinity, alignment: .leading)
         // While this row is the active streaming message, animate its height
         // growth at the same curve as the bottom-follow scroll so the streaming

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -66,7 +66,6 @@ struct MessageBubbleView: View {
         VStack(alignment: .trailing, spacing: 8) {
             if let attachments = message.attachments, !attachments.isEmpty {
                 attachmentPreviews
-                    .chatMessageContextMenu(contextMenu)
             }
 
             // When the attachment-path line is hidden, an attachment-only
@@ -275,6 +274,8 @@ struct MessageBubbleView: View {
                 )
             }
         }
+        // Before the full-width frame, so the marker covers the grid only.
+        .chatMessageContextMenu(contextMenu)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
 

--- a/HermesMobileTests/ChatMessageActionMenuTests.swift
+++ b/HermesMobileTests/ChatMessageActionMenuTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import HermesMobile
+
+final class ChatMessageActionMenuTests: XCTestCase {
+    func testAssistantMenuListsAssistantActionsInOrder() throws {
+        let menu = try makeMenu(role: "assistant")
+
+        XCTAssertEqual(menu.items.map(\.kind), [.listen, .selectText, .regenerate, .fork, .copy])
+        XCTAssertTrue(menu.items.allSatisfy(\.isEnabled))
+    }
+
+    func testUserMenuListsUserActionsInOrder() throws {
+        let menu = try makeMenu(role: "user")
+
+        XCTAssertEqual(menu.items.map(\.kind), [.edit, .fork, .copy])
+    }
+
+    func testMutatingActionsDisableWhileStreaming() throws {
+        let menu = try makeMenu(role: "assistant", hasActiveStream: true)
+
+        let enabledByKind = Dictionary(uniqueKeysWithValues: menu.items.map { ($0.kind, $0.isEnabled) })
+        XCTAssertEqual(enabledByKind[.regenerate], false)
+        XCTAssertEqual(enabledByKind[.fork], false)
+        XCTAssertEqual(enabledByKind[.listen], true)
+        XCTAssertEqual(enabledByKind[.selectText], true)
+        XCTAssertEqual(enabledByKind[.copy], true)
+
+        let uiMenu = menu.uiMenu()
+        let disabledTitles = uiMenu.children.compactMap { $0 as? UIAction }
+            .filter { $0.attributes.contains(.disabled) }
+            .map(\.title)
+        XCTAssertEqual(disabledTitles, ["Regenerate Response", "Fork From Here"])
+    }
+
+    func testListenItemReflectsListeningState() throws {
+        let idle = try makeMenu(role: "assistant")
+        XCTAssertEqual(idle.items.first?.title, "Listen")
+
+        let listening = try makeMenu(role: "assistant", listeningMessageID: "message-1")
+        XCTAssertEqual(listening.items.first?.title, "Stop Listening")
+    }
+
+    func testPerformRoutesToTheMatchingCallback() throws {
+        var copied: MessageActionContext?
+        let menu = try makeMenu(role: "user", onCopy: { copied = $0 })
+
+        let copy = try XCTUnwrap(menu.items.first { $0.kind == .copy })
+        copy.perform()
+
+        XCTAssertEqual(copied?.messageID, "message-1")
+    }
+
+    private func makeMenu(
+        role: String,
+        listeningMessageID: String? = nil,
+        hasActiveStream: Bool = false,
+        onCopy: @escaping (MessageActionContext) -> Void = { _ in }
+    ) throws -> ChatMessageActionMenu {
+        let message = ChatMessage(
+            role: role,
+            content: "Hello there",
+            timestamp: 1_770_000_000,
+            messageId: "message-1"
+        )
+        let context = try XCTUnwrap(
+            MessageActionContext(message: message, visibleIndex: 0, messagesOffset: 0)
+        )
+        return ChatMessageActionMenu(
+            context: context,
+            listeningMessageID: listeningMessageID,
+            isViewingCachedData: false,
+            hasActiveStream: hasActiveStream,
+            isRegeneratingMessage: false,
+            isEditingMessage: false,
+            isForkingMessage: false,
+            onToggleListening: { _ in },
+            onSelectText: { _ in },
+            onRegenerate: { _ in },
+            onEdit: { _ in },
+            onFork: { _ in },
+            onCopy: onCopy
+        )
+    }
+}


### PR DESCRIPTION
## Linked issue

Fixes #208

## What changed

Long-pressing a reply made SwiftUI snapshot the whole bubble as the lifted preview before it could dim the transcript and show the menu. On a multi-screen reply that snapshot was slow and taller than the screen, so the menu appeared over the undimmed text and then jumped once UIKit made room for it. Long-pressing a link also opened the message menu on top of the link interaction.

The menu now comes from a single `UIContextMenuInteraction` on the transcript's scroll view (`ChatMessageContextMenuView.swift`). Each bubble registers a clear, touch-transparent marker view behind itself; a long-press resolves to the bubble under the touch and the menu is anchored at the press point with nothing lifted. The transcript dims and the menu opens in one motion at any reply length, and nothing is re-rendered or snapshotted. Menu items are built from one shared list (`ChatMessageActionItem`) used by both the SwiftUI menu and the UIKit menu, and are also exposed as VoiceOver custom actions.

Why not lift a clipped preview: a copy that fills the viewport leaves UIKit no room for the menu, so it draws the menu first and relocates the copy a frame later (the same pop iMessage shows on long messages). A smaller slice cut the text off and needed a hide-and-restore dance that left a gap on dismissal. The maintainer tried both on the simulator and picked the no-lift behavior; the trade-off is that the pressed message is not visually highlighted, only anchored.

Links: the press cannot be told apart from plain text at the UIKit level, so a long-press on a link opens the message menu (owner decision on the issue's Q1). Taps still open links.

## How it was tested

- Full XCTest suite on iPhone 17 simulator: 1868 passed, 0 failed, 2 pre-existing skips.
- New `ChatMessageActionMenuTests`: item order per role, disabled states while streaming, listening toggle, callback routing, and the UIKit menu mirroring disabled items.
- Manual on the simulator (maintainer): long-press on one-line, multi-screen, and user bubbles, mid-scroll; link long-press; dismiss; Copy and Select Text from the menu.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no server changes)

---
Implemented by Claude Fable 5.1 via Claude Code.