### PR TITLE
feat(sessions): show why a search result matched

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BC /* APIClientTests.swift */; };
 		C0FF000000000000000000C1 /* CustomHeaderInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF000000000000000000C2 /* CustomHeaderInjectionTests.swift */; };
 		C03910000000000000000001 /* APIClientSessionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000001 /* APIClientSessionListTests.swift */; };
+		B23000000000000000000003 /* SessionSearchExcerptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23000000000000000000004 /* SessionSearchExcerptTests.swift */; };
 		C03910000000000000000002 /* APIClientInsightsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000002 /* APIClientInsightsTests.swift */; };
 		C03910000000000000000017 /* APIClientUpdatesCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000017 /* APIClientUpdatesCheckTests.swift */; };
 		C03910000000000000000018 /* APIClientUpdatesApplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000018 /* APIClientUpdatesApplyTests.swift */; };
@@ -121,6 +122,7 @@
 		C05100000000000000000003 /* ChatGoalControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000013 /* ChatGoalControls.swift */; };
 		C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */; };
 		1A2B3C4D5E6F7000000000D0 /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */; };
+		B23000000000000000000001 /* SessionSearchExcerpt.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23000000000000000000002 /* SessionSearchExcerpt.swift */; };
 		1A2B3C4D5E6F7000000000D1 /* SessionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */; };
 		A04300000000000000000001 /* SessionListComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04300000000000000000011 /* SessionListComponents.swift */; };
 		A10900000000000000000001 /* SessionNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000011 /* SessionNavigationState.swift */; };
@@ -439,6 +441,7 @@
 		1A2B3C4D5E6F7000000000BC /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		C0FF000000000000000000C2 /* CustomHeaderInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeaderInjectionTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000001 /* APIClientSessionListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSessionListTests.swift; sourceTree = "<group>"; };
+		B23000000000000000000004 /* SessionSearchExcerptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSearchExcerptTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000002 /* APIClientInsightsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientInsightsTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000017 /* APIClientUpdatesCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUpdatesCheckTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000018 /* APIClientUpdatesApplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientUpdatesApplyTests.swift; sourceTree = "<group>"; };
@@ -496,6 +499,7 @@
 		C05100000000000000000013 /* ChatGoalControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGoalControls.swift; sourceTree = "<group>"; };
 		C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptSupportingViews.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
+		B23000000000000000000002 /* SessionSearchExcerpt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSearchExcerpt.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListViewModel.swift; sourceTree = "<group>"; };
 		A04300000000000000000011 /* SessionListComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListComponents.swift; sourceTree = "<group>"; };
 		A10900000000000000000011 /* SessionNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationState.swift; sourceTree = "<group>"; };
@@ -844,6 +848,7 @@
 				B5A1000000000000000000A1 /* ServerRegistryTests.swift */,
 				C0FF000000000000000000C2 /* CustomHeaderInjectionTests.swift */,
 				C03900000000000000000001 /* APIClientSessionListTests.swift */,
+				B23000000000000000000004 /* SessionSearchExcerptTests.swift */,
 				C03900000000000000000002 /* APIClientInsightsTests.swift */,
 				C03900000000000000000017 /* APIClientUpdatesCheckTests.swift */,
 				C03900000000000000000018 /* APIClientUpdatesApplyTests.swift */,
