### PR TITLE
refactor(settings): give Providers the #361 glyphs and list chrome

### DIFF
--- a/HermesMobile/Features/Settings/ProvidersView.swift
+++ b/HermesMobile/Features/Settings/ProvidersView.swift
@@ -4,11 +4,16 @@ import SwiftUI
 /// about, whether each has a credential (and where it came from), which one is
 /// active, and each provider's model catalog. Deliberately carries no write
 /// affordances — API-key set/delete stays a server-side operation.
+///
+/// Chrome matches the composer's model picker (#361): a plain `List` of
+/// provider disclosures, each labelled with the bundled provider glyph, the
+/// name, and the catalog count.
 struct ProvidersView: View {
     let server: URL
 
     @State private var viewModel: ProvidersViewModel
     @State private var expandedProviderKeys: Set<String> = []
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     init(server: URL) {
         self.server = server
@@ -16,70 +21,82 @@ struct ProvidersView: View {
     }
 
     var body: some View {
-        content
-            .navigationTitle("Providers")
-            .background(Color(.systemBackground))
-            .task {
-                await viewModel.load()
+        List {
+            if viewModel.providers.isEmpty {
+                statusRow
+                    .frame(maxWidth: .infinity)
+                    .containerRelativeFrame(.vertical)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+            } else {
+                if let errorMessage = viewModel.errorMessage {
+                    refreshFailureBanner(detail: errorMessage)
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 4, trailing: 16))
+                        .listRowSeparator(.hidden)
+                }
+
+                ForEach(Array(viewModel.providers.enumerated()), id: \.offset) { index, provider in
+                    let key = Self.expansionKey(for: provider, at: index)
+                    ProviderDisclosure(
+                        provider: provider,
+                        isActive: viewModel.isActive(provider),
+                        isExpanded: Binding(
+                            get: { expandedProviderKeys.contains(key) },
+                            set: { setExpanded($0, forKey: key) }
+                        )
+                    )
+                    .listRowInsets(EdgeInsets(top: 5, leading: 16, bottom: 5, trailing: 12))
+                    .listRowSeparator(.hidden)
+                }
+
+                Text("Provider keys are managed on the server. This screen is read-only.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 24, trailing: 16))
+                    .listRowSeparator(.hidden)
             }
-            .refreshable {
-                await viewModel.load()
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Color(.systemBackground))
+        .navigationTitle("Providers")
+        .task {
+            await viewModel.load()
+        }
+        .refreshable {
+            await viewModel.load()
+        }
+        .transaction { transaction in
+            if reduceMotion {
+                transaction.animation = nil
             }
+        }
     }
 
+    /// Loading, load-failure, and empty-catalog states. Rendered as a full-height
+    /// list row rather than an overlay so pull-to-refresh keeps working.
     @ViewBuilder
-    private var content: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                if viewModel.isLoading && viewModel.providers.isEmpty {
-                    ProvidersStatusRow(title: String(localized: "Loading providers…"), systemImage: "key.horizontal")
-                        .padding(.horizontal, 24)
-                } else if let errorMessage = viewModel.errorMessage, viewModel.providers.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        ProvidersStatusRow(title: String(localized: "Could not load providers"), systemImage: "exclamationmark.triangle")
-
-                        Text(errorMessage)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(3)
-
-                        Button("Try Again") {
-                            Task { await viewModel.load() }
-                        }
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.primary)
-                    }
-                    .padding(.horizontal, 24)
-                } else if viewModel.providers.isEmpty {
-                    ProvidersStatusRow(title: String(localized: "No providers reported by this server."), systemImage: "key.horizontal")
-                        .padding(.horizontal, 24)
-                } else {
-                    VStack(alignment: .leading, spacing: 10) {
-                        if let errorMessage = viewModel.errorMessage {
-                            refreshFailureBanner(detail: errorMessage)
-                        }
-
-                        ForEach(Array(viewModel.providers.enumerated()), id: \.offset) { index, provider in
-                            let key = Self.expansionKey(for: provider, at: index)
-                            ProviderRow(
-                                provider: provider,
-                                isActive: viewModel.isActive(provider),
-                                isExpanded: expandedProviderKeys.contains(key),
-                                toggleExpanded: { toggleExpanded(key) }
-                            )
-                        }
-
-                        Text("Provider keys are managed on the server. This screen is read-only.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .padding(.top, 6)
-                            .padding(.horizontal, 4)
-                    }
-                    .padding(.horizontal, 16)
+    private var statusRow: some View {
+        if viewModel.isLoading {
+            ContentUnavailableView {
+                ProgressView()
+            } description: {
+                Text("Loading providers…")
+            }
+        } else if let errorMessage = viewModel.errorMessage {
+            ContentUnavailableView {
+                Label("Could not load providers", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(verbatim: errorMessage)
+            } actions: {
+                Button("Try Again") {
+                    Task { await viewModel.load() }
                 }
             }
-            .padding(.top, 20)
-            .padding(.bottom, 44)
+        } else {
+            ContentUnavailableView {
+                Label("No providers reported by this server.", systemImage: "key.horizontal")
+            }
         }
     }
 
@@ -124,55 +141,63 @@ struct ProvidersView: View {
         return "#\(index)"
     }
 
-    private func toggleExpanded(_ key: String) {
-        withAnimation(.snappy(duration: 0.22)) {
-            if expandedProviderKeys.contains(key) {
-                expandedProviderKeys.remove(key)
-            } else {
-                expandedProviderKeys.insert(key)
-            }
+    private func setExpanded(_ isExpanded: Bool, forKey key: String) {
+        if isExpanded {
+            expandedProviderKeys.insert(key)
+        } else {
+            expandedProviderKeys.remove(key)
         }
     }
 }
 
-private struct ProviderRow: View {
+/// One provider: a disclosure whose label carries the glyph, name, catalog
+/// count, and credential state, and whose body lists the provider's models.
+/// A provider the server sent no models for renders the label alone.
+private struct ProviderDisclosure: View {
     let provider: ProviderSummary
     let isActive: Bool
-    let isExpanded: Bool
-    let toggleExpanded: () -> Void
+    @Binding var isExpanded: Bool
 
+    @ViewBuilder
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text(ProvidersViewModel.displayName(for: provider))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
+        if let models = provider.models, !models.isEmpty {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                modelList(models)
+            } label: {
+                header
+            }
+            .tint(Color(.secondaryLabel))
+            .accessibilityHint("Shows this provider's model list.")
+        } else {
+            header
+        }
+    }
 
-                if isActive {
-                    Text("Active")
-                        .font(.caption2.weight(.semibold))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(Capsule().fill(Color.green.opacity(0.16)))
-                        .foregroundStyle(.green)
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                if ProviderGlyphKind.resolve(providerID: provider.id) != nil {
+                    ProviderGlyph(providerID: provider.id)
+                        .frame(width: 17, height: 17)
+                }
+
+                Text(ProvidersViewModel.displayName(for: provider))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .textCase(.uppercase)
+
+                if let count = ProvidersViewModel.modelCountLabel(for: provider) {
+                    Text(verbatim: count)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel(modelCountAccessibilityLabel)
                 }
 
                 Spacer(minLength: 0)
-
-                if let badge = ProvidersViewModel.keySourceBadge(for: provider) {
-                    // Technical token (env / OAuth / config) — deliberately not localized.
-                    Text(verbatim: badge)
-                        .font(.caption2.weight(.medium))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(Capsule().fill(Color(.tertiarySystemFill)))
-                        .foregroundStyle(.secondary)
-                }
             }
 
-            keyStatusLine
+            statusLine
 
             if let authError = ProvidersViewModel.authErrorText(for: provider) {
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
@@ -189,78 +214,93 @@ private struct ProviderRow: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(Text("Authentication error: \(authError)"))
             }
-
-            if let models = provider.models, !models.isEmpty {
-                modelsDisclosure(models)
-            }
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color(.secondarySystemBackground))
-        )
+        .padding(.vertical, 7)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
     }
 
+    /// Key status on the leading edge, the Active and key-source badges trailing.
+    /// The badges keep their intrinsic width so the status text wraps first.
     @ViewBuilder
-    private var keyStatusLine: some View {
-        if let hasKey = provider.hasKey {
+    private var statusLine: some View {
+        let badge = ProvidersViewModel.keySourceBadge(for: provider)
+
+        if provider.hasKey != nil || isActive || badge != nil {
             HStack(spacing: 6) {
-                Image(systemName: hasKey ? "checkmark.seal.fill" : "key.slash")
-                    .font(.caption)
-                    .foregroundStyle(hasKey ? Color.green : Color.secondary)
-                    .accessibilityHidden(true)
-
-                Text(hasKey ? "Key configured" : "No key")
-                    .font(.footnote)
-                    .foregroundStyle(hasKey ? Color.primary : Color.secondary)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func modelsDisclosure(_ models: [ProviderModel]) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Button(action: toggleExpanded) {
-                HStack(spacing: 6) {
-                    Image(systemName: "chevron.right")
-                        .font(.caption2.weight(.semibold))
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                if let hasKey = provider.hasKey {
+                    Image(systemName: hasKey ? "checkmark.seal.fill" : "key.slash")
+                        .font(.caption)
+                        .foregroundStyle(hasKey ? Color.green : Color.secondary)
                         .accessibilityHidden(true)
 
-                    Text("Models (\(ProvidersViewModel.modelCount(for: provider)))")
-                        .font(.footnote.weight(.medium))
+                    Text(hasKey ? "Key configured" : "No key")
+                        .font(.footnote)
+                        .foregroundStyle(hasKey ? Color.primary : Color.secondary)
+                        .multilineTextAlignment(.leading)
                 }
-                .foregroundStyle(.secondary)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityHint("Shows this provider's model list.")
 
-            if isExpanded {
-                VStack(alignment: .leading, spacing: 4) {
-                    ForEach(Array(models.enumerated()), id: \.offset) { _, model in
-                        if let title = modelTitle(model) {
-                            Text(verbatim: title)
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-                    }
+                Spacer(minLength: 0)
 
-                    if let info = ProvidersViewModel.truncatedModelInfo(for: provider) {
-                        Text("Showing \(info.shown) of \(info.total) models")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .padding(.top, 2)
-                    }
+                if isActive {
+                    Text("Active")
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color.green.opacity(0.16)))
+                        .foregroundStyle(.green)
+                        .layoutPriority(1)
                 }
-                .padding(.leading, 18)
+
+                if let badge {
+                    // Technical token (env / OAuth / config) — deliberately not localized.
+                    Text(verbatim: badge)
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color(.tertiarySystemFill)))
+                        .foregroundStyle(.secondary)
+                        .layoutPriority(1)
+                }
             }
         }
     }
 
-    private func modelTitle(_ model: ProviderModel) -> String? {
+    /// Model rows reuse the picker's row geometry so a provider's catalog reads
+    /// the same on both screens. Entries without a label or id are skipped.
+    private func modelList(_ models: [ProviderModel]) -> some View {
+        let titles = models.enumerated().compactMap { index, model in
+            Self.modelTitle(model).map { (index: index, title: $0) }
+        }
+
+        return VStack(spacing: 1) {
+            Divider()
+                .padding(.leading, 10)
+
+            LazyVStack(spacing: 1) {
+                ForEach(titles, id: \.index) { entry in
+                    Text(verbatim: entry.title)
+                        .font(.body)
+                        .lineLimit(2)
+                        .padding(.horizontal, 12)
+                        .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+                }
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    /// "Showing X of Y models" when the server trimmed the catalog, otherwise the
+    /// plain count — the visible label is compact, so VoiceOver gets the words.
+    private var modelCountAccessibilityLabel: Text {
+        if let info = ProvidersViewModel.truncatedModelInfo(for: provider) {
+            return Text("Showing \(info.shown) of \(info.total) models")
+        }
+
+        return Text("Models (\(ProvidersViewModel.modelCount(for: provider)))")
+    }
+
+    private static func modelTitle(_ model: ProviderModel) -> String? {
         let label = model.label?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let label, !label.isEmpty {
             return label
@@ -272,28 +312,5 @@ private struct ProviderRow: View {
         }
 
         return nil
-    }
-}
-
-private struct ProvidersStatusRow: View {
-    let title: String
-    let systemImage: String
-
-    var body: some View {
-        HStack(spacing: 14) {
-            Image(systemName: systemImage)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .frame(width: 24)
-                .accessibilityHidden(true)
-
-            Text(title)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-
-            Spacer(minLength: 0)
-        }
-        .frame(minHeight: 42)
     }
 }

--- a/HermesMobile/Features/Settings/ProvidersViewModel.swift
+++ b/HermesMobile/Features/Settings/ProvidersViewModel.swift
@@ -129,6 +129,18 @@ final class ProvidersViewModel {
         max(provider.modelsTotal ?? 0, provider.models?.count ?? 0)
     }
 
+    /// Compact catalog count for a provider's disclosure, following the model
+    /// picker's convention: `shown / total` when the server trimmed the list,
+    /// the plain count otherwise. `nil` when the provider reports no models.
+    static func modelCountLabel(for provider: ProviderSummary) -> String? {
+        if let info = truncatedModelInfo(for: provider) {
+            return "\(info.shown.formatted()) / \(info.total.formatted())"
+        }
+
+        let count = modelCount(for: provider)
+        return count > 0 ? count.formatted() : nil
+    }
+
     /// Non-nil only when the server trimmed the model list (`models_total` exceeds
     /// the entries actually sent) — drives the "Showing X of Y models" footer.
     static func truncatedModelInfo(for provider: ProviderSummary) -> (shown: Int, total: Int)? {

--- a/HermesMobileTests/ProvidersViewModelTests.swift
+++ b/HermesMobileTests/ProvidersViewModelTests.swift
@@ -234,6 +234,44 @@ final class ProvidersViewModelTests: APIClientTestCase {
         XCTAssertEqual(ProvidersViewModel.modelCount(for: bare), 0)
         XCTAssertNil(ProvidersViewModel.truncatedModelInfo(for: bare))
     }
+
+    /// The disclosure count follows the model picker: `shown / total` only when
+    /// the server trimmed the catalog, a plain count otherwise.
+    @MainActor
+    func testModelCountLabelShowsShownOverTotalOnlyWhenTrimmed() {
+        let trimmed = ProviderSummary(
+            id: "nous",
+            models: [ProviderModel(id: "a"), ProviderModel(id: "b")],
+            modelsTotal: 396
+        )
+        XCTAssertEqual(ProvidersViewModel.modelCountLabel(for: trimmed), "2 / 396")
+
+        let complete = ProviderSummary(
+            id: "openai",
+            models: [ProviderModel(id: "a"), ProviderModel(id: "b")],
+            modelsTotal: 2
+        )
+        XCTAssertEqual(ProvidersViewModel.modelCountLabel(for: complete), "2")
+
+        // A total with nothing visible is not a trim — advertise the total alone.
+        let hidden = ProviderSummary(id: "p", models: [], modelsTotal: 4)
+        XCTAssertEqual(ProvidersViewModel.modelCountLabel(for: hidden), "4")
+
+        // No catalog at all reserves no count slot.
+        XCTAssertNil(ProvidersViewModel.modelCountLabel(for: ProviderSummary(id: "p")))
+    }
+
+    /// The Providers rows only reserve a glyph slot when the provider id resolves,
+    /// matching #361's "unknown providers render nothing" rule.
+    @MainActor
+    func testProviderGlyphResolutionSkipsUnknownAndMissingIDs() {
+        XCTAssertEqual(ProviderGlyphKind.resolve(providerID: "anthropic"), .anthropic)
+        XCTAssertEqual(ProviderGlyphKind.resolve(providerID: " OpenAI-Codex "), .openAI)
+        XCTAssertNil(ProviderGlyphKind.resolve(providerID: nil))
+        XCTAssertNil(ProviderGlyphKind.resolve(providerID: "   "))
+        XCTAssertNil(ProviderGlyphKind.resolve(providerID: "huggingface"))
+        XCTAssertNil(ProviderGlyphKind.resolve(providerID: "custom:glmcode"))
+    }
 }
 
 /// URLProtocol whose responses are completed manually by the test, so two


### PR DESCRIPTION
## Linked issue

Fixes #368

## What changed

Settings › Providers is the one screen in the app whose entire subject is
providers, and it was the only one showing no provider glyphs — still on the
pre-#361 card chrome while the composer had moved on.

It is now a plain `List` of provider disclosures. Each label carries the
bundled `ProviderGlyph`, the uppercased provider name, and the catalog count
in the model picker's header geometry; the expanded body lists the provider's
models at `.body` in the picker's row geometry, so a provider's catalog reads
the same on both screens. The count follows the picker's convention —
`shown / total` only when the server trimmed the list, a plain count otherwise
— via a new `ProvidersViewModel.modelCountLabel`, which replaces the separate
"Showing X of Y models" footer. Loading, load-failure, and empty states become
`ContentUnavailableView`, rendered as a full-height list row rather than an
overlay so pull-to-refresh keeps working when the list is empty.

One real fix rides along: the old chevron's `rotationEffect` animated
unconditionally. The screen now carries #361's `transaction` guard, so
expanding a provider does not animate under Reduce Motion.

Everything the restyle had to preserve is preserved: the screen is still
read-only (#26) with the "managed on the server" footer, the Active badge, the
key-source token, the key-status line and the auth-error line all survive,
expansion is still keyed by the provider's stable id so a refresh that reorders
active-first keeps the right rows open, and a failed pull-to-refresh still
banners above the cached rows.

No new localized strings — the new labels reuse existing catalog keys.

## How it was tested

Full XCTest suite via XcodeBuildMCP `test_sim` (scheme `HermesMobile`, sim
iPhone 17) on `5df0ff0`: **1879 passed, 0 failed, 2 skipped**. The existing
`ProvidersViewModel` tests (`displayName`, `keySourceBadge`, `authErrorText`,
`modelCount`, `truncatedModelInfo`, `expansionKey`) pass unchanged.

Two new tests in `ProvidersViewModelTests`:

- `testModelCountLabelShowsShownOverTotalOnlyWhenTrimmed` — `2 / 396` when the
  server trims, `2` when it does not, `nil` when the provider reports no models.
- `testProviderGlyphResolutionSkipsUnknownAndMissingIDs` — nil for a nil, blank,
  or unrecognized provider id, so no glyph slot is reserved.

No before/after images here: this screen needs a configured server and a login,
so the visual pass belongs to the maintainer's simulator run against a real
server (the issue is labelled `needs-manual-validation`).

## Owner checks

1. Settings › Providers against a real server: glyphs on the providers that have
   assets, nothing on the ones that do not, no layout gap either way.
2. Expand a provider, pull to refresh, confirm it is still expanded after the
   server reorders active-first.
3. Kill the server mid-refresh: the failure banner appears above the cached rows.
4. A provider with an auth error and one with no key both read correctly.
5. Reduce Motion on: expanding a provider does not animate.
6. Dynamic Type, VoiceOver on a row, light and dark.
7. Two configured servers: switch and confirm the list follows the active server.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly — no model changes
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes — no wire changes

---

Implemented by Claude Opus 5 (1M context) in Claude Code.
