### PR TITLE
feat(chat): trigger slash completion at the caret, not the whole draft

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		8618A9261B8047CEA6084798 /* SlashCommandAutocompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */; };
 		8B71DA2AAC521382F54A841C /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */; };
 		8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */; };
+		F06907881C5B4BCCB98D2EBA /* ComposerSlashTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */; };
 		941A67322EB54169A55D7A64 /* SlashCommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */; };
 		75D7C575386EE8C6D442A967 /* SlashCommandRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19468599B2A57CAFAF8A3357 /* SlashCommandRanker.swift */; };
 		5927FF7204918E46CCE7387C /* SlashAutocompleteRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82A2A58F08883E396B94B1C /* SlashAutocompleteRanking.swift */; };
@@ -361,6 +362,8 @@
 		B53F3F24A5C24D9E8E54A810 /* SlashCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1CE5F12B9E4D4D9E5A01C1 /* SlashCommandExecutor.swift */; };
 		C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CAM000000000000000B002 /* CameraPickerView.swift */; };
 		C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000002 /* ChatComposerView.swift */; };
+		D01ECB8354BE43609DB90E77 /* ComposerTextEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */; };
+		E067C191AC494934863F613D /* ComposerSlashTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */; };
 		C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */; };
 		105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */; };
 		105050000000000000000003 /* ComposerModelPickerSectionExpansionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000004 /* ComposerModelPickerSectionExpansionStateTests.swift */; };
@@ -411,6 +414,7 @@
 
 /* Begin PBXFileReference section */
 		0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandTests.swift; sourceTree = "<group>"; };
+		92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerSlashTriggerTests.swift; sourceTree = "<group>"; };
 		351C0F1600000000000000A1 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
 		1A2B3C4D5E6F700000000301 /* ServerAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAccount.swift; sourceTree = "<group>"; };
 		B5A1000000000000000000A1 /* ServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRegistryTests.swift; sourceTree = "<group>"; };
@@ -759,6 +763,8 @@
 		A04500000000000000000018 /* LiveActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityTests.swift; sourceTree = "<group>"; };
 		C0CAM000000000000000B002 /* CameraPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPickerView.swift; sourceTree = "<group>"; };
 		C0DEC0DE0000000000000002 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
+		93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTextEditing.swift; sourceTree = "<group>"; };
+		417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerSlashTrigger.swift; sourceTree = "<group>"; };
 		C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelTests.swift; sourceTree = "<group>"; };
 		FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandAutocompleteView.swift; sourceTree = "<group>"; };
 		105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerModelPickerSectionExpansionState.swift; sourceTree = "<group>"; };
@@ -960,6 +966,7 @@
 				C0369000000000000000006 /* CronJobEditorConfigurationTests.swift */,
 				1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */,
 				0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */,
+				92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */,
 				6809B8F1391248A4AA77C453 /* SlashCommandExecutorTests.swift */,
 				A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */,
 				C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */,
@@ -1143,6 +1150,8 @@
 				C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */,
 				C0CAM000000000000000B002 /* CameraPickerView.swift */,
 				C0DEC0DE0000000000000002 /* ChatComposerView.swift */,
+				93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */,
+				417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */,
 				C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */,
 				C04900000000000000000002 /* ChatComposerTextInputView.swift */,
 				C04900000000000000000004 /* ChatComposerVoiceControls.swift */,
@@ -1690,6 +1699,8 @@
 					C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */,
 					C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */,
 				C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */,
+				D01ECB8354BE43609DB90E77 /* ComposerTextEditing.swift in Sources */,
+				E067C191AC494934863F613D /* ComposerSlashTrigger.swift in Sources */,
 					C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */,
 					C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */,
 					C04900000000000000000003 /* ChatComposerVoiceControls.swift in Sources */,
@@ -1912,6 +1923,7 @@
 					C0369000000000000000005 /* CronJobEditorConfigurationTests.swift in Sources */,
 					1050500000000000000000B1 /* OnboardingViewModelIdentityTests.swift in Sources */,
 					8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */,
