### PR TITLE
feat(tasks): redesign Task Detail and add per-task run history

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		1A2B3C4D5E6F700000000300 /* ServerAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F700000000301 /* ServerAccount.swift */; };
 		B5A1000000000000000000A0 /* ServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A1000000000000000000A1 /* ServerRegistryTests.swift */; };
 		C0DE512E0000000000000202 /* InsightsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000201 /* InsightsModels.swift */; };
-		C0DE512E0000000000000204 /* UsageCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000203 /* UsageCard.swift */; };
+		C0DE512E0000000000000204 /* SectionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E0000000000000203 /* SectionCard.swift */; };
 		C0DE512E00000000000002206 /* UsageChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E00000000000002205 /* UsageChartData.swift */; };
 		C0DE512E00000000000002208 /* UsageChartCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E00000000000002207 /* UsageChartCard.swift */; };
 		C0DE512E0000000000000220A /* UsageTotalsGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE512E00000000000002209 /* UsageTotalsGrid.swift */; };
@@ -94,6 +94,7 @@
 		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
 		C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000010 /* APIEndpointContractTests.swift */; };
 		C03910000000000000000011 /* CronManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000011 /* CronManagementTests.swift */; };
+		D600000000000000000012 /* TaskRunHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600000000000000000011 /* TaskRunHistoryTests.swift */; };
 		D500000000000000000002 /* TaskAgendaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000001 /* TaskAgendaTests.swift */; };
 		C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000012 /* MemoryViewModelTests.swift */; };
 		C03910000000000000000013 /* ModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000013 /* ModelCatalogTests.swift */; };
@@ -331,6 +332,10 @@
 		2BE8F2B38F094C4C9EB18301 /* SkillsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */; };
 		22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */; };
 		36CD9EF0B0734E5F8C28BB92 /* SlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA59130ED4141049177576C /* SlashCommand.swift */; };
+		D600000000000000000002 /* CronRunHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600000000000000000001 /* CronRunHistory.swift */; };
+		D500000000000000000012 /* TaskDetailHeaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000011 /* TaskDetailHeaderCard.swift */; };
+		D500000000000000000022 /* TaskRunHistorySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000021 /* TaskRunHistorySection.swift */; };
+		D500000000000000000032 /* TaskRunOutputSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000031 /* TaskRunOutputSheet.swift */; };
 		3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01011 /* Cron.swift */; };
 		D100000000000000000002 /* ANSIEscapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000000000001 /* ANSIEscapes.swift */; };
 		3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01012 /* TasksView.swift */; };
@@ -476,6 +481,7 @@
 		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000010 /* APIEndpointContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointContractTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000011 /* CronManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronManagementTests.swift; sourceTree = "<group>"; };
+		D600000000000000000011 /* TaskRunHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunHistoryTests.swift; sourceTree = "<group>"; };
 		D500000000000000000001 /* TaskAgendaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskAgendaTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000012 /* MemoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewModelTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000013 /* ModelCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCatalogTests.swift; sourceTree = "<group>"; };
@@ -663,6 +669,10 @@
 		2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsViewModelTests.swift; sourceTree = "<group>"; };
 		22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModelTests.swift; sourceTree = "<group>"; };
 		1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandCatalog.swift; sourceTree = "<group>"; };
+		D600000000000000000001 /* CronRunHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronRunHistory.swift; sourceTree = "<group>"; };
+		D500000000000000000011 /* TaskDetailHeaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailHeaderCard.swift; sourceTree = "<group>"; };
+		D500000000000000000021 /* TaskRunHistorySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunHistorySection.swift; sourceTree = "<group>"; };
+		D500000000000000000031 /* TaskRunOutputSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunOutputSheet.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01011 /* Cron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cron.swift; sourceTree = "<group>"; };
 		D100000000000000000001 /* ANSIEscapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIEscapes.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01012 /* TasksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksView.swift; sourceTree = "<group>"; };
@@ -678,7 +688,7 @@
 		3F91D2A54B9A4F66A2C01015 /* TaskDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModel.swift; sourceTree = "<group>"; };
 		57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsView.swift; sourceTree = "<group>"; };
 		C0DE512E0000000000000201 /* InsightsModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightsModels.swift; sourceTree = "<group>"; };
-		C0DE512E0000000000000203 /* UsageCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsageCard.swift; sourceTree = "<group>"; };
+		C0DE512E0000000000000203 /* SectionCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SectionCard.swift; sourceTree = "<group>"; };
 		C0DE512E00000000000002205 /* UsageChartData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsageChartData.swift; sourceTree = "<group>"; };
 		C0DE512E00000000000002207 /* UsageChartCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsageChartCard.swift; sourceTree = "<group>"; };
 		C0DE512E00000000000002209 /* UsageTotalsGrid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsageTotalsGrid.swift; sourceTree = "<group>"; };
@@ -891,6 +901,7 @@
 				C03900000000000000000010 /* APIEndpointContractTests.swift */,
 				C03900000000000000000011 /* CronManagementTests.swift */,
 				D500000000000000000001 /* TaskAgendaTests.swift */,
+				D600000000000000000011 /* TaskRunHistoryTests.swift */,
 				C03900000000000000000012 /* MemoryViewModelTests.swift */,
 				C03900000000000000000013 /* ModelCatalogTests.swift */,
 				C03900000000000000000014 /* MessageActionContextTests.swift */,
@@ -1027,6 +1038,7 @@
 				C1A042000000000000000002 /* Clarification.swift */,
 				A02400000000000000000002 /* Goal.swift */,
 				3F91D2A54B9A4F66A2C01011 /* Cron.swift */,
+				D600000000000000000001 /* CronRunHistory.swift */,
 				D100000000000000000001 /* ANSIEscapes.swift */,
 				1A2B3C4D5E6F70000000201 /* Memory.swift */,
 				1A2B3C4D5E6F70000000211 /* Skills.swift */,
@@ -1092,6 +1104,7 @@
 				C0FF000000000000000000B2 /* CustomHeadersEditor.swift */,
 				C0366000000000000000002 /* ModelPickerSheet.swift */,
 				C0366000000000000000004 /* ModelPickerConfiguration.swift */,
+				C0DE512E0000000000000203 /* SectionCard.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1348,6 +1361,9 @@
 				D200000000000000000001 /* CronScheduleHumanizer.swift */,
 				3F91D2A54B9A4F66A2C01014 /* TaskDetailView.swift */,
 				3F91D2A54B9A4F66A2C01015 /* TaskDetailViewModel.swift */,
+				D500000000000000000031 /* TaskRunOutputSheet.swift */,
+				D500000000000000000021 /* TaskRunHistorySection.swift */,
+				D500000000000000000011 /* TaskDetailHeaderCard.swift */,
 				C0369000000000000000002 /* CronJobEditorConfigurationLoader.swift */,
 				C0369000000000000000008 /* CronJobEditorSheet.swift */,
 				C0369000000000000000004 /* CronJobConfigurationPickers.swift */,
@@ -1361,7 +1377,6 @@
 			children = (
 				57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */,
 				C0DE512E0000000000000201 /* InsightsModels.swift */,
-				C0DE512E0000000000000203 /* UsageCard.swift */,
 				C0DE512E00000000000002205 /* UsageChartData.swift */,
 				C0DE512E00000000000002207 /* UsageChartCard.swift */,
 				C0DE512E00000000000002209 /* UsageTotalsGrid.swift */,
@@ -1747,6 +1762,10 @@
 				C1A042000000000000000001 /* Clarification.swift in Sources */,
 				C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */,
 				A02400000000000000000001 /* Goal.swift in Sources */,
+				D600000000000000000002 /* CronRunHistory.swift in Sources */,
+				D500000000000000000012 /* TaskDetailHeaderCard.swift in Sources */,
+				D500000000000000000022 /* TaskRunHistorySection.swift in Sources */,
+				D500000000000000000032 /* TaskRunOutputSheet.swift in Sources */,
 				3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */,
 				D100000000000000000002 /* ANSIEscapes.swift in Sources */,
 				3F91D2A54B9A4F66A2C01002 /* TasksView.swift in Sources */,
@@ -1773,7 +1792,7 @@
 				A710739233F64F4FA4C2B700 /* ComposerVoiceInputController.swift in Sources */,
 				8B71DA2AAC521382F54A841C /* InsightsView.swift in Sources */,
 				C0DE512E0000000000000202 /* InsightsModels.swift in Sources */,
-				C0DE512E0000000000000204 /* UsageCard.swift in Sources */,
+				C0DE512E0000000000000204 /* SectionCard.swift in Sources */,
 				C0DE512E00000000000002206 /* UsageChartData.swift in Sources */,
 				C0DE512E00000000000002208 /* UsageChartCard.swift in Sources */,
 				C0DE512E0000000000000220A /* UsageTotalsGrid.swift in Sources */,
@@ -1828,6 +1847,7 @@
 				C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */,
 				C03910000000000000000011 /* CronManagementTests.swift in Sources */,
 				D500000000000000000002 /* TaskAgendaTests.swift in Sources */,
+				D600000000000000000012 /* TaskRunHistoryTests.swift in Sources */,
 				C03910000000000000000012 /* MemoryViewModelTests.swift in Sources */,
 				C03910000000000000000013 /* ModelCatalogTests.swift in Sources */,
 				C03910000000000000000014 /* MessageActionContextTests.swift in Sources */,

--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		2BE8F2B38F094C4C9EB18301 /* SkillsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */; };
 		22AB000000000000000000B3 /* WorkspaceRegistryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */; };
 		36CD9EF0B0734E5F8C28BB92 /* SlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA59130ED4141049177576C /* SlashCommand.swift */; };
+		D600000000000000000022 /* TaskConfigurationFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600000000000000000021 /* TaskConfigurationFields.swift */; };
 		D600000000000000000002 /* CronRunHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600000000000000000001 /* CronRunHistory.swift */; };
 		D500000000000000000012 /* TaskDetailHeaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000011 /* TaskDetailHeaderCard.swift */; };
 		D500000000000000000022 /* TaskRunHistorySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000021 /* TaskRunHistorySection.swift */; };
@@ -669,6 +670,7 @@
 		2BE8F2B38F094C4C9EB18300 /* SkillsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsViewModelTests.swift; sourceTree = "<group>"; };
 		22AB000000000000000000F3 /* WorkspaceRegistryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRegistryViewModelTests.swift; sourceTree = "<group>"; };
 		1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandCatalog.swift; sourceTree = "<group>"; };
+		D600000000000000000021 /* TaskConfigurationFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskConfigurationFields.swift; sourceTree = "<group>"; };
 		D600000000000000000001 /* CronRunHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronRunHistory.swift; sourceTree = "<group>"; };
 		D500000000000000000011 /* TaskDetailHeaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailHeaderCard.swift; sourceTree = "<group>"; };
 		D500000000000000000021 /* TaskRunHistorySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunHistorySection.swift; sourceTree = "<group>"; };
@@ -1362,6 +1364,7 @@
 				3F91D2A54B9A4F66A2C01014 /* TaskDetailView.swift */,
 				3F91D2A54B9A4F66A2C01015 /* TaskDetailViewModel.swift */,
 				D500000000000000000031 /* TaskRunOutputSheet.swift */,
+				D600000000000000000021 /* TaskConfigurationFields.swift */,
 				D500000000000000000021 /* TaskRunHistorySection.swift */,
 				D500000000000000000011 /* TaskDetailHeaderCard.swift */,
 				C0369000000000000000002 /* CronJobEditorConfigurationLoader.swift */,
@@ -1763,6 +1766,7 @@
 				C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */,
 				A02400000000000000000001 /* Goal.swift in Sources */,
 				D600000000000000000002 /* CronRunHistory.swift in Sources */,
+				D600000000000000000022 /* TaskConfigurationFields.swift in Sources */,
 				D500000000000000000012 /* TaskDetailHeaderCard.swift in Sources */,
 				D500000000000000000022 /* TaskRunHistorySection.swift in Sources */,
 				D500000000000000000032 /* TaskRunOutputSheet.swift in Sources */,

--- a/HermesMobile/Features/Insights/InsightsModels.swift
+++ b/HermesMobile/Features/Insights/InsightsModels.swift
@@ -180,3 +180,9 @@ private extension KeyedDecodingContainer {
         return Double(normalized)
     }
 }
+
+/// Formats a server-reported 0–100 percentage (e.g. `cache_hit_percent`) with a
+/// localized percent symbol and at most one fraction digit ("87.5%", "12%").
+func insightsFormattedPercent(_ value: Double, locale: Locale = .current) -> String {
+    (value / 100).formatted(.percent.precision(.fractionLength(0...1)).locale(locale))
+}

