### PR TITLE
refactor(settings): match the Default Profile sheet to the shared model picker

### DIFF
--- a/HermesMobile/Features/Settings/DefaultProfilePickerView.swift
+++ b/HermesMobile/Features/Settings/DefaultProfilePickerView.swift
@@ -13,6 +13,7 @@ struct DefaultProfilePickerView: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var isLoading = false
     @State private var profiles: [ProfileSummary] = []
@@ -27,29 +28,42 @@ struct DefaultProfilePickerView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(spacing: 24) {
-                    ProfilePickerSearchField(text: $searchText)
-
-                    if let saveError {
-                        Text(saveError)
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    profileListContent
-
-                    // The server 403s profile creation in single-profile mode,
-                    // so the affordance is hidden there (#24).
-                    if !isSingleProfileMode {
-                        newProfileButton
-                    }
+            List {
+                if let saveError {
+                    Text(verbatim: saveError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 0, trailing: 12))
+                        .listRowSeparator(.hidden)
                 }
-                .padding()
+
+                ForEach(filteredProfiles, id: \.self) { profile in
+                    profileRow(profile)
+                        .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 12))
+                        .listRowSeparator(.hidden)
+                }
+
+                // The server 403s profile creation in single-profile mode,
+                // so the affordance is hidden there (#24).
+                if !isSingleProfileMode {
+                    newProfileRow
+                        .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 8, trailing: 12))
+                        .listRowSeparator(.hidden)
+                }
+
+                statusPlaceholder
+                    .listRowSeparator(.hidden)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
             .navigationTitle("Default Profile")
             .navigationBarTitleDisplayMode(.inline)
+            .searchable(
+                text: $searchText,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Search profiles"
+            )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
@@ -72,136 +86,146 @@ struct DefaultProfilePickerView: View {
             }
         }
         .adaptiveFormPresentation()
+        .transaction { transaction in
+            if reduceMotion {
+                transaction.animation = nil
+            }
+        }
     }
 