@@ -1084,6 +1089,7 @@
 			children = (
 				1A2B3C4D5E6F7000000000B7 /* SessionListView.swift */,
 				1A2B3C4D5E6F7000000000D2 /* SessionRowView.swift */,
+				B23000000000000000000002 /* SessionSearchExcerpt.swift */,
 				1A2B3C4D5E6F7000000000D3 /* SessionListViewModel.swift */,
 				A04300000000000000000011 /* SessionListComponents.swift */,
 				A10900000000000000000011 /* SessionNavigationState.swift */,
@@ -1709,6 +1715,7 @@
 				1A2B3C4D5E6F7000000000D6 /* SSEClient.swift in Sources */,
 				C0FF000000000000000000A1 /* CustomHeader.swift in Sources */,
 				1A2B3C4D5E6F7000000000D0 /* SessionRowView.swift in Sources */,
+				B23000000000000000000001 /* SessionSearchExcerpt.swift in Sources */,
 				1A2B3C4D5E6F7000000000D1 /* SessionListViewModel.swift in Sources */,
 				A04300000000000000000001 /* SessionListComponents.swift in Sources */,
 				A10900000000000000000001 /* SessionNavigationState.swift in Sources */,
@@ -1769,6 +1776,7 @@
 				B5A1000000000000000000A0 /* ServerRegistryTests.swift in Sources */,
 				C0FF000000000000000000C1 /* CustomHeaderInjectionTests.swift in Sources */,
 				C03910000000000000000001 /* APIClientSessionListTests.swift in Sources */,
+				B23000000000000000000003 /* SessionSearchExcerptTests.swift in Sources */,
 				C03910000000000000000002 /* APIClientInsightsTests.swift in Sources */,
 				C03910000000000000000017 /* APIClientUpdatesCheckTests.swift in Sources */,
 				C03910000000000000000018 /* APIClientUpdatesApplyTests.swift in Sources */,

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -526,7 +526,8 @@ struct SessionInteractiveRow: View {
                 session: session,
                 showsMessageCount: showsMessageCount,
                 showsWorkspace: showsWorkspace,
-                isViewingCachedData: viewModel.isViewingCachedData
+                isViewingCachedData: viewModel.isViewingCachedData,
+                searchExcerpt: viewModel.searchExcerpt(for: session)
             )
         }
         .buttonStyle(.plain)

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -392,7 +392,8 @@ struct SessionSidebarUtilityRows: View {
 
 struct SessionListRowsSection: View {
     let viewModel: SessionListViewModel
-
+    /// The sidebar's current query, forwarded to rows for match excerpts.
+    var searchText: String = ""
     let sessions: [SessionSummary]
     let emptyTitle: String
     let emptyDescription: String?
@@ -429,7 +430,8 @@ struct SessionListRowsSection: View {
                     showsMessageCount: showsMessageCount,
                     showsWorkspace: showsWorkspace,
                     selectedSessionID: selectedSessionID,
-                    actions: actions
+                    actions: actions,
+                    searchText: searchText
                 )
             }
         }
