### PR TITLE
feat(tasks): rebuild the Tasks list as an agenda with filters and row actions

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
 		C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000010 /* APIEndpointContractTests.swift */; };
 		C03910000000000000000011 /* CronManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000011 /* CronManagementTests.swift */; };
+		D500000000000000000002 /* TaskAgendaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000001 /* TaskAgendaTests.swift */; };
 		C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000012 /* MemoryViewModelTests.swift */; };
 		C03910000000000000000013 /* ModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000013 /* ModelCatalogTests.swift */; };
 		C03910000000000000000014 /* MessageActionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000014 /* MessageActionContextTests.swift */; };
@@ -331,8 +332,12 @@
 		22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */; };
 		36CD9EF0B0734E5F8C28BB92 /* SlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA59130ED4141049177576C /* SlashCommand.swift */; };
 		3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01011 /* Cron.swift */; };
+		D100000000000000000002 /* ANSIEscapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000000000001 /* ANSIEscapes.swift */; };
 		3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01012 /* TasksView.swift */; };
+		D400000000000000000002 /* CronJobRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D400000000000000000001 /* CronJobRowView.swift */; };
 		3F91D2A54B9A4F66A2C01003 /* TasksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01013 /* TasksViewModel.swift */; };
+		D300000000000000000002 /* TaskAgenda.swift in Sources */ = {isa = PBXBuildFile; fileRef = D300000000000000000001 /* TaskAgenda.swift */; };
+		D200000000000000000002 /* CronScheduleHumanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D200000000000000000001 /* CronScheduleHumanizer.swift */; };
 		C0369000000000000000001 /* CronJobEditorConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0369000000000000000002 /* CronJobEditorConfigurationLoader.swift */; };
 		C0369000000000000000007 /* CronJobEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0369000000000000000008 /* CronJobEditorSheet.swift */; };
 		C0369000000000000000003 /* CronJobConfigurationPickers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0369000000000000000004 /* CronJobConfigurationPickers.swift */; };
@@ -471,6 +476,7 @@
 		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000010 /* APIEndpointContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointContractTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000011 /* CronManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronManagementTests.swift; sourceTree = "<group>"; };
+		D500000000000000000001 /* TaskAgendaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskAgendaTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000012 /* MemoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewModelTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000013 /* ModelCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCatalogTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000014 /* MessageActionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionContextTests.swift; sourceTree = "<group>"; };
@@ -658,8 +664,12 @@
 		22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModelTests.swift; sourceTree = "<group>"; };
 		1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandCatalog.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01011 /* Cron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cron.swift; sourceTree = "<group>"; };
+		D100000000000000000001 /* ANSIEscapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIEscapes.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01012 /* TasksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksView.swift; sourceTree = "<group>"; };
+		D400000000000000000001 /* CronJobRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronJobRowView.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01013 /* TasksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksViewModel.swift; sourceTree = "<group>"; };
+		D300000000000000000001 /* TaskAgenda.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskAgenda.swift; sourceTree = "<group>"; };
+		D200000000000000000001 /* CronScheduleHumanizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronScheduleHumanizer.swift; sourceTree = "<group>"; };
 		C0369000000000000000002 /* CronJobEditorConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronJobEditorConfigurationLoader.swift; sourceTree = "<group>"; };
 		C0369000000000000000008 /* CronJobEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronJobEditorSheet.swift; sourceTree = "<group>"; };
 		C0369000000000000000004 /* CronJobConfigurationPickers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronJobConfigurationPickers.swift; sourceTree = "<group>"; };
@@ -880,6 +890,7 @@
 				19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */,
 				C03900000000000000000010 /* APIEndpointContractTests.swift */,
 				C03900000000000000000011 /* CronManagementTests.swift */,
+				D500000000000000000001 /* TaskAgendaTests.swift */,
 				C03900000000000000000012 /* MemoryViewModelTests.swift */,
 				C03900000000000000000013 /* ModelCatalogTests.swift */,
 				C03900000000000000000014 /* MessageActionContextTests.swift */,
@@ -1016,6 +1027,7 @@
 				C1A042000000000000000002 /* Clarification.swift */,
 				A02400000000000000000002 /* Goal.swift */,
 				3F91D2A54B9A4F66A2C01011 /* Cron.swift */,
+				D100000000000000000001 /* ANSIEscapes.swift */,
 				1A2B3C4D5E6F70000000201 /* Memory.swift */,
 				1A2B3C4D5E6F70000000211 /* Skills.swift */,
 				C14900000000000000000002 /* Kanban.swift */,
@@ -1330,7 +1342,10 @@
 			isa = PBXGroup;
 			children = (
 				3F91D2A54B9A4F66A2C01012 /* TasksView.swift */,
+				D400000000000000000001 /* CronJobRowView.swift */,
 				3F91D2A54B9A4F66A2C01013 /* TasksViewModel.swift */,
+				D300000000000000000001 /* TaskAgenda.swift */,
+				D200000000000000000001 /* CronScheduleHumanizer.swift */,
 				3F91D2A54B9A4F66A2C01014 /* TaskDetailView.swift */,
 				3F91D2A54B9A4F66A2C01015 /* TaskDetailViewModel.swift */,
 				C0369000000000000000002 /* CronJobEditorConfigurationLoader.swift */,
@@ -1733,8 +1748,12 @@
 				C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */,
 				A02400000000000000000001 /* Goal.swift in Sources */,
 				3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */,
+				D100000000000000000002 /* ANSIEscapes.swift in Sources */,
 				3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */,
+				D400000000000000000002 /* CronJobRowView.swift in Sources */,
 				3F91D2A54B9A4F66A2C01003 /* TasksViewModel.swift in Sources */,
+				D300000000000000000002 /* TaskAgenda.swift in Sources */,
+				D200000000000000000002 /* CronScheduleHumanizer.swift in Sources */,
 				C0369000000000000000001 /* CronJobEditorConfigurationLoader.swift in Sources */,
 				C0369000000000000000007 /* CronJobEditorSheet.swift in Sources */,
 				C0369000000000000000003 /* CronJobConfigurationPickers.swift in Sources */,
@@ -1808,6 +1827,7 @@
 				19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */,
 				C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */,
 				C03910000000000000000011 /* CronManagementTests.swift in Sources */,
+				D500000000000000000002 /* TaskAgendaTests.swift in Sources */,
 				C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */,
 				C03910000000000000000013 /* ModelCatalogTests.swift in Sources */,
 				C03910000000000000000014 /* MessageActionContextTests.swift in Sources */,

--- a/HermesMobile/Features/Tasks/CronJobRowView.swift
+++ b/HermesMobile/Features/Tasks/CronJobRowView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+/// One agenda row: a status rail, the job's name, and a single meta line whose
+/// content is chosen by the group the row sits in. Model, provider, profile,
+/// skills, deliver and the prompt live on Task Detail — a list that repeats
+/// them reads as a wall.
+struct CronJobRowView: View {
+    let job: CronJob
+    let group: TaskAgendaGroup
+    let runningElapsed: Double?
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.calendar) private var calendar
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Capsule(style: .continuous)
+                .fill(tint)
+                .frame(width: 3)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(job.displayName)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(isDimmed ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary))
+                    .lineLimit(nameLineLimit)
+
+                Text(metaText)
+                    .font(.caption)
+                    .foregroundStyle(metaStyle)
+                    .lineLimit(metaLineLimit)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(verbatim: [job.displayName, statusWord, metaText].joined(separator: ", ")))
+    }
+
+    // MARK: - Meta line
+
+    private var metaText: String {
+        switch group {
+        case .now:
+            guard let runningElapsed else { return String(localized: "Running") }
+            return "\(String(localized: "Running")) · \(Self.elapsedText(runningElapsed))"
+        case .needsAttention:
+            let headline = String(localized: "Last run failed")
+            guard let reason = job.failureSummary else { return headline }
+            return "\(headline) · \(reason)"
+        case .paused:
+            return scheduleSentence
+        case .laterToday, .tomorrow, .thisWeek, .later:
+            guard let next = job.nextRunAt?.date else { return scheduleSentence }
+            return "\(nextRunText(next)) · \(scheduleRecurrence)"
+        }
+    }
+
+    /// The humanised schedule, or the server's own string when the expression
+    /// is not one we recognise — never a guess.
+    private var scheduleSentence: String {
+        job.scheduleDescription?.sentence ?? job.scheduleText ?? String(localized: "Not available")
+    }
+
+    private var scheduleRecurrence: String {
+        job.scheduleDescription?.recurrence ?? job.scheduleText ?? String(localized: "Not available")
+    }
+
+    /// Today and tomorrow need only a clock time; the group header already
+    /// says which day.
+    private func nextRunText(_ date: Date) -> String {
+        if calendar.isDateInToday(date) || calendar.isDateInTomorrow(date) {
+            return date.formatted(date: .omitted, time: .shortened)
+        }
+        return date.formatted(.dateTime.month().day().hour().minute())
+    }
+
+    static func elapsedText(_ elapsed: Double) -> String {
+        if elapsed < 60 {
+            return "\(Int(elapsed.rounded()))s"
+        }
+
+        let minutes = Int(elapsed / 60)
+        let seconds = Int(elapsed.truncatingRemainder(dividingBy: 60))
+        return "\(minutes)m \(seconds)s"
+    }
+
+    // MARK: - Presentation
+
+    private var tint: Color {
+        switch group {
+        case .now:
+            return .blue
+        case .needsAttention:
+            return .red
+        case .paused:
+            return .secondary
+        case .laterToday, .tomorrow, .thisWeek, .later:
+            return .green
+        }
+    }
+
+    private var isDimmed: Bool { group == .paused }
+
+    private var metaStyle: AnyShapeStyle {
+        switch group {
+        case .needsAttention:
+            return AnyShapeStyle(.red)
+        case .paused:
+            return AnyShapeStyle(.tertiary)
+        default:
+            return AnyShapeStyle(.secondary)
+        }
+    }
+
+    private var nameLineLimit: Int {
+        dynamicTypeSize.isAccessibilitySize ? 3 : 1
+    }
+
+    private var metaLineLimit: Int {
+        dynamicTypeSize.isAccessibilitySize ? 4 : 1
+    }
+
+    private var statusWord: String {
+        switch group {
+        case .now:
+            return String(localized: "Running")
+        case .needsAttention:
+            return String(localized: "Needs Attention")
+        case .paused:
+            return String(localized: "Paused")
+        case .laterToday, .tomorrow, .thisWeek, .later:
+            return String(localized: "Active")
+        }
+    }
+}

