### PR TITLE
feat(chat): pill composer with a toolbar row when focused

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */; };
 		C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */; };
 		C042A000000000000000001 /* ChatComposerSelectorControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000002 /* ChatComposerSelectorControls.swift */; };
+		C0A5C9000000000000000001 /* ChatComposerToolbarScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A5C9000000000000000002 /* ChatComposerToolbarScroller.swift */; };
 		C042A000000000000000003 /* ChatComposerSelectorSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A000000000000000004 /* ChatComposerSelectorSheets.swift */; };
 		C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04900000000000000000002 /* ChatComposerTextInputView.swift */; };
 		C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04900000000000000000004 /* ChatComposerVoiceControls.swift */; };
@@ -154,6 +155,7 @@
 		C27800000000000000000003 /* ChatGitControlsVisibilityPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27800000000000000000004 /* ChatGitControlsVisibilityPolicyTests.swift */; };
 		C0DE22000000000000000001 /* ChatHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000002 /* ChatHaptics.swift */; };
 		C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE22000000000000000004 /* ChatHapticsTests.swift */; };
+		C0A5C9000000000000000003 /* ComposerToolbarScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A5C9000000000000000004 /* ComposerToolbarScrollerTests.swift */; };
 		C08800000000000000000001 /* SessionHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08800000000000000000002 /* SessionHaptics.swift */; };
 		C08800000000000000000003 /* SessionHapticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08800000000000000000004 /* SessionHapticsTests.swift */; };
 		C09300000000000000000001 /* HapticButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09300000000000000000002 /* HapticButton.swift */; };
@@ -463,6 +465,7 @@
 		C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerConfigLoaderTests.swift; sourceTree = "<group>"; };
 		C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerAttachmentStripView.swift; sourceTree = "<group>"; };
 		C042A000000000000000002 /* ChatComposerSelectorControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorControls.swift; sourceTree = "<group>"; };
+		C0A5C9000000000000000002 /* ChatComposerToolbarScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerToolbarScroller.swift; sourceTree = "<group>"; };
 		C042A000000000000000004 /* ChatComposerSelectorSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSelectorSheets.swift; sourceTree = "<group>"; };
 		C04900000000000000000002 /* ChatComposerTextInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerTextInputView.swift; sourceTree = "<group>"; };
 		C04900000000000000000004 /* ChatComposerVoiceControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerVoiceControls.swift; sourceTree = "<group>"; };
@@ -517,6 +520,7 @@
 		C27800000000000000000004 /* ChatGitControlsVisibilityPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGitControlsVisibilityPolicyTests.swift; sourceTree = "<group>"; };
 		C0DE22000000000000000002 /* ChatHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHaptics.swift; sourceTree = "<group>"; };
 		C0DE22000000000000000004 /* ChatHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHapticsTests.swift; sourceTree = "<group>"; };
+		C0A5C9000000000000000004 /* ComposerToolbarScrollerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerToolbarScrollerTests.swift; sourceTree = "<group>"; };
 		C08800000000000000000002 /* SessionHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHaptics.swift; sourceTree = "<group>"; };
 		C08800000000000000000004 /* SessionHapticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHapticsTests.swift; sourceTree = "<group>"; };
 		C09300000000000000000002 /* HapticButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticButton.swift; sourceTree = "<group>"; };
@@ -882,6 +886,7 @@
 				C0AA05000000000000000F02 /* ChatMessageMetaTests.swift */,
 				C03190000000000000F003 /* AttachmentAudioDetectionTests.swift */,
 				C0DE22000000000000000004 /* ChatHapticsTests.swift */,
+				C0A5C9000000000000000004 /* ComposerToolbarScrollerTests.swift */,
 				C08800000000000000000004 /* SessionHapticsTests.swift */,
 				C09300000000000000000004 /* HapticButtonTests.swift */,
 				C09500000000000000000004 /* AdaptiveGlassTests.swift */,
@@ -1072,6 +1077,7 @@
 				C04900000000000000000002 /* ChatComposerTextInputView.swift */,
 				C04900000000000000000004 /* ChatComposerVoiceControls.swift */,
 				C042A000000000000000002 /* ChatComposerSelectorControls.swift */,
+				C0A5C9000000000000000002 /* ChatComposerToolbarScroller.swift */,
 				C042A000000000000000004 /* ChatComposerSelectorSheets.swift */,
 				C0DE20000000000000000002 /* ChatTactileButtonStyle.swift */,
 				C0DE21000000000000000002 /* ChatMotion.swift */,
@@ -1597,6 +1603,7 @@
 					C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */,
 					C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */,
 					C042A000000000000000001 /* ChatComposerSelectorControls.swift in Sources */,
+					C0A5C9000000000000000001 /* ChatComposerToolbarScroller.swift in Sources */,
 					C042A000000000000000003 /* ChatComposerSelectorSheets.swift in Sources */,
 					105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */,
 				1A2B3C4D5E6F7000000000D8 /* MessageBubbleView.swift in Sources */,
@@ -1779,6 +1786,7 @@
 				C0AA05000000000000000B02 /* ChatMessageMetaTests.swift in Sources */,
 				C03190000000000000B003 /* AttachmentAudioDetectionTests.swift in Sources */,
 				C0DE22000000000000000003 /* ChatHapticsTests.swift in Sources */,