@@ -517,6 +519,9 @@ struct SessionInteractiveRow: View {
     let showsWorkspace: Bool
     let selectedSessionID: String?
     let actions: SessionListRowActions
+    /// The query of the screen showing this row, so a screen with its own search
+    /// field never shows another screen's excerpts.
+    var searchText: String = ""
 
     var body: some View {
         Button {
@@ -527,7 +532,7 @@ struct SessionInteractiveRow: View {
                 showsMessageCount: showsMessageCount,
                 showsWorkspace: showsWorkspace,
                 isViewingCachedData: viewModel.isViewingCachedData,
-                searchExcerpt: viewModel.searchExcerpt(for: session)
+                searchExcerpt: viewModel.searchExcerpt(for: session, searchText: searchText)
             )
         }
         .buttonStyle(.plain)
@@ -605,6 +610,8 @@ struct SessionInteractiveRow: View {
 struct ScheduledSessionsDisclosure: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let viewModel: SessionListViewModel
+    /// The sidebar's current query, forwarded to rows for match excerpts.
+    var searchText: String = ""
     let sessions: [SessionSummary]
     let totalCount: Int
     let isSearchActive: Bool
@@ -655,7 +662,8 @@ struct ScheduledSessionsDisclosure: View {
                     showsMessageCount: showsMessageCount,
                     showsWorkspace: showsWorkspace,
                     selectedSessionID: selectedSessionID,
-                    actions: actions
+                    actions: actions,
+                    searchText: searchText
                 )
                 .transition(SessionListMotion.disclosureContentTransition(reduceMotion: reduceMotion))
             }
@@ -716,7 +724,8 @@ struct ScheduledSessionsView: View {
                         showsMessageCount: showsMessageCount,
                         showsWorkspace: showsWorkspace,
                         selectedSessionID: selectedSessionID,
-                        actions: actions
+                        actions: actions,
+                        searchText: searchText
                     )
                 }
             }

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -491,6 +491,7 @@ struct SessionListView: View {
             if scheduledSessionGroups.showsDisclosure(isSearchActive: isSearchingSessions) {
                 ScheduledSessionsDisclosure(
                     viewModel: viewModel,
+                    searchText: searchText,
                     sessions: scheduledSessionGroups.scheduled,
                     totalCount: scheduledSessionGroups.totalScheduledCount,
                     isSearchActive: isSearchingSessions,
@@ -507,6 +508,7 @@ struct SessionListView: View {
 
             SessionListRowsSection(
                 viewModel: viewModel,
+                searchText: searchText,
                 sessions: scheduledSessionGroups.ordinary,
                 emptyTitle: emptySessionsTitle,
                 emptyDescription: emptySessionsDescription,

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -390,8 +390,15 @@ final class SessionListViewModel {
     /// The excerpt to show under a row, paired with the query that produced it.
     /// nil when the row did not match on content, when the search was cleared,
     /// or when the server is older than `match_preview`.
-    func searchExcerpt(for session: SessionSummary) -> SessionSearchExcerpt? {
-        guard let query = activeRemoteSearchQuery, !query.isEmpty,
+    ///
+    /// `searchText` is the query of the *screen* asking, not the view model's:
+    /// screens with their own search field (Scheduled sessions) share this view
+    /// model, and they must not inherit the sidebar's last excerpts. Same guard
+    /// `visibleSessions(searchText:selectedProjectID:)` applies to remote rows.
+    func searchExcerpt(for session: SessionSummary, searchText: String) -> SessionSearchExcerpt? {
+        let query = Self.normalizedSearchQuery(searchText)
+
+        guard !query.isEmpty, activeRemoteSearchQuery == query,
               let sessionID = session.sessionId,
               let text = remoteContentSearchExcerpts[sessionID]
         else {

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -80,6 +80,9 @@ final class SessionListViewModel {
     private(set) var archivedCount: Int?
 
     private(set) var remoteContentSearchSessionIDs: [String] = []
+    /// `match_preview` per content-matched session from the last search, so a
+    /// row can show why it matched. Empty against servers that omit the field.
+    private(set) var remoteContentSearchExcerpts: [String: String] = [:]
     private var activeRemoteSearchQuery: String?
     private var sessionOpenGeneration = 0
 
@@ -347,6 +350,7 @@ final class SessionListViewModel {
         let query = Self.normalizedSearchQuery(rawQuery)
         activeRemoteSearchQuery = query
         remoteContentSearchSessionIDs = []
+        remoteContentSearchExcerpts = [:]
         searchErrorMessage = nil
 
         guard !query.isEmpty, !isViewingCachedData else {
@@ -366,7 +370,9 @@ final class SessionListViewModel {
 
             guard !Task.isCancelled, activeRemoteSearchQuery == query else { return }
 
-            remoteContentSearchSessionIDs = contentMatchIDs(from: response.sessions ?? [])
+            let matches = contentMatches(from: response.sessions ?? [])
+            remoteContentSearchSessionIDs = matches.sessionIDs
+            remoteContentSearchExcerpts = matches.excerpts
             isSearchingRemoteSessions = false
         } catch {
             guard activeRemoteSearchQuery == query else { return }
@@ -375,14 +381,30 @@ final class SessionListViewModel {
             guard !isCancellationError(error) else { return }
 
             remoteContentSearchSessionIDs = []
+            remoteContentSearchExcerpts = [:]
             searchErrorMessage = error.localizedDescription
             lastError = error
         }
     }
 
+    /// The excerpt to show under a row, paired with the query that produced it.
+    /// nil when the row did not match on content, when the search was cleared,
+    /// or when the server is older than `match_preview`.
+    func searchExcerpt(for session: SessionSummary) -> SessionSearchExcerpt? {
+        guard let query = activeRemoteSearchQuery, !query.isEmpty,
+              let sessionID = session.sessionId,
+              let text = remoteContentSearchExcerpts[sessionID]
+        else {
+            return nil
+        }
+
+        return SessionSearchExcerpt(text: text, query: query)
+    }
+
     func clearSearchResults() {
         activeRemoteSearchQuery = nil
         remoteContentSearchSessionIDs = []
+        remoteContentSearchExcerpts = [:]
         searchErrorMessage = nil
         isSearchingRemoteSessions = false
     }
@@ -1128,7 +1150,11 @@ final class SessionListViewModel {
         }
     }
 
-    private func contentMatchIDs(from sessions: [SessionSummary]) -> [String] {
+    /// Content-match rows narrowed to sessions the list can actually show, in
+    /// server order, plus each row's excerpt when the server sent one.
+    private func contentMatches(
+        from sessions: [SessionSummary]
+    ) -> (sessionIDs: [String], excerpts: [String: String]) {
         let locallyVisibleSessionIDs = Set(self.sessions.compactMap { session -> String? in
             guard session.archived != true, let sessionID = session.sessionId, !sessionID.isEmpty else {
                 return nil
@@ -1137,19 +1163,28 @@ final class SessionListViewModel {
             return sessionID
         })
         var seenSessionIDs = Set<String>()
+        var sessionIDs: [String] = []
+        var excerpts: [String: String] = [:]
 
-        return sessions.compactMap { session in
+        for session in sessions {
             guard session.matchType?.lowercased() == "content",
                   let sessionID = session.sessionId,
                   locallyVisibleSessionIDs.contains(sessionID),
                   !seenSessionIDs.contains(sessionID)
             else {
-                return nil
+                continue
             }
 
             seenSessionIDs.insert(sessionID)
-            return sessionID
+            sessionIDs.append(sessionID)
+
+            if let preview = session.matchPreview?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !preview.isEmpty {
+                excerpts[sessionID] = preview
+            }
         }
+
+        return (sessionIDs, excerpts)
     }
 
     private func timestamp(for session: SessionSummary) -> Double {

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -9,6 +9,9 @@ struct SessionRowView: View {
     var showsMessageCount = true
     var showsWorkspace = true
     var isViewingCachedData = false
+    /// Set only while a remote content search is showing this row, so the row
+    /// can say why it matched.
+    var searchExcerpt: SessionSearchExcerpt?
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -115,6 +118,10 @@ struct SessionRowView: View {
         VStack(alignment: .leading, spacing: rowContentSpacing) {
             titleArea
 
+            if let searchExcerpt {
+                excerptText(searchExcerpt)
+            }
+
             if showsSupplementalContent {
                 supplementalArea
             }
@@ -170,6 +177,18 @@ struct SessionRowView: View {
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
+            .accessibilityHidden(true)
+    }
+
+    /// One-line "why this row matched", with the query bolded. Hidden from
+    /// VoiceOver because `accessibilitySummary` already reads it in order.
+    private func excerptText(_ excerpt: SessionSearchExcerpt) -> some View {
+        Text(excerpt.highlighted)
+            .font(AppFont.caption())
+            .foregroundStyle(.secondary)
+            .lineLimit(excerptLineLimit)
+            .truncationMode(.tail)
+            .fixedSize(horizontal: false, vertical: true)
             .accessibilityHidden(true)
     }
 
@@ -260,7 +279,8 @@ struct SessionRowView: View {
     }
 
     private var rowMinimumHeight: CGFloat {
-        showsSupplementalContent ? 54 : 46
+        let base: CGFloat = showsSupplementalContent ? 54 : 46
+        return searchExcerpt == nil ? base : base + 16
     }
 
     private var titleLineLimit: Int {
@@ -268,6 +288,10 @@ struct SessionRowView: View {
     }
 
     private var metadataLineLimit: Int {
+        dynamicTypeSize.isAccessibilitySize ? 3 : 1
+    }
+
+    private var excerptLineLimit: Int {
         dynamicTypeSize.isAccessibilitySize ? 3 : 1
     }
 
@@ -287,6 +311,10 @@ struct SessionRowView: View {
 
     private var accessibilitySummary: String {
         var parts = [displayTitle]
+
+        if let searchExcerpt {
+            parts.append(String(localized: "Matched: \(searchExcerpt.text)"))
+        }
 
         parts.append(contentsOf: Self.accessibilityStateLabels(for: session, isViewingCachedData: isViewingCachedData))
 

--- a/HermesMobile/Features/SessionList/SessionSearchExcerpt.swift
+++ b/HermesMobile/Features/SessionList/SessionSearchExcerpt.swift
@@ -11,6 +11,30 @@ struct SessionSearchExcerpt: Equatable {
     let text: String
     let query: String
 
+    init(text: String, query: String) {
+        self.text = Self.displayText(text)
+        self.query = query
+    }
+
+    /// The server previews the raw stored message text, so an excerpt taken
+    /// from a serialized tool result arrives carrying that JSON's escapes:
+    /// `...0% /\n---\nRAM: 8.0 GB", "exit_code": 0,...`. Those two-character
+    /// escapes become spaces and runs of whitespace collapse, so the one line
+    /// reads instead of showing its own punctuation.
+    ///
+    /// A Windows path (`C:\new`) is the false positive this accepts. It is
+    /// worth it for a truncated preview line that is never used as data, and
+    /// the alternative — guessing whether the excerpt "is JSON" — misfires in
+    /// both directions.
+    private static func displayText(_ raw: String) -> String {
+        var text = raw
+        for escape in ["\\r\\n", "\\n", "\\r", "\\t"] {
+            text = text.replacingOccurrences(of: escape, with: " ")
+        }
+
+        return text.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+
     /// The excerpt with every occurrence of the query bolded.
     ///
     /// Matching is case-insensitive and runs over `String` ranges, so composed

--- a/HermesMobile/Features/SessionList/SessionSearchExcerpt.swift
+++ b/HermesMobile/Features/SessionList/SessionSearchExcerpt.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// One content-search excerpt to show under a session row, paired with the
+/// query that produced it so the row can bold the matched ranges.
+///
+/// `text` is the server's `match_preview`: a redacted, whitespace-collapsed
+/// window of the matched message, already elided with `...` on either side when
+/// it was cut. Servers older than the upstream commit that added
+/// `_session_search_preview` omit the field, so no excerpt is built at all.
+struct SessionSearchExcerpt: Equatable {
+    let text: String
+    let query: String
+
+    /// The excerpt with every occurrence of the query bolded.
+    ///
+    /// Matching is case-insensitive and runs over `String` ranges, so composed
+    /// and decomposed spellings of the same characters match each other and the
+    /// bolded range is the text's own, not the query's length. Diacritics are
+    /// *not* folded: the server matched the query literally, so folding them
+    /// here would bold a span the server never treated as the hit. When
+    /// redaction has replaced the match, nothing is bolded and the plain
+    /// excerpt still shows.
+    var highlighted: AttributedString {
+        guard !query.isEmpty else { return AttributedString(text) }
+
+        var result = AttributedString()
+        var cursor = text.startIndex
+
+        while cursor < text.endIndex,
+              let match = text.range(of: query, options: .caseInsensitive, range: cursor..<text.endIndex),
+              !match.isEmpty {
+            if match.lowerBound > cursor {
+                result += AttributedString(String(text[cursor..<match.lowerBound]))
+            }
+
+            var hit = AttributedString(String(text[match]))
+            hit.inlinePresentationIntent = .stronglyEmphasized
+            result += hit
+
+            cursor = match.upperBound
+        }
+
+        if cursor < text.endIndex {
+            result += AttributedString(String(text[cursor...]))
+        }
+
+        return result
+    }
+}

--- a/HermesMobile/Models/Session.swift
+++ b/HermesMobile/Models/Session.swift
@@ -222,6 +222,11 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
     let readOnly: Bool?
     let isReadOnly: Bool?
     let matchType: String?
+    /// Server-built excerpt of the matched message text on a content-search row
+    /// (`match_preview`, upstream `_session_search_preview`, <=124 chars and
+    /// redacted like the title). Absent on title matches, on every non-search
+    /// response, and on servers older than the commit that added it.
+    let matchPreview: String?
 
     init(
         sessionId: String? = nil,
@@ -255,7 +260,8 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         relationshipType: String? = nil,
         readOnly: Bool? = nil,
         isReadOnly: Bool? = nil,
-        matchType: String? = nil
+        matchType: String? = nil,
+        matchPreview: String? = nil
     ) {
         self.sessionId = sessionId
         self.title = title
@@ -289,6 +295,7 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         self.readOnly = readOnly
         self.isReadOnly = isReadOnly
         self.matchType = matchType
+        self.matchPreview = matchPreview
     }
 
     enum CodingKeys: String, CodingKey {
@@ -299,7 +306,7 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         case activeStreamId, isStreaming, isCliSession
         case userMessageCount, hasPendingUserMessage, pendingStartedAt, worktreePath
         case sourceTag, rawSource, sessionSource, sourceLabel
-        case parentSessionId, relationshipType, readOnly, isReadOnly, matchType
+        case parentSessionId, relationshipType, readOnly, isReadOnly, matchType, matchPreview
     }
 
     /// Lossy field by field, like `SessionDetail` and `ProjectSummary` already
@@ -346,6 +353,7 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         readOnly = container.decodeLossyBoolIfPresent(forKey: .readOnly)
         isReadOnly = container.decodeLossyBoolIfPresent(forKey: .isReadOnly)
         matchType = container.decodeLossyStringIfPresent(forKey: .matchType)
+        matchPreview = container.decodeLossyStringIfPresent(forKey: .matchPreview)
     }
 
     /// Decodes a session array a row at a time, so one unreadable row costs that
@@ -408,6 +416,7 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
         readOnly = detail.readOnly
         isReadOnly = detail.isReadOnly
         matchType = nil
+        matchPreview = nil
     }
 
     /// Applies the import response without dropping list metadata that the
@@ -446,7 +455,8 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
             relationshipType: imported.relationshipType ?? relationshipType,
             readOnly: imported.readOnly ?? readOnly,
             isReadOnly: imported.isReadOnly ?? isReadOnly,
-            matchType: imported.matchType ?? matchType
+            matchType: imported.matchType ?? matchType,
+            matchPreview: imported.matchPreview ?? matchPreview
         )
     }
 
@@ -485,7 +495,8 @@ struct SessionSummary: Decodable, Equatable, Hashable, Identifiable {
             relationshipType: relationshipType,
             readOnly: readOnly,
             isReadOnly: isReadOnly,
-            matchType: matchType
+            matchType: matchType,
+            matchPreview: matchPreview
         )
     }
 }

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -323,6 +323,7 @@ private extension SessionSummary {
         readOnly = cachedSession.readOnly
         isReadOnly = cachedSession.isReadOnly
         matchType = nil
+        matchPreview = nil
     }
 }
 

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -123424,6 +123424,112 @@
           }
         }
       }
+    },
+    "Matched: %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مطابقة: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Treffer: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Coincidencia: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Correspondance : %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "התאמה: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Corrispondenza: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一致：%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "일치: %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Overeenkomst: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dopasowanie: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Correspondência: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Совпадение: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eşleşme: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مماثلت: %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "符合：%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匹配：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "符合：%@"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/APIClientSessionListTests.swift
+++ b/HermesMobileTests/APIClientSessionListTests.swift
@@ -184,6 +184,7 @@ final class APIClientSessionListTests: APIClientTestCase {
                   "session_id": "content-123",
                   "title": "Planning",
                   "match_type": "content",
+                  "match_preview": "...we compared the billing plan tiers...",
                   "unexpected": "ignored"
                 }
               ],
@@ -199,6 +200,7 @@ final class APIClientSessionListTests: APIClientTestCase {
         XCTAssertEqual(response.count, 1)
         XCTAssertEqual(response.sessions?.first?.sessionId, "content-123")
         XCTAssertEqual(response.sessions?.first?.matchType, "content")
+        XCTAssertEqual(response.sessions?.first?.matchPreview, "...we compared the billing plan tiers...")
     }
 
     func testSessionSearchDecodesEmptyQueryResponseWithoutQueryOrCount() async throws {
@@ -227,6 +229,8 @@ final class APIClientSessionListTests: APIClientTestCase {
 
         XCTAssertEqual(response.sessions?.first?.sessionId, "abc123")
         XCTAssertNil(response.sessions?.first?.matchType)
+        // A server older than `_session_search_preview` omits match_preview.
+        XCTAssertNil(response.sessions?.first?.matchPreview)
         XCTAssertNil(response.query)
         XCTAssertNil(response.count)
     }

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2190,6 +2190,68 @@ final class SessionListMutationTests: XCTestCase {
         )
     }
 
+    /// The excerpt has to reach the row that displays it, which comes from the
+    /// local session list, not the search response — so it is looked up by
+    /// session ID and paired with the query that produced it.
+    @MainActor
+    func testRemoteSessionSearchExposesMatchPreviewPerSession() async throws {
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/sessions":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [
+                    {"session_id": "with-preview", "title": "Budget", "archived": false},
+                    {"session_id": "no-preview", "title": "Roadmap", "archived": false},
+                    {"session_id": "title-match", "title": "Needle plan", "archived": false}
+                  ]
+                }
+                """, for: request)
+            case "/api/sessions/search":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [
+                    {
+                      "session_id": "with-preview",
+                      "title": "Budget",
+                      "match_type": "content",
+                      "match_preview": "...found the needle in the haystack..."
+                    },
+                    {"session_id": "no-preview", "title": "Roadmap", "match_type": "content"},
+                    {
+                      "session_id": "title-match",
+                      "title": "Needle plan",
+                      "match_type": "title",
+                      "match_preview": "ignored on a title match"
+                    }
+                  ],
+                  "query": "needle",
+                  "count": 3
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.load()
+        await viewModel.searchSessions(query: "Needle", debounceNanoseconds: 0)
+
+        let excerpt = viewModel.searchExcerpt(for: SessionSummary(sessionId: "with-preview"))
+        XCTAssertEqual(excerpt?.text, "...found the needle in the haystack...")
+        // The query is normalized, so the row bolds case-insensitively either way.
+        XCTAssertEqual(excerpt?.query, "needle")
+
+        // An older server sends the row without a preview: no excerpt, no crash.
+        XCTAssertNil(viewModel.searchExcerpt(for: SessionSummary(sessionId: "no-preview")))
+        // A title match never gets an excerpt, even if the server sent one.
+        XCTAssertNil(viewModel.searchExcerpt(for: SessionSummary(sessionId: "title-match")))
+
+        viewModel.clearSearchResults()
+        XCTAssertNil(viewModel.searchExcerpt(for: SessionSummary(sessionId: "with-preview")))
+    }
+
     // MARK: - Cron/CLI session classification (#256)
 
     func testCronSessionDetectedBySessionIdPrefix() {

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -2238,18 +2238,37 @@ final class SessionListMutationTests: XCTestCase {
         await viewModel.load()
         await viewModel.searchSessions(query: "Needle", debounceNanoseconds: 0)
 
-        let excerpt = viewModel.searchExcerpt(for: SessionSummary(sessionId: "with-preview"))
+        let excerpt = viewModel.searchExcerpt(
+            for: SessionSummary(sessionId: "with-preview"),
+            searchText: "Needle"
+        )
         XCTAssertEqual(excerpt?.text, "...found the needle in the haystack...")
         // The query is normalized, so the row bolds case-insensitively either way.
         XCTAssertEqual(excerpt?.query, "needle")
 
         // An older server sends the row without a preview: no excerpt, no crash.
-        XCTAssertNil(viewModel.searchExcerpt(for: SessionSummary(sessionId: "no-preview")))
+        XCTAssertNil(
+            viewModel.searchExcerpt(for: SessionSummary(sessionId: "no-preview"), searchText: "needle")
+        )
         // A title match never gets an excerpt, even if the server sent one.
-        XCTAssertNil(viewModel.searchExcerpt(for: SessionSummary(sessionId: "title-match")))
+        XCTAssertNil(
+            viewModel.searchExcerpt(for: SessionSummary(sessionId: "title-match"), searchText: "needle")
+        )
+
+        // Scheduled sessions has its own search field and shares this view
+        // model. Its empty query must not inherit the sidebar's excerpts.
+        XCTAssertNil(
+            viewModel.searchExcerpt(for: SessionSummary(sessionId: "with-preview"), searchText: "")
+        )
+        // Nor may a different query on another screen borrow them.
+        XCTAssertNil(
+            viewModel.searchExcerpt(for: SessionSummary(sessionId: "with-preview"), searchText: "haystack")
+        )
 
         viewModel.clearSearchResults()
-        XCTAssertNil(viewModel.searchExcerpt(for: SessionSummary(sessionId: "with-preview")))
+        XCTAssertNil(
+            viewModel.searchExcerpt(for: SessionSummary(sessionId: "with-preview"), searchText: "needle")
+        )
     }
 
     // MARK: - Cron/CLI session classification (#256)

--- a/HermesMobileTests/SessionSearchExcerptTests.swift
+++ b/HermesMobileTests/SessionSearchExcerptTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import HermesMobile
+
+final class SessionSearchExcerptTests: XCTestCase {
+    /// Every bolded run of the excerpt, in order.
+    private func boldRuns(_ excerpt: SessionSearchExcerpt) -> [String] {
+        excerpt.highlighted.runs.compactMap { run in
+            guard run.inlinePresentationIntent == .stronglyEmphasized else { return nil }
+            return String(excerpt.highlighted[run.range].characters)
+        }
+    }
+
+    private func plainText(_ excerpt: SessionSearchExcerpt) -> String {
+        String(excerpt.highlighted.characters)
+    }
+
+    func testHighlightsEveryOccurrenceRegardlessOfCase() {
+        let excerpt = SessionSearchExcerpt(
+            text: "...Billing failed, so retry the billing job...",
+            query: "billing"
+        )
+
+        XCTAssertEqual(boldRuns(excerpt), ["Billing", "billing"])
+        XCTAssertEqual(plainText(excerpt), excerpt.text)
+    }
+
+    /// The server sends whatever the transcript held, which may be decomposed
+    /// while the typed query is composed (or the reverse). Bolding the text's
+    /// own range keeps the combining marks attached to their base character.
+    func testHighlightsAcrossComposedAndDecomposedSpellings() {
+        let decomposedText = "meet at the cafe\u{0301} tonight"
+        let excerpt = SessionSearchExcerpt(text: decomposedText, query: "café")
+
+        XCTAssertEqual(boldRuns(excerpt), ["cafe\u{0301}"])
+        XCTAssertEqual(plainText(excerpt), decomposedText)
+    }
+
+    /// Diacritics are not folded: the server matched the query literally, so
+    /// bolding "café" for a query of "cafe" would claim a hit that never was.
+    func testDoesNotFoldDiacritics() {
+        let excerpt = SessionSearchExcerpt(text: "meet at the café tonight", query: "cafe")
+
+        XCTAssertTrue(boldRuns(excerpt).isEmpty)
+    }
+
+    /// Redaction can replace the matched span, leaving an excerpt the query is
+    /// no longer in. The excerpt still reads; nothing is bolded.
+    func testShowsPlainExcerptWhenTheQueryIsAbsent() {
+        let excerpt = SessionSearchExcerpt(text: "...the token is [redacted]...", query: "sk-live")
+
+        XCTAssertTrue(boldRuns(excerpt).isEmpty)
+        XCTAssertEqual(plainText(excerpt), excerpt.text)
+    }
+
+    func testEmptyQueryHighlightsNothing() {
+        let excerpt = SessionSearchExcerpt(text: "...deploy the worker...", query: "")
+
+        XCTAssertTrue(boldRuns(excerpt).isEmpty)
+        XCTAssertEqual(plainText(excerpt), excerpt.text)
+    }
+
+    func testHighlightsAMatchAtEitherEdge() {
+        let excerpt = SessionSearchExcerpt(text: "deploy the deploy", query: "deploy")
+
+        XCTAssertEqual(boldRuns(excerpt), ["deploy", "deploy"])
+        XCTAssertEqual(plainText(excerpt), excerpt.text)
+    }
+}

--- a/HermesMobileTests/SessionSearchExcerptTests.swift
+++ b/HermesMobileTests/SessionSearchExcerptTests.swift
@@ -59,6 +59,31 @@ final class SessionSearchExcerptTests: XCTestCase {
         XCTAssertEqual(plainText(excerpt), excerpt.text)
     }
 
+    /// Excerpts windowed out of a serialized tool result arrive with that
+    /// JSON's escapes still in them; the row must not print them.
+    func testTurnsEscapedWhitespaceIntoSpaces() {
+        let excerpt = SessionSearchExcerpt(
+            text: #"...459k 419M 0% /\n---\nRAM: 8.0 GB", "exit_code": 0,..."#,
+            query: "RAM"
+        )
+
+        XCTAssertEqual(excerpt.text, #"...459k 419M 0% / --- RAM: 8.0 GB", "exit_code": 0,..."#)
+        XCTAssertEqual(boldRuns(excerpt), ["RAM"])
+    }
+
+    func testCollapsesRunsOfWhitespaceAndTrims() {
+        let excerpt = SessionSearchExcerpt(text: "  deploy\tthe\t\tworker  ", query: "deploy")
+
+        XCTAssertEqual(excerpt.text, "deploy the worker")
+    }
+
+    func testLeavesAnOrdinaryExcerptAlone() {
+        let text = "...decided to move the billing plan tiers behind a flag..."
+        let excerpt = SessionSearchExcerpt(text: text, query: "billing")
+
+        XCTAssertEqual(excerpt.text, text)
+    }
+
     func testHighlightsAMatchAtEitherEdge() {
         let excerpt = SessionSearchExcerpt(text: "deploy the deploy", query: "deploy")
 


### PR DESCRIPTION
## Linked issue

None — approved local work.

## What changed

Searching your sessions returns rows that matched somewhere in the transcript, but the row looked identical to a title match: you had to open the session to find out why it came back.

Content-search rows now carry the server's `match_preview` excerpt through to the session row, which shows it on one line under the title with every occurrence of your query bolded.

- `SessionSummary` decodes an optional `match_preview` alongside the existing `match_type`, lossily like every other field.
- `SessionListViewModel` keeps a session-ID → excerpt map from the last search (content matches only, narrowed to sessions the list can actually show) and hands the row an excerpt paired with the query that produced it.
- `SessionSearchExcerpt.highlighted` bolds the matched ranges. Matching is case-insensitive and runs over `String` ranges, so composed and decomposed spellings match each other and combining marks stay attached to their base character. Diacritics are deliberately **not** folded — the server matched the query literally, so folding here would bold a span the server never treated as the hit. When redaction has replaced the match, the plain excerpt still shows and nothing is bolded.

Servers older than the upstream commit that added `_session_search_preview` omit the field, so those rows are byte-for-byte unchanged.

## Before / after

The row gains one line under the title; nothing else moves.

**Before** — `Q3 infrastructure planning` · `42 messages • hermex`

**After** — `Q3 infrastructure planning` · `...decided to move the **billing** plan tiers behind a flag before th...` · `42 messages • hermex`

Rendered variants (light and dark) plus live simulator captures before and after the escape fix are on the maintainer's machine at `/tmp/hermex-row-{before,after}-{light,dark}.png`, `/tmp/hermex-search-excerpts-live.jpg`, and `/tmp/hermex-search-excerpts-normalized.jpg`.

## How it was tested

Full XCTest suite on the simulator (iPhone 17, scheme `HermesMobile`): **1937 passed, 0 failed, 2 skipped**.

New focused tests:
- `SessionSearchExcerptTests` — case-insensitive highlighting, composed vs. decomposed spellings, diacritics not folded, redacted excerpt with no match, empty query, match at either edge.
- `SessionListMutationTests.testRemoteSessionSearchExposesMatchPreviewPerSession` — the excerpt reaches the right session by ID, a row without a preview yields nothing, a title match never gets one, and clearing the search clears the excerpts.
- `APIClientSessionListTests` — `match_preview` decodes, and is nil when an older server omits it.

Surfaces walked: all three `SessionInteractiveRow` call sites (main list, scheduled group, project group) go through one wrapper, so they all get the excerpt. The Archived screen has no search and its rows are excluded from content matches by design. `Localizable.xcstrings` gained one key (`Matched: %@`, the VoiceOver prefix) in all 17 shipped languages, appended without touching any existing entry.

### Live server pass

Verified in the simulator against the maintainer's server, which does send `match_preview`. Searching `error` returns title matches with no excerpt and content matches with a one-line excerpt, `error` / `Error` / `errors` all bolded.

That pass surfaced one thing worth its own commit. The server previews raw stored message text, so an excerpt windowed out of a serialized tool result arrived carrying that JSON's escapes and printed them:

```
before  ...23% 459k 419M 0% /\n---\nRAM: 8.0 GB", "exit_code": 0,...
after   ...23% 459k 419M 0% / --- RAM: 8.0 GB", "exit_code": 0, "e...
```

`SessionSearchExcerpt` now turns those two-character escapes into spaces and collapses whitespace runs. The false positive it accepts is a Windows path (`C:\new`); that is worth it for a truncated preview line that is never used as data, and the alternative — guessing whether an excerpt "is JSON" — misfires in both directions.

What this deliberately does **not** fix: excerpts can still show JSON envelope fragments (`"exit_code": 0`), and a query like `error` can still bold a JSON *key* rather than prose. Both are upstream deciding what text to search and preview, and unwrapping the tool-result envelope client-side is its own change.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (verified against `.codex-tmp/hermes-webui/api/routes.py` `_session_search_preview` / `_handle_sessions_search`, and the `match_preview` entry in the sidebar field allowlist)

---

Implemented by Claude Opus 5 (1M context) in Claude Code.