--- a/HermesMobile/Features/Tasks/CronScheduleHumanizer.swift
+++ b/HermesMobile/Features/Tasks/CronScheduleHumanizer.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+/// A cron expression rendered for people.
+///
+/// `recurrence` is the period on its own ("Every 15 minutes", "Weekdays"), for
+/// a row that already shows the next run time beside it. `sentence` folds the
+/// time of day back in ("Weekdays at 9:25 AM"), for rows with no next run and
+/// for Task Detail.
+struct CronScheduleDescription: Equatable {
+    let recurrence: String
+    let sentence: String
+}
+
+/// Turns the standard five-field cron expressions the server sends into
+/// English.
+///
+/// Deliberately narrow: it recognises the shapes people actually schedule and
+/// returns `nil` for everything else, so callers fall back to the server's own
+/// string. A wrong guess about when a job runs is worse than a raw expression.
+enum CronScheduleHumanizer {
+    /// Describes `expression`, or `nil` when it is not a five-field cron
+    /// expression in one of the recognised shapes.
+    static func describe(
+        _ expression: String?,
+        locale: Locale = .current,
+        calendar: Calendar = .current
+    ) -> CronScheduleDescription? {
+        guard let expression else { return nil }
+
+        let fields = expression.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard fields.count == 5 else { return nil }
+
+        let (minuteField, hourField, dayOfMonthField, monthField, dayOfWeekField) =
+            (fields[0], fields[1], fields[2], fields[3], fields[4])
+
+        // Anything month-scoped beyond "every month" is rare enough that the
+        // raw expression is the honest answer.
+        guard monthField == "*" else { return nil }
+
+        if let recurrence = intervalRecurrence(
+            minuteField: minuteField,
+            hourField: hourField,
+            dayOfMonthField: dayOfMonthField,
+            dayOfWeekField: dayOfWeekField,
+            locale: locale
+        ) {
+            // An interval has no single time of day to append.
+            return CronScheduleDescription(recurrence: recurrence, sentence: recurrence)
+        }
+
+        guard let minute = fixedValue(minuteField, in: 0...59),
+              let hour = fixedValue(hourField, in: 0...23),
+              let recurrence = calendarRecurrence(
+                  dayOfMonthField: dayOfMonthField,
+                  dayOfWeekField: dayOfWeekField,
+                  locale: locale
+              )
+        else { return nil }
+
+        let time = timeText(hour: hour, minute: minute, locale: locale, calendar: calendar)
+        return CronScheduleDescription(
+            recurrence: recurrence,
+            sentence: String(localized: "\(recurrence) at \(time)")
+        )
+    }
+
+    // MARK: - Shapes
+
+    /// `*/15 * * * *` and `0 */2 * * *`: a step over an otherwise unrestricted
+    /// field. The hourly form requires minute zero so the phrase cannot imply
+    /// an offset it is not describing.
+    private static func intervalRecurrence(
+        minuteField: String,
+        hourField: String,
+        dayOfMonthField: String,
+        dayOfWeekField: String,
+        locale: Locale
+    ) -> String? {
+        guard dayOfMonthField == "*", dayOfWeekField == "*" else { return nil }
+
+        if hourField == "*" {
+            if minuteField == "*" { return String(localized: "Every minute") }
+            guard let step = stepValue(minuteField, in: 1...59) else { return nil }
+            guard step > 1 else { return String(localized: "Every minute") }
+            return String(localized: "Every \(durationText(minutes: step, locale: locale))")
+        }
+
+        guard minuteField == "0", let step = stepValue(hourField, in: 1...23) else { return nil }
+        guard step > 1 else { return nil }   // `0 */1 * * *` is just hourly; let it fall through.
+        return String(localized: "Every \(durationText(hours: step, locale: locale))")
+    }
+
+    /// The day-of-week and day-of-month shapes that pair with a fixed time.
+    private static func calendarRecurrence(
+        dayOfMonthField: String,
+        dayOfWeekField: String,
+        locale: Locale
+    ) -> String? {
+        if dayOfMonthField == "*" {
+            if dayOfWeekField == "*" { return String(localized: "Daily") }
+
+            guard let days = dayOfWeekSet(dayOfWeekField) else { return nil }
+            if days == [1, 2, 3, 4, 5] { return String(localized: "Weekdays") }
+            if days == [0, 6] { return String(localized: "Weekends") }
+            guard days.count == 1, let day = days.first else { return nil }
+            // A separate frame from the interval one: "Every %@" has to read
+            // correctly for "15 minutes" in every language, and a weekday would
+            // force a different article or case in several of them.
+            return String(localized: "Weekly on \(weekdayName(day, locale: locale))")
+        }
+
+        // A day-of-month and a day-of-week together mean different things on
+        // different cron implementations, so only the unambiguous form counts.
+        guard dayOfWeekField == "*",
+              let day = fixedValue(dayOfMonthField, in: 1...31),
+              let ordinal = ordinalText(day, locale: locale)
+        else { return nil }
+
+        return String(localized: "Monthly on the \(ordinal)")
+    }
+
+    // MARK: - Field parsing
+
+    /// A single literal number, e.g. `25`. Lists, ranges and steps are not
+    /// fixed values.
+    private static func fixedValue(_ field: String, in range: ClosedRange<Int>) -> Int? {
+        guard let value = Int(field), range.contains(value) else { return nil }
+        return value
+    }
+
+    /// The `N` of `*/N`, valid only when the rest of the field is unrestricted.
+    private static func stepValue(_ field: String, in range: ClosedRange<Int>) -> Int? {
+        guard field.hasPrefix("*/") else { return nil }
+        guard let step = Int(field.dropFirst(2)), range.contains(step) else { return nil }
+        return step
+    }
+
+    /// Day-of-week as Sunday-zero indices. Accepts `3`, `1-5` and `0,6`; cron's
+    /// `7` is Sunday. Anything else is unrecognised.
+    private static func dayOfWeekSet(_ field: String) -> Set<Int>? {
+        func normalized(_ token: String) -> Int? {
+            guard let value = Int(token), (0...7).contains(value) else { return nil }
+            return value % 7
+        }
+
+        if field.contains("-") {
+            let bounds = field.split(separator: "-", omittingEmptySubsequences: false)
+            guard bounds.count == 2,
+                  let lower = normalized(String(bounds[0])),
+                  let upper = normalized(String(bounds[1])),
+                  lower <= upper
+            else { return nil }
+            return Set(lower...upper)
+        }
+
+        let tokens = field.split(separator: ",", omittingEmptySubsequences: false)
+        guard !tokens.isEmpty else { return nil }
+
+        var days: Set<Int> = []
+        for token in tokens {
+            guard let day = normalized(String(token)) else { return nil }
+            days.insert(day)
+        }
+        return days
+    }
+
+    // MARK: - Locale-aware pieces
+
+    private static func timeText(hour: Int, minute: Int, locale: Locale, calendar: Calendar) -> String {
+        var components = DateComponents()
+        components.year = 2001
+        components.month = 1
+        components.day = 1
+        components.hour = hour
+        components.minute = minute
+
+        guard let date = calendar.date(from: components) else {
+            return String(format: "%02d:%02d", hour, minute)
+        }
+
+        // Pin calendar and time zone to the ones the components were built in,
+        // so the rendered clock time is the one cron will actually fire at.
+        let style = Date.FormatStyle(
+            date: .omitted,
+            time: .shortened,
+            locale: locale,
+            calendar: calendar,
+            timeZone: calendar.timeZone
+        )
+        return style.format(date)
+    }
+
+    /// Foundation owns the plural rules here, so "15 minutes" is correct in
+    /// every language without a plural entry per interval in the catalog.
+    private static func durationText(minutes: Int, locale: Locale) -> String {
+        Duration.seconds(minutes * 60)
+            .formatted(.units(allowed: [.minutes], width: .wide).locale(locale))
+    }
+
+    private static func durationText(hours: Int, locale: Locale) -> String {
+        Duration.seconds(hours * 3600)
+            .formatted(.units(allowed: [.hours], width: .wide).locale(locale))
+    }
+
+    /// Sunday-zero index to a standalone weekday name in `locale`.
+    private static func weekdayName(_ day: Int, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        let symbols = formatter.standaloneWeekdaySymbols ?? []
+        guard symbols.indices.contains(day) else { return "\(day)" }
+        return symbols[day]
+    }
+
+    private static func ordinalText(_ value: Int, locale: Locale) -> String? {
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.numberStyle = .ordinal
+        return formatter.string(from: NSNumber(value: value))
+    }
+}