+				F06907881C5B4BCCB98D2EBA /* ComposerSlashTriggerTests.swift in Sources */,
 				0D82B28493C6401D98DA9C0E /* SlashCommandExecutorTests.swift in Sources */,
 				A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */,
 				C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct ComposerTextInputView: View {
     @Binding var text: String
+    @Binding var selection: ComposerSelection
     @Binding var isFocused: Bool
     @Binding var inputHeight: CGFloat
     @Binding var measuredHeight: CGFloat
@@ -29,6 +30,7 @@ struct ComposerTextInputView: View {
         ZStack(alignment: isCollapsed ? .leading : .topLeading) {
             ComposerTextView(
                 text: $text,
+                selection: $selection,
                 isFocused: $isFocused,
                 isDisabled: isDisabled,
                 isKeyboardSendEnabled: isKeyboardSendEnabled,
@@ -85,6 +87,7 @@ struct ComposerTextInputView: View {
 
 private struct ComposerTextView: UIViewRepresentable {
     @Binding var text: String
+    @Binding var selection: ComposerSelection
     @Binding var isFocused: Bool
     let isDisabled: Bool
     let isKeyboardSendEnabled: Bool
@@ -96,7 +99,7 @@ private struct ComposerTextView: UIViewRepresentable {
     let onPasteImages: ([UIImage]) -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, isFocused: $isFocused, onHeightChange: onHeightChange)
+        Coordinator(text: $text, selection: $selection, isFocused: $isFocused, onHeightChange: onHeightChange)
     }
 
     func makeUIView(context: Context) -> PastingTextView {
@@ -128,9 +131,7 @@ private struct ComposerTextView: UIViewRepresentable {
 
     func updateUIView(_ textView: PastingTextView, context: Context) {
         context.coordinator.onHeightChange = onHeightChange
-        if textView.text != text {
-            textView.text = text
-        }
+        context.coordinator.applyBoundText(text, to: textView)
         // Mirror the chat RTL toggle onto the text view itself (#259): SwiftUI's
         // layoutDirection environment does not propagate into a wrapped UITextView,
         // so set the base direction directly so the cursor/empty-field rests on the
@@ -148,6 +149,7 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.onPasteFileURLs = onPasteFileURLs
         textView.onPasteImageProviders = onPasteImageProviders
         textView.onPasteImages = onPasteImages
+        context.coordinator.syncSelection(selection, to: textView, expecting: text)
         context.coordinator.syncFocus(for: textView, shouldFocus: isFocused, isDisabled: isDisabled)
         context.coordinator.reportHeight(for: textView)
     }
@@ -155,18 +157,132 @@ private struct ComposerTextView: UIViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, UITextViewDelegate {
         @Binding var text: String
+        @Binding var selection: ComposerSelection
         @Binding var isFocused: Bool
         var onHeightChange: (CGFloat) -> Void
         private var pendingFocusTarget: Bool?
+        /// Set while we push a bound value into the editor, so the delegate
+        /// callbacks it provokes do not write the bindings back mid-update.
+        private var isApplyingBoundValue = false
+        private var appliedSelectionRevision = 0
 
         init(
             text: Binding<String>,
+            selection: Binding<ComposerSelection>,
             isFocused: Binding<Bool>,
             onHeightChange: @escaping (CGFloat) -> Void
         ) {
             _text = text
+            _selection = selection
             _isFocused = isFocused
             self.onHeightChange = onHeightChange
+        }
+
+        /// Pushes a parent-side draft change into the editor as an *edit* rather
+        /// than a wholesale assignment, so the change lands on the editor's undo
+        /// stack and the caret follows the insertion. Accepting a slash
+        /// completion is the case that matters: undo puts back what was typed.
+        ///
+        /// While an IME composition is marked, assigning text commits it
+        /// half-formed and splits characters such as 자 into ㅈㅏ (#312). A
+        /// binding that simply has not seen the marked text yet is not a real
+        /// change, so it is ignored; a deliberate clear or replacement still
+        /// applies.
+        func applyBoundText(_ text: String, to textView: UITextView) {
+            guard textView.text != text else { return }
+
+            if let marked = textView.markedTextRange {
+                guard ComposerMarkedText.isDeliberateReplacement(
+                    text,
+                    editorText: textView.text,
+                    marked: markedRange(of: textView, marked: marked)
+                ) else {
+                    return
+                }
+
+                applyingBoundValue { textView.text = text }
+                return
+            }
+
+            applyingBoundValue {
+                // An empty editor has no typing attributes to insert with, so
+                // filling or emptying one stays a plain assignment; everything
+                // in between goes through the input system for its undo stack.
+                if textView.isEditable,
+                   !textView.text.isEmpty,
+                   !text.isEmpty,
+                   let edit = ComposerTextEdit.between(current: textView.text, target: text),
+                   let range = textView.textRange(from: edit.range) {
+                    textView.replace(range, withText: edit.replacement)
+                }
+
+                // `replace` goes through the input system, which can normalize
+                // what it inserts; fall back rather than leave the editor out
+                // of sync.
+                if textView.text != text {
+                    textView.text = text
+                }
+            }
+        }
+
+        /// Keeps the editor's caret and the composer's idea of it in step.
+        ///
+        /// A caret the composer asked for is applied once, keyed on its
+        /// revision, so a later update replaying the same value cannot yank the
+        /// caret away from where the user has since put it. Every other pass
+        /// leaves the editor's own caret alone and reports it back.
+        func syncSelection(_ selection: ComposerSelection, to textView: UITextView, expecting expectedText: String) {
+            guard textView.markedTextRange == nil, textView.text == expectedText else { return }
+
+            guard selection.revision == appliedSelectionRevision else {
+                appliedSelectionRevision = selection.revision
+
+                let clamped = Self.clamp(selection.range, toLengthOf: textView.text)
+                // Assigning `selectedRange` resets predictive text, so never
+                // assign a range the editor already holds.
+                if textView.selectedRange != clamped {
+                    applyingBoundValue { textView.selectedRange = clamped }
+                }
+                return
+            }
+
+            publishSelection(of: textView)
+        }
+
+        /// Reports the caret the editor settled on. Deferred, because a binding
+        /// cannot be written during a view update.
+        private func publishSelection(of textView: UITextView) {
+            let range = textView.selectedRange
+            guard selection.range != range else { return }
+
+            DispatchQueue.main.async { [weak self, weak textView] in
+                guard let self, let textView,
+                      textView.selectedRange == range,
+                      self.selection.range != range
+                else {
+                    return
+                }
+                self.selection.range = range
+            }
+        }
+
+        static func clamp(_ selection: NSRange, toLengthOf text: String) -> NSRange {
+            let length = (text as NSString).length
+            let location = min(max(0, selection.location), length)
+            return NSRange(location: location, length: min(max(0, selection.length), length - location))
+        }
+
+        private func markedRange(of textView: UITextView, marked: UITextRange) -> NSRange {
+            NSRange(
+                location: textView.offset(from: textView.beginningOfDocument, to: marked.start),
+                length: textView.offset(from: marked.start, to: marked.end)
+            )
+        }
+
+        private func applyingBoundValue(_ body: () -> Void) {
+            isApplyingBoundValue = true
+            body()
+            isApplyingBoundValue = false
         }
 
         func syncFocus(for textView: UITextView, shouldFocus: Bool, isDisabled: Bool) {
@@ -216,8 +332,24 @@ private struct ComposerTextView: UIViewRepresentable {
         }
 
         func textViewDidChange(_ textView: UITextView) {
+            guard !isApplyingBoundValue else { return }
+
+            // Text and caret travel together: publishing them in one update is
+            // what keeps the two consistent when the composer maps the caret
+            // back onto the draft to find the slash trigger.
             text = textView.text
+            selection.range = textView.selectedRange
             reportHeight(for: textView)
+        }
+
+        /// Publishes pure caret moves — a tap, an arrow key, a selection drag.
+        /// Edits are left to `textViewDidChange`, which carries both halves, and
+        /// a live IME composition is left alone entirely.
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            guard !isApplyingBoundValue, textView.markedTextRange == nil else { return }
+            guard textView.text == text, selection.range != textView.selectedRange else { return }
+
+            selection.range = textView.selectedRange
         }
 
         func reportHeight(for textView: UITextView) {

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -131,7 +131,7 @@ private struct ComposerTextView: UIViewRepresentable {
 
     func updateUIView(_ textView: PastingTextView, context: Context) {
         context.coordinator.onHeightChange = onHeightChange
-        context.coordinator.applyBoundText(text, to: textView)
+        context.coordinator.applyBoundText(text, generation: selection.publishGeneration, to: textView)
         // Mirror the chat RTL toggle onto the text view itself (#259): SwiftUI's
         // layoutDirection environment does not propagate into a wrapped UITextView,
         // so set the base direction directly so the cursor/empty-field rests on the
@@ -165,6 +165,9 @@ private struct ComposerTextView: UIViewRepresentable {
         /// callbacks it provokes do not write the bindings back mid-update.
         private var isApplyingBoundValue = false
         private var appliedSelectionRevision = 0
+        /// Publishes made to the bindings, matched against the generation the
+        /// bound value carries to spot one the parent has not caught up with.
+        private var publishGeneration = 0
 
         init(
             text: Binding<String>,
@@ -187,15 +190,17 @@ private struct ComposerTextView: UIViewRepresentable {
         /// half-formed and splits characters such as 자 into ㅈㅏ (#312). A
         /// binding that simply has not seen the marked text yet is not a real
         /// change, so it is ignored; a deliberate clear or replacement still
-        /// applies.
-        func applyBoundText(_ text: String, to textView: UITextView) {
+        /// applies. `generation` is the publish count the bound value was built
+        /// from, which is what tells those two apart when the value is empty.
+        func applyBoundText(_ text: String, generation: Int, to textView: UITextView) {
             guard textView.text != text else { return }
 
             if let marked = textView.markedTextRange {
                 guard ComposerMarkedText.isDeliberateReplacement(
                     text,
                     editorText: textView.text,
-                    marked: markedRange(of: textView, marked: marked)
+                    marked: markedRange(of: textView, marked: marked),
+                    isCurrent: generation >= publishGeneration
                 ) else {
                     return
                 }
@@ -336,9 +341,12 @@ private struct ComposerTextView: UIViewRepresentable {
 
             // Text and caret travel together: publishing them in one update is
             // what keeps the two consistent when the composer maps the caret
-            // back onto the draft to find the slash trigger.
+            // back onto the draft to find the slash trigger. The generation
+            // rides along so a later update can be dated against this one.
+            publishGeneration &+= 1
             text = textView.text
             selection.range = textView.selectedRange
+            selection.publishGeneration = publishGeneration
             reportHeight(for: textView)
         }
 

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -183,28 +183,16 @@ struct MessageComposerView: View {
         ComposerSlashTrigger.detect(in: draftMessage, selection: composerSelection.range)
     }
 
-    /// What the panel filters on, or `nil` when it should be closed because the
-    /// trigger has already resolved to something the user finished typing.
+    /// What the panel filters on, or `nil` when it should be closed.
+    ///
+    /// A command the user has typed past no longer produces a trigger at all —
+    /// `ComposerSlashTrigger` ends at the space after a command that takes no
+    /// sub-argument — so the only cases left here are the two sub-argument lists
+    /// that go quiet once their argument is settled.
     private var slashQuery: String? {
         guard let query = slashTrigger?.text else { return nil }
 
         let parsed = ParsedSlashQuery(query: query)
-        if let command = parsed.command,
-           command.subArgs == .none,
-           hasWhitespaceAfterSlashCommand(command.name, in: query) {
-            return nil
-        }
-
-        if SlashSkillFormatter.skill(named: parsed.commandName, in: skillSuggestions) != nil,
-           hasWhitespaceAfterSlashCommand(parsed.commandName, in: query) {
-            return nil
-        }
-
-        if AgentSlashCommandSuggestion.command(named: parsed.commandName, in: agentCommands) != nil,
-           hasWhitespaceAfterSlashCommand(parsed.commandName, in: query) {
-            return nil
-        }
-
         if parsed.commandName.lowercased() == "skills",
            SlashSkillFormatter.invocation(from: parsed.argQuery, suggestions: skillSuggestions) != nil {
             return nil
@@ -234,13 +222,6 @@ struct MessageComposerView: View {
         let completed = trigger.applying(replacement, to: draftMessage)
         draftMessage = completed.draft
         composerSelection = composerSelection.moved(to: completed.selection)
-    }
-
-    private func hasWhitespaceAfterSlashCommand(_ commandName: String, in query: String) -> Bool {
-        let prefix = "/\(commandName)"
-        guard query.lowercased().hasPrefix(prefix.lowercased()) else { return false }
-        let afterCommand = query.dropFirst(prefix.count)
-        return afterCommand.first?.isWhitespace == true
     }
 
     private var parsedSlashQuery: ParsedSlashQuery {

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -142,6 +142,10 @@ struct MessageComposerView: View {
 
     @State private var textFieldHeight: CGFloat = 0
     @State private var textInputHeight: CGFloat = 22
+    /// Where the caret is in `draftMessage`, in UTF-16 units. Transient by
+    /// design: a restored draft starts with the caret at its end, not wherever
+    /// it was left last week.
+    @State private var composerSelection = ComposerSelection()
     @State private var noticeMessage: String?
     @State private var showsAllModelsSheet = false
     @State private var showsWorkspaceSheet = false
@@ -173,30 +177,37 @@ struct MessageComposerView: View {
         case waitingForUploadsToFinish
     }
 
-    private var showsSlashAutocomplete: Bool {
-        let query = draftMessage.drop(while: { $0.isWhitespace })
-        guard query.hasPrefix("/") else { return false }
+    /// The `/…` the caret is sitting in, whether that is the start of the draft
+    /// or the middle of a sentence.
+    private var slashTrigger: ComposerSlashTrigger? {
+        ComposerSlashTrigger.detect(in: draftMessage, selection: composerSelection.range)
+    }
 
-        let parsed = ParsedSlashQuery(query: draftMessage)
+    /// What the panel filters on, or `nil` when it should be closed because the
+    /// trigger has already resolved to something the user finished typing.
+    private var slashQuery: String? {
+        guard let query = slashTrigger?.text else { return nil }
+
+        let parsed = ParsedSlashQuery(query: query)
         if let command = parsed.command,
            command.subArgs == .none,
-           hasWhitespaceAfterSlashCommand(command.name, in: String(query)) {
-            return false
+           hasWhitespaceAfterSlashCommand(command.name, in: query) {
+            return nil
         }
 
         if SlashSkillFormatter.skill(named: parsed.commandName, in: skillSuggestions) != nil,
-           hasWhitespaceAfterSlashCommand(parsed.commandName, in: String(query)) {
-            return false
+           hasWhitespaceAfterSlashCommand(parsed.commandName, in: query) {
+            return nil
         }
 
         if AgentSlashCommandSuggestion.command(named: parsed.commandName, in: agentCommands) != nil,
-           hasWhitespaceAfterSlashCommand(parsed.commandName, in: String(query)) {
-            return false
+           hasWhitespaceAfterSlashCommand(parsed.commandName, in: query) {
+            return nil
         }
 
         if parsed.commandName.lowercased() == "skills",
            SlashSkillFormatter.invocation(from: parsed.argQuery, suggestions: skillSuggestions) != nil {
-            return false
+            return nil
         }
 
         if parsed.command?.subArgs == .goalActions,
@@ -205,10 +216,24 @@ struct MessageComposerView: View {
            !SlashCommandCatalog.goalActions.contains(where: {
                $0.hasPrefix(parsed.argQuery.lowercased())
            }) {
-            return false
+            return nil
         }
 
-        return true
+        return query
+    }
+
+    private var showsSlashAutocomplete: Bool {
+        slashQuery != nil
+    }
+
+    /// Swaps the `/…` at the caret for `replacement` and leaves the caret just
+    /// after it, so the rest of the draft survives accepting a row.
+    private func applyCompletion(_ replacement: String) {
+        guard let trigger = slashTrigger else { return }
+
+        let completed = trigger.applying(replacement, to: draftMessage)
+        draftMessage = completed.draft
+        composerSelection = composerSelection.moved(to: completed.selection)
     }
 
     private func hasWhitespaceAfterSlashCommand(_ commandName: String, in query: String) -> Bool {
@@ -219,7 +244,7 @@ struct MessageComposerView: View {
     }
 
     private var parsedSlashQuery: ParsedSlashQuery {
-        ParsedSlashQuery(query: draftMessage)
+        ParsedSlashQuery(query: slashQuery ?? "")
     }
 
     private var slashAutocompleteLoadKey: String {
@@ -270,9 +295,9 @@ struct MessageComposerView: View {
                 }
 
                 Group {
-                    if showsSlashAutocomplete {
+                    if let slashQuery {
                         SlashCommandAutocompleteView(
-                            query: draftMessage,
+                            query: slashQuery,
                             selectedModelID: selectedModelID,
                             modelGroups: modelGroups,
                             workspaceRoots: workspaceRoots,
@@ -282,23 +307,22 @@ struct MessageComposerView: View {
                             agentCommands: agentCommands,
                             selectedReasoningEffort: selectedReasoningEffort,
                             onSelectCommand: { command in
-                                draftMessage = "/\(command.name) "
+                                applyCompletion("/\(command.name) ")
                             },
                             onSelectSkillCommand: { skill in
-                                draftMessage = "/\(skill.slashName) "
+                                applyCompletion("/\(skill.slashName) ")
                             },
                             onSelectAgentCommand: { command in
-                                draftMessage = "/\(command.name) "
+                                applyCompletion("/\(command.name) ")
                             },
                             onSelectSkillSubArg: { skill in
-                                draftMessage = "/skills \(skill.slashName) "
+                                applyCompletion("/skills \(skill.slashName) ")
                             },
                             onSelectSubArg: { subArg in
-                                let parsed = ParsedSlashQuery(query: draftMessage)
-                                draftMessage = "/\(parsed.commandName) \(subArg)"
+                                applyCompletion("/\(parsedSlashQuery.commandName) \(subArg)")
                             },
                             onDismiss: {
-                                draftMessage = ""
+                                applyCompletion("")
                             }
                         )
                         .padding(.horizontal)
@@ -564,6 +588,7 @@ struct MessageComposerView: View {
             HStack(alignment: .center, spacing: 4) {
                 ComposerTextInputView(
                     text: $draftMessage,
+                    selection: $composerSelection,
                     isFocused: $isFocused,
                     inputHeight: $textInputHeight,
                     measuredHeight: $textFieldHeight,

--- a/HermesMobile/Features/Chat/ComposerSlashTrigger.swift
+++ b/HermesMobile/Features/Chat/ComposerSlashTrigger.swift
@@ -27,20 +27,29 @@ struct ComposerSlashTrigger: Equatable {
         let caret = selection.location
         guard caret >= 0, caret <= draft.length else { return nil }
 
+        // Every `/` on the caret's line that could open a trigger, then the
+        // outermost one that holds up. A path argument such as
+        // `/workspace /Users/me/app` belongs to the command in front of it, so
+        // the inner slash must never win.
+        var starts: [Int] = []
         var index = caret - 1
         while index >= 0 {
             let unit = draft.character(at: index)
-            if isNewline(unit) { return nil }
+            if isNewline(unit) { break }
 
             if unit == slash, index == 0 || isWhitespaceOrNewline(draft.character(at: index - 1)) {
-                let range = NSRange(location: index, length: caret - index)
-                let text = draft.substring(with: range)
-                if isTrigger(text) {
-                    return ComposerSlashTrigger(range: range, text: text)
-                }
+                starts.append(index)
             }
 
             index -= 1
+        }
+
+        for start in starts.reversed() {
+            let range = NSRange(location: start, length: caret - start)
+            let text = draft.substring(with: range)
+            if isTrigger(text) {
+                return ComposerSlashTrigger(range: range, text: text)
+            }
         }
 
         return nil
@@ -49,10 +58,10 @@ struct ComposerSlashTrigger: Equatable {
     /// What the draft and caret become when the user accepts `replacement`.
     ///
     /// Only the trigger's own range changes. When the completion wants a
-    /// trailing space and the draft already has whitespace waiting there, the
-    /// space is dropped and the caret steps over the existing one instead, so
-    /// accepting a command mid-sentence leaves neither a double space nor a
-    /// caret stranded in front of one.
+    /// trailing space and the draft already has one waiting there, the space is
+    /// dropped and the caret steps over the existing one instead, so accepting a
+    /// command mid-sentence leaves neither a double space nor a caret stranded in
+    /// front of one. A line break is not a separator, so it keeps the space.
     func applying(_ replacement: String, to draft: String) -> (draft: String, selection: NSRange) {
         let draft = draft as NSString
         let location = min(max(0, range.location), draft.length)
@@ -62,7 +71,7 @@ struct ComposerSlashTrigger: Equatable {
         var caretOffset = 0
         if inserted.hasSuffix(" "),
            range.upperBound < draft.length,
-           Self.isWhitespaceOrNewline(draft.character(at: range.upperBound)) {
+           Self.isSpace(draft.character(at: range.upperBound)) {
             inserted.removeLast()
             caretOffset = 1
         }
@@ -76,21 +85,32 @@ struct ComposerSlashTrigger: Equatable {
 
     /// Whether `text` can still be a command being typed.
     ///
-    /// Everything up to the first space has to be a command that takes a
-    /// sub-argument, otherwise ordinary prose such as "check the /tmp folder for
-    /// it" would hold the panel open for the rest of the sentence.
+    /// One word is always a candidate. Past the first space, the word has to be
+    /// a command that takes a sub-argument, and the trigger ends as soon as the
+    /// user types past that argument — otherwise prose such as "check the /tmp
+    /// folder" or "use /reasoning high for this task" would hold an empty panel
+    /// open for the rest of the sentence.
     private static func isTrigger(_ text: String) -> Bool {
         let body = text.dropFirst()
         guard let space = body.firstIndex(where: { $0.isWhitespace }) else { return true }
-        guard let command = SlashCommandCatalog.command(named: String(body[body.startIndex..<space])) else {
+        guard let command = SlashCommandCatalog.command(named: String(body[body.startIndex..<space])),
+              command.subArgs != .none
+        else {
             return false
         }
-        return command.subArgs != .none
+
+        let argument = body[body.index(after: space)...].drop(while: { $0.isWhitespace })
+        return !argument.contains(where: { $0.isWhitespace })
     }
 
     private static func isWhitespaceOrNewline(_ unit: UInt16) -> Bool {
         guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
         return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+
+    private static func isSpace(_ unit: UInt16) -> Bool {
+        guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        return CharacterSet.whitespaces.contains(scalar)
     }
 
     private static func isNewline(_ unit: UInt16) -> Bool {

--- a/HermesMobile/Features/Chat/ComposerSlashTrigger.swift
+++ b/HermesMobile/Features/Chat/ComposerSlashTrigger.swift
@@ -86,10 +86,12 @@ struct ComposerSlashTrigger: Equatable {
     /// Whether `text` can still be a command being typed.
     ///
     /// One word is always a candidate. Past the first space, the word has to be
-    /// a command that takes a sub-argument, and the trigger ends as soon as the
-    /// user types past that argument — otherwise prose such as "check the /tmp
-    /// folder" or "use /reasoning high for this task" would hold an empty panel
-    /// open for the rest of the sentence.
+    /// a command that takes a sub-argument. Where that argument is one of a
+    /// fixed list the trigger ends as soon as the user types past it, so prose
+    /// such as "check the /tmp folder" or "use /reasoning high for this task"
+    /// does not hold an empty panel open for the rest of the sentence. Where it
+    /// is free-form — a workspace path, a personality name, a skill query — the
+    /// spaces are part of the value, so the trigger runs to the caret.
     private static func isTrigger(_ text: String) -> Bool {
         let body = text.dropFirst()
         guard let space = body.firstIndex(where: { $0.isWhitespace }) else { return true }
@@ -98,6 +100,7 @@ struct ComposerSlashTrigger: Equatable {
         else {
             return false
         }
+        guard !command.subArgs.allowsSpaces else { return true }
 
         let argument = body[body.index(after: space)...].drop(while: { $0.isWhitespace })
         return !argument.contains(where: { $0.isWhitespace })

--- a/HermesMobile/Features/Chat/ComposerSlashTrigger.swift
+++ b/HermesMobile/Features/Chat/ComposerSlashTrigger.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// The `/…` run the caret is sitting in, if there is one.
+///
+/// The composer used to treat a draft as a slash query only when the whole draft
+/// started with `/`, so `/` halfway through a sentence did nothing and accepting
+/// a row threw the rest of the draft away. This finds the trigger at the caret
+/// and reports the range it occupies, so accepting a row replaces only that much.
+struct ComposerSlashTrigger: Equatable {
+    /// UTF-16 range of the trigger inside the draft: the `/` up to the caret.
+    let range: NSRange
+    /// The trigger's text, `/` included. This is what the panel filters on.
+    let text: String
+
+    private static let slash: UInt16 = 0x2F
+
+    /// The trigger `selection` sits in, or `nil` when there is none.
+    ///
+    /// A trigger is a `/` that starts the draft or follows whitespace, running
+    /// forward to the caret and never across a line break. A selection with a
+    /// length is never a trigger: the user is selecting text, not typing a
+    /// command.
+    static func detect(in draft: String, selection: NSRange) -> ComposerSlashTrigger? {
+        guard selection.length == 0 else { return nil }
+
+        let draft = draft as NSString
+        let caret = selection.location
+        guard caret >= 0, caret <= draft.length else { return nil }
+
+        var index = caret - 1
+        while index >= 0 {
+            let unit = draft.character(at: index)
+            if isNewline(unit) { return nil }
+
+            if unit == slash, index == 0 || isWhitespaceOrNewline(draft.character(at: index - 1)) {
+                let range = NSRange(location: index, length: caret - index)
+                let text = draft.substring(with: range)
+                if isTrigger(text) {
+                    return ComposerSlashTrigger(range: range, text: text)
+                }
+            }
+
+            index -= 1
+        }
+
+        return nil
+    }
+
+    /// What the draft and caret become when the user accepts `replacement`.
+    ///
+    /// Only the trigger's own range changes. When the completion wants a
+    /// trailing space and the draft already has whitespace waiting there, the
+    /// space is dropped and the caret steps over the existing one instead, so
+    /// accepting a command mid-sentence leaves neither a double space nor a
+    /// caret stranded in front of one.
+    func applying(_ replacement: String, to draft: String) -> (draft: String, selection: NSRange) {
+        let draft = draft as NSString
+        let location = min(max(0, range.location), draft.length)
+        let range = NSRange(location: location, length: min(max(0, range.length), draft.length - location))
+
+        var inserted = replacement
+        var caretOffset = 0
+        if inserted.hasSuffix(" "),
+           range.upperBound < draft.length,
+           Self.isWhitespaceOrNewline(draft.character(at: range.upperBound)) {
+            inserted.removeLast()
+            caretOffset = 1
+        }
+
+        let caret = range.location + (inserted as NSString).length + caretOffset
+        return (
+            draft.replacingCharacters(in: range, with: inserted),
+            NSRange(location: caret, length: 0)
+        )
+    }
+
+    /// Whether `text` can still be a command being typed.
+    ///
+    /// Everything up to the first space has to be a command that takes a
+    /// sub-argument, otherwise ordinary prose such as "check the /tmp folder for
+    /// it" would hold the panel open for the rest of the sentence.
+    private static func isTrigger(_ text: String) -> Bool {
+        let body = text.dropFirst()
+        guard let space = body.firstIndex(where: { $0.isWhitespace }) else { return true }
+        guard let command = SlashCommandCatalog.command(named: String(body[body.startIndex..<space])) else {
+            return false
+        }
+        return command.subArgs != .none
+    }
+
+    private static func isWhitespaceOrNewline(_ unit: UInt16) -> Bool {
+        guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+
+    private static func isNewline(_ unit: UInt16) -> Bool {
+        guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        return CharacterSet.newlines.contains(scalar)
+    }
+}

--- a/HermesMobile/Features/Chat/ComposerTextEditing.swift
+++ b/HermesMobile/Features/Chat/ComposerTextEditing.swift
@@ -9,10 +9,17 @@ import UIKit
 struct ComposerSelection: Equatable {
     var range = NSRange(location: 0, length: 0)
     var revision = 0
+    /// How many editor-to-composer publishes this value was built from.
+    ///
+    /// The editor bumps it every time it pushes an edit up. Because text and
+    /// caret are published together, it dates the draft as well, which lets the
+    /// bridge tell a binding that has caught up from one still carrying the
+    /// draft from before the user's last keystroke.
+    var publishGeneration = 0
 
     /// A caret the composer is moving on purpose.
     func moved(to range: NSRange) -> ComposerSelection {
-        ComposerSelection(range: range, revision: revision &+ 1)
+        ComposerSelection(range: range, revision: revision &+ 1, publishGeneration: publishGeneration)
     }
 }
 
@@ -26,12 +33,22 @@ enum ComposerMarkedText {
     /// simply not seen the marked text yet is echoing the committed draft back,
     /// which is not a change worth breaking a composition for. A deliberate
     /// clear or replacement still is.
-    static func isDeliberateReplacement(_ boundText: String, editorText: String, marked: NSRange) -> Bool {
+    ///
+    /// Two questions decide it. Is this value the editor's own committed text
+    /// coming back — the comparison against the draft with the marked range
+    /// removed? And has the parent seen the composition at all — `isCurrent`,
+    /// from the publish generation the binding carries. They agree everywhere
+    /// but on an empty value, where a send that cleared a whole-draft
+    /// composition and a binding that predates that composition are the same
+    /// two strings, and only the generation can break the tie.
+    static func isDeliberateReplacement(
+        _ boundText: String,
+        editorText: String,
+        marked: NSRange,
+        isCurrent: Bool
+    ) -> Bool {
         guard boundText != editorText else { return false }
-        // Emptying the composer is always meant: sending is the case, and when
-        // the composition is the whole draft its committed text is empty too,
-        // so the echo test alone would leave the sent text sitting there.
-        guard !boundText.isEmpty else { return true }
+        guard !boundText.isEmpty else { return isCurrent }
 
         let editor = editorText as NSString
         guard marked.location >= 0, marked.length >= 0, marked.upperBound <= editor.length else {

--- a/HermesMobile/Features/Chat/ComposerTextEditing.swift
+++ b/HermesMobile/Features/Chat/ComposerTextEditing.swift
@@ -1,0 +1,103 @@
+import UIKit
+
+/// Where the composer's caret is, and whose idea that was.
+///
+/// The range is reported up on every edit and caret move, so the composer can
+/// tell what the user is typing *at*. `revision` moves only when the composer
+/// deliberately places the caret — accepting a slash completion is the one case
+/// — so an update replaying an older value can never yank the caret back.
+struct ComposerSelection: Equatable {
+    var range = NSRange(location: 0, length: 0)
+    var revision = 0
+
+    /// A caret the composer is moving on purpose.
+    func moved(to range: NSRange) -> ComposerSelection {
+        ComposerSelection(range: range, revision: revision &+ 1)
+    }
+}
+
+/// When a bound draft may overwrite a live IME composition.
+enum ComposerMarkedText {
+    /// Whether `boundText` is a real replacement rather than an echo of what the
+    /// editor has already committed.
+    ///
+    /// While an IME composition is marked, assigning text commits it half-formed
+    /// and splits characters such as 자 into ㅈㅏ (#312). A parent that has
+    /// simply not seen the marked text yet is echoing the committed draft back,
+    /// which is not a change worth breaking a composition for. A deliberate
+    /// clear or replacement still is.
+    static func isDeliberateReplacement(_ boundText: String, editorText: String, marked: NSRange) -> Bool {
+        let editor = editorText as NSString
+        guard marked.location >= 0, marked.length >= 0, marked.upperBound <= editor.length else {
+            return boundText != editorText
+        }
+
+        return boundText != editorText && boundText != editor.replacingCharacters(in: marked, with: "")
+    }
+}
+
+/// One replacement that turns the editor's text into the text the composer wants.
+///
+/// Applying it through `UITextView.replace(_:withText:)` keeps the change on the
+/// editor's undo stack and leaves the rest of the draft untouched, neither of
+/// which assigning `text` wholesale does.
+struct ComposerTextEdit: Equatable {
+    /// UTF-16 range to replace, in the editor's current text.
+    let range: NSRange
+    let replacement: String
+
+    /// The smallest edit from `current` to `target`, or `nil` when they match.
+    static func between(current: String, target: String) -> ComposerTextEdit? {
+        guard current != target else { return nil }
+
+        let current = current as NSString
+        let target = target as NSString
+        let shortest = min(current.length, target.length)
+
+        var prefix = 0
+        while prefix < shortest, current.character(at: prefix) == target.character(at: prefix) {
+            prefix += 1
+        }
+
+        var suffix = 0
+        while suffix < shortest - prefix,
+              current.character(at: current.length - 1 - suffix) == target.character(at: target.length - 1 - suffix) {
+            suffix += 1
+        }
+
+        // A range that cuts a surrogate pair in half has no `UITextRange`, so
+        // back the boundary off onto the character it belongs to.
+        if prefix > 0, isTrailingSurrogate(at: prefix, in: current) || isTrailingSurrogate(at: prefix, in: target) {
+            prefix -= 1
+        }
+        if suffix > 0, isTrailingSurrogate(at: current.length - suffix, in: current) {
+            suffix -= 1
+        }
+
+        return ComposerTextEdit(
+            range: NSRange(location: prefix, length: current.length - prefix - suffix),
+            replacement: target.substring(with: NSRange(location: prefix, length: target.length - prefix - suffix))
+        )
+    }
+
+    private static func isTrailingSurrogate(at index: Int, in text: NSString) -> Bool {
+        guard index >= 0, index < text.length else { return false }
+        return UTF16.isTrailSurrogate(text.character(at: index))
+    }
+}
+
+extension UITextView {
+    /// The `UITextRange` for a UTF-16 range, or `nil` when it does not land on
+    /// positions this editor recognises.
+    func textRange(from range: NSRange) -> UITextRange? {
+        guard range.location >= 0, range.length >= 0, range.upperBound <= (text as NSString).length else {
+            return nil
+        }
+        guard let start = position(from: beginningOfDocument, offset: range.location),
+              let end = position(from: start, offset: range.length)
+        else {
+            return nil
+        }
+        return textRange(from: start, to: end)
+    }
+}

--- a/HermesMobile/Features/Chat/ComposerTextEditing.swift
+++ b/HermesMobile/Features/Chat/ComposerTextEditing.swift
@@ -27,12 +27,18 @@ enum ComposerMarkedText {
     /// which is not a change worth breaking a composition for. A deliberate
     /// clear or replacement still is.
     static func isDeliberateReplacement(_ boundText: String, editorText: String, marked: NSRange) -> Bool {
+        guard boundText != editorText else { return false }
+        // Emptying the composer is always meant: sending is the case, and when
+        // the composition is the whole draft its committed text is empty too,
+        // so the echo test alone would leave the sent text sitting there.
+        guard !boundText.isEmpty else { return true }
+
         let editor = editorText as NSString
         guard marked.location >= 0, marked.length >= 0, marked.upperBound <= editor.length else {
-            return boundText != editorText
+            return true
         }
 
-        return boundText != editorText && boundText != editor.replacingCharacters(in: marked, with: "")
+        return boundText != editor.replacingCharacters(in: marked, with: "")
     }
 }
 

--- a/HermesMobile/Features/Chat/SlashCommand.swift
+++ b/HermesMobile/Features/Chat/SlashCommand.swift
@@ -72,3 +72,21 @@ enum SlashCommandSubArgs: Equatable, Sendable {
     case skills
     case goalActions
 }
+
+extension SlashCommandSubArgs {
+    /// Whether the argument is free-form and so may contain spaces.
+    ///
+    /// A path, a personality name, and a skill query are all things the user
+    /// types spaces into, and `ParsedSlashQuery` splits them off with
+    /// `maxSplits: 1` so the whole rest of the line is the argument. The other
+    /// lists are fixed single tokens, so a space after one means the user has
+    /// stopped naming a value and gone back to writing prose.
+    var allowsSpaces: Bool {
+        switch self {
+        case .workspaces, .personalities, .skills:
+            return true
+        case .models, .reasoningLevels, .goalActions, .none:
+            return false
+        }
+    }
+}

--- a/HermesMobileTests/ComposerSlashTriggerTests.swift
+++ b/HermesMobileTests/ComposerSlashTriggerTests.swift
@@ -65,6 +65,27 @@ final class ComposerSlashTriggerTests: XCTestCase {
         XCTAssertEqual(trigger?.text, "/workspace ")
     }
 
+    func testAWorkspacePathContainingASpaceKeepsTheTriggerOpen() {
+        let draft = "/workspace /Users/me/My App"
+        let trigger = ComposerSlashTrigger.detect(in: draft, selection: caret((draft as NSString).length))
+
+        XCTAssertEqual(trigger?.text, draft)
+    }
+
+    func testAMultiWordSkillQueryKeepsTheTriggerOpen() {
+        let draft = "/skills read files"
+        let trigger = ComposerSlashTrigger.detect(in: draft, selection: caret((draft as NSString).length))
+
+        XCTAssertEqual(trigger?.text, draft)
+    }
+
+    func testAPersonalityNameContainingASpaceKeepsTheTriggerOpen() {
+        let draft = "/personality Terse Reviewer"
+        let trigger = ComposerSlashTrigger.detect(in: draft, selection: caret((draft as NSString).length))
+
+        XCTAssertEqual(trigger?.text, draft)
+    }
+
     func testTriggerNeverCrossesALineBreak() {
         XCTAssertNil(ComposerSlashTrigger.detect(in: "/model\nnow", selection: caret(10)))
     }
@@ -159,7 +180,8 @@ final class ComposerSlashTriggerTests: XCTestCase {
             ComposerMarkedText.isDeliberateReplacement(
                 "안녕 ",
                 editorText: "안녕 ㅈ",
-                marked: NSRange(location: 3, length: 1)
+                marked: NSRange(location: 3, length: 1),
+                isCurrent: false
             )
         )
     }
@@ -169,7 +191,8 @@ final class ComposerSlashTriggerTests: XCTestCase {
             ComposerMarkedText.isDeliberateReplacement(
                 "안녕 ㅈ",
                 editorText: "안녕 ㅈ",
-                marked: NSRange(location: 3, length: 1)
+                marked: NSRange(location: 3, length: 1),
+                isCurrent: true
             )
         )
     }
@@ -179,19 +202,43 @@ final class ComposerSlashTriggerTests: XCTestCase {
             ComposerMarkedText.isDeliberateReplacement(
                 "",
                 editorText: "안녕 ㅈ",
-                marked: NSRange(location: 3, length: 1)
+                marked: NSRange(location: 3, length: 1),
+                isCurrent: true
             )
         )
     }
 
     func testClearingTheDraftAppliesEvenWhenTheCompositionIsTheWholeDraft() {
+        // Sending while the whole draft is one composition: the parent has seen
+        // the composition and is emptying the composer on purpose.
         XCTAssertTrue(
             ComposerMarkedText.isDeliberateReplacement(
                 "",
                 editorText: "\u{3148}",
-                marked: NSRange(location: 0, length: 1)
+                marked: NSRange(location: 0, length: 1),
+                isCurrent: true
             )
         )
+    }
+
+    func testAStaleEmptyBindingNeverErasesAWholeDraftComposition() {
+        // The same two strings as the send above, but the parent is still on the
+        // empty composer it rendered before the user started composing, so this
+        // is an echo rather than a clear.
+        XCTAssertFalse(
+            ComposerMarkedText.isDeliberateReplacement(
+                "",
+                editorText: "\u{3148}",
+                marked: NSRange(location: 0, length: 1),
+                isCurrent: false
+            )
+        )
+    }
+
+    func testADeliberateCaretMoveKeepsThePublishGeneration() {
+        let published = ComposerSelection(range: NSRange(location: 3, length: 0), publishGeneration: 7)
+
+        XCTAssertEqual(published.moved(to: NSRange(location: 5, length: 0)).publishGeneration, 7)
     }
 
     // MARK: - Undo

--- a/HermesMobileTests/ComposerSlashTriggerTests.swift
+++ b/HermesMobileTests/ComposerSlashTriggerTests.swift
@@ -38,6 +38,33 @@ final class ComposerSlashTriggerTests: XCTestCase {
         XCTAssertEqual(trigger?.range, NSRange(location: 0, length: 17))
     }
 
+    func testAnAbsolutePathArgumentBelongsToTheCommandInFrontOfIt() {
+        let draft = "/workspace /Users/me/app"
+        let trigger = ComposerSlashTrigger.detect(in: draft, selection: caret(24))
+
+        XCTAssertEqual(trigger?.text, draft)
+        XCTAssertEqual(trigger?.range, NSRange(location: 0, length: 24))
+    }
+
+    func testTheOutermostTriggerWinsOnlyWhenItHoldsUp() {
+        let trigger = ComposerSlashTrigger.detect(in: "notes /rough draft /mod", selection: caret(23))
+
+        XCTAssertEqual(trigger?.text, "/mod")
+        XCTAssertEqual(trigger?.range, NSRange(location: 19, length: 4))
+    }
+
+    func testTypingPastASubArgumentClosesTheTrigger() {
+        XCTAssertNil(
+            ComposerSlashTrigger.detect(in: "use /reasoning high for this task", selection: caret(33))
+        )
+    }
+
+    func testAnEmptySubArgumentKeepsTheTriggerOpen() {
+        let trigger = ComposerSlashTrigger.detect(in: "/workspace ", selection: caret(11))
+
+        XCTAssertEqual(trigger?.text, "/workspace ")
+    }
+
     func testTriggerNeverCrossesALineBreak() {
         XCTAssertNil(ComposerSlashTrigger.detect(in: "/model\nnow", selection: caret(10)))
     }
@@ -81,6 +108,16 @@ final class ComposerSlashTriggerTests: XCTestCase {
         let completed = trigger?.applying("/model ", to: draft)
 
         XCTAssertEqual(completed?.draft, "/model gpt-5")
+        XCTAssertEqual(completed?.selection, caret(7))
+    }
+
+    func testAcceptingBeforeALineBreakKeepsTheCompletionsSpace() {
+        let draft = "/mod\nnext line"
+        let trigger = ComposerSlashTrigger.detect(in: draft, selection: caret(4))
+
+        let completed = trigger?.applying("/model ", to: draft)
+
+        XCTAssertEqual(completed?.draft, "/model \nnext line")
         XCTAssertEqual(completed?.selection, caret(7))
     }
 
@@ -143,6 +180,16 @@ final class ComposerSlashTriggerTests: XCTestCase {
                 "",
                 editorText: "안녕 ㅈ",
                 marked: NSRange(location: 3, length: 1)
+            )
+        )
+    }
+
+    func testClearingTheDraftAppliesEvenWhenTheCompositionIsTheWholeDraft() {
+        XCTAssertTrue(
+            ComposerMarkedText.isDeliberateReplacement(
+                "",
+                editorText: "\u{3148}",
+                marked: NSRange(location: 0, length: 1)
             )
         )
     }

--- a/HermesMobileTests/ComposerSlashTriggerTests.swift
+++ b/HermesMobileTests/ComposerSlashTriggerTests.swift
@@ -1,0 +1,172 @@
+import UIKit
+import XCTest
+
+@testable import HermesMobile
+
+final class ComposerSlashTriggerTests: XCTestCase {
+    // MARK: - Detection
+
+    func testDetectsTriggerAtStartOfDraft() {
+        let trigger = ComposerSlashTrigger.detect(in: "/mod", selection: caret(4))
+
+        XCTAssertEqual(trigger?.text, "/mod")
+        XCTAssertEqual(trigger?.range, NSRange(location: 0, length: 4))
+    }
+
+    func testDetectsTriggerMidSentence() {
+        let trigger = ComposerSlashTrigger.detect(in: "please run /mod", selection: caret(15))
+
+        XCTAssertEqual(trigger?.text, "/mod")
+        XCTAssertEqual(trigger?.range, NSRange(location: 11, length: 4))
+    }
+
+    func testTriggerStopsAtTheCaretRatherThanTheEndOfTheDraft() {
+        let trigger = ComposerSlashTrigger.detect(in: "/model gpt", selection: caret(3))
+
+        XCTAssertEqual(trigger?.text, "/mo")
+        XCTAssertEqual(trigger?.range, NSRange(location: 0, length: 3))
+    }
+
+    func testSlashGluedToPrecedingTextIsNotATrigger() {
+        XCTAssertNil(ComposerSlashTrigger.detect(in: "hermex/main", selection: caret(11)))
+    }
+
+    func testSkipsAGluedSlashAndFindsTheRealTriggerBehindIt() {
+        let trigger = ComposerSlashTrigger.detect(in: "/workspace ~/proj", selection: caret(17))
+
+        XCTAssertEqual(trigger?.text, "/workspace ~/proj")
+        XCTAssertEqual(trigger?.range, NSRange(location: 0, length: 17))
+    }
+
+    func testTriggerNeverCrossesALineBreak() {
+        XCTAssertNil(ComposerSlashTrigger.detect(in: "/model\nnow", selection: caret(10)))
+    }
+
+    func testProseAfterAnUnknownCommandClosesTheTrigger() {
+        XCTAssertNil(ComposerSlashTrigger.detect(in: "check the /tmp folder", selection: caret(21)))
+    }
+
+    func testSubArgCommandKeepsTheTriggerOpenAcrossItsSpace() {
+        let trigger = ComposerSlashTrigger.detect(in: "/skills rev", selection: caret(11))
+
+        XCTAssertEqual(trigger?.text, "/skills rev")
+    }
+
+    func testSelectionWithALengthIsNeverATrigger() {
+        XCTAssertNil(
+            ComposerSlashTrigger.detect(in: "/model", selection: NSRange(location: 1, length: 3))
+        )
+    }
+
+    func testCaretPastTheEndOfTheDraftIsNotATrigger() {
+        XCTAssertNil(ComposerSlashTrigger.detect(in: "/mod", selection: caret(9)))
+    }
+
+    // MARK: - Accepting a row
+
+    func testAcceptingReplacesOnlyTheTriggerAndParksTheCaretAfterIt() {
+        let draft = "please run /mod for me"
+        let trigger = ComposerSlashTrigger.detect(in: draft, selection: caret(15))
+
+        let completed = trigger?.applying("/model ", to: draft)
+
+        XCTAssertEqual(completed?.draft, "please run /model for me")
+        XCTAssertEqual(completed?.selection, caret(18))
+    }
+
+    func testAcceptingKeepsTextThatFollowsTheCaret() {
+        let draft = "/mo gpt-5"
+        let trigger = ComposerSlashTrigger.detect(in: draft, selection: caret(3))
+
+        let completed = trigger?.applying("/model ", to: draft)
+
+        XCTAssertEqual(completed?.draft, "/model gpt-5")
+        XCTAssertEqual(completed?.selection, caret(7))
+    }
+
+    func testAcceptingAtTheEndOfTheDraftKeepsItsTrailingSpace() {
+        let trigger = ComposerSlashTrigger.detect(in: "/mod", selection: caret(4))
+
+        let completed = trigger?.applying("/model ", to: "/mod")
+
+        XCTAssertEqual(completed?.draft, "/model ")
+        XCTAssertEqual(completed?.selection, caret(7))
+    }
+
+    // MARK: - Minimal edits
+
+    func testNoEditBetweenIdenticalText() {
+        XCTAssertNil(ComposerTextEdit.between(current: "/model ", target: "/model "))
+    }
+
+    func testEditTouchesOnlyWhatChanged() {
+        let edit = ComposerTextEdit.between(current: "please run /mod for me", target: "please run /model for me")
+
+        XCTAssertEqual(edit?.range, NSRange(location: 15, length: 0))
+        XCTAssertEqual(edit?.replacement, "el")
+    }
+
+    func testEditNeverSplitsASurrogatePair() {
+        let edit = ComposerTextEdit.between(current: "hi 👍", target: "hi 👋")
+
+        XCTAssertEqual(edit?.range, NSRange(location: 3, length: 2))
+        XCTAssertEqual(edit?.replacement, "👋")
+    }
+
+    // MARK: - IME composition (#312)
+
+    func testABindingThatHasNotSeenTheCompositionLeavesItAlone() {
+        // The user has started composing 자; the parent still holds the draft as
+        // it was before the composition began.
+        XCTAssertFalse(
+            ComposerMarkedText.isDeliberateReplacement(
+                "안녕 ",
+                editorText: "안녕 ㅈ",
+                marked: NSRange(location: 3, length: 1)
+            )
+        )
+    }
+
+    func testABindingThatMatchesTheEditorLeavesTheCompositionAlone() {
+        XCTAssertFalse(
+            ComposerMarkedText.isDeliberateReplacement(
+                "안녕 ㅈ",
+                editorText: "안녕 ㅈ",
+                marked: NSRange(location: 3, length: 1)
+            )
+        )
+    }
+
+    func testADeliberateClearStillAppliesDuringComposition() {
+        XCTAssertTrue(
+            ComposerMarkedText.isDeliberateReplacement(
+                "",
+                editorText: "안녕 ㅈ",
+                marked: NSRange(location: 3, length: 1)
+            )
+        )
+    }
+
+    // MARK: - Undo
+
+    @MainActor
+    func testApplyingAnEditThroughTheEditorIsUndoable() throws {
+        let textView = UITextView()
+        textView.text = "please run /mod for me"
+
+        let edit = try XCTUnwrap(ComposerTextEdit.between(current: textView.text, target: "please run /model for me"))
+        let range = try XCTUnwrap(textView.textRange(from: edit.range))
+        textView.replace(range, withText: edit.replacement)
+
+        XCTAssertEqual(textView.text, "please run /model for me")
+        XCTAssertEqual(textView.selectedRange, caret(17))
+
+        textView.undoManager?.undo()
+
+        XCTAssertEqual(textView.text, "please run /mod for me")
+    }
+
+    private func caret(_ location: Int) -> NSRange {
+        NSRange(location: location, length: 0)
+    }
+}


### PR DESCRIPTION
Stacked on #383; merge after it.

## What changed

Typing `/` only opened the command panel when the *whole draft* started with it. So `write a note about /model` did nothing, and if the panel was open, picking a row replaced everything you had typed with `/model `.

The composer now knows where its caret is. It looks for the `/` the caret is sitting in — start of the draft or the middle of a sentence — and when you pick a row it swaps just that `/…` for the completion, leaves the rest of the draft alone, and parks the caret right after what it inserted. Undo puts back what you typed.

## Plan

1. `ComposerTextInputView` reports the caret up alongside the text, in one update, so the two can never disagree. A caret the composer places itself carries a revision, so a replayed update cannot yank the caret out from under the user, and a no-op `selectedRange` assignment is skipped because assigning it at all resets predictive text.
2. `ComposerSlashTrigger` finds the trigger at the caret and reports its range. A trigger is a `/` at the start of the draft or after whitespace, running to the caret, never across a line break. It may span a space only when the first word is a command that takes a sub-argument (`/skills`, `/workspace`, `/goal`, …), so ordinary prose like "check the /tmp folder" does not hold the panel open.
3. Accepting a row replaces only that range. A trailing space is dropped when the draft already has one there, and the caret steps over it instead.
4. Programmatic draft changes reach the editor as edits (`UITextView.replace(_:withText:)`) rather than a wholesale `text` assignment, which is what makes the change undoable.
5. A live IME composition is no longer committed half-formed by a parent rerender (#312): a binding that has merely not seen the marked text yet is an echo and is ignored; a deliberate clear or replacement still applies.

Files: `ComposerSlashTrigger.swift` (new), `ComposerTextEditing.swift` (new — selection, minimal edit, marked-text policy, lifted out of the bridge to keep it under the size warning), `ChatComposerTextInputView.swift`, `ChatComposerView.swift`, and `ComposerSlashTriggerTests.swift` (new).

Main risk is the caret: a UIKit text bridge that pushes selection down can fight the user. The revision counter is the guard, and the editor keeps the caret in every case except a completion.

## How it was tested

Full XCTest suite on the iPhone 17 simulator: **2010 tests, 0 failures** (2 pre-existing photo-library skips).

```
xcodebuild -project HermesMobile.xcodeproj -scheme HermesMobile \
  -destination 'platform=iOS Simulator,name=iPhone 17' test
```

20 new tests cover trigger detection (start of draft, mid-sentence, stopping at the caret rather than the end of the draft, a slash glued to preceding text, `~/path` inside `/workspace`, line breaks, prose after an unknown command, sub-arg commands, a non-empty selection, an out-of-range caret), accepting a row (surrounding text preserved, caret placement, the double-space case), the minimal-edit diff including surrogate pairs, undo through a real `UITextView`, and the three IME marked-text cases from #312.

No server contract, `Codable` model, endpoint, or dependency was touched.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no server contact)

---

Written by Claude Opus 5 in Claude Code.
