### PR TITLE
fix(chat): keep the composer toolbar row readable and behind the send button

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -314,6 +314,19 @@ struct MessageComposerView: View {
                     toolbarRow
                         .padding(.horizontal)
                         .padding(.top, 8)
+                        .frame(maxWidth: .infinity)
+                        // Solid chat background behind the controls: the card
+                        // above is glass on purpose, but transcript text
+                        // scrolling under the row made the pills unreadable.
+                        // Bleeds up into the gap under the card and down past
+                        // the keyboard gap and the bottom safe area, so no strip
+                        // of transcript shows around the row.
+                        .background(
+                            Color(.systemBackground)
+                                .padding(.top, -10)
+                                .padding(.bottom, -12)
+                                .ignoresSafeArea(edges: .bottom)
+                        )
                         .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
                 }
             }

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -699,10 +699,12 @@ struct MessageComposerView: View {
                 .font(.system(size: plusIconSize, weight: .medium))
                 .foregroundStyle(metaControlColor)
                 .frame(width: circleSize, height: circleSize)
+                // Inside the masked toolbar scroller, like the context ring.
                 .adaptiveGlass(
                     .regular,
                     isInteractive: true,
                     fallbackMaterial: .ultraThinMaterial,
+                    inheritsClipping: true,
                     in: Circle()
                 )
                 .clipShape(Circle())

--- a/HermesMobile/Features/Chat/ContextWindowIndicatorView.swift
+++ b/HermesMobile/Features/Chat/ContextWindowIndicatorView.swift
@@ -48,10 +48,13 @@ struct ContextWindowIndicatorView: View {
                     .foregroundStyle(presentation.isInteractive ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
             }
             .frame(width: ringSize, height: ringSize)
+            // Lives inside the masked toolbar scroller: glass would draw over
+            // the pinned Send button instead of fading behind it.
             .adaptiveGlass(
                 .regular,
                 isInteractive: presentation.isInteractive,
                 fallbackMaterial: .ultraThinMaterial,
+                inheritsClipping: true,
                 in: Circle()
             )
             .frame(width: tapTargetSize, height: tapTargetSize)

--- a/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
+++ b/HermesMobile/Features/Shared/AdaptiveGlassModifier.swift
@@ -140,6 +140,7 @@ private struct AdaptiveGlassModifier<S: Shape>: ViewModifier {
     let isInteractive: Bool
     let tint: Color?
     let fallbackMaterial: Material
+    let inheritsClipping: Bool
     let shape: S
 
     @ViewBuilder
@@ -160,7 +161,7 @@ private struct AdaptiveGlassModifier<S: Shape>: ViewModifier {
 
     private var resolvedSurface: AdaptiveGlassSurface {
         AdaptiveGlassSurface.resolve(
-            liquidGlassAvailable: GlassPreference.isLiquidGlassSupported,
+            liquidGlassAvailable: GlassPreference.isLiquidGlassSupported && !inheritsClipping,
             isGlassEnabled: isGlassEnabled,
             reduceTransparency: reduceTransparency
         )
@@ -283,11 +284,16 @@ private extension View {
 }
 
 extension View {
+    /// `inheritsClipping` keeps the surface on the material path even when
+    /// Liquid Glass is available. Glass is composited outside the SwiftUI
+    /// layer tree, so it ignores an ancestor's clip or mask and draws over
+    /// neighbouring views; controls inside a masked scroller need this.
     func adaptiveGlass(
         _ style: AdaptiveGlassStyle = .regular,
         isInteractive: Bool = false,
         tint: Color? = nil,
         fallbackMaterial: Material = .regularMaterial,
+        inheritsClipping: Bool = false,
         in shape: some Shape
     ) -> some View {
         modifier(AdaptiveGlassModifier(
@@ -295,6 +301,7 @@ extension View {
             isInteractive: isInteractive,
             tint: tint,
             fallbackMaterial: fallbackMaterial,
+            inheritsClipping: inheritsClipping,
             shape: shape
         ))
     }


### PR DESCRIPTION
## Linked issue

No issue. Two maintainer-reported defects found while testing #361 on device, fixed together because both are the card-state toolbar row.

## What changed

**Context ring drew over the Send button.** The ring and the plus button are the only toolbar items rendered with Liquid Glass. Glass is composited outside the SwiftUI layer tree, so it ignored the scroller's clip and its edge fade mask and sat on top of the pinned Send circle while every plain pill faded behind it. `adaptiveGlass` gains an `inheritsClipping` option that keeps a surface on the material path even when glass is available; the two controls inside the scroller use it. Reduce Transparency and the contrast stroke go through the same paths as before.

**Transcript text under the row made the pills unreadable.** The composer's existing material fade is translucent by design and the row had no surface of its own. The row now sits on a full-width fill in the chat background color that bleeds up into the gap under the card and down past the keyboard gap and the bottom safe area. The glass card above is unchanged.

## How it was tested

- Full XCTest suite via XcodeBuildMCP `test_sim` on iPhone 17 on the combined branch: 1878 passed, 0 failed, 2 skipped.
- Signed Debug build on the simulator: focused the composer, scrolled the transcript under the row, and scrolled the toolbar row; the pills stay readable and the ring fades at the edge.

Before/after: https://postplan.dev/d/d4y8ucs7z7qm/raw

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (nothing crosses the wire)

Implemented by Claude Fable 5.1 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)