--- a/HermesMobile/Features/Tasks/TaskAgenda.swift
+++ b/HermesMobile/Features/Tasks/TaskAgenda.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+/// The segments above the Tasks list. Selection is view state: it is never
+/// persisted and never travels between servers.
+enum TaskFilter: Int, CaseIterable, Identifiable {
+    case all
+    case live
+    case paused
+    case errors
+
+    var id: Int { rawValue }
+
+    /// The segment label, count included — a segmented control can only show
+    /// one string per segment.
+    func title(count: Int) -> String {
+        switch self {
+        case .all:
+            return String(localized: "All \(count)")
+        case .live:
+            return String(localized: "Live \(count)")
+        case .paused:
+            return String(localized: "Paused \(count)")
+        case .errors:
+            return String(localized: "Errors \(count)")
+        }
+    }
+}
+
+/// Agenda buckets, declared in the order they appear on screen: what is
+/// happening now, then what happens next, then what is broken, then what is
+/// dormant.
+enum TaskAgendaGroup: Int, CaseIterable, Identifiable {
+    case now
+    case laterToday
+    case tomorrow
+    case thisWeek
+    case later
+    case needsAttention
+    case paused
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .now:
+            return String(localized: "Now")
+        case .laterToday:
+            return String(localized: "Later Today")
+        case .tomorrow:
+            return String(localized: "Tomorrow")
+        case .thisWeek:
+            return String(localized: "This Week")
+        case .later:
+            return String(localized: "Later")
+        case .needsAttention:
+            return String(localized: "Needs Attention")
+        case .paused:
+            return String(localized: "Paused")
+        }
+    }
+}
+
+/// One rendered group. Empty groups are never built, so a section always has
+/// rows.
+struct TaskAgendaSection: Identifiable {
+    let group: TaskAgendaGroup
+    let jobs: [CronJob]
+
+    var id: Int { group.id }
+}
+
+enum TaskAgenda {
+    /// The single group a job belongs to.
+    ///
+    /// Precedence is what keeps the buckets disjoint: a running job is always
+    /// "Now", a failed last run is always "Needs Attention" whatever the job's
+    /// enabled state, and everything that is neither running nor scheduled
+    /// falls to "Paused".
+    static func group(
+        for job: CronJob,
+        isRunning: Bool,
+        now: Date,
+        calendar: Calendar = .current
+    ) -> TaskAgendaGroup {
+        if isRunning { return .now }
+        if job.hasFailedRun { return .needsAttention }
+        guard job.isLive else { return .paused }
+        guard let next = job.nextRunAt?.date else { return .later }
+
+        let startOfToday = calendar.startOfDay(for: now)
+        guard let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday),
+              let startOfDayAfterTomorrow = calendar.date(byAdding: .day, value: 2, to: startOfToday),
+              let weekHorizon = calendar.date(byAdding: .day, value: 7, to: startOfToday)
+        else { return .later }
+
+        // An overdue next run — the server's schedule lagging behind the clock
+        // — still reads as today's business rather than sinking to "Later".
+        if next < startOfTomorrow { return .laterToday }
+        if next < startOfDayAfterTomorrow { return .tomorrow }
+        if next < weekHorizon { return .thisWeek }
+        return .later
+    }
+
+    /// Whether a job survives the selected filter.
+    static func matches(_ job: CronJob, filter: TaskFilter, isRunning: Bool) -> Bool {
+        switch filter {
+        case .all:
+            return true
+        case .live:
+            return isRunning || job.isLive
+        case .paused:
+            return !isRunning && !job.isLive
+        case .errors:
+            return job.hasFailedRun
+        }
+    }
+
+    static func count(
+        of filter: TaskFilter,
+        in jobs: [CronJob],
+        runningJobIDs: Set<String>
+    ) -> Int {
+        jobs.reduce(into: 0) { total, job in
+            if matches(job, filter: filter, isRunning: isRunning(job, in: runningJobIDs)) {
+                total += 1
+            }
+        }
+    }
+
+    /// The filtered, grouped, sorted agenda. Groups keep their declared order;
+    /// within a group jobs sort by next run, soonest first, then by name.
+    static func sections(
+        jobs: [CronJob],
+        runningJobIDs: Set<String>,
+        filter: TaskFilter,
+        now: Date,
+        calendar: Calendar = .current
+    ) -> [TaskAgendaSection] {
+        var grouped: [TaskAgendaGroup: [CronJob]] = [:]
+
+        for job in jobs {
+            let running = isRunning(job, in: runningJobIDs)
+            guard matches(job, filter: filter, isRunning: running) else { continue }
+            let group = group(for: job, isRunning: running, now: now, calendar: calendar)
+            grouped[group, default: []].append(job)
+        }
+
+        return TaskAgendaGroup.allCases.compactMap { group in
+            guard let jobs = grouped[group], !jobs.isEmpty else { return nil }
+            return TaskAgendaSection(group: group, jobs: jobs.sorted(by: precedes))
+        }
+    }
+
+    static func isRunning(_ job: CronJob, in runningJobIDs: Set<String>) -> Bool {
+        guard let jobID = job.jobId else { return false }
+        return runningJobIDs.contains(jobID)
+    }
+
+    private static func precedes(_ left: CronJob, _ right: CronJob) -> Bool {
+        switch (left.nextRunAt?.date, right.nextRunAt?.date) {
+        case let (leftDate?, rightDate?) where leftDate != rightDate:
+            return leftDate < rightDate
+        case (.some, nil):
+            return true
+        case (nil, .some):
+            return false
+        default:
+            return left.displayName.localizedCaseInsensitiveCompare(right.displayName) == .orderedAscending
+        }
+    }
+}
+
+extension CronJob {
+    /// Live means the server will fire this job again. `enabled` and
+    /// `state` are the same fact surfaced twice, and a paused job can still
+    /// carry `enabled: true` briefly, so both have to agree.
+    var isLive: Bool {
+        enabled != false && state != "paused"
+    }
+
+    /// True when the last run, or its delivery, failed.
+    var hasFailedRun: Bool {
+        if lastStatus == "error" { return true }
+        if let lastError, !lastError.isEmpty { return true }
+        if let lastDeliveryError, !lastDeliveryError.isEmpty { return true }
+        return false
+    }
+
+    /// One readable line explaining the failure, safe for a list row: escapes
+    /// stripped, first meaningful line only. The full text lives on Task
+    /// Detail.
+    var failureSummary: String? {
+        for candidate in [lastError, lastDeliveryError] {
+            guard let candidate, !candidate.isEmpty else { continue }
+            if let summary = candidate.firstLineSummary() { return summary }
+        }
+        return nil
+    }
+
+    /// The schedule in English, or `nil` when the expression is not one the
+    /// humaniser recognises.
+    var scheduleDescription: CronScheduleDescription? {
+        CronScheduleHumanizer.describe(editableScheduleText ?? scheduleText)
+    }
+}

--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -229,7 +229,9 @@ struct TaskDetailView: View {
             }
 
             if let error = viewModel.job.lastError ?? viewModel.job.lastDeliveryError, !error.isEmpty {
-                CronJobMetadataRow(title: String(localized: "Error"), value: error)
+                // Run text arrives with the shell's escape codes intact; showing
+                // them raw renders as garbage.
+                CronJobMetadataRow(title: String(localized: "Error"), value: error.strippingANSIEscapes())
                     .foregroundStyle(.red)
             }
         }