+				C0A5C9000000000000000003 /* ComposerToolbarScrollerTests.swift in Sources */,
 				C08800000000000000000003 /* SessionHapticsTests.swift in Sources */,
 				C09300000000000000000003 /* HapticButtonTests.swift in Sources */,
 				C09500000000000000000003 /* AdaptiveGlassTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatComposerAttachmentStripView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerAttachmentStripView.swift
@@ -25,11 +25,68 @@ struct ComposerAttachmentStripView: View {
                 .padding(.bottom, 4)
             }
             .frame(height: stripHeight)
+            .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
         }
     }
 
     private var stripHeight: CGFloat {
         dynamicTypeSize.isAccessibilitySize ? 132 : 108
+    }
+}
+
+/// Pill-state summary of pending attachments: up to three 30 pt tiles plus a
+/// `+N` chip, so nothing pending is ever out of sight while the editor is idle.
+struct ComposerAttachmentPillPreview: View {
+    let attachments: [PendingAttachment]
+    let onPreview: (PendingAttachment) -> Void
+
+    private let tileSize: CGFloat = 30
+    private let visibleLimit = 3
+
+    var body: some View {
+        if !attachments.isEmpty {
+            HStack(spacing: 4) {
+                ForEach(attachments.prefix(visibleLimit)) { attachment in
+                    Button {
+                        onPreview(attachment)
+                    } label: {
+                        tile(for: attachment)
+                    }
+                    .buttonStyle(.chatTactile(.thumbnail))
+                    .accessibilityLabel("Open attachment \(attachment.name)")
+                }
+
+                if attachments.count > visibleLimit {
+                    Text("+\(attachments.count - visibleLimit)")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(Color(.secondaryLabel))
+                        .frame(width: tileSize, height: tileSize)
+                        .background(Color(.tertiarySystemFill), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .accessibilityLabel(Text("\(attachments.count - visibleLimit) more attachments"))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tile(for attachment: PendingAttachment) -> some View {
+        Group {
+            if attachment.isImage,
+               let thumbnailData = attachment.thumbnailData,
+               let uiImage = UIImage(data: thumbnailData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Image(systemName: attachment.isImage ? "photo" : "doc")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.tertiarySystemFill))
+            }
+        }
+        .frame(width: tileSize, height: tileSize)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
@@ -4,9 +4,6 @@ import UIKit
 struct ComposerWorkspaceSelectorButton: View {
     let title: String
     let isDisabled: Bool
-    let lineLimit: Int
-    let verticalPadding: CGFloat
-    let horizontalPadding: CGFloat
     let color: Color
     let controlFont: Font
     let chevronFont: Font
@@ -14,18 +11,15 @@ struct ComposerWorkspaceSelectorButton: View {
 
     var body: some View {
         Button(action: onTap) {
-            ComposerSecondaryBarLabel(
+            ComposerInlineControlLabel(
                 title: title,
                 systemImage: "folder",
-                lineLimit: lineLimit,
-                verticalPadding: verticalPadding,
-                horizontalPadding: horizontalPadding,
                 color: color,
                 controlFont: controlFont,
                 chevronFont: chevronFont
             )
         }
-        .buttonStyle(.chatTactile(.capsule))
+        .buttonStyle(.chatTactile(.compactControl))
         .disabled(isDisabled)
         .accessibilityLabel("Choose workspace path")
     }
@@ -35,16 +29,33 @@ struct ComposerProfileSelectorMenu: View {
     let profileOptions: [ProfileSummary]
     let selectedProfileName: String?
     let selectedProfileTitle: String
+    /// Single-profile servers reject switches (#24), so the control is a plain
+    /// label: no chevron, no menu, no button trait.
+    let isStatic: Bool
     let isDisabled: Bool
-    let lineLimit: Int
-    let verticalPadding: CGFloat
-    let horizontalPadding: CGFloat
     let color: Color
     let controlFont: Font
     let chevronFont: Font
     let onSelectProfile: (ProfileSummary) -> Void
 
     var body: some View {
+        if isStatic {
+            ComposerInlineControlLabel(
+                title: selectedProfileTitle,
+                systemImage: "person.crop.circle",
+                showsChevron: false,
+                color: color,
+                controlFont: controlFont,
+                chevronFont: chevronFont
+            )
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text("Profile: \(selectedProfileTitle)"))
+        } else {
+            profileMenu
+        }
+    }
+
+    private var profileMenu: some View {
         Menu {
             if profileOptions.isEmpty {
                 Text("No profiles available")
@@ -64,18 +75,15 @@ struct ComposerProfileSelectorMenu: View {
                 }
             }
         } label: {
-            ComposerSecondaryBarLabel(
+            ComposerInlineControlLabel(
                 title: selectedProfileTitle,
                 systemImage: "person.crop.circle",
-                lineLimit: lineLimit,
-                verticalPadding: verticalPadding,
-                horizontalPadding: horizontalPadding,
                 color: color,
                 controlFont: controlFont,
                 chevronFont: chevronFont
             )
         }
-        .buttonStyle(.chatTactile(.capsule))
+        .buttonStyle(.chatTactile(.compactControl))
         .tint(color)
         .disabled(isDisabled)
         .accessibilityLabel("Choose profile")
@@ -99,7 +107,7 @@ struct ComposerModelMenu: View {
     let onShowAllModels: () -> Void
 
     var body: some View {
-        ChatUIKitMenuButton(horizontalPadding: 0, verticalPadding: 14) {
+        ChatUIKitMenuButton {
             ComposerMetaControlLabel(
                 title: selectedModelTitle,
                 systemImage: nil,
@@ -246,29 +254,42 @@ struct ComposerReasoningMenu: View {
     let supportedEfforts: [String]?
     let reasoningTitle: String
     let isDisabled: Bool
-    let width: CGFloat
     let color: Color
     let controlFont: Font
     let chevronFont: Font
     let onSelectReasoningEffort: (String) -> Void
 
     var body: some View {
-        ChatUIKitMenuButton(horizontalPadding: 0, verticalPadding: 14) {
+        if let onlyOption = ReasoningEffortOption.singleOption(forSupportedEfforts: supportedEfforts) {
+            // One effort means nothing to choose: a plain label, not a disabled menu.
             ComposerMetaControlLabel(
-                title: reasoningTitle,
+                title: onlyOption.title,
                 systemImage: "lucide.brain",
-                minWidth: width,
-                maxWidth: width,
+                maxWidth: nil,
+                showsChevron: false,
                 color: color,
                 controlFont: controlFont,
                 chevronFont: chevronFont
             )
-        } menu: {
-            makeReasoningMenu()
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text("Reasoning effort: \(onlyOption.title)"))
+        } else {
+            ChatUIKitMenuButton {
+                ComposerMetaControlLabel(
+                    title: reasoningTitle,
+                    systemImage: "lucide.brain",
+                    maxWidth: nil,
+                    color: color,
+                    controlFont: controlFont,
+                    chevronFont: chevronFont
+                )
+            } menu: {
+                makeReasoningMenu()
+            }
+            .tint(color)
+            .disabled(isDisabled)
+            .accessibilityLabel("Select reasoning effort")
         }
-        .tint(color)
-        .disabled(isDisabled)
-        .accessibilityLabel("Select reasoning effort")
     }
 
     private func makeReasoningMenu() -> UIMenu {
@@ -294,8 +315,8 @@ private struct ComposerMetaControlLabel: View {
 
     let title: String
     let systemImage: String?
-    var minWidth: CGFloat?
-    let maxWidth: CGFloat
+    let maxWidth: CGFloat?
+    var showsChevron = true
     let color: Color
     let controlFont: Font
     let chevronFont: Font
@@ -318,24 +339,31 @@ private struct ComposerMetaControlLabel: View {
                 .font(controlFont)
                 .layoutPriority(1)
 
-            Image(systemName: "chevron.down")
-                .font(chevronFont)
+            if showsChevron {
+                Image(systemName: "chevron.down")
+                    .font(chevronFont)
+            }
         }
         .foregroundStyle(color)
-        .frame(minWidth: minWidth, maxWidth: maxWidth, alignment: .leading)
+        .frame(maxWidth: maxWidth, alignment: .leading)
+        .padding(.horizontal, ComposerInlineControlLabel.horizontalPadding)
+        .frame(minHeight: ComposerInlineControlLabel.minimumHeight)
+        .contentShape(Rectangle())
         .transaction { transaction in
             transaction.animation = nil
         }
-        .chatMinimumHitTarget(horizontalPadding: 0, verticalPadding: 14, in: Rectangle())
     }
 }
 
-private struct ComposerSecondaryBarLabel: View {
+/// Quiet toolbar-row control: icon, one-line title, optional chevron, no pill
+/// background, so the row reads as one surface. 44 pt tall for the hit target.
+private struct ComposerInlineControlLabel: View {
+    static let minimumHeight: CGFloat = 44
+    static let horizontalPadding: CGFloat = 6
+
     let title: String
     let systemImage: String
-    let lineLimit: Int
-    let verticalPadding: CGFloat
-    let horizontalPadding: CGFloat
+    var showsChevron = true
     let color: Color
     let controlFont: Font
     let chevronFont: Font
@@ -346,24 +374,19 @@ private struct ComposerSecondaryBarLabel: View {
                 .font(controlFont)
 
             Text(title)
-                .lineLimit(lineLimit)
+                .lineLimit(1)
                 .truncationMode(.middle)
                 .font(controlFont)
 
-            Image(systemName: "chevron.down")
-                .font(chevronFont)
+            if showsChevron {
+                Image(systemName: "chevron.down")
+                    .font(chevronFont)
+            }
         }
         .foregroundStyle(color)
-        .padding(.horizontal, horizontalPadding)
-        .padding(.vertical, verticalPadding)
-        .adaptiveGlass(
-            .regular,
-            isInteractive: true,
-            fallbackMaterial: .ultraThinMaterial,
-            in: Capsule()
-        )
-        .clipShape(Capsule())
-        .chatMinimumHitTarget(in: Capsule())
+        .padding(.horizontal, Self.horizontalPadding)
+        .frame(minHeight: Self.minimumHeight)
+        .contentShape(Rectangle())
     }
 }
 
@@ -466,6 +489,13 @@ struct ReasoningEffortOption: Identifiable, CaseIterable {
                 allCases.first(where: { $0.id == id })
                     ?? ReasoningEffortOption(id: id, title: id.capitalized)
             }
+    }
+
+    /// The lone effort when the server vocabulary leaves nothing to choose, so the
+    /// composer can render a static label instead of a one-item menu.
+    static func singleOption(forSupportedEfforts supportedEfforts: [String]?) -> ReasoningEffortOption? {
+        let options = options(forSupportedEfforts: supportedEfforts)
+        return options.count == 1 ? options[0] : nil
     }
 
     /// Whether the composer should show the effort control at all (issue #18).

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -9,6 +9,10 @@ struct ComposerTextInputView: View {
     @Binding var measuredHeight: CGFloat
 
     let isDisabled: Bool
+    /// Pill mode: a single truncated line stands in for the editor and a tap
+    /// focuses it. The text view stays in the hierarchy (invisible) so focus and
+    /// the draft survive the pill-to-card morph without recreating it.
+    let isCollapsed: Bool
     let isKeyboardSendEnabled: Bool
     let verticalPadding: CGFloat
     let onKeyboardSend: () -> Void
@@ -17,8 +21,12 @@ struct ComposerTextInputView: View {
     let onPasteImageProviders: ([NSItemProvider]) -> Void
     let onPasteImages: ([UIImage]) -> Void
 
+    private let placeholder = String(localized: "Ask anything... /commands")
+    private let collapsedLineHeight: CGFloat = 22
+    private let expandedMinimumHeight: CGFloat = 72
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack(alignment: isCollapsed ? .leading : .topLeading) {
             ComposerTextView(
                 text: $text,
                 isFocused: $isFocused,
@@ -31,19 +39,35 @@ struct ComposerTextInputView: View {
                 onPasteImageProviders: onPasteImageProviders,
                 onPasteImages: onPasteImages
             )
-            .frame(height: inputHeight)
-            .padding(.vertical, verticalPadding)
+            .frame(height: isCollapsed ? collapsedLineHeight : inputHeight)
+            .padding(.vertical, isCollapsed ? 0 : verticalPadding)
             .padding(.horizontal, 16)
+            .opacity(isCollapsed ? 0 : 1)
+            .allowsHitTesting(!isCollapsed)
+            .accessibilityHidden(isCollapsed)
 
-            if text.isEmpty {
-                Text("Ask anything... /commands")
+            if isCollapsed {
+                Text(text.isEmpty ? placeholder : text)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(text.isEmpty ? Color(.placeholderText) : Color(.label))
+                    .padding(.horizontal, 16)
+                    .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        if !isDisabled { isFocused = true }
+                    }
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityHint(Text("Edit message"))
+            } else if text.isEmpty {
+                Text(placeholder)
                     .foregroundStyle(Color(.placeholderText))
                     .padding(.horizontal, 16)
                     .padding(.vertical, verticalPadding)
                     .allowsHitTesting(false)
             }
         }
-        .frame(minHeight: 42, alignment: .topLeading)
+        .frame(minHeight: isCollapsed ? 44 : expandedMinimumHeight + verticalPadding * 2, alignment: isCollapsed ? .leading : .topLeading)
     }
 
     private func updateMeasuredHeight(_ newHeight: CGFloat) {
@@ -199,7 +223,7 @@ private struct ComposerTextView: UIViewRepresentable {
 
             let fittingSize = CGSize(width: textView.bounds.width, height: .greatestFiniteMagnitude)
             let height = ceil(textView.sizeThatFits(fittingSize).height)
-            onHeightChange(min(96, max(22, height)))
+            onHeightChange(min(160, max(22, height)))
         }
     }
 

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -39,7 +39,9 @@ struct ComposerTextInputView: View {
                 onPasteImageProviders: onPasteImageProviders,
                 onPasteImages: onPasteImages
             )
-            .frame(height: isCollapsed ? collapsedLineHeight : inputHeight)
+            // The card editor is at least 72 pt of real text view, so a tap
+            // anywhere in it lands on the editor rather than dead space.
+            .frame(height: isCollapsed ? collapsedLineHeight : max(expandedMinimumHeight, inputHeight))
             .padding(.vertical, isCollapsed ? 0 : verticalPadding)
             .padding(.horizontal, 16)
             .opacity(isCollapsed ? 0 : 1)
@@ -67,7 +69,7 @@ struct ComposerTextInputView: View {
                     .allowsHitTesting(false)
             }
         }
-        .frame(minHeight: isCollapsed ? 44 : expandedMinimumHeight + verticalPadding * 2, alignment: isCollapsed ? .leading : .topLeading)
+        .frame(minHeight: isCollapsed ? 44 : nil, alignment: isCollapsed ? .leading : .topLeading)
     }
 
     private func updateMeasuredHeight(_ newHeight: CGFloat) {

--- a/HermesMobile/Features/Chat/ChatComposerToolbarScroller.swift
+++ b/HermesMobile/Features/Chat/ChatComposerToolbarScroller.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Which edges of the composer toolbar scroller currently hide content.
+/// A fade is only ever shown on an edge with something behind it, so a fade
+/// never reads as a disabled control. Pure so the rule is unit-testable.
+struct ComposerToolbarEdgeFades: Equatable {
+    /// Offsets this close to an edge count as sitting on it.
+    static let scrollEpsilon: CGFloat = 4
+
+    let leading: Bool
+    let trailing: Bool
+
+    init(leading: Bool = false, trailing: Bool = false) {
+        self.leading = leading
+        self.trailing = trailing
+    }
+
+    /// - Parameters:
+    ///   - offset: horizontal content offset as the scroll view reports it, measured
+    ///     from the left edge regardless of layout direction.
+    ///   - layoutDirection: in right-to-left layouts the visual start of the content
+    ///     is at the right, so the raw offset is flipped before comparing.
+    init(
+        offset: CGFloat,
+        contentWidth: CGFloat,
+        viewportWidth: CGFloat,
+        layoutDirection: LayoutDirection = .leftToRight
+    ) {
+        let maxOffset = max(0, contentWidth - viewportWidth)
+        let logicalOffset = layoutDirection == .rightToLeft ? maxOffset - offset : offset
+        leading = logicalOffset > Self.scrollEpsilon
+        trailing = logicalOffset < maxOffset - Self.scrollEpsilon
+    }
+}
+
+/// Horizontal scroller for the composer toolbar row (add, model, reasoning,
+/// workspace, profile, git branch, mic, context meter). The Stop/Send circle
+/// stays outside it, pinned to the row's trailing edge.
+struct ComposerToolbarScroller<Content: View>: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.layoutDirection) private var layoutDirection
+
+    private let content: Content
+
+    @State private var fades = ComposerToolbarEdgeFades()
+
+    private let fadeWidth: CGFloat = 18
+    private let itemSpacing: CGFloat = 8
+    private let minimumRowHeight: CGFloat = 44
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: itemSpacing) {
+                content
+            }
+            .frame(minHeight: minimumRowHeight, alignment: .leading)
+        }
+        .scrollIndicators(.hidden)
+        // Horizontal only, and inert when everything fits, so the row never
+        // feels draggable for no reason.
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+        // Taps on toolbar controls must never dismiss the keyboard first.
+        .scrollDismissesKeyboard(.never)
+        .onScrollGeometryChange(for: ComposerToolbarEdgeFades.self) { geometry in
+            ComposerToolbarEdgeFades(
+                offset: geometry.contentOffset.x,
+                contentWidth: geometry.contentSize.width,
+                viewportWidth: geometry.containerSize.width,
+                layoutDirection: layoutDirection
+            )
+        } action: { _, newFades in
+            fades = newFades
+        }
+        .mask { fadeMask }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.15), value: fades)
+    }
+
+    /// Alpha mask: opaque everywhere except an edge that hides content, which
+    /// fades over `fadeWidth` so the glass surface shows through.
+    private var fadeMask: some View {
+        HStack(spacing: 0) {
+            LinearGradient(
+                colors: [fades.leading ? .clear : .black, .black],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: fadeWidth)
+
+            Color.black
+
+            LinearGradient(
+                colors: [.black, fades.trailing ? .clear : .black],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: fadeWidth)
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -60,10 +60,14 @@ struct MessageComposerView: View {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(HeaderLogoColor.storageKey) private var headerLogoColorHex = HeaderLogoColor.defaultHex
     @AppStorage(PrimaryActionTintSettings.isEnabledKey) private var tintsPrimaryActions = false
-    @ScaledMetric(relativeTo: .footnote) private var actionIconSize: CGFloat = 13
-    @ScaledMetric(relativeTo: .footnote) private var actionButtonSize: CGFloat = 30
-    @ScaledMetric(relativeTo: .title3) private var plusIconSize: CGFloat = 24
-    @ScaledMetric(relativeTo: .title3) private var plusButtonSize: CGFloat = 28
+    @ScaledMetric(relativeTo: .body) private var actionIconSize: CGFloat = 16
+    @ScaledMetric(relativeTo: .body) private var plusIconSize: CGFloat = 20
+
+    /// t3code sizing: every circle in the composer is 44 pt, which is also the
+    /// minimum hit target, so no invisible hit padding is needed.
+    private let circleSize: CGFloat = 44
+    private let cardCornerRadius: CGFloat = 26
+    private let pillInset: CGFloat = 5
 
     @Binding var draftMessage: String
     @Binding var isFocused: Bool
@@ -72,7 +76,6 @@ struct MessageComposerView: View {
     let isWaitingForStream: Bool
     let isCancellingStream: Bool
     let readOnlyMessage: String?
-    let isChromeCompact: Bool
     let errorMessage: String?
     let configurationErrorMessage: String?
     let contextWindowSnapshot: ContextWindowSnapshot?
@@ -304,84 +307,15 @@ struct MessageComposerView: View {
                 }
                 .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: showsSlashAutocomplete)
 
-                VStack(spacing: 0) {
-                    ComposerAttachmentStripView(
-                        attachments: pendingAttachments,
-                        onRemove: onRemoveAttachment,
-                        onPreview: onPreviewAttachment
-                    )
-
-                    ComposerTextInputView(
-                        text: $draftMessage,
-                        isFocused: $isFocused,
-                        inputHeight: $textInputHeight,
-                        measuredHeight: $textFieldHeight,
-                        isDisabled: isReadOnly,
-                        isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
-                        verticalPadding: textFieldVerticalPadding,
-                        onKeyboardSend: actionButtonTapped,
-                        onPasteFileProviders: onPasteFileProviders,
-                        onPasteFileURLs: onPasteFileURLs,
-                        onPasteImageProviders: onPasteImageProviders,
-                        onPasteImages: onPasteImages
-                    )
-
-                    HStack(alignment: .center, spacing: 12) {
-                        composerPlusMenu
-
-                        modelMenu
-
-                        if showsReasoningControl {
-                            reasoningMenu
-                        }
-
-                        Spacer(minLength: 0)
-
-                        ComposerVoiceControlButton(
-                            isListening: voiceInput.isListening,
-                            isDisabled: isVoiceInputDisabled,
-                            color: metaControlColor,
-                            isRecordingVoiceNote: voiceNoteRecorder.isRecording,
-                            onTap: toggleVoiceInput,
-                            onRecordingStart: startVoiceNoteRecording,
-                            onRecordingDragChanged: { height in
-                                voiceNoteCancelArmed = ComposerVoiceNoteGesture.isCancelArmed(dragTranslationHeight: height)
-                            },
-                            onRecordingEnd: { height in
-                                finishVoiceNote(translationHeight: height)
-                            }
-                        )
-
-                        Button(action: actionButtonTapped) {
-                            actionButtonLabel
-                                .frame(width: actionButtonSize, height: actionButtonSize)
-                                .background(actionButtonBackground)
-                                .foregroundStyle(actionButtonForeground)
-                                .clipShape(Circle())
-                                .chatMinimumHitTarget(in: Circle())
-                        }
-                        .buttonStyle(.chatTactile(.icon))
-                        .disabled(isActionButtonDisabled)
-                        .accessibilityLabel(showsStopButton ? "Stop response" : "Send")
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 2)
-                    .padding(.bottom, 8)
-                }
-                .adaptiveGlass(
-                    .regular,
-                    isInteractive: true,
-                    fallbackMaterial: .ultraThinMaterial,
-                    in: RoundedRectangle(cornerRadius: composerCornerRadius, style: .continuous)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: composerCornerRadius, style: .continuous))
-                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.28 : 0.12), radius: 14, y: 6)
-                .padding(.horizontal)
-
-                secondaryBar
+                composerSurface
                     .padding(.horizontal)
-                    .padding(.bottom, 7)
-                    .animation(ChatMotion.composerChrome(reduceMotion: reduceMotion), value: showsSecondaryChrome)
+
+                if isExpanded {
+                    toolbarRow
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+                        .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
+                }
             }
         }
         .background(
@@ -420,6 +354,28 @@ struct MessageComposerView: View {
             // the clip hits the limit, mirroring a finger release.
             if voiceNoteRecorder.isRecording, elapsed >= ComposerVoiceNoteRecorder.maximumDuration {
                 finishVoiceNote(translationHeight: 0)
+            }
+        }
+        .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItems, matching: .images)
+        .onChange(of: selectedPhotoItems) {
+            let items = selectedPhotoItems
+            guard !items.isEmpty else { return }
+            deferFocusRestoreUntilUploadCompletes()
+            selectedPhotoItems.removeAll()
+            for item in items {
+                onPhotoItemSelected(item)
+            }
+        }
+        .fullScreenCover(isPresented: $showCameraPicker) {
+            CameraPickerView { image in
+                deferFocusRestoreUntilUploadCompletes()
+                onPasteImages([image])
+            }
+            .ignoresSafeArea()
+        }
+        .onChange(of: showCameraPicker) { _, isPresented in
+            if !isPresented {
+                restoreFocusAfterPresentationDismissalSettles()
             }
         }
         .sheet(isPresented: $showsAllModelsSheet, onDismiss: restoreFocusAfterPresentationIfNeeded) {
@@ -552,12 +508,148 @@ struct MessageComposerView: View {
         .padding(.bottom, keyboardIsVisible ? 10 : 0)
     }
 
+    /// Pill while the editor is idle; card while it is focused or a composer
+    /// sheet is up (so a picker never snaps it shut). `shouldRestoreFocus…`
+    /// bridges the gap between a sheet dismissing and focus coming back.
+    private var isExpanded: Bool {
+        isFocused
+            || shouldRestoreFocusAfterPresentation
+            || showsAllModelsSheet
+            || showsWorkspaceSheet
+            || showPhotoPicker
+            || showCameraPicker
+            || showFileImporter
+    }
+
+    private var composerSurfaceShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: isExpanded ? cardCornerRadius : (circleSize + pillInset * 2) / 2, style: .continuous)
+    }
+
+    /// The glass surface: one text view in both states so focus and the draft
+    /// survive the morph. Pill: text, thumbnails, mic, Stop/Send in a row.
+    /// Card: strip above the editor, controls move to `toolbarRow` below.
+    private var composerSurface: some View {
+        VStack(spacing: 0) {
+            if isExpanded {
+                ComposerAttachmentStripView(
+                    attachments: pendingAttachments,
+                    onRemove: onRemoveAttachment,
+                    onPreview: onPreviewAttachment
+                )
+                .transition(.opacity)
+            }
+
+            HStack(alignment: .center, spacing: 4) {
+                ComposerTextInputView(
+                    text: $draftMessage,
+                    isFocused: $isFocused,
+                    inputHeight: $textInputHeight,
+                    measuredHeight: $textFieldHeight,
+                    isDisabled: isReadOnly,
+                    isCollapsed: !isExpanded,
+                    isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
+                    verticalPadding: 12,
+                    onKeyboardSend: actionButtonTapped,
+                    onPasteFileProviders: onPasteFileProviders,
+                    onPasteFileURLs: onPasteFileURLs,
+                    onPasteImageProviders: onPasteImageProviders,
+                    onPasteImages: onPasteImages
+                )
+
+                if !isExpanded {
+                    ComposerAttachmentPillPreview(
+                        attachments: pendingAttachments,
+                        onPreview: onPreviewAttachment
+                    )
+
+                    voiceControlButton
+
+                    actionButton
+                }
+            }
+            .padding(.trailing, isExpanded ? 0 : pillInset)
+            .padding(.vertical, isExpanded ? 0 : pillInset)
+        }
+        .padding(.top, isExpanded ? 2 : 0)
+        .padding(.bottom, isExpanded ? 4 : 0)
+        .adaptiveGlass(
+            .regular,
+            isInteractive: true,
+            fallbackMaterial: .ultraThinMaterial,
+            in: composerSurfaceShape
+        )
+        .clipShape(composerSurfaceShape)
+        .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.28 : 0.12), radius: 14, y: 6)
+        .animation(ChatMotion.composerChrome(reduceMotion: reduceMotion), value: isExpanded)
+    }
+
+    /// Card-state row under the surface: a scroller of secondary controls plus
+    /// the pinned Stop/Send circle. Visual order is VoiceOver order.
+    private var toolbarRow: some View {
+        HStack(alignment: .center, spacing: 8) {
+            ComposerToolbarScroller {
+                composerPlusMenu
+
+                modelMenu
+
+                if showsReasoningControl {
+                    reasoningMenu
+                }
+
+                workspaceSelector
+
+                profileSelector
+
+                gitBranchPicker
+
+                voiceControlButton
+
+                ContextWindowIndicatorView(snapshot: contextWindowSnapshot)
+                    .padding(.horizontal, 4)
+            }
+
+            actionButton
+        }
+    }
+
+    private var voiceControlButton: some View {
+        ComposerVoiceControlButton(
+            isListening: voiceInput.isListening,
+            isDisabled: isVoiceInputDisabled,
+            color: metaControlColor,
+            isRecordingVoiceNote: voiceNoteRecorder.isRecording,
+            onTap: toggleVoiceInput,
+            onRecordingStart: startVoiceNoteRecording,
+            onRecordingDragChanged: { height in
+                voiceNoteCancelArmed = ComposerVoiceNoteGesture.isCancelArmed(dragTranslationHeight: height)
+            },
+            onRecordingEnd: { height in
+                finishVoiceNote(translationHeight: height)
+            }
+        )
+    }
+
+    /// One trailing circle in both states. Stop while a response streams and the
+    /// draft is empty; Send (which queues mid-run) as soon as there is text.
+    private var actionButton: some View {
+        Button(action: actionButtonTapped) {
+            actionButtonLabel
+                .frame(width: circleSize, height: circleSize)
+                .background(actionButtonBackground)
+                .foregroundStyle(actionButtonForeground)
+                .clipShape(Circle())
+        }
+        .buttonStyle(.chatTactile(.icon))
+        .disabled(isActionButtonDisabled)
+        .accessibilityLabel(showsStopButton ? "Stop response" : "Send")
+    }
+
     @ViewBuilder
     private var actionButtonLabel: some View {
         if isSending || isCancellingStream || isCompressingSession {
             ProgressView()
                 .tint(actionButtonForeground)
-                .scaleEffect(0.82)
+                .scaleEffect(0.9)
         } else if showsStopButton {
             Image(systemName: "stop.fill")
                 .font(.system(size: actionIconSize, weight: .semibold))
@@ -592,40 +684,24 @@ struct MessageComposerView: View {
     }
 
     private var composerPlusMenu: some View {
-        ChatUIKitMenuButton(horizontalPadding: 8, verticalPadding: 8) {
+        ChatUIKitMenuButton {
             Image(systemName: "plus")
-                .font(.system(size: plusIconSize, weight: .regular))
+                .font(.system(size: plusIconSize, weight: .medium))
                 .foregroundStyle(metaControlColor)
-                .frame(width: plusButtonSize, height: plusButtonSize)
-                .chatMinimumHitTarget(in: Circle())
+                .frame(width: circleSize, height: circleSize)
+                .adaptiveGlass(
+                    .regular,
+                    isInteractive: true,
+                    fallbackMaterial: .ultraThinMaterial,
+                    in: Circle()
+                )
+                .clipShape(Circle())
         } menu: {
             composerOptionsMenu()
         }
         .tint(metaControlColor)
         .disabled(isConfigurationControlDisabled)
         .accessibilityLabel("Composer options")
-        .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItems, matching: .images)
-        .onChange(of: selectedPhotoItems) {
-            let items = selectedPhotoItems
-            guard !items.isEmpty else { return }
-            deferFocusRestoreUntilUploadCompletes()
-            selectedPhotoItems.removeAll()
-            for item in items {
-                onPhotoItemSelected(item)
-            }
-        }
-        .fullScreenCover(isPresented: $showCameraPicker) {
-            CameraPickerView { image in
-                deferFocusRestoreUntilUploadCompletes()
-                onPasteImages([image])
-            }
-            .ignoresSafeArea()
-        }
-        .onChange(of: showCameraPicker) { _, isPresented in
-            if !isPresented {
-                restoreFocusAfterPresentationDismissalSettles()
-            }
-        }
     }
 
     private func composerOptionsMenu() -> UIMenu {
@@ -668,48 +744,6 @@ struct MessageComposerView: View {
     }
 
     @ViewBuilder
-    private var secondaryBar: some View {
-        if showsSecondaryChrome {
-            if usesAccessibilityLayout {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(spacing: 8) {
-                        workspaceSelector
-
-                        // Single-profile mode: the server rejects profile switches,
-                        // so the selector could only no-op or error (#24).
-                        if !isSingleProfileMode {
-                            profileSelector
-                        }
-
-                        gitBranchPicker
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    ContextWindowIndicatorView(snapshot: contextWindowSnapshot)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
-            } else {
-                HStack(spacing: 8) {
-                    workspaceSelector
-
-                    if !isSingleProfileMode {
-                        profileSelector
-                    }
-
-                    gitBranchPicker
-
-                    Spacer(minLength: 0)
-
-                    ContextWindowIndicatorView(snapshot: contextWindowSnapshot)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
-            }
-        }
-    }
-
-    @ViewBuilder
     private var gitBranchPicker: some View {
         // One "Git Actions" toggle covers every git control in chat (#189), so the
         // branch chip goes with the toolbar menu rather than lingering alone.
@@ -727,49 +761,28 @@ struct MessageComposerView: View {
         }
     }
 
-    private var showsSecondaryChrome: Bool {
-        !keyboardIsVisible && !isChromeCompact
-    }
-
     private var usesAccessibilityLayout: Bool {
         dynamicTypeSize.isAccessibilitySize
     }
 
     private var metaControlFont: Font {
-        AppFont.footnote()
+        AppFont.subheadline()
     }
 
     private var metaChevronFont: Font {
         AppFont.caption2()
     }
 
+    /// Soft cap so a very long model id still leaves room to see the row scrolls;
+    /// the scroller, not truncation, absorbs the rest.
     private var modelControlMaxWidth: CGFloat {
-        usesAccessibilityLayout ? 156 : 132
-    }
-
-    private var reasoningControlWidth: CGFloat {
-        usesAccessibilityLayout ? 126 : 104
-    }
-
-    private var secondaryBarLineLimit: Int {
-        usesAccessibilityLayout ? 2 : 1
-    }
-
-    private var secondaryBarVerticalPadding: CGFloat {
-        usesAccessibilityLayout ? 10 : 8
-    }
-
-    private var secondaryBarHorizontalPadding: CGFloat {
-        usesAccessibilityLayout ? 16 : 14
+        usesAccessibilityLayout ? 260 : 200
     }
 
     private var workspaceSelector: some View {
         ComposerWorkspaceSelectorButton(
             title: workspaceTitle,
             isDisabled: isConfigurationControlDisabled,
-            lineLimit: secondaryBarLineLimit,
-            verticalPadding: secondaryBarVerticalPadding,
-            horizontalPadding: secondaryBarHorizontalPadding,
             color: metaControlColor,
             controlFont: metaControlFont,
             chevronFont: metaChevronFont
@@ -784,10 +797,8 @@ struct MessageComposerView: View {
             profileOptions: profileOptions,
             selectedProfileName: selectedProfileName,
             selectedProfileTitle: selectedProfileTitle,
+            isStatic: isSingleProfileMode,
             isDisabled: isConfigurationControlDisabled,
-            lineLimit: secondaryBarLineLimit,
-            verticalPadding: secondaryBarVerticalPadding,
-            horizontalPadding: secondaryBarHorizontalPadding,
             color: metaControlColor,
             controlFont: metaControlFont,
             chevronFont: metaChevronFont,
@@ -822,7 +833,6 @@ struct MessageComposerView: View {
             supportedEfforts: supportedReasoningEfforts,
             reasoningTitle: reasoningTitle,
             isDisabled: isConfigurationControlDisabled,
-            width: reasoningControlWidth,
             color: metaControlColor,
             controlFont: metaControlFont,
             chevronFont: metaChevronFont,
@@ -966,6 +976,10 @@ struct MessageComposerView: View {
     }
 
     private var actionButtonBackground: Color {
+        if showsStopButton {
+            return Color.red.opacity(colorScheme == .dark ? 0.22 : 0.14)
+        }
+
         if PrimaryActionTintSettings.usesThemeColor(
             isEnabled: tintsPrimaryActions,
             controlIsEnabled: !isActionButtonDisabled
@@ -981,6 +995,10 @@ struct MessageComposerView: View {
     }
 
     private var actionButtonForeground: Color {
+        if showsStopButton {
+            return Color.red
+        }
+
         if PrimaryActionTintSettings.usesThemeColor(
             isEnabled: tintsPrimaryActions,
             controlIsEnabled: !isActionButtonDisabled
@@ -993,18 +1011,6 @@ struct MessageComposerView: View {
         }
 
         return colorScheme == .dark ? .black : .white
-    }
-
-    private var isComposerExpanded: Bool {
-        draftMessage.contains("\n") || textFieldHeight > 44
-    }
-
-    private var composerCornerRadius: CGFloat {
-        isComposerExpanded ? 26 : 22
-    }
-
-    private var textFieldVerticalPadding: CGFloat {
-        isComposerExpanded ? 12 : 14
     }
 
     private var reasoningTitle: String {

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -317,6 +317,9 @@ struct MessageComposerView: View {
                         .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
                 }
             }
+            // Focus flips arrive from UIKit outside any withAnimation, so the
+            // morph and the row's insertion take their animation from here.
+            .animation(ChatMotion.composerChrome(reduceMotion: reduceMotion), value: isExpanded)
         }
         .background(
             GeometryReader { proxy in
@@ -580,7 +583,6 @@ struct MessageComposerView: View {
         )
         .clipShape(composerSurfaceShape)
         .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.28 : 0.12), radius: 14, y: 6)
-        .animation(ChatMotion.composerChrome(reduceMotion: reduceMotion), value: isExpanded)
     }
 
     /// Card-state row under the surface: a scroller of secondary controls plus

--- a/HermesMobile/Features/Chat/ChatComposerVoiceControls.swift
+++ b/HermesMobile/Features/Chat/ChatComposerVoiceControls.swift
@@ -41,8 +41,7 @@ struct ComposerVoiceControlButton: View {
     var body: some View {
         Image(systemName: symbolName)
             .font(.system(size: 18, weight: .regular))
-            .frame(width: 28, height: 28)
-            .chatMinimumHitTarget(in: Circle())
+            .frame(width: 44, height: 44)
             .foregroundStyle(isListening || isRecordingVoiceNote ? Color.red : color)
             .scaleEffect(isRecordingVoiceNote ? 1.3 : 1)
             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isRecordingVoiceNote)

--- a/HermesMobile/Features/Chat/ChatScrollPolicy.swift
+++ b/HermesMobile/Features/Chat/ChatScrollPolicy.swift
@@ -45,10 +45,6 @@ enum ChatScrollPolicy {
     /// jitter from incoming tokens does not flash the scroll-to-bottom button.
     static let streamingBottomDetectionThreshold: CGFloat = 160
 
-    /// Extra distance past the bottom threshold required before the composer
-    /// chrome collapses into its compact "reading older" presentation.
-    static let readingOlderHysteresis: CGFloat = 64
-
     /// Strict bottom tolerance (pt) that re-arms follow when a gesture ends there.
     static let followReArmThreshold: CGFloat = 12
 
@@ -171,13 +167,6 @@ enum ChatScrollPolicy {
 
     static func isNearBottom(distanceFromBottom: CGFloat, isStreaming: Bool) -> Bool {
         distanceFromBottom <= bottomThreshold(isStreaming: isStreaming)
-    }
-
-    /// True once the user has scrolled far enough above the bottom that the
-    /// composer chrome should collapse. The hysteresis keeps the chrome stable
-    /// when hovering right around the bottom threshold.
-    static func shouldEnterReadingOlder(distanceFromBottom: CGFloat, isStreaming: Bool) -> Bool {
-        distanceFromBottom > bottomThreshold(isStreaming: isStreaming) + readingOlderHysteresis
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -295,7 +295,6 @@ struct ChatView: View {
     @State private var draftMessage = ""
     @State private var draftRevision = 0
     @State private var isScrolledNearBottom = true
-    @State private var isReadingOlderTranscript = false
     @State private var followLatch = ChatScrollPolicy.FollowLatch()
     @State private var followScrollGeneration = 0
     /// While true the transcript's bottom size-change anchor and follow-driven
@@ -409,7 +408,6 @@ struct ChatView: View {
             isWaitingForStream: viewModel.activeStreamID != nil,
             isCancellingStream: viewModel.isCancellingStream,
             readOnlyMessage: composerReadOnlyMessage,
-            isChromeCompact: isComposerChromeCompact,
             errorMessage: viewModel.sendErrorMessage,
             configurationErrorMessage: viewModel.composerConfigurationErrorMessage,
             contextWindowSnapshot: viewModel.contextWindowSnapshot,
@@ -1349,10 +1347,6 @@ struct ChatView: View {
         )
     }
 
-    private var isComposerChromeCompact: Bool {
-        isReadingOlderTranscript && !viewModel.messages.isEmpty
-    }
-
     private var transcriptBottomInsetHeight: CGFloat {
         max(96, composerHeight + 44 + composerAccessorySpacerHeight + clarificationFootprintHeight)
     }
@@ -1603,11 +1597,6 @@ struct ChatView: View {
 
     private func loadOlderMessages() async -> Bool {
         followLatch.isFollowing = false
-        if !isReadingOlderTranscript {
-            withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
-                isReadingOlderTranscript = true
-            }
-        }
 
         let didLoad = await viewModel.loadOlderMessages(modelContext: modelContext)
         if let lastError = viewModel.lastError {
@@ -2521,7 +2510,6 @@ struct ChatView: View {
             return
         }
 
-        isReadingOlderTranscript = false
         followScrollGeneration += 1
         let generation = followScrollGeneration
 
@@ -2659,33 +2647,10 @@ struct ChatView: View {
             movedAwayFromBottom: metrics.movedAwayFromBottom,
             wasNearBottom: wasNearBottom
         ))
-
-        if isNearBottom {
-            if isReadingOlderTranscript {
-                withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
-                    isReadingOlderTranscript = false
-                }
-            }
-        } else if metrics.isUserInteracting {
-            if !isReadingOlderTranscript,
-               ChatScrollPolicy.shouldEnterReadingOlder(
-                   distanceFromBottom: metrics.distanceFromBottom,
-                   isStreaming: isStreaming
-               ) {
-                withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
-                    isReadingOlderTranscript = true
-                }
-            }
-        }
     }
 
     private func prepareTranscriptForExplicitSend() {
         handleFollowEvent(.reset)
-        if isReadingOlderTranscript {
-            withAnimation(ChatMotion.quickState(reduceMotion: reduceMotion)) {
-                isReadingOlderTranscript = false
-            }
-        }
     }
 
     private func beginEditMessage(_ context: MessageActionContext) {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -284,9 +284,6 @@ struct SessionListView: View {
                     refreshSessions: refreshAfterReturningIfNeeded
                 )
             }
-            .refreshable {
-                await refreshSessionsAndActiveProfile()
-            }
             .modifier(
                 SessionActionConfirmations(
                     viewModel: viewModel,
@@ -534,6 +531,12 @@ struct SessionListView: View {
                 .accessibilityHidden(true)
         }
         .listStyle(.plain)
+        // On the List itself, not the navigation container: a refresh action
+        // set higher up is inherited by every ScrollView in pushed chats, which
+        // made the composer's attachment strip pullable.
+        .refreshable {
+            await refreshSessionsAndActiveProfile()
+        }
         // Let rows hug their content instead of the 44pt default minimum, so the
         // single-line utility/disclosure rows aren't padded out and stay aligned
         // with the tightly-packed navigation rows.

--- a/HermesMobile/Features/Workspace/GitBranchPickerView.swift
+++ b/HermesMobile/Features/Workspace/GitBranchPickerView.swift
@@ -19,27 +19,24 @@ struct GitBranchPickerButton: View {
             HapticButtonHaptics.tap(isEnabled: isHapticsEnabled)
             showsPicker = true
         } label: {
+            // Quiet inline control matching the composer toolbar row: no pill
+            // background, 44 pt tall for the hit target.
             HStack(spacing: 6) {
                 Image(systemName: "arrow.triangle.branch")
-                    .font(.system(size: 16, weight: .regular))
+                    .font(AppFont.subheadline())
                 Text(currentBranch)
                     .font(AppFont.subheadline())
                     .lineLimit(1)
                     .truncationMode(.middle)
+                Image(systemName: "chevron.down")
+                    .font(AppFont.caption2())
             }
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .adaptiveGlass(
-                .regular,
-                isInteractive: true,
-                fallbackMaterial: .ultraThinMaterial,
-                in: Capsule()
-            )
-            .clipShape(Capsule())
-            .chatMinimumHitTarget(in: Capsule())
+            .padding(.horizontal, 6)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.chatTactile(.compactControl))
         .disabled(isDisabled || isLoading || isSwitching)
         .accessibilityLabel("Current Git branch")
         .accessibilityValue(currentBranch)

--- a/HermesMobileTests/ChatScrollPolicyTests.swift
+++ b/HermesMobileTests/ChatScrollPolicyTests.swift
@@ -46,24 +46,6 @@ final class ChatScrollPolicyTests: XCTestCase {
         XCTAssertFalse(ChatScrollPolicy.isNearBottom(distanceFromBottom: 161, isStreaming: true))
     }
 
-    func testShouldEnterReadingOlderRequiresHysteresisPastThreshold() {
-        let threshold = ChatScrollPolicy.bottomThreshold(isStreaming: false)
-        let hysteresis = ChatScrollPolicy.readingOlderHysteresis
-
-        XCTAssertFalse(
-            ChatScrollPolicy.shouldEnterReadingOlder(
-                distanceFromBottom: threshold + hysteresis,
-                isStreaming: false
-            )
-        )
-        XCTAssertTrue(
-            ChatScrollPolicy.shouldEnterReadingOlder(
-                distanceFromBottom: threshold + hysteresis + 1,
-                isStreaming: false
-            )
-        )
-    }
-
     // MARK: Follow latch
 
     private typealias Latch = ChatScrollPolicy.FollowLatch

--- a/HermesMobileTests/ComposerToolbarScrollerTests.swift
+++ b/HermesMobileTests/ComposerToolbarScrollerTests.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import XCTest
+@testable import HermesMobile
+
+final class ComposerToolbarScrollerTests: XCTestCase {
+    func testNoFadesWhenContentFits() {
+        let fades = ComposerToolbarEdgeFades(offset: 0, contentWidth: 300, viewportWidth: 320)
+
+        XCTAssertFalse(fades.leading)
+        XCTAssertFalse(fades.trailing)
+    }
+
+    func testOnlyTrailingFadeAtStartOfOverflowingContent() {
+        let fades = ComposerToolbarEdgeFades(offset: 0, contentWidth: 500, viewportWidth: 320)
+
+        XCTAssertFalse(fades.leading)
+        XCTAssertTrue(fades.trailing)
+    }
+
+    func testBothFadesMidScroll() {
+        let fades = ComposerToolbarEdgeFades(offset: 90, contentWidth: 500, viewportWidth: 320)
+
+        XCTAssertTrue(fades.leading)
+        XCTAssertTrue(fades.trailing)
+    }
+
+    func testOnlyLeadingFadeAtEnd() {
+        let fades = ComposerToolbarEdgeFades(offset: 180, contentWidth: 500, viewportWidth: 320)
+
+        XCTAssertTrue(fades.leading)
+        XCTAssertFalse(fades.trailing)
+    }
+
+    func testEdgesWithinEpsilonCountAsReached() {
+        let nearStart = ComposerToolbarEdgeFades(offset: 3, contentWidth: 500, viewportWidth: 320)
+        let nearEnd = ComposerToolbarEdgeFades(offset: 177, contentWidth: 500, viewportWidth: 320)
+
+        XCTAssertFalse(nearStart.leading)
+        XCTAssertFalse(nearEnd.trailing)
+    }
+
+    func testRightToLeftFlipsRawOffset() {
+        // Raw offset 0 in RTL shows the visual start of the content (its right end),
+        // so only the trailing (left) edge hides anything.
+        let atStart = ComposerToolbarEdgeFades(
+            offset: 180, contentWidth: 500, viewportWidth: 320, layoutDirection: .rightToLeft
+        )
+        let atEnd = ComposerToolbarEdgeFades(
+            offset: 0, contentWidth: 500, viewportWidth: 320, layoutDirection: .rightToLeft
+        )
+
+        XCTAssertFalse(atStart.leading)
+        XCTAssertTrue(atStart.trailing)
+        XCTAssertTrue(atEnd.leading)
+        XCTAssertFalse(atEnd.trailing)
+    }
+
+    func testReasoningRendersStaticOnlyForOneSupportedEffort() {
+        XCTAssertEqual(ReasoningEffortOption.singleOption(forSupportedEfforts: ["high"])?.id, "high")
+        XCTAssertEqual(ReasoningEffortOption.singleOption(forSupportedEfforts: [" High ", "high"])?.id, "high")
+        XCTAssertNil(ReasoningEffortOption.singleOption(forSupportedEfforts: ["low", "high"]))
+        XCTAssertNil(ReasoningEffortOption.singleOption(forSupportedEfforts: nil))
+        XCTAssertNil(ReasoningEffortOption.singleOption(forSupportedEfforts: []))
+    }
+}


### PR DESCRIPTION
## Linked issue

No linked issue; approved maintainer work on the composer layout (follows #358).

## What changed

The composer was always a full card with a fixed control row inside it and a second always-on bar under it for workspace, profile, git, and the context meter. Model and reasoning were hard-clamped to ~130 and ~104 pt and truncated, big text sizes ran out of room, and the whole thing took a lot of screen while you were just reading.

Now the composer has two states.

- **Pill** (editor not focused): one capsule with the text, up to three inline attachment thumbnails plus a `+N` chip, the mic, and one trailing circle. The circle is Stop while a response streams and the draft is empty, and Send (which queues mid-run) as soon as there is text.
- **Card** (editor focused, or a composer sheet is up): radius-26 surface with the attachment strip inside above the editor, and a toolbar row under the card, above the keyboard. The row is a horizontal scroller holding add, model, reasoning, workspace, profile, git branch, mic, and the context meter, with an 18 pt fade only on an edge that hides content, plus the pinned Stop/Send circle.

Details:

- `ComposerToolbarScroller` owns the row: horizontal only, no bounce when it fits, taps never dismiss the keyboard, and `ComposerToolbarEdgeFades` is the pure fade rule (4 pt epsilon, RTL-aware).
- One `UITextView` in both states. In the pill it is invisible behind a one-line preview so focus and the draft survive the morph; the card editor runs 72 to 160 pt.
- Every circle and row control is 44 pt. Workspace, profile, and git branch become quiet inline controls to match model and reasoning. Reasoning with one server-supported effort and the profile in single-profile mode render as static labels.
- Surface, editor, row, and the feed inset all animate on `ChatMotion.composerChrome`; Reduce Motion snaps.
- Retired: the always-on secondary bar and the reading-older compact-chrome flag (`ChatScrollPolicy.shouldEnterReadingOlder` and its test go with it).
- The session list's `.refreshable` moves onto the `List`. On the navigation container it was inherited by every `ScrollView` in a pushed chat, which made the attachment strip and the new row pull-to-refresh and drag vertically.

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP `test_sim`: 1874 passed, 0 failed, 2 pre-existing integration skips.
- New `ComposerToolbarScrollerTests` cover the fade rule (fits, start, middle, end, epsilon, RTL) and the single-effort static rule.
- Simulator pass: pill renders; tapping morphs to the card with the row; the row scrolls horizontally with fades on the hidden edge; row menus open and the card stays open with the caret when they close; at an accessibility text size the row overflows and scrolls. Maintainer verified on device: attachments in both states, Stop/Send flip during a run, thumbnails no longer scroll vertically or pull-to-refresh.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (nothing crosses the wire)

---

Changes made by Claude Fable 5.1 through Claude Code.