--- a/HermesMobile/Features/Insights/InsightsView.swift
+++ b/HermesMobile/Features/Insights/InsightsView.swift
@@ -76,7 +76,7 @@ struct InsightsView: View {
                 .pickerStyle(.segmented)
 
                 if viewModel.dataSource != .server {
-                    UsageCard {
+                    SectionCard {
                         Label {
                             Text(viewModel.sourceDescription)
                                 .font(AppFont.caption())

--- a/HermesMobile/Features/Insights/UsageChartCard.swift
+++ b/HermesMobile/Features/Insights/UsageChartCard.swift
@@ -22,7 +22,7 @@ struct UsageChartCard: View {
     private static let chartHeight: CGFloat = 180
 
     var body: some View {
-        UsageCard {
+        SectionCard {
             VStack(alignment: .leading, spacing: 14) {
                 header
                 chart

--- a/HermesMobile/Features/Insights/UsageModelRows.swift
+++ b/HermesMobile/Features/Insights/UsageModelRows.swift
@@ -10,7 +10,7 @@ struct UsageModelsCard: View {
     let hasCost: Bool
 
     var body: some View {
-        UsageCard(title: String(localized: "By model")) {
+        SectionCard(title: String(localized: "By model")) {
             VStack(alignment: .leading, spacing: 14) {
                 ForEach(Array(models.enumerated()), id: \.offset) { _, model in
                     UsageModelRow(model: model, hasCost: hasCost)
@@ -76,7 +76,7 @@ struct UsageTopSessionsCard: View {
     let sessions: [SessionSummary]
 
     var body: some View {
-        UsageCard(title: String(localized: "Top Sessions")) {
+        SectionCard(title: String(localized: "Top Sessions")) {
             VStack(alignment: .leading, spacing: 14) {
                 ForEach(sessions.prefix(10)) { session in
                     VStack(alignment: .leading, spacing: 2) {

--- a/HermesMobile/Features/Insights/UsageTotalsGrid.swift
+++ b/HermesMobile/Features/Insights/UsageTotalsGrid.swift
@@ -13,7 +13,7 @@ struct UsageTotalsGrid: View {
     }
 
     var body: some View {
-        UsageCard(title: String(localized: "Totals")) {
+        SectionCard(title: String(localized: "Totals")) {
             LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
                 ForEach(cells) { cell in
                     UsageMetricCell(cell: cell)

--- a/HermesMobile/Features/Shared/SectionCard.swift
+++ b/HermesMobile/Features/Shared/SectionCard.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
-/// The Usage screen's card container: an optional uppercase title over a glass
-/// panel. Matches the Settings card chrome so the two screens read as one app.
-struct UsageCard<Content: View>: View {
+/// A card container: an optional uppercase title over a glass panel. Shared by
+/// Usage and Task Detail, and matched to the Settings card chrome, so the
+/// screens read as one app.
+struct SectionCard<Content: View>: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
@@ -42,10 +43,4 @@ struct UsageCard<Content: View>: View {
                 }
         }
     }
-}
-
-/// Formats a server-reported 0–100 percentage (e.g. `cache_hit_percent`) with a
-/// localized percent symbol and at most one fraction digit ("87.5%", "12%").
-func insightsFormattedPercent(_ value: Double, locale: Locale = .current) -> String {
-    (value / 100).formatted(.percent.precision(.fractionLength(0...1)).locale(locale))
 }

--- a/HermesMobile/Features/Shared/SectionCard.swift
+++ b/HermesMobile/Features/Shared/SectionCard.swift
@@ -3,16 +3,31 @@ import SwiftUI
 /// A card container: an optional uppercase title over a glass panel. Shared by
 /// Usage and Task Detail, and matched to the Settings card chrome, so the
 /// screens read as one app.
-struct SectionCard<Content: View>: View {
+///
+/// An optional `footer` sits flush against the card's bottom edge, under a
+/// full-width divider and outside the content's padding — the shape a row of
+/// card actions wants. Passing it here rather than cancelling the padding at
+/// the call site keeps the card's insets its own business.
+struct SectionCard<Content: View, Footer: View>: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     let title: String?
     @ViewBuilder let content: Content
+    @ViewBuilder let footer: Footer
+    /// Set by the initializer rather than inferred from `Footer`, so an empty
+    /// footer never leaves a divider hanging under the content.
+    private let hasFooter: Bool
 
-    init(title: String? = nil, @ViewBuilder content: () -> Content) {
+    init(
+        title: String? = nil,
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder footer: () -> Footer
+    ) {
         self.title = title
         self.content = content()
+        self.footer = footer()
+        self.hasFooter = true
     }
 
     var body: some View {
@@ -28,19 +43,36 @@ struct SectionCard<Content: View>: View {
                     .padding(.bottom, 8)
             }
 
-            content
-                .padding(.horizontal, 16)
-                .padding(.vertical, 14)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background {
-                    shape.fill(Color(.secondarySystemBackground).opacity(reduceTransparency ? 1 : 0.34))
+            VStack(spacing: 0) {
+                content
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if hasFooter {
+                    Divider()
+                    footer
                 }
-                .adaptiveGlass(.regular, fallbackMaterial: .regularMaterial, in: shape)
-                .overlay {
-                    shape
-                        .stroke(Color.primary.opacity(colorSchemeContrast == .increased ? 0.16 : 0.06), lineWidth: 0.7)
-                        .allowsHitTesting(false)
-                }
+            }
+            .background {
+                shape.fill(Color(.secondarySystemBackground).opacity(reduceTransparency ? 1 : 0.34))
+            }
+            .adaptiveGlass(.regular, fallbackMaterial: .regularMaterial, in: shape)
+            .clipShape(shape)
+            .overlay {
+                shape
+                    .stroke(Color.primary.opacity(colorSchemeContrast == .increased ? 0.16 : 0.06), lineWidth: 0.7)
+                    .allowsHitTesting(false)
+            }
         }
+    }
+}
+
+extension SectionCard where Footer == EmptyView {
+    init(title: String? = nil, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+        self.footer = EmptyView()
+        self.hasFooter = false
     }
 }

--- a/HermesMobile/Features/Tasks/CronScheduleHumanizer.swift
+++ b/HermesMobile/Features/Tasks/CronScheduleHumanizer.swift
@@ -192,6 +192,36 @@ enum CronScheduleHumanizer {
 
     /// Foundation owns the plural rules here, so "15 minutes" is correct in
     /// every language without a plural entry per interval in the catalog.
+    /// The wait until `date` as one compact figure — "in 6m", "in 12h 21m",
+    /// "in 3d 4h" — for the number Task Detail leads with.
+    ///
+    /// Deliberately computed on demand instead of ticked by a timer: a
+    /// self-updating label repaints its whole card every second for a figure
+    /// nobody watches count down, and Refresh already brings it current.
+    static func countdown(
+        to date: Date,
+        from now: Date = .now,
+        locale: Locale = .current
+    ) -> String {
+        let interval = date.timeIntervalSince(now)
+        guard interval >= 60 else {
+            return interval > 0 ? String(localized: "Due now") : String(localized: "Overdue")
+        }
+
+        let allowed: Set<Duration.UnitsFormatStyle.Unit>
+        if interval < 3_600 {
+            allowed = [.minutes]
+        } else if interval < 86_400 {
+            allowed = [.hours, .minutes]
+        } else {
+            allowed = [.days, .hours]
+        }
+
+        let duration = Duration.seconds(interval)
+            .formatted(.units(allowed: allowed, width: .narrow, maximumUnitCount: 2).locale(locale))
+        return String(localized: "in \(duration)", comment: "Countdown to a task's next run, e.g. 'in 12h 21m'")
+    }
+
     private static func durationText(minutes: Int, locale: Locale) -> String {
         Duration.seconds(minutes * 60)
             .formatted(.units(allowed: [.minutes], width: .wide).locale(locale))

--- a/HermesMobile/Features/Tasks/TaskConfigurationFields.swift
+++ b/HermesMobile/Features/Tasks/TaskConfigurationFields.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// One row of Task Detail's Configuration card.
+struct TaskConfigurationField: Identifiable, Equatable {
+    /// The label. Unique within a card, so it is also the row's identity.
+    let title: String
+    let value: String
+    /// A dimmer second line under the value — the raw cron expression under
+    /// its English sentence. `nil` when there is nothing more to say.
+    let detail: String?
+
+    var id: String { title }
+
+    init(title: String, value: String, detail: String? = nil) {
+        self.title = title
+        self.value = value
+        self.detail = detail
+    }
+}
+
+extension TaskConfigurationField {
+    /// The Configuration card's rows, in reading order.
+    ///
+    /// How a job runs is a fixed set of questions, so the answers to them are
+    /// always shown: a missing model means "Server default", not a row that
+    /// silently disappears. The two exceptions earn their absence —
+    /// **Provider** only qualifies an explicitly chosen model, and
+    /// **Notifications** is omitted when the server did not say, because
+    /// printing "On" for a value we do not have would be a guess rather than
+    /// a stand-in for absence.
+    static func fields(for job: CronJob) -> [TaskConfigurationField] {
+        var fields: [TaskConfigurationField] = []
+
+        let schedule = job.scheduleDescription?.sentence
+            ?? job.scheduleText
+            ?? String(localized: "Not available")
+        fields.append(
+            TaskConfigurationField(
+                title: String(localized: "Schedule"),
+                value: schedule,
+                // Only worth a second line when it is not already the value.
+                detail: job.editableScheduleText.flatMap { $0 == schedule ? nil : $0 }
+            )
+        )
+
+        fields.append(
+            TaskConfigurationField(
+                title: String(localized: "Deliver"),
+                value: trimmed(job.deliver) ?? "local"
+            )
+        )
+
+        let model = trimmed(job.model)
+        fields.append(
+            TaskConfigurationField(
+                title: String(localized: "Model"),
+                value: model ?? String(localized: "Server default")
+            )
+        )
+
+        if model != nil, let provider = trimmed(job.provider) {
+            fields.append(TaskConfigurationField(title: String(localized: "Provider"), value: provider))
+        }
+
+        fields.append(
+            TaskConfigurationField(
+                title: String(localized: "Profile"),
+                value: trimmed(job.profile) ?? String(localized: "Server default")
+            )
+        )
+
+        let skills = (job.skills ?? []).compactMap(trimmed)
+        fields.append(
+            TaskConfigurationField(
+                title: String(localized: "Skills"),
+                value: skills.isEmpty ? String(localized: "None") : skills.joined(separator: ", ")
+            )
+        )
+
+        if let toastNotifications = job.toastNotifications {
+            fields.append(
+                TaskConfigurationField(
+                    title: String(localized: "Notifications"),
+                    value: toastNotifications ? String(localized: "On") : String(localized: "Off")
+                )
+            )
+        }
+
+        return fields
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/HermesMobile/Features/Tasks/TaskConfigurationFields.swift
+++ b/HermesMobile/Features/Tasks/TaskConfigurationFields.swift
@@ -21,13 +21,13 @@ struct TaskConfigurationField: Identifiable, Equatable {
 extension TaskConfigurationField {
     /// The Configuration card's rows, in reading order.
     ///
-    /// How a job runs is a fixed set of questions, so the answers to them are
-    /// always shown: a missing model means "Server default", not a row that
-    /// silently disappears. The two exceptions earn their absence —
-    /// **Provider** only qualifies an explicitly chosen model, and
-    /// **Notifications** is omitted when the server did not say, because
-    /// printing "On" for a value we do not have would be a guess rather than
-    /// a stand-in for absence.
+    /// A field the job does not have does not get a row. A job that leaves the
+    /// model, profile or skills to the server has nothing to say about them,
+    /// and a row saying so is a line of card the reader has to discount.
+    ///
+    /// Schedule and Deliver are the exceptions, because every job has both:
+    /// Deliver falls back to `local`, which is the server's own default rather
+    /// than a stand-in for a missing value.
     static func fields(for job: CronJob) -> [TaskConfigurationField] {
         var fields: [TaskConfigurationField] = []
 
@@ -50,32 +50,27 @@ extension TaskConfigurationField {
             )
         )
 
-        let model = trimmed(job.model)
-        fields.append(
-            TaskConfigurationField(
-                title: String(localized: "Model"),
-                value: model ?? String(localized: "Server default")
-            )
-        )
+        if let model = trimmed(job.model) {
+            fields.append(TaskConfigurationField(title: String(localized: "Model"), value: model))
+        }
 
-        if model != nil, let provider = trimmed(job.provider) {
+        if let provider = trimmed(job.provider) {
             fields.append(TaskConfigurationField(title: String(localized: "Provider"), value: provider))
         }
 
-        fields.append(
-            TaskConfigurationField(
-                title: String(localized: "Profile"),
-                value: trimmed(job.profile) ?? String(localized: "Server default")
-            )
-        )
+        if let profile = trimmed(job.profile) {
+            fields.append(TaskConfigurationField(title: String(localized: "Profile"), value: profile))
+        }
 
         let skills = (job.skills ?? []).compactMap(trimmed)
-        fields.append(
-            TaskConfigurationField(
-                title: String(localized: "Skills"),
-                value: skills.isEmpty ? String(localized: "None") : skills.joined(separator: ", ")
+        if !skills.isEmpty {
+            fields.append(
+                TaskConfigurationField(
+                    title: String(localized: "Skills"),
+                    value: skills.joined(separator: ", ")
+                )
             )
-        )
+        }
 
         if let toastNotifications = job.toastNotifications {
             fields.append(

--- a/HermesMobile/Features/Tasks/TaskDetailHeaderCard.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailHeaderCard.swift
@@ -24,9 +24,9 @@ struct TaskDetailHeaderCard: View {
                 if let failure = job.failureSummary {
                     failureBlock(failure)
                 }
-
-                actionRow
             }
+        } footer: {
+            actionFooter
         }
     }
 
@@ -117,29 +117,64 @@ struct TaskDetailHeaderCard: View {
         .background(Color.red.opacity(0.10), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
+    /// The card's two controls, as its bottom edge rather than as objects
+    /// sitting on it.
+    ///
+    /// Neither action is the primary one — you press whichever matches what you
+    /// want — so they carry equal weight, and no fill competes with the error
+    /// box above them for the one colour on this card that means something.
     @ViewBuilder
-    private var actionRow: some View {
-        let buttons = Group {
-            Button(action: runNow) {
-                Label("Run now", systemImage: "play.fill")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
+    private var actionFooter: some View {
+        let runButton = footerButton(
+            title: String(localized: "Run now"),
+            systemImage: "play.fill",
+            action: runNow
+        )
+        let pauseButton = footerButton(
+            title: pauseResumeTitle,
+            systemImage: pauseResumeSystemImage,
+            action: togglePauseResume
+        )
 
-            Button(action: togglePauseResume) {
-                Label(pauseResumeTitle, systemImage: pauseResumeSystemImage)
-                    .frame(maxWidth: .infinity)
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                // Two labels will not sit side by side at these sizes, so the
+                // divider turns with them.
+                VStack(spacing: 0) {
+                    runButton
+                    Divider()
+                    pauseButton
+                }
+            } else {
+                HStack(spacing: 0) {
+                    runButton
+                    Divider()
+                    pauseButton
+                }
             }
-            .buttonStyle(.bordered)
         }
-        .controlSize(.regular)
         .disabled(isBusy)
+    }
 
-        if dynamicTypeSize.isAccessibilitySize {
-            VStack(spacing: 8) { buttons }
-        } else {
-            HStack(spacing: 8) { buttons }
+    private func footerButton(
+        title: String,
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: systemImage)
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .frame(maxWidth: .infinity, minHeight: 46)
+            .contentShape(Rectangle())
         }
+        // Plain keeps the label as the whole control, so the row reads as part
+        // of the card; the style's press dimming is the tap confirmation.
+        .buttonStyle(.plain)
     }
 
     // MARK: - Presentation
@@ -177,7 +212,9 @@ struct TaskDetailHeaderCard: View {
         shouldResume ? String(localized: "Resume") : String(localized: "Pause")
     }
 
+    /// Resume is a circled triangle, never `play.fill`: beside "Run now" the
+    /// same solid triangle twice would say the two buttons do the same thing.
     private var pauseResumeSystemImage: String {
-        shouldResume ? "play.circle" : "pause.circle"
+        shouldResume ? "play.circle" : "pause.fill"
     }
 }

--- a/HermesMobile/Features/Tasks/TaskDetailHeaderCard.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailHeaderCard.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+/// Task Detail's first card: what this task is, when it runs next, and the two
+/// controls an operator reaches for. When the last run failed the card takes an
+/// error tint and carries the reason, because that is the only thing on the
+/// screen worth reading first.
+struct TaskDetailHeaderCard: View {
+    let job: CronJob
+    let runningElapsed: Double?
+    let isBusy: Bool
+    let canSeeFullOutput: Bool
+    let runNow: () -> Void
+    let togglePauseResume: () -> Void
+    let seeFullOutput: () -> Void
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        SectionCard {
+            VStack(alignment: .leading, spacing: 14) {
+                titleRow
+                nextRunBlock
+
+                if let failure = job.failureSummary {
+                    failureBlock(failure)
+                }
+
+                actionRow
+            }
+        }
+    }
+
+    // MARK: - Pieces
+
+    private var titleRow: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(job.displayName)
+                    .font(.title3.bold())
+                    .lineLimit(3)
+
+                Text(scheduleSentence)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 8)
+
+            StatusBadge(text: statusText, color: statusColor)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    /// The countdown reads big; the absolute time sits under it for the reader
+    /// who wants the actual clock. Both are computed on render rather than
+    /// ticked by a timer — a label that repaints every second costs more than
+    /// the freshness is worth, and Refresh brings it up to date.
+    @ViewBuilder
+    private var nextRunBlock: some View {
+        if let running = runningElapsed {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(CronJobRowView.elapsedText(running))
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(.blue)
+                Text("Running now")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+        } else if let next = job.nextRunAt?.date {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(CronScheduleHumanizer.countdown(to: next))
+                    .font(.title2.weight(.semibold))
+                Text("Next run · \(next.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+        } else if let last = job.lastRunAt?.date {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Not scheduled")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text("Last run · \(last.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+        }
+    }
+
+    @ViewBuilder
+    private func failureBlock(_ failure: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label {
+                Text(failure)
+                    .font(.footnote)
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text("Last run failed. \(failure)"))
+
+            if canSeeFullOutput {
+                Button("See full output", action: seeFullOutput)
+                    .font(.footnote.weight(.semibold))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tint)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(Color.red.opacity(0.10), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var actionRow: some View {
+        let buttons = Group {
+            Button(action: runNow) {
+                Label("Run now", systemImage: "play.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button(action: togglePauseResume) {
+                Label(pauseResumeTitle, systemImage: pauseResumeSystemImage)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+        .controlSize(.regular)
+        .disabled(isBusy)
+
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: 8) { buttons }
+        } else {
+            HStack(spacing: 8) { buttons }
+        }
+    }
+
+    // MARK: - Presentation
+
+    /// The humanised schedule, or the server's own string when the expression
+    /// is not one we recognise — never a guess.
+    private var scheduleSentence: String {
+        job.scheduleDescription?.sentence ?? job.scheduleText ?? String(localized: "Not available")
+    }
+
+    private var statusText: String {
+        runningElapsed == nil ? job.status.label : String(localized: "Running")
+    }
+
+    private var statusColor: Color {
+        guard runningElapsed == nil else { return .blue }
+
+        switch job.status {
+        case .active:
+            return .green
+        case .paused, .off:
+            return .orange
+        case .error:
+            return .red
+        case .needsAttention:
+            return .yellow
+        }
+    }
+
+    private var shouldResume: Bool {
+        job.status == .paused || job.status == .off
+    }
+
+    private var pauseResumeTitle: String {
+        shouldResume ? String(localized: "Resume") : String(localized: "Pause")
+    }
+
+    private var pauseResumeSystemImage: String {
+        shouldResume ? "play.circle" : "pause.circle"
+    }
+}

--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -194,7 +194,7 @@ struct TaskDetailView: View {
 
                 if let toastNotifications = job.toastNotifications {
                     CronJobMetadataRow(
-                        title: String(localized: "Notifications"),
+                        title: String(localized: "Toast Notifications"),
                         value: toastNotifications ? String(localized: "On") : String(localized: "Off")
                     )
                 }

--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -14,6 +14,7 @@ struct TaskDetailView: View {
     /// tapped; the view model only fetches its text.
     @State private var selectedRun: CronRunHistoryItem?
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(
         job: CronJob,
@@ -159,48 +160,66 @@ struct TaskDetailView: View {
         }
     }
 
-    /// Everything the list row deliberately stopped showing. A field the server
-    /// did not send is absent, not rendered as "Not available".
+    /// Everything the list row deliberately stopped showing.
+    ///
+    /// Laid out as a grid so the label column takes the width of its widest
+    /// label. A fixed column has to guess, and guesses low: "Notifications"
+    /// wrapped onto three lines against the 64pt the old rows used.
     private var configurationCard: some View {
-        let job = viewModel.job
+        let fields = TaskConfigurationField.fields(for: viewModel.job)
 
         return SectionCard(title: String(localized: "Configuration")) {
-            VStack(alignment: .leading, spacing: 8) {
-                CronJobMetadataRow(
-                    title: String(localized: "Schedule"),
-                    value: job.scheduleDescription?.sentence ?? job.scheduleText ?? String(localized: "Not available"),
-                    detail: job.editableScheduleText
-                )
-
-                if let deliver = job.deliver, !deliver.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Deliver"), value: deliver)
-                }
-
-                if let model = job.model, !model.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Model"), value: model)
-                }
-
-                if let provider = job.provider, !provider.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Provider"), value: provider)
-                }
-
-                if let profile = job.profile, !profile.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Profile"), value: profile)
-                }
-
-                if let skills = job.skills, !skills.isEmpty {
-                    CronJobMetadataRow(title: String(localized: "Skills"), value: skills.joined(separator: ", "))
-                }
-
-                if let toastNotifications = job.toastNotifications {
-                    CronJobMetadataRow(
-                        title: String(localized: "Toast Notifications"),
-                        value: toastNotifications ? String(localized: "On") : String(localized: "Off")
-                    )
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    // At accessibility sizes two columns leave no room for
+                    // either, so the label sits above its value instead.
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(fields) { field in
+                            VStack(alignment: .leading, spacing: 1) {
+                                configurationLabel(field)
+                                configurationValue(field)
+                            }
+                            .accessibilityElement(children: .combine)
+                        }
+                    }
+                } else {
+                    Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 12, verticalSpacing: 8) {
+                        ForEach(fields) { field in
+                            GridRow {
+                                configurationLabel(field)
+                                    .gridColumnAlignment(.leading)
+                                configurationValue(field)
+                            }
+                            .accessibilityElement(children: .combine)
+                        }
+                    }
                 }
             }
             .font(.footnote)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    private func configurationLabel(_ field: TaskConfigurationField) -> some View {
+        Text(field.title)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func configurationValue(_ field: TaskConfigurationField) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(field.value)
+                .foregroundStyle(.primary)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 4 : 3)
+
+            if let detail = field.detail {
+                Text(detail)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ToolbarContentBuilder

--- a/HermesMobile/Features/Tasks/TaskDetailView.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+/// Task Detail: what the task is, when it runs next, how it is configured, and
+/// — the part the list cannot answer — what it has actually been doing.
 struct TaskDetailView: View {
     let server: URL
     let onAPIError: (Error) -> Void
@@ -8,6 +10,9 @@ struct TaskDetailView: View {
     @State private var viewModel: TaskDetailViewModel
     @State private var isPresentingEditTask = false
     @State private var isConfirmingDelete = false
+    /// Sheet identity lives here so the sheet is always tied to the run that was
+    /// tapped; the view model only fetches its text.
+    @State private var selectedRun: CronRunHistoryItem?
     @Environment(\.dismiss) private var dismiss
 
     init(
@@ -26,89 +31,45 @@ struct TaskDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                headerSection
-                actionStatusSection
-                metadataSection
+                TaskDetailHeaderCard(
+                    job: viewModel.job,
+                    runningElapsed: viewModel.runningElapsed,
+                    isBusy: isActionDisabled,
+                    canSeeFullOutput: viewModel.latestRun != nil,
+                    runNow: { Task { await runNow() } },
+                    togglePauseResume: { Task { await togglePauseResume() } },
+                    seeFullOutput: {
+                        if let latest = viewModel.latestRun { open(latest) }
+                    }
+                )
 
-                if viewModel.isLoading && viewModel.outputs.isEmpty {
-                    ProgressView("Loading output...")
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, 24)
-                } else if let errorMessage = viewModel.errorMessage, viewModel.outputs.isEmpty {
-                    ContentUnavailableView {
-                        Label("Could Not Load Output", systemImage: "exclamationmark.triangle")
-                    } description: {
-                        Text(errorMessage)
-                    } actions: {
-                        Button("Try Again") {
-                            Task { await loadOutput() }
-                        }
-                    }
-                    .padding(.top, 24)
-                } else if viewModel.outputs.isEmpty {
-                    ContentUnavailableView {
-                        Label("No Recent Output", systemImage: "doc.text")
-                    } description: {
-                        Text("This task has not produced any output yet.")
-                    }
-                    .padding(.top, 24)
-                } else {
-                    outputsSection
+                actionStatusSection
+                promptCard
+                latestOutputCard
+                configurationCard
+
+                if !viewModel.isHistoryUnavailable {
+                    TaskRunHistorySection(
+                        runs: viewModel.runs,
+                        total: viewModel.runTotal,
+                        isLoading: viewModel.isLoadingHistory,
+                        isLoadingMore: viewModel.isLoadingMoreRuns,
+                        canLoadMore: viewModel.canLoadMoreRuns,
+                        remainingCount: viewModel.remainingRunCount,
+                        errorMessage: viewModel.historyErrorMessage,
+                        isFailedRun: viewModel.isFailedRun,
+                        selectRun: open,
+                        retry: { Task { await viewModel.loadHistory() } },
+                        loadMore: { Task { await viewModel.loadMoreRuns() } }
+                    )
                 }
             }
             .padding()
         }
         .navigationTitle(viewModel.job.displayName)
-        .toolbar {
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                Button {
-                    Task { await loadOutput() }
-                } label: {
-                    if viewModel.isLoading {
-                        ProgressView()
-                    } else {
-                        Label("Refresh", systemImage: "arrow.clockwise")
-                    }
-                }
-                .disabled(viewModel.isLoading)
-
-                Menu {
-                    Button {
-                        Task { await runNow() }
-                    } label: {
-                        Label("Run Now", systemImage: "play.fill")
-                    }
-                    .disabled(isActionDisabled)
-
-                    Button {
-                        Task { await togglePauseResume() }
-                    } label: {
-                        Label(pauseResumeTitle, systemImage: pauseResumeSystemImage)
-                    }
-                    .disabled(isActionDisabled)
-
-                    Button {
-                        viewModel.clearActionError()
-                        isPresentingEditTask = true
-                    } label: {
-                        Label("Edit", systemImage: "pencil")
-                    }
-                    .disabled(isActionDisabled)
-
-                    Divider()
-
-                    Button(role: .destructive) {
-                        isConfirmingDelete = true
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                    .disabled(isActionDisabled)
-                } label: {
-                    Label("Task Actions", systemImage: "ellipsis.circle")
-                }
-                .disabled(viewModel.isMutating)
-            }
-        }
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable { await loadDetail() }
+        .toolbar { toolbarContent }
         .sheet(isPresented: $isPresentingEditTask) {
             CronJobEditorSheet(
                 title: String(localized: "Edit Task"),
@@ -124,6 +85,15 @@ struct TaskDetailView: View {
                 return didUpdate
             }
         }
+        .sheet(item: $selectedRun, onDismiss: viewModel.clearRunOutput) { run in
+            TaskRunOutputSheet(
+                run: run,
+                output: viewModel.runOutput,
+                isLoading: viewModel.isLoadingRunOutput,
+                errorMessage: viewModel.runOutputErrorMessage,
+                retry: { Task { await viewModel.loadRunOutput(for: run) } }
+            )
+        }
         .alert("Delete Task?", isPresented: $isConfirmingDelete) {
             Button("Delete", role: .destructive) {
                 Task { await deleteTask() }
@@ -133,34 +103,11 @@ struct TaskDetailView: View {
             Text("This removes the scheduled task from the Hermes server.")
         }
         .task {
-            await loadOutput()
+            await loadDetail()
         }
     }
 
-    @ViewBuilder
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text(viewModel.job.displayName)
-                    .font(.title2.bold())
-                    .lineLimit(2)
-
-                Spacer(minLength: 8)
-
-                StatusBadge(
-                    text: viewModel.runningElapsed == nil ? viewModel.job.status.label : String(localized: "Running"),
-                    color: statusColor
-                )
-            }
-
-            if let prompt = viewModel.job.prompt, !prompt.isEmpty {
-                Text(prompt)
-                    .font(.body)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(5)
-            }
-        }
-    }
+    // MARK: - Cards
 
     @ViewBuilder
     private var actionStatusSection: some View {
@@ -179,111 +126,136 @@ struct TaskDetailView: View {
     }
 
     @ViewBuilder
-    private var metadataSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            CronJobMetadataRow(
-                title: String(localized: "Schedule"),
-                value: viewModel.job.scheduleText ?? String(localized: "Not available")
-            )
-
-            CronJobMetadataRow(
-                title: String(localized: "Next"),
-                value: viewModel.job.nextRunAt?.formatted ?? String(localized: "Not available")
-            )
-
-            CronJobMetadataRow(
-                title: String(localized: "Last"),
-                value: viewModel.job.lastRunAt?.formatted ?? String(localized: "Never")
-            )
-
-            if let runningElapsed = viewModel.runningElapsed {
-                CronJobMetadataRow(
-                    title: String(localized: "Elapsed"),
-                    value: elapsedText(runningElapsed)
-                )
-            }
-
-            CronJobMetadataRow(
-                title: String(localized: "Deliver"),
-                value: viewModel.job.deliver ?? "local"
-            )
-
-            if let model = viewModel.job.model, !model.isEmpty {
-                CronJobMetadataRow(title: String(localized: "Model"), value: model)
-            }
-
-            if let provider = viewModel.job.provider, !provider.isEmpty {
-                CronJobMetadataRow(title: String(localized: "Provider"), value: provider)
-            }
-
-            if let profile = viewModel.job.profile, !profile.isEmpty {
-                CronJobMetadataRow(title: String(localized: "Profile"), value: profile)
-            }
-
-            if let toastNotifications = viewModel.job.toastNotifications {
-                CronJobMetadataRow(title: String(localized: "Toasts"), value: toastNotifications ? String(localized: "On") : String(localized: "Off"))
-            }
-
-            if let skills = viewModel.job.skills, !skills.isEmpty {
-                CronJobMetadataRow(title: String(localized: "Skills"), value: skills.joined(separator: ", "))
-            }
-
-            if let error = viewModel.job.lastError ?? viewModel.job.lastDeliveryError, !error.isEmpty {
-                // Run text arrives with the shell's escape codes intact; showing
-                // them raw renders as garbage.
-                CronJobMetadataRow(title: String(localized: "Error"), value: error.strippingANSIEscapes())
-                    .foregroundStyle(.red)
+    private var promptCard: some View {
+        if let prompt = viewModel.job.prompt, !prompt.isEmpty {
+            SectionCard(title: String(localized: "Prompt")) {
+                Text(prompt)
+                    .font(.callout)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .font(.footnote)
     }
 
+    /// The last run's text, inline.
+    ///
+    /// Shown when the last run failed — a failure is the one case where the
+    /// output is the point of the screen — and also when this server has no
+    /// history endpoint, so an older server keeps the only view of its output
+    /// it ever had.
     @ViewBuilder
-    private var outputsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Recent Output")
-                .font(.headline)
-
-            ForEach(viewModel.outputs) { output in
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(output.filename ?? String(localized: "Untitled"))
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.secondary)
-
-                    if let content = output.content, !content.isEmpty {
-                        Text(content.strippingANSIEscapes())
-                            .font(.system(.body, design: .monospaced))
-                            .textSelection(.enabled)
-                            .padding(12)
-                            .background(Color(.secondarySystemBackground))
-                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    } else {
-                        Text("Empty output")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .padding(.vertical, 8)
+    private var latestOutputCard: some View {
+        if viewModel.job.hasFailedRun || viewModel.isHistoryUnavailable,
+           let output = viewModel.outputs.first,
+           let content = output.content,
+           !content.isEmpty {
+            SectionCard(title: String(localized: "Run Output")) {
+                Text(content.strippingANSIEscapes())
+                    .font(.system(.footnote, design: .monospaced))
+                    .textSelection(.enabled)
+                    .lineLimit(14)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }
 
-    private var statusColor: Color {
-        if viewModel.runningElapsed != nil {
-            return .blue
-        }
+    /// Everything the list row deliberately stopped showing. A field the server
+    /// did not send is absent, not rendered as "Not available".
+    private var configurationCard: some View {
+        let job = viewModel.job
 
-        switch viewModel.job.status {
-        case .active:
-            return .green
-        case .paused, .off:
-            return .orange
-        case .error:
-            return .red
-        case .needsAttention:
-            return .yellow
+        return SectionCard(title: String(localized: "Configuration")) {
+            VStack(alignment: .leading, spacing: 8) {
+                CronJobMetadataRow(
+                    title: String(localized: "Schedule"),
+                    value: job.scheduleDescription?.sentence ?? job.scheduleText ?? String(localized: "Not available"),
+                    detail: job.editableScheduleText
+                )
+
+                if let deliver = job.deliver, !deliver.isEmpty {
+                    CronJobMetadataRow(title: String(localized: "Deliver"), value: deliver)
+                }
+
+                if let model = job.model, !model.isEmpty {
+                    CronJobMetadataRow(title: String(localized: "Model"), value: model)
+                }
+
+                if let provider = job.provider, !provider.isEmpty {
+                    CronJobMetadataRow(title: String(localized: "Provider"), value: provider)
+                }
+
+                if let profile = job.profile, !profile.isEmpty {
+                    CronJobMetadataRow(title: String(localized: "Profile"), value: profile)
+                }
+
+                if let skills = job.skills, !skills.isEmpty {
+                    CronJobMetadataRow(title: String(localized: "Skills"), value: skills.joined(separator: ", "))
+                }
+
+                if let toastNotifications = job.toastNotifications {
+                    CronJobMetadataRow(
+                        title: String(localized: "Notifications"),
+                        value: toastNotifications ? String(localized: "On") : String(localized: "Off")
+                    )
+                }
+            }
+            .font(.footnote)
         }
     }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            Button {
+                Task { await loadDetail() }
+            } label: {
+                if viewModel.isLoading {
+                    ProgressView()
+                } else {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+            }
+            .disabled(viewModel.isLoading)
+
+            Menu {
+                Button {
+                    Task { await runNow() }
+                } label: {
+                    Label("Run Now", systemImage: "play.fill")
+                }
+                .disabled(isActionDisabled)
+
+                Button {
+                    Task { await togglePauseResume() }
+                } label: {
+                    Label(pauseResumeTitle, systemImage: pauseResumeSystemImage)
+                }
+                .disabled(isActionDisabled)
+
+                Button {
+                    viewModel.clearActionError()
+                    isPresentingEditTask = true
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .disabled(isActionDisabled)
+
+                Divider()
+
+                Button(role: .destructive) {
+                    isConfirmingDelete = true
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+                .disabled(isActionDisabled)
+            } label: {
+                Label("Task Actions", systemImage: "ellipsis.circle")
+            }
+            .disabled(viewModel.isMutating)
+        }
+    }
+
+    // MARK: - State
 
     private var isActionDisabled: Bool {
         viewModel.isMutating || viewModel.job.jobId == nil
@@ -301,17 +273,14 @@ struct TaskDetailView: View {
         viewModel.job.status == .paused || viewModel.job.status == .off
     }
 
-    private func elapsedText(_ elapsed: Double) -> String {
-        if elapsed < 60 {
-            return "\(Int(elapsed.rounded()))s"
-        }
+    // MARK: - Actions
 
-        let minutes = Int(elapsed / 60)
-        let seconds = Int(elapsed.truncatingRemainder(dividingBy: 60))
-        return "\(minutes)m \(seconds)s"
+    private func open(_ run: CronRunHistoryItem) {
+        selectedRun = run
+        Task { await viewModel.loadRunOutput(for: run) }
     }
 
-    private func loadOutput() async {
+    private func loadDetail() async {
         await viewModel.load()
 
         if let lastError = viewModel.lastError {

--- a/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
@@ -139,7 +139,10 @@ final class TaskDetailViewModel {
     }
 
     func loadMoreRuns() async {
-        guard let jobID = job.jobId, canLoadMoreRuns, !isLoadingMoreRuns else { return }
+        // Nothing is paged while a reload is in flight: until its first page
+        // lands, `historyOffset` still points into the list being replaced, so
+        // any page fetched now would be a page of the wrong list.
+        guard let jobID = job.jobId, canLoadMoreRuns, !isLoadingMoreRuns, !isLoadingHistory else { return }
 
         let offset = historyOffset
         let generation = historyGeneration
@@ -151,8 +154,11 @@ final class TaskDetailViewModel {
 
         // A refresh landed while this page was in flight. The page describes a
         // list that no longer exists, so it is dropped rather than spliced onto
-        // the new one.
-        guard generation == historyGeneration else { return }
+        // the new one, which would leave the pages between them unreachable.
+        // The cursor is checked as well as the generation: a reload that began
+        // before this request bumped the generation ahead of it, so matching
+        // generations alone would not prove the two describe the same list.
+        guard generation == historyGeneration, offset == historyOffset else { return }
 
         switch result {
         case let .success(response):

--- a/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
@@ -18,6 +18,34 @@ final class TaskDetailViewModel {
     private(set) var lastError: Error?
     private(set) var lastMutation: CronJobListMutation?
 
+    // MARK: - Run history
+
+    /// Loaded runs, newest first, accumulated across pages.
+    private(set) var runs: [CronRunHistoryItem] = []
+    /// The server's full run count, which is what "Load more" counts down.
+    private(set) var runTotal: Int?
+    private(set) var isLoadingHistory = false
+    private(set) var isLoadingMoreRuns = false
+    private(set) var historyErrorMessage: String?
+    /// `true` once the server has answered 404 for the history endpoint: an
+    /// older `hermes-webui` that predates it. The section then disappears
+    /// rather than showing a permanent error.
+    private(set) var isHistoryUnavailable = false
+
+    /// The output of the run whose sheet is open, tagged with its filename so a
+    /// slow response can never be shown under a different run.
+    private(set) var runOutput: CronRunOutput?
+    private(set) var isLoadingRunOutput = false
+    private(set) var runOutputErrorMessage: String?
+
+    /// Runs are requested 50 at a time — the server's own default page size.
+    static let historyPageSize = 50
+
+    /// How far the next page starts. Advances by `historyPageSize`, never by
+    /// the number of rows a page returned.
+    private var historyOffset = 0
+    private var runOutputToken = 0
+
     private let client: APIClient
 
     init(job: CronJob, runningElapsed: Double?, server: URL, client: APIClient? = nil) {
@@ -37,9 +65,14 @@ final class TaskDetailViewModel {
         lastError = nil
         defer { isLoading = false }
 
-        // Optional endpoint: failure must not break the detail view, and a
-        // nil result keeps the editor's free-text deliver fallback.
+        // Optional endpoints: failure must not break the detail view. A nil
+        // delivery result keeps the editor's free-text deliver fallback, and
+        // history is its own failure domain that reports inline.
         async let deliveryOptionsResponse = try? client.cronDeliveryOptions()
+        async let historyResult = Self.fetchHistory(client: client, jobID: jobID, offset: 0)
+
+        isLoadingHistory = true
+        historyErrorMessage = nil
 
         do {
             let response = try await client.cronOutput(jobID: jobID, limit: 5)
@@ -50,6 +83,162 @@ final class TaskDetailViewModel {
         }
 
         deliveryOptions = await deliveryOptionsResponse?.platforms
+        applyFirstHistoryPage(await historyResult)
+        isLoadingHistory = false
+    }
+
+    /// Loads the first page of run history, replacing what is on screen.
+    ///
+    /// A failed refresh keeps the runs already loaded — losing a list the user
+    /// was reading is worse than showing it beside a retry.
+    func loadHistory() async {
+        guard let jobID = job.jobId else { return }
+
+        isLoadingHistory = true
+        historyErrorMessage = nil
+        defer { isLoadingHistory = false }
+
+        applyFirstHistoryPage(await Self.fetchHistory(client: client, jobID: jobID, offset: 0))
+    }
+
+    /// `true` while the server still holds runs past the ones on screen.
+    var canLoadMoreRuns: Bool {
+        guard !isHistoryUnavailable, let runTotal else { return false }
+        return historyOffset < runTotal
+    }
+
+    /// How many runs "Load more" would still be working through.
+    var remainingRunCount: Int {
+        guard let runTotal else { return 0 }
+        return max(0, runTotal - runs.count)
+    }
+
+    /// The newest run — the one the header's "See full output" opens.
+    var latestRun: CronRunHistoryItem? { runs.first }
+
+    /// `true` when `run` is the run the job's failed last-run status describes.
+    ///
+    /// History carries no per-run status, and the job record only ever reports
+    /// on its most recent run, so no older row may claim a verdict it has no
+    /// evidence for.
+    func isFailedRun(_ run: CronRunHistoryItem) -> Bool {
+        job.hasFailedRun && run.filename == runs.first?.filename
+    }
+
+    func loadMoreRuns() async {
+        guard let jobID = job.jobId, canLoadMoreRuns, !isLoadingMoreRuns else { return }
+
+        let offset = historyOffset
+        isLoadingMoreRuns = true
+        historyErrorMessage = nil
+        defer { isLoadingMoreRuns = false }
+
+        switch await Self.fetchHistory(client: client, jobID: jobID, offset: offset) {
+        case let .success(response):
+            // The requested window is consumed whether or not every file in it
+            // could be read, so the cursor moves by `limit`.
+            historyOffset = offset + Self.historyPageSize
+            if let total = response.total {
+                runTotal = total
+            }
+            appendRuns(response.runs)
+        case let .failure(error):
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// Fetches one run's full text for the output sheet.
+    ///
+    /// Only the newest request may write `runOutput`, so tapping a second run
+    /// while the first is still in flight cannot leave the sheet showing the
+    /// wrong run's output.
+    func loadRunOutput(for run: CronRunHistoryItem) async {
+        guard let jobID = job.jobId else {
+            runOutputErrorMessage = String(localized: "Missing job identifier.")
+            return
+        }
+
+        runOutputToken += 1
+        let token = runOutputToken
+        runOutput = nil
+        runOutputErrorMessage = nil
+        isLoadingRunOutput = true
+
+        do {
+            let response = try await client.cronRunDetail(jobID: jobID, filename: run.filename)
+            guard token == runOutputToken else { return }
+            isLoadingRunOutput = false
+            runOutput = CronRunOutput(
+                filename: run.filename,
+                text: (response.content ?? response.snippet ?? "").strippingANSIEscapes()
+            )
+        } catch {
+            guard token == runOutputToken else { return }
+            isLoadingRunOutput = false
+            runOutputErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// Drops the sheet's output so a reopened sheet never flashes the previous
+    /// run's text.
+    func clearRunOutput() {
+        runOutputToken += 1
+        runOutput = nil
+        runOutputErrorMessage = nil
+        isLoadingRunOutput = false
+    }
+
+    /// Applies a first page, or its failure. A 404 retires the section for this
+    /// server; any other error is transient and reports beside the runs already
+    /// on screen.
+    private func applyFirstHistoryPage(_ result: Result<CronRunHistoryResponse, Error>) {
+        switch result {
+        case let .success(response):
+            runs = response.runs
+            runTotal = response.total
+            historyOffset = Self.historyPageSize
+            isHistoryUnavailable = false
+        case let .failure(error):
+            if Self.isMissingEndpoint(error) {
+                isHistoryUnavailable = true
+                runs = []
+                runTotal = nil
+                historyOffset = 0
+            } else {
+                historyErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    /// Appends a page, skipping runs already on screen. `total` can shift under
+    /// us while a job is writing new output, which is enough to make two pages
+    /// overlap.
+    private func appendRuns(_ page: [CronRunHistoryItem]) {
+        var seen = Set(runs.map(\.filename))
+        for run in page where seen.insert(run.filename).inserted {
+            runs.append(run)
+        }
+    }
+
+    /// Static so `load()` can start it with `async let` without capturing the
+    /// view model in a child task.
+    private static func fetchHistory(
+        client: APIClient,
+        jobID: String,
+        offset: Int
+    ) async -> Result<CronRunHistoryResponse, Error> {
+        do {
+            return .success(try await client.cronHistory(jobID: jobID, offset: offset, limit: historyPageSize))
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// A 404 means this server has no history endpoint, not that the request
+    /// was wrong.
+    private static func isMissingEndpoint(_ error: Error) -> Bool {
+        guard case let APIError.http(statusCode, _) = error else { return false }
+        return statusCode == 404
     }
 
     func clearActionError() {
@@ -164,4 +353,11 @@ final class TaskDetailViewModel {
             return false
         }
     }
+}
+
+/// One run's text, carried with the filename it belongs to so the sheet can
+/// refuse to render output that arrived for a different run.
+struct CronRunOutput: Equatable {
+    let filename: String
+    let text: String
 }

--- a/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
+++ b/HermesMobile/Features/Tasks/TaskDetailViewModel.swift
@@ -44,6 +44,11 @@ final class TaskDetailViewModel {
     /// How far the next page starts. Advances by `historyPageSize`, never by
     /// the number of rows a page returned.
     private var historyOffset = 0
+    /// Bumped by every first-page load, so `runs` and `historyOffset` always
+    /// describe the same list. A page fetched before a refresh belongs to a
+    /// list that no longer exists: splicing it on would leave the pages between
+    /// them loaded nowhere and unreachable.
+    private var historyGeneration = 0
     private var runOutputToken = 0
 
     private let client: APIClient
@@ -71,8 +76,7 @@ final class TaskDetailViewModel {
         async let deliveryOptionsResponse = try? client.cronDeliveryOptions()
         async let historyResult = Self.fetchHistory(client: client, jobID: jobID, offset: 0)
 
-        isLoadingHistory = true
-        historyErrorMessage = nil
+        let generation = beginHistoryReload()
 
         do {
             let response = try await client.cronOutput(jobID: jobID, limit: 5)
@@ -83,8 +87,7 @@ final class TaskDetailViewModel {
         }
 
         deliveryOptions = await deliveryOptionsResponse?.platforms
-        applyFirstHistoryPage(await historyResult)
-        isLoadingHistory = false
+        applyFirstHistoryPage(await historyResult, generation: generation)
     }
 
     /// Loads the first page of run history, replacing what is on screen.
@@ -94,11 +97,21 @@ final class TaskDetailViewModel {
     func loadHistory() async {
         guard let jobID = job.jobId else { return }
 
+        let generation = beginHistoryReload()
+        applyFirstHistoryPage(
+            await Self.fetchHistory(client: client, jobID: jobID, offset: 0),
+            generation: generation
+        )
+    }
+
+    /// Opens a new history generation and returns it. Every first-page load
+    /// goes through here so overlapping reloads cannot be mistaken for one
+    /// another.
+    private func beginHistoryReload() -> Int {
+        historyGeneration += 1
         isLoadingHistory = true
         historyErrorMessage = nil
-        defer { isLoadingHistory = false }
-
-        applyFirstHistoryPage(await Self.fetchHistory(client: client, jobID: jobID, offset: 0))
+        return historyGeneration
     }
 
     /// `true` while the server still holds runs past the ones on screen.
@@ -129,11 +142,19 @@ final class TaskDetailViewModel {
         guard let jobID = job.jobId, canLoadMoreRuns, !isLoadingMoreRuns else { return }
 
         let offset = historyOffset
+        let generation = historyGeneration
         isLoadingMoreRuns = true
         historyErrorMessage = nil
         defer { isLoadingMoreRuns = false }
 
-        switch await Self.fetchHistory(client: client, jobID: jobID, offset: offset) {
+        let result = await Self.fetchHistory(client: client, jobID: jobID, offset: offset)
+
+        // A refresh landed while this page was in flight. The page describes a
+        // list that no longer exists, so it is dropped rather than spliced onto
+        // the new one.
+        guard generation == historyGeneration else { return }
+
+        switch result {
         case let .success(response):
             // The requested window is consumed whether or not every file in it
             // could be read, so the cursor moves by `limit`.
@@ -191,7 +212,17 @@ final class TaskDetailViewModel {
     /// Applies a first page, or its failure. A 404 retires the section for this
     /// server; any other error is transient and reports beside the runs already
     /// on screen.
-    private func applyFirstHistoryPage(_ result: Result<CronRunHistoryResponse, Error>) {
+    ///
+    /// A page from a superseded generation is dropped, so a slow reload cannot
+    /// replace — or, on a stale 404, erase — a list that a newer one has since
+    /// loaded.
+    private func applyFirstHistoryPage(
+        _ result: Result<CronRunHistoryResponse, Error>,
+        generation: Int
+    ) {
+        guard generation == historyGeneration else { return }
+        isLoadingHistory = false
+
         switch result {
         case let .success(response):
             runs = response.runs

--- a/HermesMobile/Features/Tasks/TaskRunHistorySection.swift
+++ b/HermesMobile/Features/Tasks/TaskRunHistorySection.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+
+/// Task Detail's run history: every past run the server still holds, newest
+/// first, a page at a time.
+///
+/// Rows carry only what the server actually reports for every run — when it
+/// finished and how big it was. Model, duration and cost come from `usage`,
+/// which is empty for most runs, so they are appended when present and take no
+/// space when not.
+struct TaskRunHistorySection: View {
+    let runs: [CronRunHistoryItem]
+    let total: Int?
+    let isLoading: Bool
+    let isLoadingMore: Bool
+    let canLoadMore: Bool
+    let remainingCount: Int
+    let errorMessage: String?
+    /// Reports the one run the job record can vouch for. See
+    /// `TaskDetailViewModel.isFailedRun(_:)`.
+    let isFailedRun: (CronRunHistoryItem) -> Bool
+    let selectRun: (CronRunHistoryItem) -> Void
+    let retry: () -> Void
+    let loadMore: () -> Void
+
+    var body: some View {
+        SectionCard(title: sectionTitle) {
+            VStack(alignment: .leading, spacing: 0) {
+                if let errorMessage {
+                    inlineError(errorMessage)
+                }
+
+                if runs.isEmpty {
+                    emptyState
+                } else {
+                    ForEach(Array(runs.enumerated()), id: \.element.id) { index, run in
+                        if index > 0 {
+                            Divider()
+                        }
+
+                        Button {
+                            selectRun(run)
+                        } label: {
+                            TaskRunHistoryRow(run: run, hasFailed: isFailedRun(run))
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    if canLoadMore {
+                        Divider()
+                        loadMoreRow
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Pieces
+
+    private var sectionTitle: String {
+        guard let total else { return String(localized: "Run History") }
+        return String(localized: "Run History · \(total)")
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if isLoading {
+            HStack(spacing: 8) {
+                ProgressView()
+                Text("Loading runs...")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        } else if errorMessage == nil {
+            Text("This task has not produced any output yet.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.vertical, 4)
+        }
+    }
+
+    /// History failing is a section-local problem: it never takes the screen
+    /// down with it, so the retry lives here rather than in a full-page state.
+    private func inlineError(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Button("Try Again", action: retry)
+                .font(.footnote.weight(.semibold))
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, runs.isEmpty ? 0 : 10)
+    }
+
+    private var loadMoreRow: some View {
+        Button(action: loadMore) {
+            HStack(spacing: 8) {
+                if isLoadingMore {
+                    ProgressView()
+                }
+                Text(remainingCount > 0 ? String(localized: "Load \(remainingCount) more") : String(localized: "Load more"))
+                    .font(.footnote.weight(.semibold))
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.tint)
+        .disabled(isLoadingMore)
+    }
+}
+
+/// One past run. Date and size are always there; everything after them is a
+/// decoration the server may or may not have parsed.
+struct TaskRunHistoryRow: View {
+    let run: CronRunHistoryItem
+    let hasFailed: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(hasFailed ? Color.red : Color.green)
+                .frame(width: 7, height: 7)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(titleText)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+
+                if let detail = detailText {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Image(systemName: "chevron.forward")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(verbatim: ([titleText, statusWord] + metaParts).joined(separator: ", ")))
+        .accessibilityHint(Text("Opens this run's full output"))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var titleText: String {
+        guard let modified = run.modified else { return run.filename }
+        return modified.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    /// The status word plus `metaParts`, joined rather than laid out in columns
+    /// so a run with empty `usage` leaves no gap where its decorations would be.
+    private var detailText: String? {
+        let parts = hasFailed ? [statusWord] + metaParts : metaParts
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// Size first, because the server reports it for every run, then whatever
+    /// `usage` happened to carry.
+    private var metaParts: [String] {
+        var parts: [String] = []
+
+        if let size = run.size, size >= 0 {
+            parts.append(size.formatted(.byteCount(style: .file)))
+        }
+
+        if let duration = run.usage.durationSeconds, duration.isFinite, duration > 0 {
+            parts.append(
+                Duration.seconds(duration)
+                    .formatted(.units(allowed: [.hours, .minutes, .seconds], width: .narrow, maximumUnitCount: 2))
+            )
+        }
+
+        if let model = run.usage.model, !model.isEmpty {
+            parts.append(model)
+        }
+
+        if let cost = run.usage.estimatedCostUsd, cost.isFinite, cost > 0 {
+            parts.append(cost.formatted(.currency(code: "USD").precision(.fractionLength(0...4))))
+        }
+
+        return parts
+    }
+
+    private var statusWord: String {
+        hasFailed ? String(localized: "Failed") : String(localized: "Completed")
+    }
+}

--- a/HermesMobile/Features/Tasks/TaskRunOutputSheet.swift
+++ b/HermesMobile/Features/Tasks/TaskRunOutputSheet.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import UIKit
+
+/// One past run, read in full.
+///
+/// The sheet renders `output` only when it belongs to the run on screen, so a
+/// slow request that lands after the user has moved to another run can never
+/// put the wrong transcript under the wrong heading.
+struct TaskRunOutputSheet: View {
+    let run: CronRunHistoryItem
+    let output: CronRunOutput?
+    let isLoading: Bool
+    let errorMessage: String?
+    let retry: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let text = matchingText, !text.isEmpty {
+                    ScrollView {
+                        Text(text)
+                            .font(.system(.footnote, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                    }
+                } else if isLoading {
+                    ProgressView("Loading output...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let errorMessage {
+                    ContentUnavailableView {
+                        Label("Could Not Load Output", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(errorMessage)
+                    } actions: {
+                        Button("Try Again", action: retry)
+                    }
+                } else {
+                    ContentUnavailableView {
+                        Label("Empty Output", systemImage: "doc.text")
+                    } description: {
+                        Text("This run finished without writing anything.")
+                    }
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        UIPasteboard.general.string = matchingText
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                    .disabled(matchingText?.isEmpty != false)
+                }
+            }
+        }
+    }
+
+    private var title: String {
+        guard let modified = run.modified else { return run.filename }
+        return modified.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    /// The loaded text, but only if it is this run's.
+    private var matchingText: String? {
+        guard let output, output.filename == run.filename else { return nil }
+        return output.text
+    }
+}

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -251,8 +251,17 @@ struct TasksView: View {
 struct CronJobMetadataRow: View {
     let title: String
     let value: String
+    /// A dimmer second line under the value, for the raw form of something the
+    /// value states in English (a cron expression under its sentence).
+    let detail: String?
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    init(title: String, value: String, detail: String? = nil) {
+        self.title = title
+        self.value = value
+        self.detail = detail
+    }
 
     var body: some View {
         Group {
@@ -278,9 +287,19 @@ struct CronJobMetadataRow: View {
     }
 
     private var valueText: some View {
-        Text(value)
-            .foregroundStyle(.primary)
-            .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
+        VStack(alignment: .leading, spacing: 1) {
+            Text(value)
+                .foregroundStyle(.primary)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
+
+            if let detail, detail != value {
+                Text(detail)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -248,61 +248,6 @@ struct TasksView: View {
     }
 }
 
-struct CronJobMetadataRow: View {
-    let title: String
-    let value: String
-    /// A dimmer second line under the value, for the raw form of something the
-    /// value states in English (a cron expression under its sentence).
-    let detail: String?
-
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
-    init(title: String, value: String, detail: String? = nil) {
-        self.title = title
-        self.value = value
-        self.detail = detail
-    }
-
-    var body: some View {
-        Group {
-            if dynamicTypeSize.isAccessibilitySize {
-                VStack(alignment: .leading, spacing: 2) {
-                    titleText
-                    valueText
-                }
-            } else {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    titleText
-                        .frame(width: 64, alignment: .leading)
-                    valueText
-                }
-            }
-        }
-        .accessibilityElement(children: .combine)
-    }
-
-    private var titleText: some View {
-        Text(title)
-            .foregroundStyle(.secondary)
-    }
-
-    private var valueText: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(value)
-                .foregroundStyle(.primary)
-                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
-
-            if let detail, detail != value {
-                Text(detail)
-                    .font(.caption2.monospaced())
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
 struct StatusBadge: View {
     let text: String
     let color: Color

--- a/HermesMobile/Models/CronRunHistory.swift
+++ b/HermesMobile/Models/CronRunHistory.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// One page of a task's run history, from `GET /api/crons/history`.
+///
+/// `total` counts every run the server holds, not the rows in this page. The
+/// two differ on purpose: upstream slices `all_files[offset:offset + limit]`
+/// and then drops any entry whose `stat()` throws, so a page can return fewer
+/// rows than it consumed. Callers page by the `limit` they asked for and stop
+/// at `total`; advancing by `runs.count` silently re-reads rows it already has.
+struct CronRunHistoryResponse: Decodable, Equatable {
+    let jobId: String?
+    let runs: [CronRunHistoryItem]
+    let total: Int?
+    let offset: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case jobId
+        case runs
+        case total
+        case offset
+    }
+
+    init(jobId: String?, runs: [CronRunHistoryItem], total: Int?, offset: Int?) {
+        self.jobId = jobId
+        self.runs = runs
+        self.total = total
+        self.offset = offset
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jobId = container.decodeLossyStringIfPresent(forKey: .jobId)
+        total = container.decodeLossyIntIfPresent(forKey: .total)
+        offset = container.decodeLossyIntIfPresent(forKey: .offset)
+        runs = ((try? container.decodeIfPresent([LossyCronRun].self, forKey: .runs)) ?? nil)?
+            .compactMap(\.run) ?? []
+    }
+}
+
+/// One past run: enough to render a row, and the `filename` handle the
+/// run-detail endpoint needs.
+struct CronRunHistoryItem: Decodable, Equatable, Identifiable {
+    var id: String { filename }
+
+    /// Unique within a job's output directory, which is what makes it a safe
+    /// list identity as well as the detail request's key.
+    let filename: String
+    /// Bytes on disk. `nil` when the server sent something unusable rather
+    /// than a number.
+    let size: Int?
+    /// The file's mtime, which is when the run finished.
+    let modified: Date?
+    /// Parsed out of the run's markdown front matter, and frequently empty.
+    let usage: CronRunUsage
+
+    enum CodingKeys: String, CodingKey {
+        case filename
+        case size
+        case modified
+        case usage
+    }
+
+    init(filename: String, size: Int? = nil, modified: Date? = nil, usage: CronRunUsage = CronRunUsage()) {
+        self.filename = filename
+        self.size = size
+        self.modified = modified
+        self.usage = usage
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // A run with no filename cannot be opened, so it is dropped by
+        // `LossyCronRun` rather than rendered as a dead row.
+        guard let filename = container.decodeLossyStringIfPresent(forKey: .filename),
+              !filename.isEmpty
+        else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .filename,
+                in: container,
+                debugDescription: "Cron run is missing a filename"
+            )
+        }
+
+        self.filename = filename
+        size = container.decodeLossyIntIfPresent(forKey: .size)
+        // `Date(timeIntervalSince1970:)` accepts NaN and infinity and then traps
+        // deep inside date formatting, so a non-finite mtime becomes no date.
+        modified = container.decodeLossyDoubleIfPresent(forKey: .modified)
+            .flatMap { $0.isFinite ? Date(timeIntervalSince1970: $0) : nil }
+        usage = ((try? container.decodeIfPresent(CronRunUsage.self, forKey: .usage)) ?? nil) ?? CronRunUsage()
+    }
+}
+
+/// The optional token, cost and timing metadata upstream scrapes out of a run's
+/// markdown front matter.
+///
+/// Every field is a decoration. The server returns `{}` for most runs, so no
+/// layout may reserve space for these — a row shows what is there and nothing
+/// where there is not.
+struct CronRunUsage: Decodable, Equatable {
+    let model: String?
+    let provider: String?
+    let estimatedCostUsd: Double?
+    let durationSeconds: Double?
+    let inputTokens: Int?
+    let outputTokens: Int?
+    let totalTokens: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case provider
+        case estimatedCostUsd
+        case durationSeconds
+        case inputTokens
+        case outputTokens
+        case totalTokens
+    }
+
+    init(
+        model: String? = nil,
+        provider: String? = nil,
+        estimatedCostUsd: Double? = nil,
+        durationSeconds: Double? = nil,
+        inputTokens: Int? = nil,
+        outputTokens: Int? = nil,
+        totalTokens: Int? = nil
+    ) {
+        self.model = model
+        self.provider = provider
+        self.estimatedCostUsd = estimatedCostUsd
+        self.durationSeconds = durationSeconds
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.totalTokens = totalTokens
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = container.decodeLossyStringIfPresent(forKey: .model)
+        provider = container.decodeLossyStringIfPresent(forKey: .provider)
+        estimatedCostUsd = container.decodeLossyDoubleIfPresent(forKey: .estimatedCostUsd)
+        durationSeconds = container.decodeLossyDoubleIfPresent(forKey: .durationSeconds)
+        inputTokens = container.decodeLossyIntIfPresent(forKey: .inputTokens)
+        outputTokens = container.decodeLossyIntIfPresent(forKey: .outputTokens)
+        totalTokens = container.decodeLossyIntIfPresent(forKey: .totalTokens)
+    }
+}
+
+/// One run's full text, from `GET /api/crons/run` — the read that shares its
+/// path with the POST that triggers a run.
+struct CronRunDetailResponse: Decodable, Equatable {
+    let jobId: String?
+    let filename: String?
+    let content: String?
+    let snippet: String?
+    let usage: CronRunUsage
+
+    enum CodingKeys: String, CodingKey {
+        case jobId
+        case filename
+        case content
+        case snippet
+        case usage
+    }
+
+    init(jobId: String?, filename: String?, content: String?, snippet: String?, usage: CronRunUsage = CronRunUsage()) {
+        self.jobId = jobId
+        self.filename = filename
+        self.content = content
+        self.snippet = snippet
+        self.usage = usage
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jobId = container.decodeLossyStringIfPresent(forKey: .jobId)
+        filename = container.decodeLossyStringIfPresent(forKey: .filename)
+        content = try? container.decodeIfPresent(String.self, forKey: .content)
+        snippet = try? container.decodeIfPresent(String.self, forKey: .snippet)
+        usage = ((try? container.decodeIfPresent(CronRunUsage.self, forKey: .usage)) ?? nil) ?? CronRunUsage()
+    }
+}
+
+/// Decodes a run without ever throwing, so one malformed entry drops out of the
+/// page instead of failing the whole request.
+private struct LossyCronRun: Decodable {
+    let run: CronRunHistoryItem?
+
+    init(from decoder: Decoder) throws {
+        run = try? CronRunHistoryItem(from: decoder)
+    }
+}

--- a/HermesMobile/Networking/APIClient+Cron.swift
+++ b/HermesMobile/Networking/APIClient+Cron.swift
@@ -106,6 +106,20 @@ extension APIClient {
     func cronOutput(jobID: String, limit: Int? = 5) async throws -> CronOutputResponse {
         try await send(endpoint: .cronOutput(jobID: jobID, limit: limit), method: "GET")
     }
+
+    /// One page of a job's run history, newest first.
+    ///
+    /// Callers advance `offset` by the `limit` they passed, not by
+    /// `response.runs.count`: see `CronRunHistoryResponse`.
+    func cronHistory(jobID: String, offset: Int, limit: Int) async throws -> CronRunHistoryResponse {
+        try await send(endpoint: .cronHistory(jobID: jobID, offset: offset, limit: limit), method: "GET")
+    }
+
+    /// One past run's full output. The GET twin of `runCron`'s POST on the same
+    /// path.
+    func cronRunDetail(jobID: String, filename: String) async throws -> CronRunDetailResponse {
+        try await send(endpoint: .cronRunDetail(jobID: jobID, filename: filename), method: "GET")
+    }
 }
 
 private struct CronCreateRequest: Encodable {

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -91,7 +91,12 @@ enum Endpoint {
     case cronCreate
     case cronUpdate
     case cronDelete
+    /// POST: triggers a run. `/api/crons/run` also serves a GET that reads one
+    /// past run's output — that is `cronRunDetail`, a separate case.
     case cronRun
+    /// GET on `/api/crons/run`: one past run's full output.
+    case cronRunDetail(jobID: String, filename: String)
+    case cronHistory(jobID: String, offset: Int, limit: Int)
     case cronPause
     case cronResume
     case cronStatus(jobID: String?)
@@ -307,8 +312,10 @@ enum Endpoint {
             return "/api/crons/update"
         case .cronDelete:
             return "/api/crons/delete"
-        case .cronRun:
+        case .cronRun, .cronRunDetail:
             return "/api/crons/run"
+        case .cronHistory:
+            return "/api/crons/history"
         case .cronPause:
             return "/api/crons/pause"
         case .cronResume:
@@ -477,6 +484,17 @@ enum Endpoint {
         case let .cronStatus(jobID):
             guard let jobID else { return [] }
             return [URLQueryItem(name: "job_id", value: jobID)]
+        case let .cronRunDetail(jobID, filename):
+            return [
+                URLQueryItem(name: "job_id", value: jobID),
+                URLQueryItem(name: "filename", value: filename)
+            ]
+        case let .cronHistory(jobID, offset, limit):
+            return [
+                URLQueryItem(name: "job_id", value: jobID),
+                URLQueryItem(name: "offset", value: "\(offset)"),
+                URLQueryItem(name: "limit", value: "\(limit)")
+            ]
         case let .cronOutput(jobID, limit):
             var items = [URLQueryItem(name: "job_id", value: jobID)]
             if let limit {

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -127876,6 +127876,112 @@
           }
         }
       }
+    },
+    "Notifications" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "الإشعارات"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mitteilungen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificaciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notifications"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "התראות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notifiche"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "通知"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "알림"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meldingen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Powiadomienia"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificações"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Уведомления"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bildirimler"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اطلاعات"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "通知"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "通知"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -125968,6 +125968,1914 @@
           }
         }
       }
+    },
+    "Due now" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مستحق الآن"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jetzt fällig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se ejecuta ahora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Prévu maintenant"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מתוזמן כעת"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Previsto ora"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "まもなく実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "곧 실행"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nu gepland"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zaplanowane teraz"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agendado para agora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Запуск сейчас"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Şimdi çalışacak"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ابھی مقرر"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "即將執行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "即将运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "即將執行"
+          }
+        }
+      }
+    },
+    "Overdue" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "متأخر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Überfällig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atrasado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "En retard"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "באיחור"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "In ritardo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "遅延"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "지연됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Te laat"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zaległe"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atrasado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Просрочено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gecikmiş"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تاخیر شدہ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已逾期"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已逾期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已逾期"
+          }
+        }
+      }
+    },
+    "in %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "خلال %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "in %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "en %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dans %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בעוד %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "tra %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@後"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ 후"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "over %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "za %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "em %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "через %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ sonra"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ میں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@後"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@后"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@後"
+          }
+        }
+      }
+    },
+    "Next run · %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "التشغيل التالي · %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nächster Lauf · %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Próxima ejecución · %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Prochaine exécution · %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הרצה הבאה · %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Prossima esecuzione · %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "次回の実行 · %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "다음 실행 · %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Volgende uitvoering · %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Następne uruchomienie · %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Próxima execução · %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Следующий запуск · %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sonraki çalışma · %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اگلا رن · %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下次執行 · %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下次运行 · %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下次執行 · %@"
+          }
+        }
+      }
+    },
+    "Last run · %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آخر تشغيل · %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Letzter Lauf · %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última ejecución · %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dernière exécution · %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הרצה אחרונה · %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ultima esecuzione · %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "前回の実行 · %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "마지막 실행 · %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Laatste uitvoering · %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ostatnie uruchomienie · %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última execução · %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Последний запуск · %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Son çalışma · %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آخری رن · %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次執行 · %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次运行 · %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次執行 · %@"
+          }
+        }
+      }
+    },
+    "Not scheduled" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "غير مجدول"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nicht geplant"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sin programar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Non planifié"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "לא מתוזמן"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Non pianificato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "スケジュールなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "예약되지 않음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Niet gepland"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Niezaplanowane"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não agendado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Не запланировано"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zamanlanmadı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "شیڈول نہیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未排程"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未安排"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未排程"
+          }
+        }
+      }
+    },
+    "Last run failed. %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فشل آخر تشغيل. %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Letzter Lauf fehlgeschlagen. %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La última ejecución falló. %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La dernière exécution a échoué. %@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ההרצה האחרונה נכשלה. %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "L’ultima esecuzione non è riuscita. %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "前回の実行が失敗しました。%@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "마지막 실행에 실패했습니다. %@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Laatste uitvoering mislukt. %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ostatnie uruchomienie nie powiodło się. %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A última execução falhou. %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Последний запуск не удался. %@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Son çalışma başarısız oldu. %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "آخری رن ناکام ہوا۔ %@"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次執行失敗。%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次运行失败。%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次執行失敗。%@"
+          }
+        }
+      }
+    },
+    "See full output" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "عرض الإخراج الكامل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vollständige Ausgabe ansehen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ver salida completa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Voir la sortie complète"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הצג פלט מלא"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vedi output completo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全出力を表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전체 출력 보기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Volledige uitvoer bekijken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zobacz pełne wyjście"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ver saída completa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показать весь вывод"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tam çıktıyı gör"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مکمل آؤٹ پٹ دیکھیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查看完整輸出"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查看完整输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查看完整輸出"
+          }
+        }
+      }
+    },
+    "Run now" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تشغيل الآن"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jetzt ausführen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ejecutar ahora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exécuter maintenant"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הפעל כעת"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esegui ora"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今すぐ実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "지금 실행"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nu uitvoeren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uruchom teraz"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Executar agora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Запустить сейчас"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Şimdi çalıştır"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ابھی چلائیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "立即執行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "立即运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "立即執行"
+          }
+        }
+      }
+    },
+    "Run Output" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "إخراج التشغيل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lauf-Ausgabe"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salida de la ejecución"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sortie de l’exécution"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פלט ההרצה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Output dell’esecuzione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行の出力"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행 출력"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitvoer van uitvoering"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wyjście uruchomienia"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Saída da execução"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Вывод запуска"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalışma çıktısı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رن آؤٹ پٹ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行輸出"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "运行输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行輸出"
+          }
+        }
+      }
+    },
+    "Run History" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سجل التشغيل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ausführungsverlauf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historial de ejecuciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historique des exécutions"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "היסטוריית הרצות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cronologia esecuzioni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行履歴"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행 기록"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitvoeringsgeschiedenis"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historia uruchomień"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico de execuções"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "История запусков"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalışma geçmişi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رن ہسٹری"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行紀錄"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "运行历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行紀錄"
+          }
+        }
+      }
+    },
+    "Run History · %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سجل التشغيل · %lld"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ausführungsverlauf · %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historial de ejecuciones · %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historique des exécutions · %lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "היסטוריית הרצות · %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cronologia esecuzioni · %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行履歴 · %lld"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행 기록 · %lld"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitvoeringsgeschiedenis · %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Historia uruchomień · %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico de execuções · %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "История запусков · %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalışma geçmişi · %lld"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رن ہسٹری · %lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行紀錄 · %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "运行历史 · %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行紀錄 · %lld"
+          }
+        }
+      }
+    },
+    "Load more" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تحميل المزيد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mehr laden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cargar más"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Charger plus"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "טען עוד"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carica altri"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "さらに読み込む"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "더 불러오기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meer laden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Załaduj więcej"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregar mais"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загрузить ещё"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Daha fazla yükle"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مزید لوڈ کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "載入更多"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "加载更多"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "載入更多"
+          }
+        }
+      }
+    },
+    "Load %lld more" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تحميل %lld إضافية"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld weitere laden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cargar %lld más"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Charger %lld de plus"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "טען עוד %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carica altri %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "さらに %lld 件を読み込む"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld개 더 불러오기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nog %lld laden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Załaduj jeszcze %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregar mais %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загрузить ещё %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld tane daha yükle"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مزید %lld لوڈ کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "再載入 %lld 筆"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "再加载 %lld 条"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "再載入 %lld 筆"
+          }
+        }
+      }
+    },
+    "Loading runs..." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "جارٍ تحميل عمليات التشغيل..."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Läufe werden geladen …"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cargando ejecuciones..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chargement des exécutions…"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "טוען הרצות..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Caricamento esecuzioni..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "実行を読み込み中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "실행 불러오는 중..."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uitvoeringen laden..."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ładowanie uruchomień..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando execuções..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загрузка запусков..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalışmalar yükleniyor..."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "رنز لوڈ ہو رہے ہیں..."
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在載入執行…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在加载运行…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在載入執行…"
+          }
+        }
+      }
+    },
+    "Opens this run's full output" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يفتح الإخراج الكامل لهذا التشغيل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Öffnet die vollständige Ausgabe dieses Laufs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abre la salida completa de esta ejecución"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ouvre la sortie complète de cette exécution"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פותח את הפלט המלא של הרצה זו"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apre l’output completo di questa esecuzione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "この実行の全出力を開きます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 실행의 전체 출력을 엽니다"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opent de volledige uitvoer van deze uitvoering"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Otwiera pełne wyjście tego uruchomienia"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abre a saída completa desta execução"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Открывает полный вывод этого запуска"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu çalışmanın tam çıktısını açar"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اس رن کا مکمل آؤٹ پٹ کھولتا ہے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "開啟此次執行的完整輸出"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "打开此次运行的完整输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "開啟此次執行的完整輸出"
+          }
+        }
+      }
+    },
+    "Empty Output" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "إخراج فارغ"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Leere Ausgabe"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salida vacía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sortie vide"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פלט ריק"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Output vuoto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "出力なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "출력 없음"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lege uitvoer"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Puste wyjście"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Saída vazia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Пустой вывод"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Boş çıktı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "خالی آؤٹ پٹ"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "輸出為空"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "输出为空"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "輸出為空"
+          }
+        }
+      }
+    },
+    "This run finished without writing anything." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "انتهى هذا التشغيل دون كتابة أي شيء."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dieser Lauf endete, ohne etwas zu schreiben."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta ejecución terminó sin escribir nada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cette exécution s’est terminée sans rien écrire."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ההרצה הזו הסתיימה בלי לכתוב דבר."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Questa esecuzione è terminata senza scrivere nulla."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "この実行は何も出力せずに終了しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 실행은 아무것도 기록하지 않고 끝났습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deze uitvoering is beëindigd zonder iets te schrijven."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "To uruchomienie zakończyło się bez zapisania czegokolwiek."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta execução terminou sem escrever nada."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Этот запуск завершился, ничего не записав."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bu çalışma hiçbir şey yazmadan tamamlandı."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "یہ رن کچھ لکھے بغیر مکمل ہو گیا۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此次執行結束時未寫入任何內容。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此次运行结束时没有写入任何内容。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此次執行結束時未寫入任何內容。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/APIClientTests.swift
+++ b/HermesMobileTests/APIClientTests.swift
@@ -165,10 +165,10 @@ final class MockAuthAPIClient: AuthAPIClient, @unchecked Sendable {
     }
 }
 
-func apiTestJSONResponse(_ json: String, for request: URLRequest) -> (HTTPURLResponse, Data) {
+func apiTestJSONResponse(_ json: String, for request: URLRequest, status: Int = 200) -> (HTTPURLResponse, Data) {
     let response = HTTPURLResponse(
         url: request.url!,
-        statusCode: 200,
+        statusCode: status,
         httpVersion: nil,
         headerFields: ["Content-Type": "application/json"]
     )!

--- a/HermesMobileTests/APIClientTests.swift
+++ b/HermesMobileTests/APIClientTests.swift
@@ -40,8 +40,19 @@ class APIClientTestCase: XCTestCase {
     }
 }
 
-final class MockURLProtocol: URLProtocol {
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    /// Handlers run here rather than on the caller's thread. URLSession drives
+    /// every protocol instance from a single loading thread, so a handler that
+    /// waits on that thread stalls every other in-flight request — and no test
+    /// could express a race between two of them.
+    private static let queue = DispatchQueue(label: "MockURLProtocol", attributes: .concurrent)
+
+    private let lock = NSLock()
+    private var cancelled = false
+
+    private var isCancelled: Bool { lock.withLock { cancelled } }
 
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -57,17 +68,24 @@ final class MockURLProtocol: URLProtocol {
             return
         }
 
-        do {
-            let (response, data) = try requestHandler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
+        let request = request
+        Self.queue.async { [self] in
+            do {
+                let (response, data) = try requestHandler(request)
+                guard !isCancelled else { return }
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                guard !isCancelled else { return }
+                client?.urlProtocol(self, didFailWithError: error)
+            }
         }
     }
 
-    override func stopLoading() {}
+    override func stopLoading() {
+        lock.withLock { cancelled = true }
+    }
 }
 
 final class InMemoryKeychainStore: KeychainStoring {

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -222,6 +222,22 @@ final class ContractReadinessTests: XCTestCase {
             .init(name: "cron update", method: "POST", endpoint: .cronUpdate, path: "/api/crons/update"),
             .init(name: "cron delete", method: "POST", endpoint: .cronDelete, path: "/api/crons/delete"),
             .init(name: "cron run", method: "POST", endpoint: .cronRun, path: "/api/crons/run"),
+            // Same path as the POST above, different operation: GET reads one
+            // past run's output.
+            .init(
+                name: "cron run detail",
+                method: "GET",
+                endpoint: .cronRunDetail(jobID: "job-123", filename: "2026-09-03T07-00-00.md"),
+                path: "/api/crons/run",
+                query: ["job_id": "job-123", "filename": "2026-09-03T07-00-00.md"]
+            ),
+            .init(
+                name: "cron history",
+                method: "GET",
+                endpoint: .cronHistory(jobID: "job-123", offset: 50, limit: 50),
+                path: "/api/crons/history",
+                query: ["job_id": "job-123", "offset": "50", "limit": "50"]
+            ),
             .init(name: "cron pause", method: "POST", endpoint: .cronPause, path: "/api/crons/pause"),
             .init(name: "cron resume", method: "POST", endpoint: .cronResume, path: "/api/crons/resume"),
             .init(name: "cron status all", method: "GET", endpoint: .cronStatus(jobID: nil), path: "/api/crons/status"),

--- a/HermesMobileTests/TaskRunHistoryTests.swift
+++ b/HermesMobileTests/TaskRunHistoryTests.swift
@@ -416,3 +416,61 @@ private final class RequestRecorder: @unchecked Sendable {
     var limits: [Int] { lock.withLock { recorded.map(\.limit) } }
     var lastOffset: Int? { lock.withLock { recorded.last?.offset } }
 }
+
+/// The Configuration card answers a fixed set of questions about how a job
+/// runs, so the answers do not come and go with the server's payload.
+final class TaskConfigurationFieldTests: XCTestCase {
+    func testOmittedModelProfileAndSkillsStillGetRows() {
+        let fields = TaskConfigurationField.fields(for: Self.decodeJob("""
+        {"job_id": "job-123", "name": "Reddit Trending Scanner",
+         "schedule": {"kind": "cron", "expr": "0 7 * * *"},
+         "deliver": "discord:#social-posts", "toast_notifications": true}
+        """))
+
+        XCTAssertEqual(
+            fields.map(\.title),
+            ["Schedule", "Deliver", "Model", "Profile", "Skills", "Notifications"]
+        )
+        XCTAssertEqual(fields.first { $0.title == "Model" }?.value, "Server default")
+        XCTAssertEqual(fields.first { $0.title == "Profile" }?.value, "Server default")
+        XCTAssertEqual(fields.first { $0.title == "Skills" }?.value, "None")
+        XCTAssertEqual(fields.first { $0.title == "Notifications" }?.value, "On")
+        // The humanised schedule leads; the raw expression is the second line.
+        // The clock format is the locale's, so only the sentence is asserted.
+        XCTAssertTrue(fields.first?.value.hasPrefix("Daily at ") == true, "got \(fields.first?.value ?? "nil")")
+        XCTAssertEqual(fields.first?.detail, "0 7 * * *")
+    }
+
+    func testProviderAppearsOnlyBesideAnExplicitModel() {
+        let withModel = TaskConfigurationField.fields(for: Self.decodeJob("""
+        {"job_id": "job-1", "model": "sonnet-5", "provider": "anthropic", "skills": ["summarize", " "]}
+        """))
+        XCTAssertEqual(withModel.first { $0.title == "Model" }?.value, "sonnet-5")
+        XCTAssertEqual(withModel.first { $0.title == "Provider" }?.value, "anthropic")
+        XCTAssertEqual(withModel.first { $0.title == "Skills" }?.value, "summarize")
+
+        // A provider without a model describes nothing the user chose.
+        let withoutModel = TaskConfigurationField.fields(for: Self.decodeJob("""
+        {"job_id": "job-2", "model": "   ", "provider": "anthropic"}
+        """))
+        XCTAssertNil(withoutModel.first { $0.title == "Provider" })
+        XCTAssertEqual(withoutModel.first { $0.title == "Model" }?.value, "Server default")
+    }
+
+    /// "On" for a value the server never sent would be a guess, not a stand-in
+    /// for absence — unlike "Server default", which is true either way.
+    func testNotificationsRowIsAbsentWhenTheServerDidNotSay() {
+        let fields = TaskConfigurationField.fields(for: Self.decodeJob("""
+        {"job_id": "job-3"}
+        """))
+
+        XCTAssertNil(fields.first { $0.title == "Notifications" })
+        XCTAssertEqual(fields.first { $0.title == "Deliver" }?.value, "local")
+    }
+
+    private static func decodeJob(_ json: String) -> CronJob {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try! decoder.decode(CronJob.self, from: Data(json.utf8))
+    }
+}

--- a/HermesMobileTests/TaskRunHistoryTests.swift
+++ b/HermesMobileTests/TaskRunHistoryTests.swift
@@ -417,54 +417,45 @@ private final class RequestRecorder: @unchecked Sendable {
     var lastOffset: Int? { lock.withLock { recorded.last?.offset } }
 }
 
-/// The Configuration card answers a fixed set of questions about how a job
-/// runs, so the answers do not come and go with the server's payload.
+/// A field the job does not have does not get a row: a job that leaves the
+/// model, profile or skills to the server has nothing to say about them.
 final class TaskConfigurationFieldTests: XCTestCase {
-    func testOmittedModelProfileAndSkillsStillGetRows() {
+    func testFieldsTheJobDoesNotHaveAreAbsent() {
         let fields = TaskConfigurationField.fields(for: Self.decodeJob("""
         {"job_id": "job-123", "name": "Reddit Trending Scanner",
          "schedule": {"kind": "cron", "expr": "0 7 * * *"},
-         "deliver": "discord:#social-posts", "toast_notifications": true}
+         "deliver": "discord:#social-posts", "model": "  ", "skills": [],
+         "toast_notifications": true}
         """))
 
-        XCTAssertEqual(
-            fields.map(\.title),
-            ["Schedule", "Deliver", "Model", "Profile", "Skills", "Notifications"]
-        )
-        XCTAssertEqual(fields.first { $0.title == "Model" }?.value, "Server default")
-        XCTAssertEqual(fields.first { $0.title == "Profile" }?.value, "Server default")
-        XCTAssertEqual(fields.first { $0.title == "Skills" }?.value, "None")
-        XCTAssertEqual(fields.first { $0.title == "Notifications" }?.value, "On")
+        XCTAssertEqual(fields.map(\.title), ["Schedule", "Deliver", "Notifications"])
         // The humanised schedule leads; the raw expression is the second line.
         // The clock format is the locale's, so only the sentence is asserted.
         XCTAssertTrue(fields.first?.value.hasPrefix("Daily at ") == true, "got \(fields.first?.value ?? "nil")")
         XCTAssertEqual(fields.first?.detail, "0 7 * * *")
+        XCTAssertEqual(fields.first { $0.title == "Notifications" }?.value, "On")
     }
 
-    func testProviderAppearsOnlyBesideAnExplicitModel() {
-        let withModel = TaskConfigurationField.fields(for: Self.decodeJob("""
-        {"job_id": "job-1", "model": "sonnet-5", "provider": "anthropic", "skills": ["summarize", " "]}
+    func testFieldsTheJobHasAreShownAndTrimmed() {
+        let fields = TaskConfigurationField.fields(for: Self.decodeJob("""
+        {"job_id": "job-1", "model": " sonnet-5 ", "provider": "anthropic",
+         "profile": "work", "skills": ["summarize", " ", " notify "]}
         """))
-        XCTAssertEqual(withModel.first { $0.title == "Model" }?.value, "sonnet-5")
-        XCTAssertEqual(withModel.first { $0.title == "Provider" }?.value, "anthropic")
-        XCTAssertEqual(withModel.first { $0.title == "Skills" }?.value, "summarize")
 
-        // A provider without a model describes nothing the user chose.
-        let withoutModel = TaskConfigurationField.fields(for: Self.decodeJob("""
-        {"job_id": "job-2", "model": "   ", "provider": "anthropic"}
-        """))
-        XCTAssertNil(withoutModel.first { $0.title == "Provider" })
-        XCTAssertEqual(withoutModel.first { $0.title == "Model" }?.value, "Server default")
+        XCTAssertEqual(fields.map(\.title), ["Schedule", "Deliver", "Model", "Provider", "Profile", "Skills"])
+        XCTAssertEqual(fields.first { $0.title == "Model" }?.value, "sonnet-5")
+        XCTAssertEqual(fields.first { $0.title == "Skills" }?.value, "summarize, notify")
+        // Nothing said about notifications, so nothing claimed about them.
+        XCTAssertNil(fields.first { $0.title == "Notifications" })
     }
 
-    /// "On" for a value the server never sent would be a guess, not a stand-in
-    /// for absence — unlike "Server default", which is true either way.
-    func testNotificationsRowIsAbsentWhenTheServerDidNotSay() {
+    /// Every job delivers somewhere, and `local` is the server's own default
+    /// rather than a stand-in for a value it failed to send.
+    func testDeliverFallsBackToTheServerDefault() {
         let fields = TaskConfigurationField.fields(for: Self.decodeJob("""
         {"job_id": "job-3"}
         """))
 
-        XCTAssertNil(fields.first { $0.title == "Notifications" })
         XCTAssertEqual(fields.first { $0.title == "Deliver" }?.value, "local")
     }
 

--- a/HermesMobileTests/TaskRunHistoryTests.swift
+++ b/HermesMobileTests/TaskRunHistoryTests.swift
@@ -168,6 +168,51 @@ final class TaskRunHistoryTests: APIClientTestCase {
         XCTAssertEqual(recorder.offsets.last, pageSize)
     }
 
+    /// While a reload is in flight the cursor still points into the list being
+    /// replaced, so "Load more" must not fetch against it — a page taken from
+    /// the old cursor would land on the new list.
+    @MainActor
+    func testLoadMoreIsRefusedWhileAReloadIsInFlight() async {
+        let recorder = RequestRecorder()
+        let pageSize = TaskDetailViewModel.historyPageSize
+        let reloadStarted = expectation(description: "reload request started")
+        let releaseReload = DispatchSemaphore(value: 0)
+
+        let viewModel = makeViewModel { request in
+            recorder.record(request)
+            let offset = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first { $0.name == "offset" }?.value.flatMap(Int.init) ?? 0
+
+            // Hold the reload — the third request — open.
+            if recorder.offsets.count == 3 {
+                reloadStarted.fulfill()
+                releaseReload.wait()
+            }
+
+            let page = offset == 0 ? "page-1.md" : "page-2.md"
+            return apiTestJSONResponse(Self.historyJSON(total: 200, filenames: [page]), for: request)
+        }
+
+        await viewModel.loadHistory()
+        await viewModel.loadMoreRuns()
+        XCTAssertEqual(viewModel.runs.map(\.filename), ["page-1.md", "page-2.md"])
+
+        let reload = Task { await viewModel.loadHistory() }
+        await fulfillment(of: [reloadStarted], timeout: 5)
+
+        // The cursor still reads 100 here, but it belongs to the list being
+        // replaced, so no request may be made against it.
+        await viewModel.loadMoreRuns()
+        XCTAssertEqual(recorder.offsets, [0, pageSize, 0])
+
+        releaseReload.signal()
+        await reload.value
+
+        XCTAssertEqual(viewModel.runs.map(\.filename), ["page-1.md"])
+        await viewModel.loadMoreRuns()
+        XCTAssertEqual(recorder.offsets.last, pageSize)
+    }
+
     // MARK: - Failure containment
 
     @MainActor

--- a/HermesMobileTests/TaskRunHistoryTests.swift
+++ b/HermesMobileTests/TaskRunHistoryTests.swift
@@ -1,0 +1,333 @@
+import XCTest
+@testable import HermesMobile
+
+/// Covers the two places run history can quietly go wrong: paging arithmetic,
+/// which upstream makes non-obvious, and a slow run-output request landing
+/// after the user has moved on.
+final class TaskRunHistoryTests: APIClientTestCase {
+    // MARK: - Decoding
+
+    func testHistoryDecodesTolerantlyAndDropsRunsWithoutAFilename() throws {
+        let response = try decodeHistory("""
+        {
+          "job_id": "job-123",
+          "total": "120",
+          "offset": 0,
+          "runs": [
+            {
+              "filename": "2026-09-03.md",
+              "size": 12684,
+              "modified": 1772524800.5,
+              "usage": {"model": "sonnet-5", "duration_seconds": 41.2, "total_tokens": "18240"},
+              "unexpected_field": {"nested": true}
+            },
+            {"filename": "2026-09-02.md", "size": 11800, "modified": 1772438400, "usage": {}},
+            {"size": 900, "modified": 1772352000}
+          ]
+        }
+        """)
+
+        XCTAssertEqual(response.total, 120)
+        XCTAssertEqual(response.runs.map(\.filename), ["2026-09-03.md", "2026-09-02.md"])
+
+        let first = try XCTUnwrap(response.runs.first)
+        XCTAssertEqual(first.size, 12684)
+        XCTAssertEqual(first.modified?.timeIntervalSince1970 ?? 0, 1_772_524_800.5, accuracy: 0.01)
+        XCTAssertEqual(first.usage.model, "sonnet-5")
+        XCTAssertEqual(first.usage.durationSeconds ?? 0, 41.2, accuracy: 0.01)
+        XCTAssertEqual(first.usage.totalTokens, 18240)
+
+        // The common case: the server parsed nothing out of the run.
+        let second = try XCTUnwrap(response.runs.last)
+        XCTAssertEqual(second.usage, CronRunUsage())
+        XCTAssertNil(second.usage.model)
+    }
+
+    /// `size` and `modified` are numbers the server derives from `stat()`. A
+    /// value outside `Int`'s range, or a non-finite mtime, must decode to
+    /// nothing rather than trap on conversion or in date formatting.
+    func testMalformedSizeAndModifiedDecodeWithoutTrapping() throws {
+        let response = try decodeHistory("""
+        {
+          "job_id": "job-123",
+          "total": null,
+          "runs": [
+            {"filename": "huge.md", "size": 1e30, "modified": "not-a-date"},
+            {"filename": "odd.md", "size": "2048", "modified": "1772438400"},
+            {"filename": "broken.md", "size": {"bytes": 12}, "usage": "unexpected"}
+          ]
+        }
+        """)
+
+        XCTAssertNil(response.total)
+        XCTAssertEqual(response.runs.count, 3)
+        XCTAssertNil(response.runs[0].size)
+        XCTAssertNil(response.runs[0].modified)
+        XCTAssertEqual(response.runs[1].size, 2048)
+        XCTAssertEqual(response.runs[1].modified?.timeIntervalSince1970, 1_772_438_400)
+        XCTAssertNil(response.runs[2].size)
+        XCTAssertEqual(response.runs[2].usage, CronRunUsage())
+    }
+
+    // MARK: - Paging
+
+    /// Upstream slices `all_files[offset:offset + limit]` and then skips any
+    /// file it cannot `stat()`, so a page can return fewer rows than it
+    /// consumed. Paging by `runs.count` would re-request rows already shown.
+    @MainActor
+    func testPagingAdvancesByRequestedLimitEvenWhenAPageReturnsFewerRows() async {
+        let recorder = RequestRecorder()
+        let pageSize = TaskDetailViewModel.historyPageSize
+        let viewModel = makeViewModel { request in
+            recorder.record(request)
+            // Three rows for a fifty-row window: the rest failed to stat.
+            return apiTestJSONResponse(Self.historyJSON(total: 120, offset: recorder.lastOffset ?? 0, count: 3), for: request)
+        }
+
+        await viewModel.loadHistory()
+        await viewModel.loadMoreRuns()
+        await viewModel.loadMoreRuns()
+
+        XCTAssertEqual(recorder.offsets, [0, pageSize, pageSize * 2])
+        XCTAssertEqual(recorder.limits, [pageSize, pageSize, pageSize])
+        XCTAssertEqual(viewModel.runs.count, 9)
+        XCTAssertEqual(viewModel.runTotal, 120)
+        // 150 requested against a total of 120: there is nothing left to ask for.
+        XCTAssertFalse(viewModel.canLoadMoreRuns)
+    }
+
+    @MainActor
+    func testPagingStopsWhenTheFirstPageCoversTheTotal() async {
+        let viewModel = makeViewModel { request in
+            apiTestJSONResponse(Self.historyJSON(total: 50, offset: 0, count: 50), for: request)
+        }
+
+        await viewModel.loadHistory()
+
+        XCTAssertEqual(viewModel.runs.count, 50)
+        XCTAssertEqual(viewModel.remainingRunCount, 0)
+        XCTAssertFalse(viewModel.canLoadMoreRuns)
+    }
+
+    /// A job writing new output between two pages shifts every row down one, so
+    /// the second page can repeat what the first already showed.
+    @MainActor
+    func testOverlappingPagesDoNotDuplicateRuns() async {
+        let recorder = RequestRecorder()
+        let viewModel = makeViewModel { request in
+            recorder.record(request)
+            let names = (recorder.offsets.count == 1)
+                ? ["run-1.md", "run-2.md", "run-3.md"]
+                : ["run-3.md", "run-4.md"]
+            return apiTestJSONResponse(Self.historyJSON(total: 120, filenames: names), for: request)
+        }
+
+        await viewModel.loadHistory()
+        await viewModel.loadMoreRuns()
+
+        XCTAssertEqual(viewModel.runs.map(\.filename), ["run-1.md", "run-2.md", "run-3.md", "run-4.md"])
+    }
+
+    // MARK: - Failure containment
+
+    @MainActor
+    func testHistoryFailureLeavesTheRestOfTheScreenIntact() async {
+        let viewModel = makeViewModel { request in
+            if request.url?.path == "/api/crons/history" {
+                return apiTestJSONResponse("{\"error\": \"boom\"}", for: request, status: 500)
+            }
+            return apiTestJSONResponse("""
+            {"job_id": "job-123", "outputs": [{"filename": "latest.md", "content": "still here"}]}
+            """, for: request)
+        }
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.outputs.first?.content, "still here")
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNotNil(viewModel.historyErrorMessage)
+        XCTAssertFalse(viewModel.isHistoryUnavailable)
+    }
+
+    /// A refresh that fails keeps the runs the user was already reading.
+    @MainActor
+    func testFailedRefreshKeepsTheRunsAlreadyLoaded() async {
+        let recorder = RequestRecorder()
+        let viewModel = makeViewModel { request in
+            recorder.record(request)
+            guard recorder.offsets.count == 1 else {
+                return apiTestJSONResponse("{\"error\": \"boom\"}", for: request, status: 500)
+            }
+            return apiTestJSONResponse(Self.historyJSON(total: 120, filenames: ["run-1.md"]), for: request)
+        }
+
+        await viewModel.loadHistory()
+        await viewModel.loadHistory()
+
+        XCTAssertEqual(viewModel.runs.map(\.filename), ["run-1.md"])
+        XCTAssertNotNil(viewModel.historyErrorMessage)
+    }
+
+    /// A server that predates the endpoint answers 404. The section disappears
+    /// instead of parking a permanent error on the screen.
+    @MainActor
+    func testMissingEndpointRetiresTheHistorySection() async {
+        let viewModel = makeViewModel { request in
+            apiTestJSONResponse("{\"error\": \"not found\"}", for: request, status: 404)
+        }
+
+        await viewModel.loadHistory()
+
+        XCTAssertTrue(viewModel.isHistoryUnavailable)
+        XCTAssertNil(viewModel.historyErrorMessage)
+        XCTAssertTrue(viewModel.runs.isEmpty)
+        XCTAssertFalse(viewModel.canLoadMoreRuns)
+    }
+
+    // MARK: - Run output
+
+    @MainActor
+    func testRunOutputStripsEscapesAndCarriesItsFilename() async {
+        let viewModel = makeViewModel { request in
+            apiTestJSONResponse("""
+            {
+              "job_id": "job-123",
+              "filename": "run-1.md",
+              "content": "\\u001b[0;32mFAIL\\u001b[0m — did not verify",
+              "usage": {}
+            }
+            """, for: request)
+        }
+
+        await viewModel.loadRunOutput(for: CronRunHistoryItem(filename: "run-1.md"))
+
+        XCTAssertEqual(viewModel.runOutput?.filename, "run-1.md")
+        XCTAssertEqual(viewModel.runOutput?.text, "FAIL — did not verify")
+        XCTAssertFalse(viewModel.isLoadingRunOutput)
+    }
+
+    /// Tapping a second run while the first is still in flight must leave the
+    /// sheet showing the run that was tapped last.
+    @MainActor
+    func testLateRunOutputResponseCannotOverwriteANewerSelection() async {
+        let slowRequestStarted = expectation(description: "slow run output request started")
+        let releaseSlowRequest = DispatchSemaphore(value: 0)
+
+        let viewModel = makeViewModel { request in
+            let filename = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first { $0.name == "filename" }?.value
+
+            if filename == "slow.md" {
+                slowRequestStarted.fulfill()
+                releaseSlowRequest.wait()
+                return apiTestJSONResponse("""
+                {"job_id": "job-123", "filename": "slow.md", "content": "stale output"}
+                """, for: request)
+            }
+
+            return apiTestJSONResponse("""
+            {"job_id": "job-123", "filename": "fresh.md", "content": "fresh output"}
+            """, for: request)
+        }
+
+        let slowLoad = Task { await viewModel.loadRunOutput(for: CronRunHistoryItem(filename: "slow.md")) }
+        await fulfillment(of: [slowRequestStarted], timeout: 5)
+
+        await viewModel.loadRunOutput(for: CronRunHistoryItem(filename: "fresh.md"))
+        XCTAssertEqual(viewModel.runOutput?.filename, "fresh.md")
+
+        releaseSlowRequest.signal()
+        await slowLoad.value
+
+        XCTAssertEqual(viewModel.runOutput?.filename, "fresh.md")
+        XCTAssertEqual(viewModel.runOutput?.text, "fresh output")
+        XCTAssertFalse(viewModel.isLoadingRunOutput)
+    }
+
+    /// Only the newest run can carry the job's last-run verdict; history says
+    /// nothing about the status of older runs.
+    @MainActor
+    func testOnlyTheNewestRunInheritsTheJobsFailedStatus() async {
+        let viewModel = makeViewModel(job: Self.failedJob()) { request in
+            apiTestJSONResponse(Self.historyJSON(total: 3, filenames: ["newest.md", "older.md"]), for: request)
+        }
+
+        await viewModel.loadHistory()
+
+        XCTAssertEqual(viewModel.latestRun?.filename, "newest.md")
+        XCTAssertTrue(viewModel.isFailedRun(CronRunHistoryItem(filename: "newest.md")))
+        XCTAssertFalse(viewModel.isFailedRun(CronRunHistoryItem(filename: "older.md")))
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeViewModel(
+        job: CronJob? = nil,
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> TaskDetailViewModel {
+        TaskDetailViewModel(
+            job: job ?? Self.makeJob(),
+            runningElapsed: nil,
+            server: URL(string: "https://example.test")!,
+            client: makeClient(handler: handler)
+        )
+    }
+
+    private func decodeHistory(_ json: String) throws -> CronRunHistoryResponse {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(CronRunHistoryResponse.self, from: Data(json.utf8))
+    }
+
+    private static func makeJob() -> CronJob {
+        decodeJob("""
+        {"job_id": "job-123", "name": "Reddit Trending Scanner", "last_status": "ok"}
+        """)
+    }
+
+    private static func failedJob() -> CronJob {
+        decodeJob("""
+        {"job_id": "job-123", "name": "trading-bot", "last_status": "error", "last_error": "exit code 1"}
+        """)
+    }
+
+    private static func decodeJob(_ json: String) -> CronJob {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try! decoder.decode(CronJob.self, from: Data(json.utf8))
+    }
+
+    private static func historyJSON(total: Int, offset: Int = 0, count: Int) -> String {
+        historyJSON(total: total, offset: offset, filenames: (0..<count).map { "run-\(offset + $0).md" })
+    }
+
+    private static func historyJSON(total: Int, offset: Int = 0, filenames: [String]) -> String {
+        let runs = filenames.map { name in
+            "{\"filename\": \"\(name)\", \"size\": 2048, \"modified\": 1772524800, \"usage\": {}}"
+        }
+        return """
+        {"job_id": "job-123", "total": \(total), "offset": \(offset), "runs": [\(runs.joined(separator: ","))]}
+        """
+    }
+}
+
+/// Records the history requests a test made, so paging can be asserted on the
+/// offsets the client actually asked for.
+private final class RequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [(offset: Int, limit: Int)] = []
+
+    func record(_ request: URLRequest) {
+        guard let url = request.url,
+              let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+        else { return }
+
+        let value = { (name: String) in items.first { $0.name == name }?.value.flatMap(Int.init) ?? -1 }
+        lock.withLock { recorded.append((value("offset"), value("limit"))) }
+    }
+
+    var offsets: [Int] { lock.withLock { recorded.map(\.offset) } }
+    var limits: [Int] { lock.withLock { recorded.map(\.limit) } }
+    var lastOffset: Int? { lock.withLock { recorded.last?.offset } }
+}

--- a/HermesMobileTests/TaskRunHistoryTests.swift
+++ b/HermesMobileTests/TaskRunHistoryTests.swift
@@ -128,6 +128,46 @@ final class TaskRunHistoryTests: APIClientTestCase {
         XCTAssertEqual(viewModel.runs.map(\.filename), ["run-1.md", "run-2.md", "run-3.md", "run-4.md"])
     }
 
+    /// A page fetched before a refresh describes a list that no longer exists.
+    /// Splicing it onto the refreshed list would leave the pages between them
+    /// loaded nowhere and unreachable, and push the cursor past both.
+    @MainActor
+    func testAPageInFlightWhenARefreshLandsIsDiscarded() async {
+        let recorder = RequestRecorder()
+        let pageSize = TaskDetailViewModel.historyPageSize
+        let secondPageStarted = expectation(description: "second page request started")
+        let releaseSecondPage = DispatchSemaphore(value: 0)
+
+        let viewModel = makeViewModel { request in
+            recorder.record(request)
+            let offset = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first { $0.name == "offset" }?.value.flatMap(Int.init) ?? 0
+
+            // Hold only the first "Load more", so the refresh can overtake it.
+            if recorder.offsets.count == 2 {
+                secondPageStarted.fulfill()
+                releaseSecondPage.wait()
+            }
+
+            let page = offset == pageSize ? "page-2.md" : "page-1.md"
+            return apiTestJSONResponse(Self.historyJSON(total: 200, filenames: [page]), for: request)
+        }
+
+        await viewModel.loadHistory()
+        let loadMore = Task { await viewModel.loadMoreRuns() }
+        await fulfillment(of: [secondPageStarted], timeout: 5)
+
+        // The user pulls to refresh while the page is still in flight.
+        await viewModel.loadHistory()
+        releaseSecondPage.signal()
+        await loadMore.value
+
+        XCTAssertEqual(viewModel.runs.map(\.filename), ["page-1.md"])
+        // The cursor still points at the page after the one on screen.
+        await viewModel.loadMoreRuns()
+        XCTAssertEqual(recorder.offsets.last, pageSize)
+    }
+
     // MARK: - Failure containment
 
     @MainActor


### PR DESCRIPTION
## Linked issue

Fixes #377

## What changed

Task Detail could not answer the one question it exists for: what has this task actually been doing? It showed eight metadata rows and the most recent output snippet, and nothing else — when a nightly job failed, that was all you got.

It is now four cards and a history:

- **Header** — name, status, humanised schedule, and the next run as a countdown ("in 7h 40m") over its absolute time. `Run now` and `Pause`/`Resume` are the card's bottom edge: a full-width divider, two flush labels split by a hairline, no fill. Neither action is more primary than the other, so they carry equal weight and nothing competes with the error box for the one colour on the card that means something. Resume takes a circled triangle so it does not read as a second Run now. When the last run failed the card takes an error tint and carries a one-line reason, ANSI stripped, with **See full output**.
- **Prompt**, selectable, in its own card.
- **Configuration** — schedule (in English, raw expression beneath), deliver, model, provider, profile, skills, notifications. Laid out as a grid so the label column takes the width of its widest label; the fixed 64pt column the old rows used wrapped "Notifications" onto three lines. A field the job does not have gets no row: a job that leaves its model to the server has nothing to say about one. Schedule and Deliver are the exceptions, since every job has both and `local` is the server's own default rather than a stand-in for a missing value.
- **Run history** — newest first from `GET /api/crons/history`, 50 at a time, total in the header, "Load more" row. Each row shows the run's date and size, an ok/failed dot, and whatever `usage` the server parsed. Tapping opens the full output from `GET /api/crons/run`, monospaced, selectable, with Copy.

Three things the contract forced:

- **Paging advances by the requested `limit`, not the returned row count.** Upstream slices `all_files[offset:offset + limit]` and then skips any entry whose `stat()` throws, so a page can return fewer rows than it consumed. Advancing by `runs.count` would silently re-fetch and duplicate.
- **`GET /api/crons/run` and `POST /api/crons/run` are different operations on one path.** `Endpoint.cronRun` stays the POST trigger; `Endpoint.cronRunDetail` is the new GET.
- **`usage` is usually `{}`.** Rows degrade to date, size and status; model, duration and cost are appended only when present, so no layout reserves space for them.

Failure stays contained: a history request that fails shows an inline retry and leaves the rest of the screen intact, and a server that 404s the endpoint drops the section entirely while keeping the inline output card it always had.

History requests are generation-and-cursor guarded. A "Load more" in flight when a refresh lands would otherwise apply its page on top of the reloaded first page and push the cursor past both, leaving the pages between them loaded nowhere and unreachable. "Load more" also declines outright while a reload is in flight, since until the first page lands the cursor still points into the list being replaced.

Also: Insights' `UsageCard` moves to `Features/Shared/SectionCard.swift` so Usage and Task Detail share one card chrome, and it grew an optional `footer` slot for the header card's action row — that keeps the card's own insets its business instead of having the call site cancel them with negative padding. `CronJobMetadataRow` had no callers left and is gone.

`MockURLProtocol` now serves handlers off a concurrent queue. URLSession drives every protocol instance from a single loading thread, so a handler that waits there stalls every other in-flight request — the stale-response tests could not otherwise express two requests racing.

## How it was tested

- Full XCTest suite on the simulator (iPhone 17, `test_sim`): **1975 passed, 0 failed, 2 skipped**, on `c060e00`.
- **`TaskRunHistoryTests` (13)**: paging advances by `limit` including a page that returns fewer rows than requested; paging terminates on `total`; overlapping pages do not duplicate; a page in flight when a refresh lands is discarded; "Load more" is refused while a reload is in flight; empty and malformed `usage`; malformed `size`/`modified` decode without trapping on `Double`→`Int`; a history failure leaves the rest of the view model intact; a failed refresh keeps the runs already on screen; a 404 retires the section; a late run-output response cannot overwrite a newer selection.
- **`TaskConfigurationFieldTests` (3)**: fields the job does not have are absent, fields it has are shown and trimmed, deliver falls back to the server default.
- `ContractReadinessTests` covers the two new endpoints' paths and query items.
- **Manual pass on the simulator against a live server** (maintainer): header card, countdown, footer actions, Configuration on a job with no model/profile/skills, run history with 50 runs, the failing `trading-bot` job's error box and full output. All confirmed working.
- 18 new strings are in `Localizable.xcstrings` across all 17 shipped languages; the catalog diff is purely additive and no pre-existing language subtree changed.
- `scripts/check-swift-file-sizes` reports the same 33 pre-existing files as `master` — no new warnings.

**Not attached:** before/after images. Screenshots exist from the manual pass but cannot be uploaded from the agent session, and PR-only assets do not get committed — @uzairansaruzi to drag them in.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes — verified against the issue's live notes and `.codex-tmp/hermes-webui/api/routes.py` (`_handle_cron_history`, `_handle_cron_run_detail`), which agree

---

Written by Claude Opus 5 in Claude Code.