@@ -249,7 +251,7 @@ struct TaskDetailView: View {
                         .foregroundStyle(.secondary)
 
                     if let content = output.content, !content.isEmpty {
-                        Text(content)
+                        Text(content.strippingANSIEscapes())
                             .font(.system(.body, design: .monospaced))
                             .textSelection(.enabled)
                             .padding(12)

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -39,7 +39,11 @@ struct TasksView: View {
                     .disabled(viewModel.isLoading)
                 }
             }
-            .sheet(isPresented: $isPresentingCreateTask) {
+            .sheet(isPresented: $isPresentingCreateTask, onDismiss: {
+                // A failed create leaves its message behind; without this the
+                // list's own alert would fire the moment the sheet closes.
+                viewModel.clearActionError()
+            }) {
                 CronJobEditorSheet(
                     title: String(localized: "New Task"),
                     server: server,
@@ -58,7 +62,7 @@ struct TasksView: View {
             }
             .alert("Delete Task?", isPresented: deletionConfirmationBinding, presenting: jobPendingDeletion) { job in
                 Button("Delete", role: .destructive) {
-                    Task { await viewModel.delete(job) }
+                    Task { await performAction { await viewModel.delete(job) } }
                 }
                 Button("Cancel", role: .cancel) {}
             } message: { job in

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -6,6 +6,7 @@ struct TasksView: View {
 
     @State private var viewModel: TasksViewModel
     @State private var isPresentingCreateTask = false
+    @State private var jobPendingDeletion: CronJob?
 
     init(server: URL, onAPIError: @escaping (Error) -> Void) {
         self.server = server
@@ -55,6 +56,19 @@ struct TasksView: View {
                     return didCreate
                 }
             }
+            .alert("Delete Task?", isPresented: deletionConfirmationBinding, presenting: jobPendingDeletion) { job in
+                Button("Delete", role: .destructive) {
+                    Task { await viewModel.delete(job) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { job in
+                Text("“\(job.displayName)” will be removed from the Hermes server.")
+            }
+            .alert("Could Not Update Task", isPresented: actionErrorBinding) {
+                Button("OK", role: .cancel) { viewModel.clearActionError() }
+            } message: {
+                Text(viewModel.actionErrorMessage ?? "")
+            }
             .task {
                 await loadTasks()
             }
@@ -81,40 +95,143 @@ struct TasksView: View {
                 Text("Scheduled jobs from the Hermes server will appear here.")
             }
         } else {
-            List {
-                Section {
-                    HStack {
-                        Label("Running now", systemImage: "bolt.fill")
-                        Spacer()
-                        Text("\(viewModel.activeRunningCount)")
-                            .foregroundStyle(.secondary)
-                    }
-                }
+            agenda
+        }
+    }
 
-                Section("Scheduled Jobs") {
-                    ForEach(viewModel.jobs) { job in
-                        NavigationLink {
-                            TaskDetailView(
-                                job: job,
-                                runningElapsed: viewModel.runningElapsed(for: job),
-                                server: server,
-                                onAPIError: onAPIError,
-                                onMutation: { mutation in
-                                    viewModel.apply(mutation)
-                                }
-                            )
-                        } label: {
-                            CronJobRowView(
-                                job: job,
-                                runningElapsed: viewModel.runningElapsed(for: job)
-                            )
+    private var sections: [TaskAgendaSection] {
+        viewModel.sections()
+    }
+
+    @ViewBuilder
+    private var agenda: some View {
+        Group {
+            if sections.isEmpty {
+                ContentUnavailableView {
+                    Label("No Matching Tasks", systemImage: "line.3.horizontal.decrease.circle")
+                } description: {
+                    Text("No tasks match this filter.")
+                }
+            } else {
+                List {
+                    ForEach(sections) { section in
+                        Section(section.group.title) {
+                            ForEach(section.jobs) { job in
+                                row(for: job, in: section.group)
+                            }
                         }
                     }
                 }
+                .refreshable {
+                    await loadTasks()
+                }
             }
-            .refreshable {
-                await loadTasks()
+        }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            filterPicker
+        }
+    }
+
+    private var filterPicker: some View {
+        Picker("Filter", selection: $viewModel.filter) {
+            ForEach(TaskFilter.allCases) { filter in
+                Text(filter.title(count: viewModel.count(for: filter))).tag(filter)
             }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private func row(for job: CronJob, in group: TaskAgendaGroup) -> some View {
+        NavigationLink {
+            TaskDetailView(
+                job: job,
+                runningElapsed: viewModel.runningElapsed(for: job),
+                server: server,
+                onAPIError: onAPIError,
+                onMutation: { mutation in
+                    viewModel.apply(mutation)
+                }
+            )
+        } label: {
+            CronJobRowView(
+                job: job,
+                group: group,
+                runningElapsed: viewModel.runningElapsed(for: job)
+            )
+        }
+        .swipeActions(edge: .trailing) {
+            pauseResumeButton(for: job)
+            runNowButton(for: job)
+        }
+        .contextMenu {
+            runNowButton(for: job)
+            pauseResumeButton(for: job)
+
+            Divider()
+
+            Button(role: .destructive) {
+                jobPendingDeletion = job
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            .disabled(job.jobId == nil)
+        }
+    }
+
+    @ViewBuilder
+    private func runNowButton(for job: CronJob) -> some View {
+        Button {
+            Task { await performAction { await viewModel.runNow(job) } }
+        } label: {
+            Label("Run Now", systemImage: "play.fill")
+        }
+        .tint(.blue)
+        .disabled(job.jobId == nil || viewModel.isPendingAction(job))
+    }
+
+    @ViewBuilder
+    private func pauseResumeButton(for job: CronJob) -> some View {
+        if job.isLive {
+            Button {
+                Task { await performAction { await viewModel.pause(job) } }
+            } label: {
+                Label("Pause", systemImage: "pause.fill")
+            }
+            .tint(.orange)
+            .disabled(job.jobId == nil || viewModel.isPendingAction(job))
+        } else {
+            Button {
+                Task { await performAction { await viewModel.resume(job) } }
+            } label: {
+                Label("Resume", systemImage: "play.circle")
+            }
+            .tint(.green)
+            .disabled(job.jobId == nil || viewModel.isPendingAction(job))
+        }
+    }
+
+    private var deletionConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { jobPendingDeletion != nil },
+            set: { if !$0 { jobPendingDeletion = nil } }
+        )
+    }
+
+    private var actionErrorBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.actionErrorMessage != nil && !isPresentingCreateTask },
+            set: { if !$0 { viewModel.clearActionError() } }
+        )
+    }
+
+    private func performAction(_ action: () async -> Void) async {
+        await action()
+
+        if let lastError = viewModel.lastError {
+            onAPIError(lastError)
         }
     }
 
@@ -124,115 +241,6 @@ struct TasksView: View {
         if let lastError = viewModel.lastError {
             onAPIError(lastError)
         }
-    }
-}
-
-private struct CronJobRowView: View {
-    let job: CronJob
-    let runningElapsed: Double?
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text(job.displayName)
-                    .font(.headline)
-                    .lineLimit(2)
-
-                Spacer(minLength: 8)
-
-                StatusBadge(
-                    text: runningElapsed == nil ? job.status.label : String(localized: "Running"),
-                    color: statusColor
-                )
-            }
-
-            if let prompt = job.prompt, !prompt.isEmpty {
-                Text(prompt)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(3)
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                CronJobMetadataRow(
-                    title: String(localized: "Schedule"),
-                    value: job.scheduleText ?? String(localized: "Not available")
-                )
-
-                CronJobMetadataRow(
-                    title: String(localized: "Next"),
-                    value: job.nextRunAt?.formatted ?? String(localized: "Not available")
-                )
-
-                CronJobMetadataRow(
-                    title: String(localized: "Last"),
-                    value: job.lastRunAt?.formatted ?? String(localized: "Never")
-                )
-
-                if let runningElapsed {
-                    CronJobMetadataRow(
-                        title: String(localized: "Elapsed"),
-                        value: Self.elapsedText(runningElapsed)
-                    )
-                }
-
-                CronJobMetadataRow(
-                    title: String(localized: "Deliver"),
-                    value: job.deliver ?? "local"
-                )
-
-                if let model = job.model, !model.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Model"), value: model)
-                }
-
-                if let provider = job.provider, !provider.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Provider"), value: provider)
-                }
-
-                if let profile = job.profile, !profile.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Profile"), value: profile)
-                }
-
-                if let skills = job.skills, !skills.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Skills"), value: skills.joined(separator: ", "))
-                }
-
-                if let error = job.lastError ?? job.lastDeliveryError, !error.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Error"), value: error)
-                        .foregroundStyle(.red)
-                }
-            }
-            .font(.footnote)
-        }
-        .padding(.vertical, 6)
-        .accessibilityElement(children: .combine)
-    }
-
-    private var statusColor: Color {
-        if runningElapsed != nil {
-            return .blue
-        }
-
-        switch job.status {
-        case .active:
-            return .green
-        case .paused, .off:
-            return .orange
-        case .error:
-            return .red
-        case .needsAttention:
-            return .yellow
-        }
-    }
-
-    private static func elapsedText(_ elapsed: Double) -> String {
-        if elapsed < 60 {
-            return "\(Int(elapsed.rounded()))s"
-        }
-
-        let minutes = Int(elapsed / 60)
-        let seconds = Int(elapsed.truncatingRemainder(dividingBy: 60))
-        return "\(minutes)m \(seconds)s"
     }
 }
 