-    private var newProfileButton: some View {
+    /// Loading, load-failure, empty, and no-match states. Each only stands in
+    /// for an empty list, so an already-loaded list keeps rendering across a
+    /// refresh.
+    @ViewBuilder
+    private var statusPlaceholder: some View {
+        if profiles.isEmpty, isLoading {
+            ContentUnavailableView {
+                ProgressView()
+            } description: {
+                Text("Loading profiles...")
+            }
+        } else if profiles.isEmpty, let errorMessage {
+            ContentUnavailableView {
+                Label("Could Not Load Profiles", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(verbatim: errorMessage)
+            }
+        } else if filteredProfiles.isEmpty, !trimmedSearchQuery.isEmpty {
+            ContentUnavailableView.search(text: searchText)
+        } else if profiles.isEmpty {
+            ContentUnavailableView("No profiles available", systemImage: "person.crop.circle")
+        }
+    }
+
+    /// "New Profile" is the last row of the list, on the shared picker's row
+    /// geometry, so it reads as part of the list rather than as its own card.
+    /// It keeps the entry chrome rather than the filled pill: a second filled
+    /// pill would compete with the selected profile.
+    private var newProfileRow: some View {
         Button {
             showsCreateProfile = true
         } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "plus.circle")
-                    .font(.subheadline)
-                    .accessibilityHidden(true)
-
-                Text("New Profile")
-                    .font(.subheadline.weight(.medium))
-
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .frame(minHeight: 44)
-            .contentShape(Rectangle())
+            Label("New Profile", systemImage: "plus")
+                .font(.body.weight(.semibold))
+                .frame(maxWidth: .infinity, minHeight: PickerRowMetrics.minHeight, alignment: .leading)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(Color.accentColor)
-        .background(Color(.tertiarySystemFill).opacity(0.5), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .disabled(isLoading)
+        .foregroundStyle(Color.primary)
+        .padding(.horizontal, 12)
+        .background(
+            Color(.tertiarySystemFill),
+            in: RoundedRectangle(cornerRadius: PickerRowMetrics.cornerRadius, style: .continuous)
+        )
+        .disabled(isLoading || isSaving)
         .accessibilityHint("Opens the new profile form.")
     }
 
-    @ViewBuilder
-    private var profileListContent: some View {
-        if isLoading && profiles.isEmpty {
-            ProfilePickerCard(title: String(localized: "Profiles")) {
-                HStack(spacing: 8) {
-                    ProgressView()
-                    Text("Loading profiles...")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-        } else if let errorMessage, profiles.isEmpty {
-            ProfilePickerCard(title: String(localized: "Profiles")) {
-                Label("Could Not Load Profiles", systemImage: "exclamationmark.triangle")
-                    .font(.subheadline.weight(.semibold))
-
-                Text(errorMessage)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        } else if filteredProfiles.isEmpty {
-            ProfilePickerCard(title: String(localized: "Profiles")) {
-                Label("No Matching Profiles", systemImage: "magnifyingglass")
-                    .font(.subheadline.weight(.semibold))
-
-                Text("Try a different profile name.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        } else {
-            ProfilePickerCard(title: String(localized: "Profiles")) {
-                VStack(spacing: 0) {
-                    ForEach(Array(filteredProfiles.enumerated()), id: \.element) { index, profile in
-                        profileRow(profile)
-
-                        if index < filteredProfiles.count - 1 {
-                            Divider()
-                        }
-                    }
-                }
-            }
-        }
+    private var trimmedSearchQuery: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private var filteredProfiles: [ProfileSummary] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        Self.filteredProfiles(profiles, query: trimmedSearchQuery)
+    }
+
+    /// `profiles` narrowed to `query`. Static so tests can pin the predicate
+    /// without driving SwiftUI.
+    static func filteredProfiles(_ profiles: [ProfileSummary], query: String) -> [ProfileSummary] {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return profiles }
 
-        return profiles.filter { profile in
-            profile.displayName.lowercased().contains(query)
-                || (profile.normalizedName?.lowercased().contains(query) ?? false)
-                || (profile.model?.lowercased().contains(query) ?? false)
-                || (profile.provider?.lowercased().contains(query) ?? false)
-        }
+        return profiles.filter { matches($0, query: query) }
+    }
+
+    /// A profile is findable by every string the row can show: the name the
+    /// picker prints, the name it saves, its model, and its provider.
+    static func matches(_ profile: ProfileSummary, query: String) -> Bool {
+        profile.displayName.localizedCaseInsensitiveContains(query)
+            || (profile.normalizedName?.localizedCaseInsensitiveContains(query) ?? false)
+            || (profile.model?.localizedCaseInsensitiveContains(query) ?? false)
+            || (profile.provider?.localizedCaseInsensitiveContains(query) ?? false)
     }
 
     private func profileRow(_ profile: ProfileSummary) -> some View {
-        Button {
+        let selected = isSelected(profile)
+        let inFlight = isSaving && selectedProfileName == profile.normalizedName
+
+        return Button {
             Task { await save(profile) }
         } label: {
             HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 5) {
+                // Same rule as the model picker: an unknown provider renders
+                // nothing at all rather than reserving an empty glyph slot.
+                if ProviderGlyphKind.resolve(providerID: profile.provider) != nil {
+                    ProviderGlyph(providerID: profile.provider)
+                        .frame(width: 17, height: 17)
+                }
+
+                VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 6) {
                         Text(profile.displayName)
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(.primary)
+                            .font(.body)
                             .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
 
-                        if isSelected(profile) {
-                            ProfileStatusBadge(title: String(localized: "Selected"))
+                        if selected {
+                            ProfileStatusBadge(title: String(localized: "Selected"), isInverted: true)
                         } else if profile.isDefault == true {
-                            ProfileStatusBadge(title: String(localized: "Server Default"))
+                            ProfileStatusBadge(title: String(localized: "Server Default"), isInverted: false)
                         }
                     }
 
                     if let details = profileDetails(profile) {
                         Text(details)
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(
+                                selected ? Color(.systemBackground).opacity(0.7) : Color.secondary
+                            )
                             .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
                     }
                 }
 
-                Spacer(minLength: 12)
+                Spacer(minLength: 0)
 
-                if isSaving && selectedProfileName == profile.normalizedName {
+                if inFlight {
                     ProgressView()
-                } else if isSelected(profile) {
+                        .controlSize(.small)
+                        .tint(selected ? Color(.systemBackground) : Color.primary)
+                } else if selected {
                     Image(systemName: "checkmark")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.accentColor)
+                        .font(.body.weight(.semibold))
                         .accessibilityHidden(true)
                 }
             }
-            .padding(.vertical, 9)
-            .frame(minHeight: 44)
+            .frame(maxWidth: .infinity, minHeight: PickerRowMetrics.minHeight, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .pickerSelectionPill(isSelected: selected)
         .disabled(isSaving || profile.normalizedName == nil)
         .accessibilityLabel(profileAccessibilityLabel(for: profile))
         .accessibilityValue(profileAccessibilityValue(for: profile))
+        .accessibilityAddTraits(selected ? .isSelected : [])
     }
 
     private func profileAccessibilityLabel(for profile: ProfileSummary) -> String {
@@ -494,74 +518,23 @@ private struct CreateProfileSheet: View {
     }
 }
 
-private struct ProfilePickerSearchField: View {
-    @Binding var text: String
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "magnifyingglass")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-
-            TextField("Search profiles", text: $text)
-                .font(.subheadline)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-
-            if !text.isEmpty {
-                Button {
-                    text = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Clear profile search")
-            }
-        }
-        .padding(.horizontal, 12)
-        .frame(minHeight: 44)
-        .background(Color(.tertiarySystemFill).opacity(0.5), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-    }
-}
-
-private struct ProfilePickerCard<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                .textCase(.uppercase)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 4)
-                .padding(.bottom, 8)
-
-            VStack(alignment: .leading, spacing: 12) {
-                content
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(.tertiarySystemFill).opacity(0.5), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        }
-    }
-}
-
+/// "Selected" and "Server Default" are different facts — the current default
+/// versus what the server would pick on its own — so the row shows both. On
+/// the filled selection pill the accent capsule stops reading, so the badge
+/// inverts onto the pill instead.
 private struct ProfileStatusBadge: View {
     let title: String
+    let isInverted: Bool
 
     var body: some View {
         Text(title)
             .font(.caption2.weight(.semibold))
-            .foregroundStyle(Color.accentColor)
+            .foregroundStyle(isInverted ? Color(.systemBackground) : Color.accentColor)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
-            .background(Color.accentColor.opacity(0.12), in: Capsule(style: .continuous))
+            .background(
+                isInverted ? Color(.systemBackground).opacity(0.22) : Color.accentColor.opacity(0.12),
+                in: Capsule(style: .continuous)
+            )
     }
 }

--- a/HermesMobile/Features/Shared/ModelPickerSheet.swift
+++ b/HermesMobile/Features/Shared/ModelPickerSheet.swift
@@ -204,10 +204,10 @@ struct ModelPickerSheet: View {
                 }
                 .foregroundStyle(customEntryForeground)
                 .padding(.horizontal, 12)
-                .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+                .frame(maxWidth: .infinity, minHeight: PickerRowMetrics.minHeight, alignment: .leading)
                 .background(
                     customOption == nil ? Color.clear : Color.primary,
-                    in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    in: RoundedRectangle(cornerRadius: PickerRowMetrics.cornerRadius, style: .continuous)
                 )
                 .disabled(customOption == nil || isSelectionDisabled)
                 .padding(.top, 2)
@@ -366,7 +366,7 @@ struct ModelPickerSheet: View {
                             .accessibilityHidden(true)
                     }
                 }
-                .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+                .frame(maxWidth: .infinity, minHeight: PickerRowMetrics.minHeight, alignment: .leading)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -383,12 +383,7 @@ struct ModelPickerSheet: View {
                 onToggleFavorite(option)
             }
         }
-        .foregroundStyle(selected ? Color(.systemBackground) : Color.primary)
-        .padding(.horizontal, 12)
-        .background(
-            selected ? Color.primary : Color.clear,
-            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-        )
+        .pickerSelectionPill(isSelected: selected)
         .contextMenu {
             Button {
                 onToggleFavorite(option)
@@ -675,7 +670,34 @@ private struct CustomModelFieldStyle: ViewModifier {
         content
             .font(.body)
             .padding(.horizontal, 12)
-            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
-            .background(Color(.tertiarySystemFill), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .frame(maxWidth: .infinity, minHeight: PickerRowMetrics.minHeight, alignment: .leading)
+            .background(
+                Color(.tertiarySystemFill),
+                in: RoundedRectangle(cornerRadius: PickerRowMetrics.cornerRadius, style: .continuous)
+            )
+    }
+}
+
+/// Row geometry shared by every picker row in Settings, so Default Model and
+/// Default Profile stay visually identical: the model rows and custom entry
+/// here, and the profile rows in `DefaultProfilePickerView`.
+enum PickerRowMetrics {
+    static let minHeight: CGFloat = 48
+    static let cornerRadius: CGFloat = 12
+}
+
+extension View {
+    /// The selected-row treatment shared by the model rows and the profile
+    /// rows: a filled `Color.primary` pill with the inverted foreground that
+    /// fill needs. The caller owns the row's frame, because the pill can wrap
+    /// content that sits outside the row's own button — the model rows'
+    /// favorite star does.
+    func pickerSelectionPill(isSelected: Bool) -> some View {
+        foregroundStyle(isSelected ? Color(.systemBackground) : Color.primary)
+            .padding(.horizontal, 12)
+            .background(
+                isSelected ? Color.primary : Color.clear,
+                in: RoundedRectangle(cornerRadius: PickerRowMetrics.cornerRadius, style: .continuous)
+            )
     }
 }

--- a/HermesMobileTests/APIClientConfigurationTests.swift
+++ b/HermesMobileTests/APIClientConfigurationTests.swift
@@ -706,6 +706,56 @@ final class APIClientConfigurationTests: APIClientTestCase {
         XCTAssertFalse(DefaultProfilePickerView.isCancellationError(APIError.unauthorized))
     }
 
+    func testProfilePickerSearchMatchesNameModelAndProvider() {
+        let profiles = [
+            ProfileSummary(
+                name: "default",
+                path: nil,
+                isDefault: true,
+                isActive: true,
+                gatewayRunning: nil,
+                model: "gpt-5.4",
+                provider: "openai",
+                hasEnv: nil,
+                skillCount: nil
+            ),
+            ProfileSummary(
+                name: "research",
+                path: nil,
+                isDefault: false,
+                isActive: false,
+                gatewayRunning: nil,
+                model: "claude-opus-5",
+                provider: "anthropic",
+                hasEnv: nil,
+                skillCount: 3
+            )
+        ]
+
+        func names(_ query: String) -> [String?] {
+            DefaultProfilePickerView.filteredProfiles(profiles, query: query).map(\.name)
+        }
+
+        // "default" is the one profile whose display name differs from its
+        // saved name, so both spellings have to find it.
+        XCTAssertEqual(names("Default"), ["default"])
+        XCTAssertEqual(names("defau"), ["default"])
+        XCTAssertEqual(names("research"), ["research"])
+        XCTAssertEqual(names("OPUS"), ["research"])
+        XCTAssertEqual(names("anthropic"), ["research"])
+        XCTAssertEqual(names("  "), ["default", "research"])
+        XCTAssertEqual(names("nonesuch"), [])
+    }
+
+    func testProfileRowGlyphResolvesOnlyForKnownProviders() {
+        XCTAssertNotNil(ProviderGlyphKind.resolve(providerID: "anthropic"))
+        XCTAssertNotNil(ProviderGlyphKind.resolve(providerID: "OpenAI"))
+        // A nil or unrecognized provider renders no glyph at all, so the
+        // profile row reserves no leading slot for it.
+        XCTAssertNil(ProviderGlyphKind.resolve(providerID: nil))
+        XCTAssertNil(ProviderGlyphKind.resolve(providerID: "acme-internal"))
+    }
+
     func testProfileNameRulesMirrorUpstreamPattern() {
         XCTAssertTrue(ProfileNameRules.isValid("work"))
         XCTAssertTrue(ProfileNameRules.isValid("a"))


### PR DESCRIPTION
## Linked issue

Fixes #367

## What changed

Settings > Default Profile still wore the pre-#361 look — grey cards, a hand-rolled search field, no provider glyphs — while Default Model right above it picked up the shared picker in #366. The two adjacent sheets read as two different apps.

The profile sheet is now a plain `List` with nav-bar `.searchable`, 48pt body-text rows, a leading provider glyph resolved from `profile.provider`, and the filled `Color.primary` pill for the current default. An unknown provider renders nothing at all rather than reserving an empty slot — the same rule as #361. "New Profile" is the last row of the list instead of its own rounded card, and loading, load-failure, no-match, and empty are `ContentUnavailableView`s.

Rather than making a third copy of the row geometry, `PickerRowMetrics` (48pt height, 12pt radius) and `pickerSelectionPill(isSelected:)` move out of `ModelPickerSheet` and both sheets use them. That extraction changes no values — the model rows render exactly as they did on `master`.

Two details that had to survive the restyle:

- **The badges mean different things.** "Selected" is the current default; "Server Default" is what the server would pick on its own. Both stay. On the filled pill an accent capsule stops reading, so the badge and the details line invert onto the pill.
- **New Profile keeps entry chrome, not the pill.** The shared picker's custom-entry action fills with `Color.primary` when it is armed, but so does the selected profile. Two filled pills in one short list would compete, so New Profile takes the same 48pt/12pt geometry with the tertiary fill.

Unchanged: the in-flight spinner keyed by `normalizedName`, dismiss-only-on-confirmation, inline `saveError` with the sheet still open, single-profile mode hiding creation (#24), `isCancellationError` swallowing a cancelled `.task`, nil-`normalizedName` rows staying disabled, and `CreateProfileSheet`'s optimistic append plus reconciling refetch.

The empty state reuses the already-localized "No profiles available" string the composer uses, so the String Catalog needed no new keys.

## How it was tested

Full XCTest suite via XcodeBuildMCP `test_sim` (scheme `HermesMobile`, sim iPhone 17) on `4cb9949`: **1892 passed, 0 failed, 2 skipped**.

New focused coverage in `APIClientConfigurationTests`:

- `testProfilePickerSearchMatchesNameModelAndProvider` — the search predicate still matches display name, normalized name, model, and provider, and a whitespace-only query is not a filter.
- `testProfileRowGlyphResolvesOnlyForKnownProviders` — resolution returns nil for a nil or unrecognized provider, so no glyph slot is reserved.

`testProfilePickerCancellationErrorDetection` passes unchanged.

Manual simulator pass on a signed Debug build (`build_run_sim`), run by the maintainer: both Settings sheets side by side, glyph presence and absence, spinner on the tapped row only, save failure keeping the sheet open, both badges in light and dark, nav-bar search by name/model/provider, profile creation, single-profile mode, Reduce Motion, accessibility text sizes, VoiceOver, and a two-server switch.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly — no model changed
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes — no wire contract touched

---

Written by Claude Opus 5 (1M context) in Claude Code.