--- a/HermesMobile/Features/Tasks/TasksViewModel.swift
+++ b/HermesMobile/Features/Tasks/TasksViewModel.swift
@@ -20,9 +20,19 @@ final class TasksViewModel {
     private(set) var actionErrorMessage: String?
     private(set) var lastError: Error?
 
+    /// Selected segment. View state only: never persisted, never carried
+    /// between servers.
+    var filter: TaskFilter = .all
+
+    /// Jobs with a row action in flight, so a row cannot be double-fired and
+    /// can show that it is waiting on the server.
+    private(set) var pendingActionJobIDs: Set<String> = []
+
+    private let server: URL
     private let client: APIClient
 
     init(server: URL, client: APIClient? = nil) {
+        self.server = server
         self.client = client ?? APIClient(baseURL: server)
     }
 
@@ -41,7 +51,7 @@ final class TasksViewModel {
 
             let (jobsResult, statusResult) = try await (jobsResponse, statusResponse)
             runningJobs = statusResult.runningJobs ?? [:]
-            jobs = (jobsResult.jobs ?? []).sorted(by: sortJobs)
+            jobs = jobsResult.jobs ?? []
             deliveryOptions = await deliveryOptionsResponse?.platforms
         } catch {
             lastError = error
@@ -52,6 +62,31 @@ final class TasksViewModel {
     func runningElapsed(for job: CronJob) -> Double? {
         guard let jobID = job.jobId else { return nil }
         return runningJobs[jobID]
+    }
+
+    var runningJobIDs: Set<String> {
+        Set(runningJobs.keys)
+    }
+
+    /// The filtered, grouped agenda. `now` is injected so tests can pin the
+    /// clock that decides today/tomorrow/this week.
+    func sections(now: Date = .now, calendar: Calendar = .current) -> [TaskAgendaSection] {
+        TaskAgenda.sections(
+            jobs: jobs,
+            runningJobIDs: runningJobIDs,
+            filter: filter,
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    func count(for filter: TaskFilter) -> Int {
+        TaskAgenda.count(of: filter, in: jobs, runningJobIDs: runningJobIDs)
+    }
+
+    func isPendingAction(_ job: CronJob) -> Bool {
+        guard let jobID = job.jobId else { return false }
+        return pendingActionJobIDs.contains(jobID)
     }
 
     func clearActionError() {
@@ -110,8 +145,67 @@ final class TasksViewModel {
         }
     }
 
-    var activeRunningCount: Int {
-        runningJobs.count
+    // MARK: - Row actions
+
+    // Row actions delegate to `TaskDetailViewModel` so the list and the detail
+    // screen can never drift apart on what a mutation means. Nothing is applied
+    // optimistically: the server's response is what moves the row, so a row
+    // never claims a state the server has not confirmed.
+
+    func runNow(_ job: CronJob) async {
+        guard let jobID = await perform(job, action: { await $0.runNow() }) else { return }
+        // The server accepted the run, so the job belongs in "Now" until the
+        // next status poll replaces this with a real elapsed time.
+        runningJobs[jobID] = 0
+    }
+
+    func pause(_ job: CronJob) async {
+        guard let jobID = await perform(job, action: { await $0.pause() }) else { return }
+        runningJobs.removeValue(forKey: jobID)
+    }
+
+    func resume(_ job: CronJob) async {
+        _ = await perform(job, action: { await $0.resume() })
+    }
+
+    func delete(_ job: CronJob) async {
+        _ = await perform(job, action: { await $0.delete() })
+    }
+
+    /// Runs one Task Detail mutation for `job` and folds the result back into
+    /// the list. Returns the job's id on success, `nil` on failure or when the
+    /// job has no id to mutate.
+    @discardableResult
+    private func perform(
+        _ job: CronJob,
+        action: (TaskDetailViewModel) async -> Bool
+    ) async -> String? {
+        guard let jobID = job.jobId, !pendingActionJobIDs.contains(jobID) else { return nil }
+
+        pendingActionJobIDs.insert(jobID)
+        actionErrorMessage = nil
+        lastError = nil
+        defer { pendingActionJobIDs.remove(jobID) }
+
+        let detail = TaskDetailViewModel(
+            job: job,
+            runningElapsed: runningElapsed(for: job),
+            server: server,
+            client: client
+        )
+
+        let succeeded = await action(detail)
+        lastError = detail.lastError
+
+        guard succeeded else {
+            actionErrorMessage = detail.actionErrorMessage ?? String(localized: "Could not update task.")
+            return nil
+        }
+
+        if let mutation = detail.lastMutation {
+            apply(mutation)
+        }
+        return jobID
     }
 
     private func upsert(_ job: CronJob) {
@@ -128,28 +222,6 @@ final class TasksViewModel {
             jobs[index] = job
         } else {
             jobs.append(job)
-        }
-        jobs.sort(by: sortJobs)
-    }
-
-    private func sortJobs(_ left: CronJob, _ right: CronJob) -> Bool {
-        if runningElapsed(for: left) != nil, runningElapsed(for: right) == nil {
-            return true
-        }
-
-        if runningElapsed(for: left) == nil, runningElapsed(for: right) != nil {
-            return false
-        }
-
-        switch (left.nextRunAt?.date, right.nextRunAt?.date) {
-        case let (leftDate?, rightDate?):
-            return leftDate < rightDate
-        case (.some, nil):
-            return true
-        case (nil, .some):
-            return false
-        case (nil, nil):
-            return left.displayName.localizedCaseInsensitiveCompare(right.displayName) == .orderedAscending
         }
     }
 }

--- a/HermesMobile/Models/ANSIEscapes.swift
+++ b/HermesMobile/Models/ANSIEscapes.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+// Cron run transcripts arrive with the shell's terminal control bytes intact
+// (`\u{1b}[0;32m`). SwiftUI has no notion of them and renders the raw bytes as
+// garbage, so every surface that shows server-supplied run text — the Tasks
+// row, Task Detail's error line, the recent-run output — puts it through
+// `strippingANSIEscapes()` first.
+extension String {
+    /// Returns the string with ANSI/VT escape sequences removed.
+    ///
+    /// Recognises CSI (`ESC [ … final`), OSC (`ESC ] … BEL` or `ESC \`) and the
+    /// two-character escapes. A sequence that never terminates — the normal
+    /// result of a transcript truncated mid-escape — is dropped through the end
+    /// of the string rather than leaking its bytes into the UI.
+    func strippingANSIEscapes() -> String {
+        guard unicodeScalars.contains("\u{1B}") else { return self }
+
+        let scalars = Array(unicodeScalars)
+        var output = String.UnicodeScalarView()
+        output.reserveCapacity(scalars.count)
+
+        var index = 0
+        while index < scalars.count {
+            let scalar = scalars[index]
+            guard scalar == "\u{1B}" else {
+                output.append(scalar)
+                index += 1
+                continue
+            }
+
+            index += 1
+            guard index < scalars.count else { break }
+
+            switch scalars[index] {
+            case "[":
+                // CSI: parameter and intermediate bytes, then one final byte.
+                index += 1
+                while index < scalars.count, !(0x40...0x7E).contains(scalars[index].value) {
+                    index += 1
+                }
+                if index < scalars.count { index += 1 }
+            case "]":
+                // OSC: runs until BEL or the string terminator `ESC \`.
+                index += 1
+                while index < scalars.count {
+                    if scalars[index] == "\u{07}" {
+                        index += 1
+                        break
+                    }
+                    if scalars[index] == "\u{1B}",
+                       index + 1 < scalars.count,
+                       scalars[index + 1] == "\\" {
+                        index += 2
+                        break
+                    }
+                    index += 1
+                }
+            default:
+                index += 1
+            }
+        }
+
+        return String(output)
+    }
+
+    /// The first meaningful line of a multi-line server transcript, escapes
+    /// stripped and clipped, for places that have room for one line only. The
+    /// full text stays reachable on Task Detail.
+    func firstLineSummary(limit: Int = 120) -> String? {
+        let stripped = strippingANSIEscapes()
+        guard let line = stripped
+            .split(whereSeparator: \.isNewline)
+            .lazy
+            .map({ $0.trimmingCharacters(in: .whitespaces) })
+            .first(where: { !$0.isEmpty })
+        else { return nil }
+
+        guard line.count > limit else { return line }
+        return line.prefix(limit).trimmingCharacters(in: .whitespaces) + "…"
+    }
+}

--- a/HermesMobile/Models/Cron.swift
+++ b/HermesMobile/Models/Cron.swift
@@ -36,8 +36,11 @@ struct CronStatusResponse: Decodable, Equatable {
 }
 
 struct CronJob: Decodable, Equatable, Identifiable {
+    /// Stable across refreshes. Never a fresh `UUID` — `id` is computed, so a
+    /// UUID fallback would hand SwiftUI a different identity on every read and
+    /// rebuild every row of the list on every poll.
     var id: String {
-        jobId ?? name ?? UUID().uuidString
+        jobId ?? name ?? ""
     }
 
     let jobId: String?

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -123530,6 +123530,2444 @@
           }
         }
       }
+    },
+    "Now" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "الآن"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jetzt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ahora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Maintenant"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "עכשיו"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adesso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "現在"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "지금"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nu"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Teraz"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сейчас"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Şimdi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ابھی"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "現在"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "现在"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "現在"
+          }
+        }
+      }
+    },
+    "Later Today" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لاحقًا اليوم"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Später heute"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hoy más tarde"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Plus tard aujourd’hui"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בהמשך היום"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Più tardi oggi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今日中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "오늘 늦게"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Later vandaag"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Później dzisiaj"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mais tarde hoje"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сегодня позже"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bugün ilerleyen saatlerde"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آج بعد میں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今日稍後"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今天稍后"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今天稍後"
+          }
+        }
+      }
+    },
+    "Tomorrow" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "غدًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Morgen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mañana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Demain"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מחר"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Domani"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "明日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "내일"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Morgen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jutro"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Amanhã"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Завтра"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yarın"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کل"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "明日"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "明天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "明天"
+          }
+        }
+      }
+    },
+    "This Week" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "هذا الأسبوع"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diese Woche"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cette semaine"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "השבוע"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Questa settimana"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今週"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이번 주"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deze week"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "W tym tygodniu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta semana"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "На этой неделе"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu hafta"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اس ہفتے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "本星期"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "本周"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "本週"
+          }
+        }
+      }
+    },
+    "Later" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لاحقًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Später"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Más adelante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Plus tard"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בהמשך"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Più avanti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今後"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "나중에"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Later"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Później"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mais tarde"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Позже"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Daha sonra"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "بعد میں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "之後"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "以后"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "之後"
+          }
+        }
+      }
+    },
+    "All %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "الكل %lld"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Todas %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toutes %lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הכול %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tutte %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "すべて %lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전체 %lld"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wszystkie %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Todas %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Все %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tümü %lld"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تمام %lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全部 %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全部 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全部 %lld"
+          }
+        }
+      }
+    },
+    "Live %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نشطة %lld"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aktiv %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Activas %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Actives %lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פעילות %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Attive %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "有効 %lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "활성 %lld"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Actief %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aktywne %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativas %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Активные %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Etkin %lld"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فعال %lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "啟用 %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "启用 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "啟用 %lld"
+          }
+        }
+      }
+    },
+    "Paused %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "متوقفة %lld"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pausiert %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pausadas %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "En pause %lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מושהות %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sospese %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一時停止 %lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "일시정지 %lld"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gepauzeerd %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wstrzymane %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pausadas %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Приостановлены %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Duraklatılmış %lld"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "روکے گئے %lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已暫停 %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已暂停 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已暫停 %lld"
+          }
+        }
+      }
+    },
+    "Errors %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "أخطاء %lld"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fehler %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Errores %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erreurs %lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "שגיאות %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Errori %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "エラー %lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "오류 %lld"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fouten %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Błędy %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erros %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ошибки %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hatalar %lld"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "خرابیاں %lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "錯誤 %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "错误 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "錯誤 %lld"
+          }
+        }
+      }
+    },
+    "Filter" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تصفية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "סינון"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "フィルタ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "필터"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filter"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtr"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Фильтр"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtre"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فلٹر"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "篩選"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "筛选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "篩選"
+          }
+        }
+      }
+    },
+    "Last run failed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فشل التشغيل الأخير"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Letzter Lauf fehlgeschlagen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La última ejecución falló"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dernière exécution échouée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ההרצה האחרונה נכשלה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ultima esecuzione non riuscita"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "前回の実行が失敗しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "마지막 실행 실패"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Laatste uitvoering mislukt"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ostatnie uruchomienie nie powiodło się"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A última execução falhou"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Последний запуск не удался"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Son çalıştırma başarısız oldu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آخری رن ناکام ہو گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次執行失敗"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次运行失败"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次執行失敗"
+          }
+        }
+      }
+    },
+    "Every minute" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "كل دقيقة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jede Minute"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cada minuto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chaque minute"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בכל דקה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ogni minuto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "毎分"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "매분"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Elke minuut"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Co minutę"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A cada minuto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Каждую минуту"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Her dakika"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ہر منٹ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每分鐘"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每分鐘"
+          }
+        }
+      }
+    },
+    "Every %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "كل %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cada %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toutes les %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "כל %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ogni %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ごと"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@마다"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Elke %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Co %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A cada %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Каждые %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Her %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ہر %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每 %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每 %@"
+          }
+        }
+      }
+    },
+    "Weekly on %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "أسبوعيًا: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wöchentlich am %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cada semana el %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chaque semaine le %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "שבועי: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ogni settimana: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "毎週%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "매주 %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wekelijks op %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Co tydzień: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Semanalmente: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Еженедельно: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Haftalık: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ہفتہ وار: %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每週%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每周%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每週%@"
+          }
+        }
+      }
+    },
+    "Daily" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يوميًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Täglich"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diariamente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tous les jours"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מדי יום"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ogni giorno"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "毎日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "매일"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dagelijks"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Codziennie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diariamente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ежедневно"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Her gün"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "روزانہ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每日"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每天"
+          }
+        }
+      }
+    },
+    "Weekdays" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "أيام العمل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wochentags"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Días laborables"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "En semaine"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בימי חול"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nei giorni feriali"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "平日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "평일"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Op werkdagen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "W dni robocze"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Em dias úteis"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "По будням"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hafta içi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کام کے دن"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "平日"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "工作日"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "平日"
+          }
+        }
+      }
+    },
+    "Weekends" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "عطلات نهاية الأسبوع"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Am Wochenende"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fines de semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Le week-end"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בסופי שבוע"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nei fine settimana"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "週末"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "주말"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "In het weekend"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "W weekendy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nos fins de semana"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "По выходным"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hafta sonu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ویک اینڈ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "週末"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "周末"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "週末"
+          }
+        }
+      }
+    },
+    "Monthly on the %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "شهريًا: %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Monatlich am %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensualmente el %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chaque mois le %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "חודשי: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ogni mese il %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "毎月%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "매월 %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Maandelijks op de %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Co miesiąc: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensalmente no %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ежемесячно: %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aylık: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ماہانہ: %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每月%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每月%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "每月%@"
+          }
+        }
+      }
+    },
+    "%@ at %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ في %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ um %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ a las %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ à %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ בשעה %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ alle %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ om %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ o %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ às %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ в %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ saat %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ %@ بجے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ %@"
+          }
+        }
+      }
+    },
+    "No Matching Tasks" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لا توجد مهام مطابقة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine passenden Aufgaben"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sin tareas coincidentes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aucune tâche correspondante"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "אין משימות תואמות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nessuna attività corrispondente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該当するタスクなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "일치하는 작업 없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geen overeenkomende taken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brak pasujących zadań"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma tarefa correspondente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Нет подходящих задач"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eşleşen Görev Yok"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کوئی مماثل ٹاسکس نہیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "沒有符合的任務"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无匹配任务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無符合的任務"
+          }
+        }
+      }
+    },
+    "No tasks match this filter." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لا توجد مهام تطابق هذه التصفية."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine Aufgaben entsprechen diesem Filter."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ninguna tarea coincide con este filtro."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aucune tâche ne correspond à ce filtre."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "אין משימות התואמות לסינון זה."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nessuna attività corrisponde a questo filtro."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "このフィルタに一致するタスクはありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 필터와 일치하는 작업이 없어요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geen taken komen overeen met dit filter."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Żadne zadanie nie pasuje do tego filtra."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma tarefa corresponde a este filtro."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ни одна задача не соответствует этому фильтру."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu filtreyle eşleşen görev yok."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اس فلٹر سے کوئی ٹاسک مماثل نہیں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "沒有符合此篩選條件的任務。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "没有任务符合此筛选条件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "沒有符合此篩選條件的任務。"
+          }
+        }
+      }
+    },
+    "“%@” will be removed from the Hermes server." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ستتم إزالة “%@” من خادم Hermes."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "„%@“ wird vom Hermes-Server entfernt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "«%@» se eliminará del servidor Hermes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "« %@ » sera supprimée du serveur Hermes."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "“%@” יוסר משרת Hermes."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "“%@” verrà rimossa dal server Hermes."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "「%@」をHermesサーバから削除します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "“%@”을(를) Hermes 서버에서 제거해요."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "‘%@’ wordt van de Hermes-server verwijderd."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "„%@” zostanie usunięte z serwera Hermes."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "“%@” será removida do servidor Hermes."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "«%@» будет удалена с сервера Hermes."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "“%@” Hermes sunucusundan kaldırılacak."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "“%@” کو Hermes سرور سے ہٹا دیا جائے گا۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "將從 Hermes 伺服器移除「%@」。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "将从 Hermes 服务器移除“%@”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "將從 Hermes 伺服器移除「%@」。"
+          }
+        }
+      }
+    },
+    "Could Not Update Task" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تعذّر تحديث المهمة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aufgabe konnte nicht aktualisiert werden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No se pudo actualizar la tarea"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossible de mettre à jour la tâche"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא ניתן לעדכן את המשימה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossibile aggiornare l’attività"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "タスクを更新できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "작업을 업데이트할 수 없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kan taak niet bijwerken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nie można zaktualizować zadania"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não foi possível atualizar a tarefa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Не удалось обновить задачу"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Görev Güncellenemedi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ٹاسک اپ ڈیٹ نہ ہو سکا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法更新任務"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法更新任务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法更新任務"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/TaskAgendaTests.swift
+++ b/HermesMobileTests/TaskAgendaTests.swift
@@ -1,0 +1,375 @@
+import XCTest
+@testable import HermesMobile
+
+/// Covers the three pieces the Tasks agenda list is built on: humanising cron
+/// expressions, assigning each job to exactly one group, and stripping the
+/// terminal escapes out of server run text.
+final class TaskAgendaTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Eastern time, matching the reference server the eleven real expressions
+    /// came from, so rendered clock times are the ones cron fires at.
+    private static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York") ?? .gmt
+        calendar.locale = Locale(identifier: "en_US")
+        return calendar
+    }()
+
+    private static let locale = Locale(identifier: "en_US")
+
+    private func makeJob(
+        id: String? = "job-1",
+        name: String = "Task",
+        schedule: String? = "0 7 * * *",
+        enabled: Bool = true,
+        state: String = "scheduled",
+        nextRunAt: Date? = nil,
+        lastStatus: String? = "ok",
+        lastError: String? = nil,
+        lastDeliveryError: String? = nil
+    ) throws -> CronJob {
+        var payload: [String: Any] = [
+            "name": name,
+            "enabled": enabled,
+            "state": state,
+            "toast_notifications": true
+        ]
+        if let id { payload["id"] = id }
+        if let schedule { payload["schedule"] = ["kind": "cron", "expr": schedule, "display": schedule] }
+        if let nextRunAt { payload["next_run_at"] = ISO8601DateFormatter().string(from: nextRunAt) }
+        if let lastStatus { payload["last_status"] = lastStatus }
+        if let lastError { payload["last_error"] = lastError }
+        if let lastDeliveryError { payload["last_delivery_error"] = lastDeliveryError }
+
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(CronJob.self, from: data)
+    }
+
+    private func describe(_ expression: String) -> CronScheduleDescription? {
+        CronScheduleHumanizer.describe(expression, locale: Self.locale, calendar: Self.calendar)
+    }
+
+    /// `Date.FormatStyle` separates the time from AM/PM with a narrow no-break
+    /// space (U+202F). Fold it back to a plain space so the expectations below
+    /// stay readable and the assertions are about the words, not the spacing.
+    private func sentence(_ expression: String) -> String? {
+        describe(expression)?.sentence.replacingOccurrences(of: "\u{202F}", with: " ")
+    }
+
+    // MARK: - Humanising
+
+    func testHumanisesEveryExpressionOnTheReferenceServer() {
+        let expectations: [String: String] = [
+            "*/15 * * * *": "Every 15 minutes",
+            "0 4 * * *": "Daily at 4:00 AM",
+            "0 7 * * *": "Daily at 7:00 AM",
+            "0 8 * * *": "Daily at 8:00 AM",
+            "0 9 * * *": "Daily at 9:00 AM",
+            "0 16 1 * *": "Monthly on the 1st at 4:00 PM",
+            "0 18 * * 5": "Weekly on Friday at 6:00 PM",
+            "0 20 * * 0": "Weekly on Sunday at 8:00 PM",
+            "25 9 * * 1-5": "Weekdays at 9:25 AM",
+            "5 16 * * 1-5": "Weekdays at 4:05 PM",
+            "30 16 * * 1-5": "Weekdays at 4:30 PM"
+        ]
+
+        for (expression, expected) in expectations {
+            XCTAssertEqual(sentence(expression), expected, expression)
+        }
+    }
+
+    func testRecurrenceDropsTheTimeOfDayForRowsThatShowTheNextRun() {
+        XCTAssertEqual(describe("0 7 * * *")?.recurrence, "Daily")
+        XCTAssertEqual(describe("25 9 * * 1-5")?.recurrence, "Weekdays")
+        XCTAssertEqual(describe("0 16 1 * *")?.recurrence, "Monthly on the 1st")
+        XCTAssertEqual(describe("0 20 * * 0")?.recurrence, "Weekly on Sunday")
+        // An interval has no time of day, so both forms are the same string.
+        XCTAssertEqual(describe("*/15 * * * *")?.recurrence, "Every 15 minutes")
+    }
+
+    func testHumanisesTheRemainingRecognisedShapes() {
+        XCTAssertEqual(sentence("* * * * *"), "Every minute")
+        XCTAssertEqual(sentence("*/1 * * * *"), "Every minute")
+        XCTAssertEqual(sentence("0 */2 * * *"), "Every 2 hours")
+        XCTAssertEqual(sentence("0 12 * * 0,6"), "Weekends at 12:00 PM")
+        // Cron's day 7 is Sunday.
+        XCTAssertEqual(sentence("0 20 * * 7"), "Weekly on Sunday at 8:00 PM")
+    }
+
+    func testUnrecognisedExpressionsFallThroughInsteadOfGuessing() {
+        let unrecognised = [
+            "",
+            "not a cron",
+            "*/15 * * *",          // too few fields
+            "*/15 * * * * *",      // too many fields
+            "0 7 * * 9",           // day of week out of range
+            "0 99 * * *",          // hour out of range
+            "*/0 * * * *",         // zero step
+            "0 7 1 * 1",           // day-of-month and day-of-week together
+            "0 7 * 3 *",           // month restricted
+            "0 7 * * 2-4",         // a weekday range we do not name
+            "0,30 7 * * *"         // a minute list
+        ]
+
+        for expression in unrecognised {
+            XCTAssertNil(describe(expression), expression)
+        }
+    }
+
+    func testHumaniserIsNilForAMissingExpression() {
+        XCTAssertNil(CronScheduleHumanizer.describe(nil, locale: Self.locale, calendar: Self.calendar))
+    }
+
+    // MARK: - Grouping
+
+    private func group(
+        _ job: CronJob,
+        isRunning: Bool = false,
+        now: Date
+    ) -> TaskAgendaGroup {
+        TaskAgenda.group(for: job, isRunning: isRunning, now: now, calendar: Self.calendar)
+    }
+
+    func testGroupsByWhenTheJobRunsNext() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let startOfToday = Self.calendar.startOfDay(for: now)
+
+        func job(offsetDays: Int, hour: Int) throws -> CronJob {
+            let day = try XCTUnwrap(Self.calendar.date(byAdding: .day, value: offsetDays, to: startOfToday))
+            let next = try XCTUnwrap(Self.calendar.date(bySettingHour: hour, minute: 0, second: 0, of: day))
+            return try makeJob(nextRunAt: next)
+        }
+
+        XCTAssertEqual(group(try job(offsetDays: 0, hour: 23), now: now), .laterToday)
+        XCTAssertEqual(group(try job(offsetDays: 1, hour: 7), now: now), .tomorrow)
+        XCTAssertEqual(group(try job(offsetDays: 3, hour: 7), now: now), .thisWeek)
+        XCTAssertEqual(group(try job(offsetDays: 6, hour: 23), now: now), .thisWeek)
+        XCTAssertEqual(group(try job(offsetDays: 7, hour: 1), now: now), .later)
+        XCTAssertEqual(group(try job(offsetDays: 30, hour: 7), now: now), .later)
+        XCTAssertEqual(group(try makeJob(nextRunAt: nil), now: now), .later)
+    }
+
+    func testAnOverdueNextRunStaysTodaysBusiness() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let overdue = try XCTUnwrap(Self.calendar.date(byAdding: .hour, value: -3, to: now))
+
+        XCTAssertEqual(group(try makeJob(nextRunAt: overdue), now: now), .laterToday)
+    }
+
+    func testRunningWinsOverEveryOtherGroup() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let job = try makeJob(
+            enabled: false,
+            state: "paused",
+            lastStatus: "error",
+            lastError: "Script exited with code 1"
+        )
+
+        XCTAssertEqual(group(job, isRunning: true, now: now), .now)
+    }
+
+    func testAFailedLastRunNeedsAttentionWhateverTheEnabledState() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+
+        let pausedFailure = try makeJob(
+            enabled: false,
+            state: "paused",
+            lastStatus: "error",
+            lastError: "Script exited with code 1"
+        )
+        XCTAssertEqual(group(pausedFailure, now: now), .needsAttention)
+
+        let liveFailure = try makeJob(
+            nextRunAt: now.addingTimeInterval(3600),
+            lastStatus: "error"
+        )
+        XCTAssertEqual(group(liveFailure, now: now), .needsAttention)
+
+        let deliveryFailure = try makeJob(lastDeliveryError: "discord: 403")
+        XCTAssertEqual(group(deliveryFailure, now: now), .needsAttention)
+    }
+
+    func testAPausedJobWithoutAFailureIsPaused() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let job = try makeJob(enabled: false, state: "paused", nextRunAt: now.addingTimeInterval(-86_400))
+
+        XCTAssertEqual(group(job, now: now), .paused)
+    }
+
+    func testEveryJobLandsInExactlyOneGroup() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let jobs = try referenceServerJobs(now: now)
+        let running: Set<String> = ["job-2"]
+
+        let sections = TaskAgenda.sections(
+            jobs: jobs,
+            runningJobIDs: running,
+            filter: .all,
+            now: now,
+            calendar: Self.calendar
+        )
+
+        let placed = sections.flatMap(\.jobs).map(\.id)
+        XCTAssertEqual(placed.count, jobs.count, "A job was dropped or duplicated by the grouping.")
+        XCTAssertEqual(Set(placed), Set(jobs.map(\.id)))
+        XCTAssertTrue(sections.allSatisfy { !$0.jobs.isEmpty }, "Empty groups must not be rendered.")
+        XCTAssertEqual(
+            sections.map(\.group),
+            sections.map(\.group).sorted { $0.rawValue < $1.rawValue },
+            "Groups must keep their declared screen order."
+        )
+    }
+
+    func testJobsSortByNextRunThenName() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let soon = now.addingTimeInterval(3600)
+        let later = now.addingTimeInterval(7200)
+
+        let jobs = [
+            try makeJob(id: "c", name: "Beta", nextRunAt: later),
+            try makeJob(id: "b", name: "Zulu", nextRunAt: soon),
+            try makeJob(id: "a", name: "Alpha", nextRunAt: soon)
+        ]
+
+        let sections = TaskAgenda.sections(
+            jobs: jobs,
+            runningJobIDs: [],
+            filter: .all,
+            now: now,
+            calendar: Self.calendar
+        )
+
+        XCTAssertEqual(sections.flatMap(\.jobs).map(\.name), ["Alpha", "Zulu", "Beta"])
+    }
+
+    // MARK: - Filters
+
+    func testFilterCountsMatchTheReferenceServer() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let jobs = try referenceServerJobs(now: now)
+
+        XCTAssertEqual(TaskAgenda.count(of: .all, in: jobs, runningJobIDs: []), 11)
+        XCTAssertEqual(TaskAgenda.count(of: .live, in: jobs, runningJobIDs: []), 3)
+        XCTAssertEqual(TaskAgenda.count(of: .paused, in: jobs, runningJobIDs: []), 8)
+        XCTAssertEqual(TaskAgenda.count(of: .errors, in: jobs, runningJobIDs: []), 1)
+    }
+
+    func testTheErrorsFilterSelectsTheFailingJob() throws {
+        let now = Date(timeIntervalSince1970: 1_772_000_000)
+        let jobs = try referenceServerJobs(now: now)
+
+        let sections = TaskAgenda.sections(
+            jobs: jobs,
+            runningJobIDs: [],
+            filter: .errors,
+            now: now,
+            calendar: Self.calendar
+        )
+
+        XCTAssertEqual(sections.flatMap(\.jobs).map(\.name), ["trading-bot-start-weekdays-0925"])
+    }
+
+    func testARunningPausedJobStillCountsAsLive() throws {
+        let job = try makeJob(id: "job-1", enabled: false, state: "paused")
+
+        XCTAssertEqual(TaskAgenda.count(of: .live, in: [job], runningJobIDs: ["job-1"]), 1)
+        XCTAssertEqual(TaskAgenda.count(of: .paused, in: [job], runningJobIDs: ["job-1"]), 0)
+    }
+
+    /// The shape of the maintainer's server: eleven jobs, three scheduled,
+    /// eight paused, one of the paused ones carrying a failed run.
+    private func referenceServerJobs(now: Date) throws -> [CronJob] {
+        var jobs: [CronJob] = [
+            try makeJob(
+                id: "job-0",
+                name: "trading-bot-start-weekdays-0925",
+                schedule: "25 9 * * 1-5",
+                enabled: false,
+                state: "paused",
+                nextRunAt: now.addingTimeInterval(-86_400 * 40),
+                lastStatus: "error",
+                lastError: "Script exited with code 1\nstdout:\nFAIL — trading bot did not verify cleanly."
+            )
+        ]
+
+        for index in 1...7 {
+            jobs.append(
+                try makeJob(
+                    id: "paused-\(index)",
+                    name: "Paused \(index)",
+                    enabled: false,
+                    state: "paused",
+                    nextRunAt: now.addingTimeInterval(-86_400 * Double(index))
+                )
+            )
+        }
+
+        for index in 1...3 {
+            jobs.append(
+                try makeJob(
+                    id: "job-\(index)",
+                    name: "Live \(index)",
+                    nextRunAt: now.addingTimeInterval(3600 * Double(index))
+                )
+            )
+        }
+
+        return jobs
+    }
+
+    // MARK: - ANSI stripping
+
+    func testStripsColourCodesFromRunOutput() {
+        let raw = "\u{1B}[0;32m[BOT START]\u{1B}[0m Starting Trading Bot"
+
+        XCTAssertEqual(raw.strippingANSIEscapes(), "[BOT START] Starting Trading Bot")
+    }
+
+    func testLeavesTextWithoutEscapesUntouched() {
+        let plain = "Script exited with code 1"
+
+        XCTAssertEqual(plain.strippingANSIEscapes(), plain)
+    }
+
+    func testDropsASequenceSplitAcrossATruncationBoundary() {
+        // A transcript clipped mid-escape must not leak its bytes into the UI.
+        XCTAssertEqual("done \u{1B}[0;3".strippingANSIEscapes(), "done ")
+        XCTAssertEqual("done \u{1B}".strippingANSIEscapes(), "done ")
+        XCTAssertEqual("done \u{1B}]0;title".strippingANSIEscapes(), "done ")
+    }
+
+    func testStripsOperatingSystemCommandsAndTwoCharacterEscapes() {
+        XCTAssertEqual("\u{1B}]0;window title\u{07}ready".strippingANSIEscapes(), "ready")
+        XCTAssertEqual("\u{1B}]0;window title\u{1B}\\ready".strippingANSIEscapes(), "ready")
+        XCTAssertEqual("\u{1B}creset".strippingANSIEscapes(), "reset")
+    }
+
+    func testFirstLineSummaryTakesOneReadableLine() {
+        let raw = "\n\n\u{1B}[0;31mScript exited with code 1\u{1B}[0m\nstdout:\nFAIL"
+
+        XCTAssertEqual(raw.firstLineSummary(), "Script exited with code 1")
+        XCTAssertNil("   \n\n".firstLineSummary())
+    }
+
+    func testFirstLineSummaryClipsALongLine() {
+        let raw = String(repeating: "a", count: 200)
+
+        let summary = raw.firstLineSummary(limit: 20)
+
+        XCTAssertEqual(summary, String(repeating: "a", count: 20) + "…")
+    }
+
+    func testFailureSummaryPrefersTheRunErrorAndIsEscapeFree() throws {
+        let job = try makeJob(
+            lastStatus: "error",
+            lastError: "\u{1B}[0;31mScript exited with code 1\u{1B}[0m\nstdout: noise"
+        )
+
+        XCTAssertEqual(job.failureSummary, "Script exited with code 1")
+        XCTAssertTrue(job.hasFailedRun)
+    }
+}


### PR DESCRIPTION
## Linked issue

Fixes #376

## What changed

The Tasks list printed eight metadata lines per job whether or not any of them mattered, so eleven jobs read as one grey wall — the three live ones sat at positions 6, 10 and 11 — and nothing was actionable without opening the job first.

Tasks is now an agenda. Jobs group by when they run next (**Now**, **Later Today**, **Tomorrow**, **This Week**, **Later**, **Needs Attention**, **Paused**), a pinned `All · Live · Paused · Errors` filter sits above the list with live counts, and each row is a status rail, the name and one meta line. Run Now, Pause and Resume are on a swipe and a long press; Delete is long-press only and confirms by name. Model, provider, profile, skills, deliver and the prompt moved off the row — they live on Task Detail.

Two supporting pieces:

- **`CronScheduleHumanizer`** renders standard 5-field cron as English (`*/15 * * * *` → "Every 15 minutes", `25 9 * * 1-5` → "Weekdays at 9:25 AM"). It is deliberately narrow: anything it does not recognise falls through to the server's own string, never to a wrong guess. Rows that already show a next-run time use the recurrence alone ("6:45 PM · Daily"), so the time is not printed twice.
- **`String.strippingANSIEscapes()`** removes CSI/OSC sequences from server run text, including one truncated mid-escape. Applied to the row's error line and to Task Detail's error and output, so slice 2 can reuse it.

Three judgement calls worth flagging:

1. **An enabled job whose last run failed goes to Needs Attention**, not to its time bucket. The issue says "regardless of enabled state" and the mock's compare table makes that group the answer to "what is broken", so all failures land there. Confirmed with @uzairansaruzi before implementing.
2. **`Weekly on Sunday` rather than `Sundays`.** One `Every %@` key cannot serve both "15 minutes" and "Sunday" — German needs "Alle 15 Minuten" but "Jeden Sonntag" — so the weekday case got its own frame. Weekday names and the ordinal in "Monthly on the 1st" come from Foundation, and intervals go through `Duration.UnitsFormatStyle`, so plurals are correct per locale without a plural entry per interval in the catalog.
3. **`CronJob.id` no longer falls back to `UUID()`.** It is a computed property, so that fallback handed SwiftUI a fresh identity on every read and rebuilt every row on every poll. It is `jobId ?? name ?? ""` now.

Row actions call `TaskDetailViewModel`'s existing mutations rather than duplicating them, and nothing is applied optimistically — the server's response is what moves the row.

## How it was tested

**Contract, against the maintainer's live server (read-only):** `GET /api/crons` and `GET /api/crons/status`. Every job carries a real hex `id` (`job_id` is separately `null`), so identity, the running-jobs join and every mutation resolve off it; `/api/crons/status` returns `{"running": {<id>: elapsed}}`. Upstream `hermes-webui` @ `e168b67e` was read for the mutation handlers. No mutating calls were made.

**Full XCTest suite** on `0679cbf` via XcodeBuildMCP `test_sim` (scheme `HermesMobile`, iPhone 17): **1959 passed, 0 failed, 2 skipped**.

**22 new tests** in `HermesMobileTests/TaskAgendaTests.swift`:
- All eleven cron expressions on the reference server, plus the recurrence-only forms, plus eleven malformed or unsupported expressions that must fall through.
- Group assignment: the exactly-one-group property over an eleven-job fixture, the running-wins and failure-wins precedence rules, each time bucket boundary, and an overdue next run.
- Filter counts matching the real server (All 11, Live 3, Paused 8, Errors 1) and the Errors filter selecting the failing job.
- ANSI stripping, including a sequence split across a truncation boundary, OSC, and two-character escapes.

`scripts/check-swift-file-sizes` reports no new oversized files. All 23 new strings are in `Localizable.xcstrings` with all 17 shipped languages; the catalog diff is purely additive (2438 added, 0 removed) and no pre-existing language subtree changed.

**Not yet done:** before/after screenshots, the AX5 and VoiceOver pass, and light/dark. Those need a signed Debug build pointed at a real server — happy to drive the simulator for them if you want, otherwise they are in your manual pass.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (no decode changes; `CronJob.id` identity only)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (verified against the running server and upstream `e168b67e`)

---

Written by Claude Opus 5 in Claude Code.
