### PR TITLE
feat(chat): show a skill you pick as a chip in the composer

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 		8B71DA2AAC521382F54A841C /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */; };
 		8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */; };
 		F06907881C5B4BCCB98D2EBA /* ComposerSlashTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */; };
+		A1C0F1000000000000000006 /* ComposerChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000005 /* ComposerChipTests.swift */; };
 		941A67322EB54169A55D7A64 /* SlashCommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */; };
 		75D7C575386EE8C6D442A967 /* SlashCommandRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19468599B2A57CAFAF8A3357 /* SlashCommandRanker.swift */; };
 		5927FF7204918E46CCE7387C /* SlashAutocompleteRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82A2A58F08883E396B94B1C /* SlashAutocompleteRanking.swift */; };
@@ -363,6 +364,9 @@
 		C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CAM000000000000000B002 /* CameraPickerView.swift */; };
 		C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000002 /* ChatComposerView.swift */; };
 		D01ECB8354BE43609DB90E77 /* ComposerTextEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */; };
+		A1C0F1000000000000000002 /* ComposerChipToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000001 /* ComposerChipToken.swift */; };
+		A1C0F1000000000000000004 /* ComposerChipRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000003 /* ComposerChipRendering.swift */; };
+		A1C0F1000000000000000008 /* ComposerChipTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000007 /* ComposerChipTextView.swift */; };
 		E067C191AC494934863F613D /* ComposerSlashTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */; };
 		C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */; };
 		105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */; };
@@ -415,6 +419,7 @@
 /* Begin PBXFileReference section */
 		0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandTests.swift; sourceTree = "<group>"; };
 		92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerSlashTriggerTests.swift; sourceTree = "<group>"; };
+		A1C0F1000000000000000005 /* ComposerChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipTests.swift; sourceTree = "<group>"; };
 		351C0F1600000000000000A1 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
 		1A2B3C4D5E6F700000000301 /* ServerAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAccount.swift; sourceTree = "<group>"; };
 		B5A1000000000000000000A1 /* ServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRegistryTests.swift; sourceTree = "<group>"; };
@@ -764,6 +769,9 @@
 		C0CAM000000000000000B002 /* CameraPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPickerView.swift; sourceTree = "<group>"; };
 		C0DEC0DE0000000000000002 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
 		93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTextEditing.swift; sourceTree = "<group>"; };
+		A1C0F1000000000000000001 /* ComposerChipToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipToken.swift; sourceTree = "<group>"; };
+		A1C0F1000000000000000003 /* ComposerChipRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipRendering.swift; sourceTree = "<group>"; };
+		A1C0F1000000000000000007 /* ComposerChipTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipTextView.swift; sourceTree = "<group>"; };
 		417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerSlashTrigger.swift; sourceTree = "<group>"; };
 		C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelTests.swift; sourceTree = "<group>"; };
 		FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandAutocompleteView.swift; sourceTree = "<group>"; };
@@ -967,6 +975,7 @@
 				1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */,
 				0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */,
 				92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */,
+				A1C0F1000000000000000005 /* ComposerChipTests.swift */,
 				6809B8F1391248A4AA77C453 /* SlashCommandExecutorTests.swift */,
 				A710739233F64F4FA4C2B711 /* ComposerVoiceDraftComposerTests.swift */,
 				C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */,
@@ -1151,6 +1160,9 @@
 				C0CAM000000000000000B002 /* CameraPickerView.swift */,
 				C0DEC0DE0000000000000002 /* ChatComposerView.swift */,
 				93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */,
+				A1C0F1000000000000000001 /* ComposerChipToken.swift */,
+				A1C0F1000000000000000003 /* ComposerChipRendering.swift */,
+				A1C0F1000000000000000007 /* ComposerChipTextView.swift */,
 				417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */,
 				C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */,
 				C04900000000000000000002 /* ChatComposerTextInputView.swift */,
@@ -1700,6 +1712,9 @@
 					C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */,
 				C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */,
 				D01ECB8354BE43609DB90E77 /* ComposerTextEditing.swift in Sources */,
+				A1C0F1000000000000000002 /* ComposerChipToken.swift in Sources */,
+				A1C0F1000000000000000004 /* ComposerChipRendering.swift in Sources */,
+				A1C0F1000000000000000008 /* ComposerChipTextView.swift in Sources */,
 				E067C191AC494934863F613D /* ComposerSlashTrigger.swift in Sources */,
 					C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */,
 					C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */,
@@ -1924,6 +1939,7 @@
 					1050500000000000000000B1 /* OnboardingViewModelIdentityTests.swift in Sources */,
 					8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */,
 				F06907881C5B4BCCB98D2EBA /* ComposerSlashTriggerTests.swift in Sources */,
+				A1C0F1000000000000000006 /* ComposerChipTests.swift in Sources */,
 				0D82B28493C6401D98DA9C0E /* SlashCommandExecutorTests.swift in Sources */,
 				A710739233F64F4FA4C2B701 /* ComposerVoiceDraftComposerTests.swift in Sources */,
 				C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -16,6 +16,9 @@ struct ComposerTextInputView: View {
     let isCollapsed: Bool
     let isKeyboardSendEnabled: Bool
     let verticalPadding: CGFloat
+    /// The skills whose references the editor draws as chips. Empty until the
+    /// server's skill list has loaded, which leaves the draft as plain text.
+    let chipSkills: [SkillSlashSuggestion]
     let onKeyboardSend: () -> Void
     let onPasteFileProviders: ([NSItemProvider]) -> Void
     let onPasteFileURLs: ([URL]) -> Void
@@ -34,6 +37,7 @@ struct ComposerTextInputView: View {
                 isFocused: $isFocused,
                 isDisabled: isDisabled,
                 isKeyboardSendEnabled: isKeyboardSendEnabled,
+                chipSkills: chipSkills,
                 onKeyboardSend: onKeyboardSend,
                 onHeightChange: updateMeasuredHeight,
                 onPasteFileProviders: onPasteFileProviders,
@@ -91,6 +95,7 @@ private struct ComposerTextView: UIViewRepresentable {
     @Binding var isFocused: Bool
     let isDisabled: Bool
     let isKeyboardSendEnabled: Bool
+    let chipSkills: [SkillSlashSuggestion]
     let onKeyboardSend: () -> Void
     let onHeightChange: (CGFloat) -> Void
     let onPasteFileProviders: ([NSItemProvider]) -> Void
@@ -102,9 +107,10 @@ private struct ComposerTextView: UIViewRepresentable {
         Coordinator(text: $text, selection: $selection, isFocused: $isFocused, onHeightChange: onHeightChange)
     }
 
-    func makeUIView(context: Context) -> PastingTextView {
-        let textView = PastingTextView()
+    func makeUIView(context: Context) -> ComposerChipTextView {
+        let textView = ComposerChipTextView()
         textView.delegate = context.coordinator
+        textView.textDropDelegate = context.coordinator
         textView.backgroundColor = .clear
         textView.font = .preferredFont(forTextStyle: .body)
         textView.adjustsFontForContentSizeCategory = true
@@ -129,9 +135,8 @@ private struct ComposerTextView: UIViewRepresentable {
         return textView
     }
 
-    func updateUIView(_ textView: PastingTextView, context: Context) {
+    func updateUIView(_ textView: ComposerChipTextView, context: Context) {
         context.coordinator.onHeightChange = onHeightChange
-        context.coordinator.applyBoundText(text, generation: selection.publishGeneration, to: textView)
         // Mirror the chat RTL toggle onto the text view itself (#259): SwiftUI's
         // layoutDirection environment does not propagate into a wrapped UITextView,
         // so set the base direction directly so the cursor/empty-field rests on the
@@ -149,17 +154,26 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.onPasteFileURLs = onPasteFileURLs
         textView.onPasteImageProviders = onPasteImageProviders
         textView.onPasteImages = onPasteImages
+        textView.chipSkills = chipSkills
+        context.coordinator.onDropFileProviders = onPasteFileProviders
+        context.coordinator.onDropImageProviders = onPasteImageProviders
+        context.coordinator.applyBoundText(text, generation: selection.publishGeneration, to: textView)
         context.coordinator.syncSelection(selection, to: textView, expecting: text)
+        // Chips are redrawn last so they settle around the caret the composer
+        // just asked for rather than the one the edit happened to leave behind.
+        context.coordinator.applyingBoundValue { textView.refreshChipsIfNeeded() }
         context.coordinator.syncFocus(for: textView, shouldFocus: isFocused, isDisabled: isDisabled)
         context.coordinator.reportHeight(for: textView)
     }
 
     @MainActor
-    final class Coordinator: NSObject, UITextViewDelegate {
+    final class Coordinator: NSObject, UITextViewDelegate, UITextDropDelegate {
         @Binding var text: String
         @Binding var selection: ComposerSelection
         @Binding var isFocused: Bool
         var onHeightChange: (CGFloat) -> Void
+        var onDropFileProviders: ([NSItemProvider]) -> Void = { _ in }
+        var onDropImageProviders: ([NSItemProvider]) -> Void = { _ in }
         private var pendingFocusTarget: Bool?
         /// Set while we push a bound value into the editor, so the delegate
         /// callbacks it provokes do not write the bindings back mid-update.
@@ -192,20 +206,21 @@ private struct ComposerTextView: UIViewRepresentable {
         /// change, so it is ignored; a deliberate clear or replacement still
         /// applies. `generation` is the publish count the bound value was built
         /// from, which is what tells those two apart when the value is empty.
-        func applyBoundText(_ text: String, generation: Int, to textView: UITextView) {
-            guard textView.text != text else { return }
+        func applyBoundText(_ text: String, generation: Int, to textView: ComposerChipTextView) {
+            let current = textView.sourceText
+            guard current != text else { return }
 
             if let marked = textView.markedTextRange {
                 guard ComposerMarkedText.isDeliberateReplacement(
                     text,
-                    editorText: textView.text,
+                    editorText: current,
                     marked: markedRange(of: textView, marked: marked),
                     isCurrent: generation >= publishGeneration
                 ) else {
                     return
                 }
 
-                applyingBoundValue { textView.text = text }
+                applyingBoundValue { textView.replaceDocument(with: text) }
                 return
             }
 
@@ -214,18 +229,19 @@ private struct ComposerTextView: UIViewRepresentable {
                 // filling or emptying one stays a plain assignment; everything
                 // in between goes through the input system for its undo stack.
                 if textView.isEditable,
-                   !textView.text.isEmpty,
+                   !current.isEmpty,
                    !text.isEmpty,
-                   let edit = ComposerTextEdit.between(current: textView.text, target: text),
-                   let range = textView.textRange(from: edit.range) {
+                   let edit = ComposerTextEdit.between(current: current, target: text),
+                   let range = textView.displayTextRange(forSourceRange: edit.range) {
                     textView.replace(range, withText: edit.replacement)
                 }
 
                 // `replace` goes through the input system, which can normalize
-                // what it inserts; fall back rather than leave the editor out
-                // of sync.
-                if textView.text != text {
-                    textView.text = text
+                // what it inserts, and a range that straddles a chip cannot be
+                // edited in place at all; rebuild rather than leave the editor
+                // out of sync.
+                if textView.sourceText != text {
+                    textView.replaceDocument(with: text)
                 }
             }
         }
@@ -236,17 +252,21 @@ private struct ComposerTextView: UIViewRepresentable {
         /// revision, so a later update replaying the same value cannot yank the
         /// caret away from where the user has since put it. Every other pass
         /// leaves the editor's own caret alone and reports it back.
-        func syncSelection(_ selection: ComposerSelection, to textView: UITextView, expecting expectedText: String) {
-            guard textView.markedTextRange == nil, textView.text == expectedText else { return }
+        func syncSelection(
+            _ selection: ComposerSelection,
+            to textView: ComposerChipTextView,
+            expecting expectedText: String
+        ) {
+            guard textView.markedTextRange == nil, textView.sourceText == expectedText else { return }
 
             guard selection.revision == appliedSelectionRevision else {
                 appliedSelectionRevision = selection.revision
 
-                let clamped = Self.clamp(selection.range, toLengthOf: textView.text)
+                let clamped = Self.clamp(selection.range, toLengthOf: expectedText)
                 // Assigning `selectedRange` resets predictive text, so never
                 // assign a range the editor already holds.
-                if textView.selectedRange != clamped {
-                    applyingBoundValue { textView.selectedRange = clamped }
+                if textView.sourceSelection != clamped {
+                    applyingBoundValue { textView.sourceSelection = clamped }
                 }
                 return
             }
@@ -256,13 +276,13 @@ private struct ComposerTextView: UIViewRepresentable {
 
         /// Reports the caret the editor settled on. Deferred, because a binding
         /// cannot be written during a view update.
-        private func publishSelection(of textView: UITextView) {
-            let range = textView.selectedRange
+        private func publishSelection(of textView: ComposerChipTextView) {
+            let range = textView.sourceSelection
             guard selection.range != range else { return }
 
             DispatchQueue.main.async { [weak self, weak textView] in
                 guard let self, let textView,
-                      textView.selectedRange == range,
+                      textView.sourceSelection == range,
                       self.selection.range != range
                 else {
                     return
@@ -284,10 +304,11 @@ private struct ComposerTextView: UIViewRepresentable {
             )
         }
 
-        private func applyingBoundValue(_ body: () -> Void) {
+        func applyingBoundValue(_ body: () -> Void) {
+            let wasApplying = isApplyingBoundValue
             isApplyingBoundValue = true
             body()
-            isApplyingBoundValue = false
+            isApplyingBoundValue = wasApplying
         }
 
         func syncFocus(for textView: UITextView, shouldFocus: Bool, isDisabled: Bool) {
@@ -337,15 +358,15 @@ private struct ComposerTextView: UIViewRepresentable {
         }
 
         func textViewDidChange(_ textView: UITextView) {
-            guard !isApplyingBoundValue else { return }
+            guard !isApplyingBoundValue, let textView = textView as? ComposerChipTextView else { return }
 
             // Text and caret travel together: publishing them in one update is
             // what keeps the two consistent when the composer maps the caret
             // back onto the draft to find the slash trigger. The generation
             // rides along so a later update can be dated against this one.
             publishGeneration &+= 1
-            text = textView.text
-            selection.range = textView.selectedRange
+            text = textView.sourceText
+            selection.range = textView.sourceSelection
             selection.publishGeneration = publishGeneration
             reportHeight(for: textView)
         }
@@ -355,9 +376,75 @@ private struct ComposerTextView: UIViewRepresentable {
         /// a live IME composition is left alone entirely.
         func textViewDidChangeSelection(_ textView: UITextView) {
             guard !isApplyingBoundValue, textView.markedTextRange == nil else { return }
-            guard textView.text == text, selection.range != textView.selectedRange else { return }
+            guard let textView = textView as? ComposerChipTextView else { return }
+            textView.restoreTypingAttributes()
 
-            selection.range = textView.selectedRange
+            let range = textView.sourceSelection
+            guard textView.sourceText == text, selection.range != range else { return }
+
+            selection.range = range
+        }
+
+        func textView(
+            _ textView: UITextView,
+            shouldChangeTextIn range: NSRange,
+            replacementText text: String
+        ) -> Bool {
+            // Typing right after a chip would otherwise inherit the attachment's
+            // attributes and swallow the new characters into the image.
+            (textView as? ComposerChipTextView)?.restoreTypingAttributes()
+            return true
+        }
+
+        // MARK: - Drops
+
+        /// Claims a drop only when the composer can route every item through the
+        /// attachment pipeline, so UIKit never inserts an attachment the draft
+        /// cannot represent. Anything mixed or unrecognised is left to UIKit.
+        func textDroppableView(
+            _ textDroppableView: UIView & UITextDroppable,
+            proposalForDrop drop: UITextDropRequest
+        ) -> UITextDropProposal {
+            guard claimedDrop(in: drop) != nil else { return drop.suggestedProposal }
+
+            let proposal = UITextDropProposal(operation: .copy)
+            proposal.dropAction = .insert
+            proposal.dropPerformer = .delegate
+            return proposal
+        }
+
+        func textDroppableView(
+            _ textDroppableView: UIView & UITextDroppable,
+            willPerformDrop drop: UITextDropRequest
+        ) {
+            switch claimedDrop(in: drop) {
+            case let .files(providers):
+                onDropFileProviders(providers)
+            case let .images(providers):
+                onDropImageProviders(providers)
+            case nil:
+                break
+            }
+        }
+
+        private enum ClaimedDrop {
+            case files([NSItemProvider])
+            case images([NSItemProvider])
+        }
+
+        /// File URLs win over images, the same order `paste` uses: a dropped
+        /// PNG file is a file the user picked, not a screenshot on the clipboard.
+        private func claimedDrop(in drop: UITextDropRequest) -> ClaimedDrop? {
+            let providers = drop.dropSession.items.map(\.itemProvider)
+            guard !providers.isEmpty else { return nil }
+
+            if providers.allSatisfy({ $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) }) {
+                return .files(providers)
+            }
+            if providers.allSatisfy({ $0.hasItemConformingToTypeIdentifier(UTType.image.identifier) }) {
+                return .images(providers)
+            }
+            return nil
         }
 
         func reportHeight(for textView: UITextView) {
@@ -366,125 +453,6 @@ private struct ComposerTextView: UIViewRepresentable {
             let fittingSize = CGSize(width: textView.bounds.width, height: .greatestFiniteMagnitude)
             let height = ceil(textView.sizeThatFits(fittingSize).height)
             onHeightChange(min(160, max(22, height)))
-        }
-    }
-
-    final class PastingTextView: UITextView {
-        var isKeyboardSendEnabled = false
-        var onKeyboardSend: () -> Void = {}
-        var onPasteFileProviders: ([NSItemProvider]) -> Void = { _ in }
-        var onPasteFileURLs: ([URL]) -> Void = { _ in }
-        var onPasteImageProviders: ([NSItemProvider]) -> Void = { _ in }
-        var onPasteImages: ([UIImage]) -> Void = { _ in }
-
-        func canPasteItemProviders(_ itemProviders: [NSItemProvider]) -> Bool {
-            itemProviders.contains {
-                $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
-                    || $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                    || $0.hasItemConformingToTypeIdentifier(UTType.text.identifier)
-            }
-        }
-
-        func pasteItemProviders(_ itemProviders: [NSItemProvider]) {
-            let fileProviders = itemProviders.filter {
-                $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
-            }
-
-            if fileProviders.isEmpty {
-                let imageProviders = itemProviders.filter {
-                    $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                }
-
-                if imageProviders.isEmpty {
-                    paste(nil)
-                } else {
-                    onPasteImageProviders(imageProviders)
-                }
-                return
-            }
-
-            onPasteFileProviders(fileProviders)
-        }
-
-        override var keyCommands: [UIKeyCommand]? {
-            let sendCommand = UIKeyCommand(
-                title: ComposerKeyboardCommand.title,
-                action: #selector(sendMessageFromKeyboard),
-                input: ComposerKeyboardCommand.input,
-                modifierFlags: ComposerKeyboardCommand.modifierFlags
-            )
-            return (super.keyCommands ?? []) + [sendCommand]
-        }
-
-        override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-            if action == #selector(sendMessageFromKeyboard) {
-                return isKeyboardSendEnabled
-            }
-
-            if action == #selector(paste(_:)), hasPasteboardContent {
-                return true
-            }
-
-            return super.canPerformAction(action, withSender: sender)
-        }
-
-        @objc private func sendMessageFromKeyboard() {
-            guard isKeyboardSendEnabled else { return }
-            onKeyboardSend()
-        }
-
-        override func paste(_ sender: Any?) {
-            let fileProviders = pasteboardFileProviders
-
-            if !fileProviders.isEmpty {
-                onPasteFileProviders(fileProviders)
-                return
-            }
-
-            let fileURLs = pasteboardFileURLs
-            if !fileURLs.isEmpty {
-                onPasteFileURLs(fileURLs)
-                return
-            }
-
-            let imageProviders = pasteboardImageProviders
-            if !imageProviders.isEmpty {
-                onPasteImageProviders(imageProviders)
-                return
-            }
-
-            let images = UIPasteboard.general.images ?? []
-            if !images.isEmpty {
-                onPasteImages(images)
-                return
-            }
-
-            super.paste(sender)
-        }
-
-        private var hasPasteboardContent: Bool {
-            let pasteboard = UIPasteboard.general
-            return pasteboard.hasStrings
-                || !pasteboardFileProviders.isEmpty
-                || !pasteboardFileURLs.isEmpty
-                || !pasteboardImageProviders.isEmpty
-                || !(pasteboard.images?.isEmpty ?? true)
-        }
-
-        private var pasteboardFileProviders: [NSItemProvider] {
-            UIPasteboard.general.itemProviders.filter {
-                $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
-            }
-        }
-
-        private var pasteboardFileURLs: [URL] {
-            UIPasteboard.general.urls?.filter(\.isFileURL) ?? []
-        }
-
-        private var pasteboardImageProviders: [NSItemProvider] {
-            UIPasteboard.general.itemProviders.filter {
-                $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-            }
         }
     }
 }

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -118,6 +118,10 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         textView.textContentType = .none
+        // The editor draws its own attachments and reads them back as draft
+        // text. Rich-text editing would let UIKit insert one it cannot read,
+        // which would reach the server as an object-replacement character.
+        textView.allowsEditingTextAttributes = false
         textView.isKeyboardSendEnabled = isKeyboardSendEnabled
         textView.onKeyboardSend = onKeyboardSend
         textView.pasteConfiguration = UIPasteConfiguration(
@@ -399,13 +403,16 @@ private struct ComposerTextView: UIViewRepresentable {
         // MARK: - Drops
 
         /// Claims a drop only when the composer can route every item through the
-        /// attachment pipeline, so UIKit never inserts an attachment the draft
-        /// cannot represent. Anything mixed or unrecognised is left to UIKit.
+        /// attachment pipeline, so UIKit never inserts something the draft
+        /// cannot represent. Anything else is left to UIKit, which drops it in
+        /// as plain text.
         func textDroppableView(
             _ textDroppableView: UIView & UITextDroppable,
             proposalForDrop drop: UITextDropRequest
         ) -> UITextDropProposal {
-            guard claimedDrop(in: drop) != nil else { return drop.suggestedProposal }
+            guard ComposerDropRoute(providers: drop.dropSession.items.map(\.itemProvider)) != nil else {
+                return drop.suggestedProposal
+            }
 
             let proposal = UITextDropProposal(operation: .copy)
             proposal.dropAction = .insert
@@ -417,34 +424,16 @@ private struct ComposerTextView: UIViewRepresentable {
             _ textDroppableView: UIView & UITextDroppable,
             willPerformDrop drop: UITextDropRequest
         ) {
-            switch claimedDrop(in: drop) {
-            case let .files(providers):
-                onDropFileProviders(providers)
-            case let .images(providers):
-                onDropImageProviders(providers)
-            case nil:
-                break
+            guard let route = ComposerDropRoute(providers: drop.dropSession.items.map(\.itemProvider)) else {
+                return
             }
-        }
 
-        private enum ClaimedDrop {
-            case files([NSItemProvider])
-            case images([NSItemProvider])
-        }
-
-        /// File URLs win over images, the same order `paste` uses: a dropped
-        /// PNG file is a file the user picked, not a screenshot on the clipboard.
-        private func claimedDrop(in drop: UITextDropRequest) -> ClaimedDrop? {
-            let providers = drop.dropSession.items.map(\.itemProvider)
-            guard !providers.isEmpty else { return nil }
-
-            if providers.allSatisfy({ $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) }) {
-                return .files(providers)
+            if !route.files.isEmpty {
+                onDropFileProviders(route.files)
             }
-            if providers.allSatisfy({ $0.hasItemConformingToTypeIdentifier(UTType.image.identifier) }) {
-                return .images(providers)
+            if !route.images.isEmpty {
+                onDropImageProviders(route.images)
             }
-            return nil
         }
 
         func reportHeight(for textView: UITextView) {
@@ -454,6 +443,40 @@ private struct ComposerTextView: UIViewRepresentable {
             let height = ceil(textView.sizeThatFits(fittingSize).height)
             onHeightChange(min(160, max(22, height)))
         }
+    }
+}
+
+/// How the composer routes a dropped set of items into the attachment pipeline.
+///
+/// All or nothing: an item the pipeline cannot take means UIKit keeps the whole
+/// drop, because a half-handled drop would leave the user with some of what they
+/// dragged and no way to tell which half went missing.
+struct ComposerDropRoute {
+    let files: [NSItemProvider]
+    let images: [NSItemProvider]
+
+    /// `nil` when any provider is neither a file nor an image.
+    ///
+    /// A provider that is both counts as a file, the same order `paste` uses: a
+    /// dropped PNG is a file the user picked, not a screenshot on the clipboard.
+    init?(providers: [NSItemProvider]) {
+        guard !providers.isEmpty else { return nil }
+
+        var files: [NSItemProvider] = []
+        var images: [NSItemProvider] = []
+
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                files.append(provider)
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                images.append(provider)
+            } else {
+                return nil
+            }
+        }
+
+        self.files = files
+        self.images = images
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -9,6 +9,11 @@ struct ComposerTextInputView: View {
     @Binding var inputHeight: CGFloat
     @Binding var measuredHeight: CGFloat
 
+    /// The chips the editor has drawn. The collapsed pill draws this same set
+    /// rather than deriving its own, because a trailing chip whose space was
+    /// deleted stays a chip only in the editor's history.
+    @State private var renderedChips: [ComposerChipToken] = []
+
     let isDisabled: Bool
     /// Pill mode: a single truncated line stands in for the editor and a tap
     /// focuses it. The text view stays in the hierarchy (invisible) so focus and
@@ -38,6 +43,7 @@ struct ComposerTextInputView: View {
                 isDisabled: isDisabled,
                 isKeyboardSendEnabled: isKeyboardSendEnabled,
                 chipSkills: chipSkills,
+                renderedChips: $renderedChips,
                 onKeyboardSend: onKeyboardSend,
                 onHeightChange: updateMeasuredHeight,
                 onPasteFileProviders: onPasteFileProviders,
@@ -57,7 +63,7 @@ struct ComposerTextInputView: View {
             if isCollapsed {
                 ComposerCollapsedDraft(
                     draft: text,
-                    chipSkills: chipSkills,
+                    chips: renderedChips,
                     placeholder: placeholder
                 )
                     .padding(.horizontal, 16)
@@ -100,7 +106,7 @@ struct ComposerTextInputView: View {
 /// it from `body` costs nothing on a re-render.
 private struct ComposerCollapsedDraft: View {
     let draft: String
-    let chipSkills: [SkillSlashSuggestion]
+    let chips: [ComposerChipToken]
     let placeholder: String
 
     @Environment(\.colorScheme) private var colorScheme
@@ -115,11 +121,17 @@ private struct ComposerCollapsedDraft: View {
             .accessibilityLabel(Text(spokenDraft))
     }
 
+    /// The chips still inside this draft. The editor reports them a beat after
+    /// it draws, so a set that no longer fits the text the pill was handed is
+    /// dropped rather than drawn in the wrong place.
     private var tokens: [ComposerChipToken] {
-        // The cheap scan first: most drafts hold no reference at all, and this
-        // way they never pay for building the catalog.
-        guard !draft.isEmpty, ComposerChipTokenizer.mayContainReference(draft) else { return [] }
-        return ComposerChipTokenizer.tokens(in: draft, catalog: ComposerChipCatalog(skills: chipSkills))
+        let text = draft as NSString
+        guard chips.allSatisfy({
+            $0.range.upperBound <= text.length && text.substring(with: $0.range) == $0.source
+        }) else {
+            return []
+        }
+        return chips
     }
 
     private var line: Text {
@@ -127,6 +139,7 @@ private struct ComposerCollapsedDraft: View {
 
         let tokens = tokens
         guard !tokens.isEmpty else { return Text(draft) }
+
 
         let metrics = ComposerChipMetrics(editorFont: editorFont)
         let traits = UITraitCollection { traits in
@@ -183,6 +196,7 @@ private struct ComposerTextView: UIViewRepresentable {
     let isDisabled: Bool
     let isKeyboardSendEnabled: Bool
     let chipSkills: [SkillSlashSuggestion]
+    @Binding var renderedChips: [ComposerChipToken]
     let onKeyboardSend: () -> Void
     let onHeightChange: (CGFloat) -> Void
     let onPasteFileProviders: ([NSItemProvider]) -> Void
@@ -191,7 +205,13 @@ private struct ComposerTextView: UIViewRepresentable {
     let onPasteImages: ([UIImage]) -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, selection: $selection, isFocused: $isFocused, onHeightChange: onHeightChange)
+        Coordinator(
+            text: $text,
+            selection: $selection,
+            isFocused: $isFocused,
+            renderedChips: $renderedChips,
+            onHeightChange: onHeightChange
+        )
     }
 
     func makeUIView(context: Context) -> ComposerChipTextView {
@@ -253,6 +273,7 @@ private struct ComposerTextView: UIViewRepresentable {
         // Chips are redrawn last so they settle around the caret the composer
         // just asked for rather than the one the edit happened to leave behind.
         context.coordinator.applyingBoundValue { textView.refreshChipsIfNeeded() }
+        context.coordinator.publishRenderedChips(of: textView)
         context.coordinator.syncFocus(for: textView, shouldFocus: isFocused, isDisabled: isDisabled)
         context.coordinator.reportHeight(for: textView)
     }
@@ -262,6 +283,7 @@ private struct ComposerTextView: UIViewRepresentable {
         @Binding var text: String
         @Binding var selection: ComposerSelection
         @Binding var isFocused: Bool
+        @Binding var renderedChips: [ComposerChipToken]
         var onHeightChange: (CGFloat) -> Void
         var onDropFileProviders: ([NSItemProvider]) -> Void = { _ in }
         var onDropImageProviders: ([NSItemProvider]) -> Void = { _ in }
@@ -278,12 +300,32 @@ private struct ComposerTextView: UIViewRepresentable {
             text: Binding<String>,
             selection: Binding<ComposerSelection>,
             isFocused: Binding<Bool>,
+            renderedChips: Binding<[ComposerChipToken]>,
             onHeightChange: @escaping (CGFloat) -> Void
         ) {
             _text = text
             _selection = selection
             _isFocused = isFocused
+            _renderedChips = renderedChips
             self.onHeightChange = onHeightChange
+        }
+
+        /// Reports the chips the editor settled on, so the collapsed pill draws
+        /// exactly what the expanded editor drew. Deferred, because a binding
+        /// cannot be written during a view update.
+        func publishRenderedChips(of textView: ComposerChipTextView) {
+            let chips = textView.renderedTokens
+            guard renderedChips != chips else { return }
+
+            DispatchQueue.main.async { [weak self, weak textView] in
+                guard let self, let textView,
+                      textView.renderedTokens == chips,
+                      self.renderedChips != chips
+                else {
+                    return
+                }
+                self.renderedChips = chips
+            }
         }
 
         /// Pushes a parent-side draft change into the editor as an *edit* rather

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -110,6 +110,7 @@ private struct ComposerCollapsedDraft: View {
     let placeholder: String
 
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     @Environment(\.layoutDirection) private var layoutDirection
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -142,8 +143,11 @@ private struct ComposerCollapsedDraft: View {
 
 
         let metrics = ComposerChipMetrics(editorFont: editorFont)
+        // Every trait the chip resolves a colour from, or the pill asks the
+        // cache for a picture drawn for someone else's settings.
         let traits = UITraitCollection { traits in
             traits.userInterfaceStyle = colorScheme == .dark ? .dark : .light
+            traits.accessibilityContrast = colorSchemeContrast == .increased ? .high : .normal
         }
         let isRightToLeft = layoutDirection == .rightToLeft
         let text = draft as NSString

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -55,10 +55,11 @@ struct ComposerTextInputView: View {
             .accessibilityHidden(isCollapsed)
 
             if isCollapsed {
-                Text(text.isEmpty ? placeholder : text)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .foregroundStyle(text.isEmpty ? Color(.placeholderText) : Color(.label))
+                ComposerCollapsedDraft(
+                    draft: text,
+                    chipSkills: chipSkills,
+                    placeholder: placeholder
+                )
                     .padding(.horizontal, 16)
                     .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
                     .contentShape(Rectangle())
@@ -86,6 +87,92 @@ struct ComposerTextInputView: View {
             inputHeight = newHeight
             measuredHeight = newHeight
         }
+    }
+}
+
+/// The draft as the collapsed pill draws it: one truncating line, with the same
+/// chips the editor bakes.
+///
+/// The pill is a stand-in rather than the editor itself — the real text view is
+/// still mounted but at `opacity(0)` — so it has to draw the references a second
+/// time. Both go through `ComposerChipRenderer`, so the collapsed and expanded
+/// composer cannot drift apart, and the renderer caches the picture so drawing
+/// it from `body` costs nothing on a re-render.
+private struct ComposerCollapsedDraft: View {
+    let draft: String
+    let chipSkills: [SkillSlashSuggestion]
+    let placeholder: String
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.layoutDirection) private var layoutDirection
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        line
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .foregroundStyle(draft.isEmpty ? Color(.placeholderText) : Color(.label))
+            .accessibilityLabel(Text(spokenDraft))
+    }
+
+    private var tokens: [ComposerChipToken] {
+        // The cheap scan first: most drafts hold no reference at all, and this
+        // way they never pay for building the catalog.
+        guard !draft.isEmpty, ComposerChipTokenizer.mayContainReference(draft) else { return [] }
+        return ComposerChipTokenizer.tokens(in: draft, catalog: ComposerChipCatalog(skills: chipSkills))
+    }
+
+    private var line: Text {
+        guard !draft.isEmpty else { return Text(placeholder) }
+
+        let tokens = tokens
+        guard !tokens.isEmpty else { return Text(draft) }
+
+        let metrics = ComposerChipMetrics(editorFont: editorFont)
+        let traits = UITraitCollection { traits in
+            traits.userInterfaceStyle = colorScheme == .dark ? .dark : .light
+        }
+        let isRightToLeft = layoutDirection == .rightToLeft
+        let text = draft as NSString
+
+        var line = Text(verbatim: "")
+        var cursor = 0
+
+        for token in tokens where token.range.location >= cursor {
+            if token.range.location > cursor {
+                let plain = text.substring(with: NSRange(location: cursor, length: token.range.location - cursor))
+                line = line + Text(verbatim: plain)
+            }
+
+            let chip = ComposerChipRenderer.image(
+                label: token.label,
+                metrics: metrics,
+                traits: traits,
+                isRightToLeft: isRightToLeft
+            )
+            line = line + Text(Image(uiImage: chip))
+            cursor = token.range.upperBound
+        }
+
+        if cursor < text.length {
+            line = line + Text(verbatim: text.substring(from: cursor))
+        }
+
+        return line
+    }
+
+    /// VoiceOver reads a chip by its label, the way the editor's attachment does,
+    /// rather than announcing an image.
+    private var spokenDraft: String {
+        draft.isEmpty ? placeholder : ComposerChipTokenizer.spokenText(in: draft, tokens: tokens)
+    }
+
+    /// Reading `dynamicTypeSize` is what makes SwiftUI re-evaluate — and so
+    /// re-measure the chips — when the user changes their text size; the size
+    /// itself comes from the same body font the editor uses.
+    private var editorFont: UIFont {
+        _ = dynamicTypeSize
+        return .preferredFont(forTextStyle: .body)
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -350,6 +350,9 @@ struct MessageComposerView: View {
                     }
             }
         )
+        .task(id: draftMayReferenceSkill) {
+            await loadSkillSuggestionsForChipsIfNeeded()
+        }
         .task(id: slashAutocompleteLoadKey) {
             await loadSlashAutocompleteSubArgsIfNeeded()
         }
@@ -577,6 +580,7 @@ struct MessageComposerView: View {
                     isCollapsed: !isExpanded,
                     isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
                     verticalPadding: 12,
+                    chipSkills: skillSuggestions,
                     onKeyboardSend: actionButtonTapped,
                     onPasteFileProviders: onPasteFileProviders,
                     onPasteFileURLs: onPasteFileURLs,
@@ -680,6 +684,20 @@ struct MessageComposerView: View {
             Image(systemName: "arrow.up")
                 .font(.system(size: actionIconSize, weight: .semibold))
         }
+    }
+
+    /// Whether the draft holds anything that could be drawn as a skill chip.
+    private var draftMayReferenceSkill: Bool {
+        ComposerChipTokenizer.mayContainReference(draftMessage)
+    }
+
+    /// A draft restored from the store can already name a skill, and chips are
+    /// only drawn for skills the app has heard of. Fetching the list the moment
+    /// the draft looks like it needs one keeps a reopened chat from showing raw
+    /// `/skill` text, without a skills request on every chat that never uses one.
+    private func loadSkillSuggestionsForChipsIfNeeded() async {
+        guard draftMayReferenceSkill, skillSuggestions.isEmpty else { return }
+        await onLoadSkillSuggestions()
     }
 
     private func loadSlashAutocompleteSubArgsIfNeeded() async {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -457,7 +457,9 @@ final class ChatViewModel {
     private var hasLoadedPersonalitySuggestions = false
     private var isLoadingPersonalitySuggestions = false
     private var hasLoadedSkillSlashSuggestions = false
-    private var isLoadingSkillSlashSuggestions = false
+    /// The in-flight skill list request, shared by every caller of
+    /// `loadSkillSlashSuggestions()` so no view's cancellation can orphan it.
+    private var skillSlashSuggestionsLoad: Task<Void, Never>?
     private var queuedSlashMessages: [QueuedSlashMessage] = []
     private var isDrainingQueuedSlashMessage = false
     private var activeBtwStreamID: String?
@@ -984,20 +986,37 @@ final class ChatViewModel {
         }
     }
 
+    /// Loads the skill list once, sharing a single request between callers.
+    ///
+    /// The composer asks for this from two `.task` modifiers — the chip warm-up
+    /// for a restored draft and the autocomplete panel — and either can be
+    /// cancelled by an unrelated view update. So the request lives on a task
+    /// this view model owns: a cancelled caller cannot take the fetch down with
+    /// it, and a caller arriving mid-flight waits for that same result instead
+    /// of racing past an "already loading" flag and finding an empty list. A
+    /// failed load clears the handle, so the next caller retries.
     func loadSkillSlashSuggestions() async {
         guard !hasLoadedSkillSlashSuggestions else { return }
-        guard !isLoadingSkillSlashSuggestions else { return }
 
-        isLoadingSkillSlashSuggestions = true
-        defer { isLoadingSkillSlashSuggestions = false }
-
-        do {
-            let response = try await client.skills()
-            skillSlashSuggestions = SlashSkillFormatter.suggestions(from: response.skills ?? [])
-            hasLoadedSkillSlashSuggestions = true
-        } catch {
-            lastError = error
+        let load: Task<Void, Never>
+        if let existing = skillSlashSuggestionsLoad {
+            load = existing
+        } else {
+            load = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let response = try await self.client.skills()
+                    self.skillSlashSuggestions = SlashSkillFormatter.suggestions(from: response.skills ?? [])
+                    self.hasLoadedSkillSlashSuggestions = true
+                } catch {
+                    self.lastError = error
+                }
+                self.skillSlashSuggestionsLoad = nil
+            }
+            skillSlashSuggestionsLoad = load
         }
+
+        await load.value
     }
 
     @discardableResult

--- a/HermesMobile/Features/Chat/ComposerChipRendering.swift
+++ b/HermesMobile/Features/Chat/ComposerChipRendering.swift
@@ -1,0 +1,232 @@
+import UIKit
+
+/// The chip a skill reference is drawn as: one attachment glyph that stands for
+/// the whole `source` string.
+///
+/// Everything that leaves the editor - what is sent, copied, cut, or saved as a
+/// draft - reads `source` back out, so the chip never changes the message.
+final class ComposerChipAttachment: NSTextAttachment {
+    let source: String
+
+    init(source: String, label: String, image: UIImage, baselineOffset: CGFloat) {
+        self.source = source
+        super.init(data: nil, ofType: nil)
+        image.accessibilityLabel = label
+        self.image = image
+        accessibilityLabel = label
+        bounds = CGRect(origin: CGPoint(x: 0, y: baselineOffset), size: image.size)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
+/// Chip geometry, derived from the editor's own font so Dynamic Type moves the
+/// chip with the text around it.
+///
+/// t3code draws a 24 pt chip against a 15 pt label; every other measurement is a
+/// fraction of that height, so scaling the height by the label's line height
+/// keeps the proportions at every content size.
+struct ComposerChipMetrics: Equatable {
+    let labelFont: UIFont
+    let height: CGFloat
+    let cornerRadius: CGFloat
+    let iconSize: CGFloat
+    let iconGap: CGFloat
+    let horizontalPadding: CGFloat
+
+    init(editorFont: UIFont) {
+        let labelFont = UIFont.systemFont(ofSize: max(12, editorFont.pointSize - 2), weight: .medium)
+        let height = ceil(labelFont.lineHeight + 6)
+        let scale = height / 24
+
+        self.labelFont = labelFont
+        self.height = height
+        cornerRadius = 7 * scale
+        iconSize = round(14 * scale)
+        iconGap = 5 * scale
+        horizontalPadding = 9 * scale
+    }
+}
+
+/// Draws the chip. The image is baked against a trait collection, so the editor
+/// re-renders it when the appearance or the content size category changes.
+enum ComposerChipRenderer {
+    /// Matches the Skills screen's own glyph so a chip reads as the same thing
+    /// the rest of the app calls a skill.
+    private static let iconName = "hammer"
+
+    static func image(
+        label: String,
+        metrics: ComposerChipMetrics,
+        traits: UITraitCollection,
+        isRightToLeft: Bool
+    ) -> UIImage {
+        let background = UIColor.secondarySystemFill.resolvedColor(with: traits)
+        let border = UIColor.separator.resolvedColor(with: traits)
+        let textColor = UIColor.label.resolvedColor(with: traits)
+        let tint = UIColor.secondaryLabel.resolvedColor(with: traits)
+
+        let icon = UIImage(
+            systemName: iconName,
+            withConfiguration: UIImage.SymbolConfiguration(
+                pointSize: metrics.iconSize - 2,
+                weight: .medium
+            )
+        )?.withTintColor(tint, renderingMode: .alwaysOriginal)
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: metrics.labelFont,
+            .foregroundColor: textColor
+        ]
+        let textSize = (label as NSString).size(withAttributes: attributes)
+        let iconWidth = icon == nil ? 0 : metrics.iconSize + metrics.iconGap
+        let width = ceil(metrics.horizontalPadding * 2 + iconWidth + textSize.width)
+
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(
+            size: CGSize(width: width, height: metrics.height),
+            format: format
+        )
+
+        return renderer.image { _ in
+            let bounds = CGRect(x: 0, y: 0, width: width, height: metrics.height)
+            let path = UIBezierPath(
+                roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
+                cornerRadius: metrics.cornerRadius
+            )
+            background.setFill()
+            path.fill()
+            border.setStroke()
+            path.lineWidth = 1
+            path.stroke()
+
+            // The icon leads in both directions: mirroring it by hand is what
+            // keeps an RTL chip from reading back to front, since the image is
+            // drawn once and reused as a glyph.
+            let iconX = isRightToLeft
+                ? width - metrics.horizontalPadding - metrics.iconSize
+                : metrics.horizontalPadding
+            let textX = isRightToLeft
+                ? metrics.horizontalPadding
+                : metrics.horizontalPadding + iconWidth
+
+            icon?.draw(
+                in: CGRect(
+                    x: iconX,
+                    y: (metrics.height - metrics.iconSize) / 2,
+                    width: metrics.iconSize,
+                    height: metrics.iconSize
+                )
+            )
+
+            (label as NSString).draw(
+                in: CGRect(
+                    x: textX,
+                    y: (metrics.height - textSize.height) / 2,
+                    width: textSize.width + 1,
+                    height: textSize.height
+                ),
+                withAttributes: attributes
+            )
+        }
+    }
+}
+
+/// Crossing between the draft the server sees and the text the editor draws.
+///
+/// A chip is one character on screen and its whole source string in the draft,
+/// so every caret the editor reports and every range the composer asks for has
+/// to be translated. The rendered document is the authority: reading the
+/// mapping off the attachments themselves means a caret can never be computed
+/// from a stale idea of where the chips are.
+extension NSAttributedString {
+    /// The draft text this document stands for.
+    var composerSourceText: String {
+        composerSourceText(in: NSRange(location: 0, length: length))
+    }
+
+    func composerSourceText(in range: NSRange) -> String {
+        guard range.length > 0 else { return "" }
+
+        let display = string as NSString
+        let source = NSMutableString()
+
+        enumerateAttribute(.attachment, in: range) { value, attributeRange, _ in
+            if let chip = value as? ComposerChipAttachment {
+                source.append(chip.source)
+            } else {
+                source.append(display.substring(with: attributeRange))
+            }
+        }
+
+        return source as String
+    }
+
+    /// The draft offset a display offset points at.
+    func composerSourceOffset(forDisplayOffset displayOffset: Int) -> Int {
+        let bounded = max(0, min(length, displayOffset))
+        guard bounded > 0 else { return 0 }
+
+        var source = 0
+        enumerateAttribute(.attachment, in: NSRange(location: 0, length: bounded)) { value, range, _ in
+            if let chip = value as? ComposerChipAttachment {
+                source += (chip.source as NSString).length
+            } else {
+                source += range.length
+            }
+        }
+        return source
+    }
+
+    /// The display offset a draft offset points at. An offset that lands inside
+    /// a chip resolves to just after it, because there is nowhere inside a chip
+    /// for a caret to be.
+    func composerDisplayOffset(forSourceOffset sourceOffset: Int) -> Int {
+        guard sourceOffset > 0 else { return 0 }
+
+        var source = 0
+        var display = 0
+
+        enumerateAttribute(.attachment, in: NSRange(location: 0, length: length)) { value, range, stop in
+            if let chip = value as? ComposerChipAttachment {
+                let chipLength = (chip.source as NSString).length
+                if sourceOffset < source + chipLength {
+                    // The chip's own start still has a caret position; anywhere
+                    // else inside it resolves to just after the chip.
+                    display = sourceOffset <= source ? range.location : NSMaxRange(range)
+                    stop.pointee = true
+                    return
+                }
+                source += chipLength
+            } else {
+                if sourceOffset < source + range.length {
+                    display = range.location + (sourceOffset - source)
+                    stop.pointee = true
+                    return
+                }
+                source += range.length
+            }
+            display = NSMaxRange(range)
+        }
+
+        return display
+    }
+
+    /// The display range a draft range covers.
+    func composerDisplayRange(forSourceRange range: NSRange) -> NSRange {
+        let start = composerDisplayOffset(forSourceOffset: range.location)
+        let end = composerDisplayOffset(forSourceOffset: range.upperBound)
+        return NSRange(location: start, length: max(0, end - start))
+    }
+
+    /// The draft range a display range covers.
+    func composerSourceRange(forDisplayRange range: NSRange) -> NSRange {
+        let start = composerSourceOffset(forDisplayOffset: range.location)
+        let end = composerSourceOffset(forDisplayOffset: range.upperBound)
+        return NSRange(location: start, length: max(0, end - start))
+    }
+}

--- a/HermesMobile/Features/Chat/ComposerChipRendering.swift
+++ b/HermesMobile/Features/Chat/ComposerChipRendering.swift
@@ -58,7 +58,37 @@ enum ComposerChipRenderer {
     /// the rest of the app calls a skill.
     private static let iconName = "hammer"
 
+    /// Baked chips, keyed by everything that changes one. The editor redraws
+    /// only when its chips or its style move, but the collapsed composer draws
+    /// from `body`, which runs again on every parent update — including each
+    /// token of a live stream. Baking there uncached would burn a render pass
+    /// per frame for a picture that never changed.
+    private static let cache = NSCache<NSString, UIImage>()
+
     static func image(
+        label: String,
+        metrics: ComposerChipMetrics,
+        traits: UITraitCollection,
+        isRightToLeft: Bool
+    ) -> UIImage {
+        let key = [
+            label,
+            String(describing: metrics.labelFont.pointSize),
+            String(describing: metrics.height),
+            String(traits.userInterfaceStyle.rawValue),
+            isRightToLeft ? "rtl" : "ltr"
+        ].joined(separator: "|") as NSString
+
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let image = draw(label: label, metrics: metrics, traits: traits, isRightToLeft: isRightToLeft)
+        cache.setObject(image, forKey: key)
+        return image
+    }
+
+    private static func draw(
         label: String,
         metrics: ComposerChipMetrics,
         traits: UITraitCollection,

--- a/HermesMobile/Features/Chat/ComposerChipRendering.swift
+++ b/HermesMobile/Features/Chat/ComposerChipRendering.swift
@@ -76,6 +76,7 @@ enum ComposerChipRenderer {
             String(describing: metrics.labelFont.pointSize),
             String(describing: metrics.height),
             String(traits.userInterfaceStyle.rawValue),
+            String(traits.accessibilityContrast.rawValue),
             isRightToLeft ? "rtl" : "ltr"
         ].joined(separator: "|") as NSString
 

--- a/HermesMobile/Features/Chat/ComposerChipTextView.swift
+++ b/HermesMobile/Features/Chat/ComposerChipTextView.swift
@@ -20,7 +20,11 @@ final class ComposerChipTextView: UITextView {
     }
 
     private var chipCatalog = ComposerChipCatalog.empty
-    private var renderedTokens: [ComposerChipToken] = []
+    /// The chips currently on screen. The collapsed pill reads this rather than
+    /// re-deriving it, because `preservingTrailing` makes the set depend on what
+    /// was drawn before — a trailing chip whose space was deleted stays a chip,
+    /// and nothing but this editor knows that.
+    private(set) var renderedTokens: [ComposerChipToken] = []
     private var renderedStyle: ChipRenderStyle?
 
     /// What the chips were drawn against. A chip is a baked image, so a change
@@ -29,6 +33,7 @@ final class ComposerChipTextView: UITextView {
     private struct ChipRenderStyle: Equatable {
         let fontPointSize: CGFloat
         let userInterfaceStyle: UIUserInterfaceStyle
+        let accessibilityContrast: UIAccessibilityContrast
         let isRightToLeft: Bool
     }
 
@@ -36,7 +41,7 @@ final class ComposerChipTextView: UITextView {
         super.init(frame: frame, textContainer: textContainer)
 
         registerForTraitChanges(
-            [UITraitUserInterfaceStyle.self, UITraitPreferredContentSizeCategory.self]
+            [UITraitUserInterfaceStyle.self, UITraitAccessibilityContrast.self, UITraitPreferredContentSizeCategory.self]
         ) { (view: ComposerChipTextView, _) in
             // Deferred: `adjustsFontForContentSizeCategory` updates `font` from
             // the same trait change, and the chips have to be sized against the
@@ -129,6 +134,7 @@ final class ComposerChipTextView: UITextView {
         ChipRenderStyle(
             fontPointSize: (font ?? .preferredFont(forTextStyle: .body)).pointSize,
             userInterfaceStyle: traitCollection.userInterfaceStyle,
+            accessibilityContrast: traitCollection.accessibilityContrast,
             isRightToLeft: isRightToLeft
         )
     }

--- a/HermesMobile/Features/Chat/ComposerChipTextView.swift
+++ b/HermesMobile/Features/Chat/ComposerChipTextView.swift
@@ -1,0 +1,370 @@
+import UIKit
+import UniformTypeIdentifiers
+
+/// The composer's editor: a text view that draws known skill references as
+/// atomic chips while every value that leaves it stays the draft's own text.
+final class ComposerChipTextView: UITextView {
+    var isKeyboardSendEnabled = false
+    var onKeyboardSend: () -> Void = {}
+    var onPasteFileProviders: ([NSItemProvider]) -> Void = { _ in }
+    var onPasteFileURLs: ([URL]) -> Void = { _ in }
+    var onPasteImageProviders: ([NSItemProvider]) -> Void = { _ in }
+    var onPasteImages: ([UIImage]) -> Void = { _ in }
+
+    /// The skills whose references are drawn as chips.
+    var chipSkills: [SkillSlashSuggestion] = [] {
+        didSet {
+            guard chipSkills != oldValue else { return }
+            chipCatalog = ComposerChipCatalog(skills: chipSkills)
+        }
+    }
+
+    private var chipCatalog = ComposerChipCatalog.empty
+    private var renderedTokens: [ComposerChipToken] = []
+    private var renderedStyle: ChipRenderStyle?
+
+    /// What the chips were drawn against. A chip is a baked image, so a change
+    /// of appearance or text size has to redraw it even when the draft has not
+    /// moved at all.
+    private struct ChipRenderStyle: Equatable {
+        let fontPointSize: CGFloat
+        let userInterfaceStyle: UIUserInterfaceStyle
+        let isRightToLeft: Bool
+    }
+
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+
+        registerForTraitChanges(
+            [UITraitUserInterfaceStyle.self, UITraitPreferredContentSizeCategory.self]
+        ) { (view: ComposerChipTextView, _) in
+            // Deferred: `adjustsFontForContentSizeCategory` updates `font` from
+            // the same trait change, and the chips have to be sized against the
+            // font that wins.
+            DispatchQueue.main.async { view.refreshChipsIfNeeded() }
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    // MARK: - Draft text
+
+    /// The draft this editor stands for: every chip contributes the reference it
+    /// was made from. This, never the on-screen text, is what is sent, saved,
+    /// copied, and matched against a slash trigger.
+    var sourceText: String {
+        attributedText.composerSourceText
+    }
+
+    /// The caret or selection in draft coordinates.
+    var sourceSelection: NSRange {
+        get { attributedText.composerSourceRange(forDisplayRange: selectedRange) }
+        set {
+            let displayRange = attributedText.composerDisplayRange(forSourceRange: newValue)
+            guard selectedRange != displayRange else { return }
+            selectedRange = displayRange
+        }
+    }
+
+    /// The on-screen range a draft range covers, or `nil` when it does not land
+    /// on positions this editor recognises.
+    func displayTextRange(forSourceRange range: NSRange) -> UITextRange? {
+        textRange(from: attributedText.composerDisplayRange(forSourceRange: range))
+    }
+
+    // MARK: - Chips
+
+    /// Redraws the document when the chips the draft calls for, or the way they
+    /// have to be drawn, no longer match what is on screen. Ordinary typing
+    /// changes neither, so it never rebuilds — which is what keeps predictive
+    /// text and the undo stack alive.
+    func refreshChipsIfNeeded() {
+        guard markedTextRange == nil else { return }
+
+        let source = sourceText
+        let tokens = ComposerChipTokenizer.tokens(
+            in: source,
+            catalog: chipCatalog,
+            preservingTrailing: renderedTokens
+        )
+        guard tokens != renderedTokens || currentStyle != renderedStyle else { return }
+
+        render(source: source, tokens: tokens, sourceSelection: sourceSelection)
+    }
+
+    /// Replaces the whole draft, chips and all. The fallback for an edit the
+    /// input system could not apply in place, and for a deliberate clear.
+    func replaceDocument(with source: String) {
+        let tokens = ComposerChipTokenizer.tokens(
+            in: source,
+            catalog: chipCatalog,
+            preservingTrailing: renderedTokens
+        )
+        render(
+            source: source,
+            tokens: tokens,
+            sourceSelection: NSRange(location: (source as NSString).length, length: 0)
+        )
+    }
+
+    /// Restores the plain typing attributes a chip attachment would otherwise
+    /// leave behind. Never while an IME composition is marked: touching typing
+    /// attributes mid-composition breaks it.
+    func restoreTypingAttributes() {
+        guard markedTextRange == nil else { return }
+
+        let attributes = baseAttributes
+        guard (typingAttributes[.attachment] != nil)
+            || (typingAttributes[.font] as? UIFont) != (attributes[.font] as? UIFont)
+        else {
+            return
+        }
+        typingAttributes = attributes
+    }
+
+    private var currentStyle: ChipRenderStyle {
+        ChipRenderStyle(
+            fontPointSize: (font ?? .preferredFont(forTextStyle: .body)).pointSize,
+            userInterfaceStyle: traitCollection.userInterfaceStyle,
+            isRightToLeft: isRightToLeft
+        )
+    }
+
+    private var isRightToLeft: Bool {
+        UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+    }
+
+    private var baseAttributes: [NSAttributedString.Key: Any] {
+        [
+            .font: font ?? .preferredFont(forTextStyle: .body),
+            .foregroundColor: textColor ?? .label
+        ]
+    }
+
+    private func render(source: String, tokens: [ComposerChipToken], sourceSelection: NSRange) {
+        let font = self.font ?? .preferredFont(forTextStyle: .body)
+        let textColor = self.textColor ?? .label
+        let attributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: textColor]
+        let metrics = ComposerChipMetrics(editorFont: font)
+        let text = source as NSString
+
+        let document = NSMutableAttributedString()
+        var cursor = 0
+        for token in tokens {
+            if token.range.location > cursor {
+                document.append(
+                    NSAttributedString(
+                        string: text.substring(with: NSRange(location: cursor, length: token.range.location - cursor)),
+                        attributes: attributes
+                    )
+                )
+            }
+            document.append(chipString(for: token, metrics: metrics, attributes: attributes))
+            cursor = token.range.upperBound
+        }
+        if cursor < text.length {
+            document.append(
+                NSAttributedString(
+                    string: text.substring(from: cursor),
+                    attributes: attributes
+                )
+            )
+        }
+
+        attributedText = document
+        // Assigning a non-uniform document clears these, and every later render
+        // reads them back for its base attributes.
+        self.font = font
+        self.textColor = textColor
+        renderedTokens = tokens
+        renderedStyle = currentStyle
+        self.sourceSelection = Self.clamp(sourceSelection, toLengthOf: source)
+        restoreTypingAttributes()
+        // The document was replaced wholesale, so an undo recorded against the
+        // old one would put back text the chips no longer describe.
+        undoManager?.removeAllActions()
+    }
+
+    private func chipString(
+        for token: ComposerChipToken,
+        metrics: ComposerChipMetrics,
+        attributes: [NSAttributedString.Key: Any]
+    ) -> NSAttributedString {
+        let image = ComposerChipRenderer.image(
+            label: token.label,
+            metrics: metrics,
+            traits: traitCollection,
+            isRightToLeft: isRightToLeft
+        )
+        let font = (attributes[.font] as? UIFont) ?? .preferredFont(forTextStyle: .body)
+        let attachment = ComposerChipAttachment(
+            source: token.source,
+            label: token.label,
+            image: image,
+            baselineOffset: floor((font.capHeight - image.size.height) / 2)
+        )
+
+        let chip = NSMutableAttributedString(attachment: attachment)
+        chip.addAttributes(attributes, range: NSRange(location: 0, length: chip.length))
+        return chip
+    }
+
+    private static func clamp(_ range: NSRange, toLengthOf text: String) -> NSRange {
+        let length = (text as NSString).length
+        let location = min(max(0, range.location), length)
+        return NSRange(location: location, length: min(max(0, range.length), length - location))
+    }
+
+    // MARK: - Editing
+
+    /// A chip deletes as one thing: backspacing next to it removes the whole
+    /// reference rather than the last character of a name the user cannot see.
+    override func deleteBackward() {
+        guard selectedRange.length == 0, selectedRange.location > 0 else {
+            super.deleteBackward()
+            return
+        }
+
+        let previous = selectedRange.location - 1
+        guard textStorage.attribute(.attachment, at: previous, effectiveRange: nil) is ComposerChipAttachment,
+              let range = textRange(from: NSRange(location: previous, length: 1))
+        else {
+            super.deleteBackward()
+            return
+        }
+
+        replace(range, withText: "")
+    }
+
+    /// Copy and cut hand over the draft text, so a chip pasted anywhere - back
+    /// into this composer, or into any other app - is the reference itself.
+    override func copy(_ sender: Any?) {
+        guard selectedRange.length > 0 else {
+            super.copy(sender)
+            return
+        }
+        UIPasteboard.general.string = attributedText.composerSourceText(in: selectedRange)
+    }
+
+    override func cut(_ sender: Any?) {
+        guard isEditable, selectedRange.length > 0, let range = textRange(from: selectedRange) else {
+            super.cut(sender)
+            return
+        }
+        UIPasteboard.general.string = attributedText.composerSourceText(in: selectedRange)
+        replace(range, withText: "")
+    }
+
+    func canPasteItemProviders(_ itemProviders: [NSItemProvider]) -> Bool {
+        itemProviders.contains {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+                || $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+                || $0.hasItemConformingToTypeIdentifier(UTType.text.identifier)
+        }
+    }
+
+    func pasteItemProviders(_ itemProviders: [NSItemProvider]) {
+        let fileProviders = itemProviders.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        }
+
+        if fileProviders.isEmpty {
+            let imageProviders = itemProviders.filter {
+                $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+            }
+
+            if imageProviders.isEmpty {
+                paste(nil)
+            } else {
+                onPasteImageProviders(imageProviders)
+            }
+            return
+        }
+
+        onPasteFileProviders(fileProviders)
+    }
+
+    override var keyCommands: [UIKeyCommand]? {
+        let sendCommand = UIKeyCommand(
+            title: ComposerKeyboardCommand.title,
+            action: #selector(sendMessageFromKeyboard),
+            input: ComposerKeyboardCommand.input,
+            modifierFlags: ComposerKeyboardCommand.modifierFlags
+        )
+        return (super.keyCommands ?? []) + [sendCommand]
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(sendMessageFromKeyboard) {
+            return isKeyboardSendEnabled
+        }
+
+        if action == #selector(paste(_:)), hasPasteboardContent {
+            return true
+        }
+
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    @objc private func sendMessageFromKeyboard() {
+        guard isKeyboardSendEnabled else { return }
+        onKeyboardSend()
+    }
+
+    override func paste(_ sender: Any?) {
+        let fileProviders = pasteboardFileProviders
+
+        if !fileProviders.isEmpty {
+            onPasteFileProviders(fileProviders)
+            return
+        }
+
+        let fileURLs = pasteboardFileURLs
+        if !fileURLs.isEmpty {
+            onPasteFileURLs(fileURLs)
+            return
+        }
+
+        let imageProviders = pasteboardImageProviders
+        if !imageProviders.isEmpty {
+            onPasteImageProviders(imageProviders)
+            return
+        }
+
+        let images = UIPasteboard.general.images ?? []
+        if !images.isEmpty {
+            onPasteImages(images)
+            return
+        }
+
+        super.paste(sender)
+    }
+
+    private var hasPasteboardContent: Bool {
+        let pasteboard = UIPasteboard.general
+        return pasteboard.hasStrings
+            || !pasteboardFileProviders.isEmpty
+            || !pasteboardFileURLs.isEmpty
+            || !pasteboardImageProviders.isEmpty
+            || !(pasteboard.images?.isEmpty ?? true)
+    }
+
+    private var pasteboardFileProviders: [NSItemProvider] {
+        UIPasteboard.general.itemProviders.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        }
+    }
+
+    private var pasteboardFileURLs: [URL] {
+        UIPasteboard.general.urls?.filter(\.isFileURL) ?? []
+    }
+
+    private var pasteboardImageProviders: [NSItemProvider] {
+        UIPasteboard.general.itemProviders.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/ComposerChipToken.swift
+++ b/HermesMobile/Features/Chat/ComposerChipToken.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// A skill reference in the draft that the composer draws as one atomic chip.
+///
+/// `range` and `source` are always in draft coordinates. The chip is a picture
+/// of `source`, never a replacement for it, so what the server receives and what
+/// the draft store keeps is exactly the text the user would have typed.
+struct ComposerChipToken: Equatable {
+    /// UTF-16 range of the reference inside the draft.
+    let range: NSRange
+    /// The exact draft substring the chip stands for, `/` included.
+    let source: String
+    /// What the chip reads on screen.
+    let label: String
+}
+
+/// The skills a draft can reference, in the shape the tokenizer needs.
+///
+/// Built from the composer's skill suggestions once and compared by value, so
+/// the editor only redraws when the server's skill list has actually changed.
+struct ComposerChipCatalog: Equatable {
+    /// Lowercased slug to chip label.
+    private let labelsBySlug: [String: String]
+
+    static let empty = ComposerChipCatalog(labelsBySlug: [:])
+
+    private init(labelsBySlug: [String: String]) {
+        self.labelsBySlug = labelsBySlug
+    }
+
+    /// A slug that is also a built-in command is left out: `/model` is the
+    /// command, whatever a server happens to call its skills.
+    init(skills: [SkillSlashSuggestion]) {
+        var labels: [String: String] = [:]
+        for skill in skills {
+            let slug = skill.slashName.lowercased()
+            guard !slug.isEmpty, !SlashCommandCatalog.builtinNames.contains(slug) else { continue }
+            labels[slug] = skill.name
+        }
+        labelsBySlug = labels
+    }
+
+    var isEmpty: Bool { labelsBySlug.isEmpty }
+
+    func label(forSlug slug: String) -> String? {
+        labelsBySlug[slug.lowercased()]
+    }
+}
+
+/// Finds the skill references in a draft. Pure: the same draft and catalog
+/// always produce the same chips, which is what lets a pasted or restored draft
+/// come back with its chips intact without storing anything beside the text.
+enum ComposerChipTokenizer {
+    private static let slash: UInt16 = 0x2F
+
+    /// Every skill reference in `draft` worth drawing as a chip.
+    ///
+    /// A reference is a `/` that starts the draft or follows whitespace, a slug
+    /// the server knows, and whitespace after it. The trailing whitespace is
+    /// what says the user is done typing the name, so a half-typed `/ask-ma`
+    /// stays ordinary editable text. `previous` keeps a chip at the very end of
+    /// the draft drawn after its trailing space is deleted, so backspacing the
+    /// space a completion added does not flicker the chip back into text.
+    static func tokens(
+        in draft: String,
+        catalog: ComposerChipCatalog,
+        preservingTrailing previous: [ComposerChipToken] = []
+    ) -> [ComposerChipToken] {
+        guard !catalog.isEmpty else { return [] }
+
+        let text = draft as NSString
+        var tokens: [ComposerChipToken] = []
+        var index = 0
+
+        while index < text.length {
+            guard text.character(at: index) == slash,
+                  index == 0 || isWhitespaceOrNewline(text.character(at: index - 1))
+            else {
+                index += 1
+                continue
+            }
+
+            var end = index + 1
+            while end < text.length, isSlugUnit(text.character(at: end)) {
+                end += 1
+            }
+
+            guard end > index + 1 else {
+                index += 1
+                continue
+            }
+
+            let range = NSRange(location: index, length: end - index)
+            let source = text.substring(with: range)
+            index = end
+
+            guard let label = catalog.label(forSlug: String(source.dropFirst())) else { continue }
+
+            let isClosed = end < text.length && isWhitespaceOrNewline(text.character(at: end))
+            let isPreservedTail = end == text.length
+                && previous.contains { $0.range == range && $0.source == source }
+            guard isClosed || isPreservedTail else { continue }
+
+            tokens.append(ComposerChipToken(range: range, source: source, label: label))
+        }
+
+        return tokens
+    }
+
+    /// Whether `draft` holds anything that could become a chip once the skill
+    /// list arrives. The composer uses it to warm that list for a restored
+    /// draft instead of fetching skills every time a chat opens.
+    static func mayContainReference(_ draft: String) -> Bool {
+        let text = draft as NSString
+        var index = 0
+
+        while index < text.length - 1 {
+            if text.character(at: index) == slash,
+               index == 0 || isWhitespaceOrNewline(text.character(at: index - 1)),
+               isSlugUnit(text.character(at: index + 1)) {
+                return true
+            }
+            index += 1
+        }
+
+        return false
+    }
+
+    /// The characters a skill slug is made of. `SlashSkillFormatter.slug`
+    /// only ever emits lowercase letters, digits, and hyphens; the rest are
+    /// accepted so a hand-typed `/Ask_Matt` is scanned as one word and rejected
+    /// by the catalog rather than cut in half.
+    private static func isSlugUnit(_ unit: UInt16) -> Bool {
+        guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        return CharacterSet.alphanumerics.contains(scalar)
+            || scalar == "-"
+            || scalar == "_"
+    }
+
+    private static func isWhitespaceOrNewline(_ unit: UInt16) -> Bool {
+        guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+}

--- a/HermesMobile/Features/Chat/ComposerChipToken.swift
+++ b/HermesMobile/Features/Chat/ComposerChipToken.swift
@@ -107,6 +107,33 @@ enum ComposerChipTokenizer {
         return tokens
     }
 
+    /// `draft` with every chip reference replaced by the chip's label, which is
+    /// what VoiceOver should read: the editor's attachments carry the same
+    /// label, so both composer states are heard the same way.
+    static func spokenText(in draft: String, tokens: [ComposerChipToken]) -> String {
+        guard !tokens.isEmpty else { return draft }
+
+        let text = draft as NSString
+        let spoken = NSMutableString()
+        var cursor = 0
+
+        for token in tokens where token.range.location >= cursor {
+            if token.range.location > cursor {
+                spoken.append(
+                    text.substring(with: NSRange(location: cursor, length: token.range.location - cursor))
+                )
+            }
+            spoken.append(token.label)
+            cursor = token.range.upperBound
+        }
+
+        if cursor < text.length {
+            spoken.append(text.substring(from: cursor))
+        }
+
+        return spoken as String
+    }
+
     /// Whether `draft` holds anything that could become a chip once the skill
     /// list arrives. The composer uses it to warm that list for a restored
     /// draft instead of fetching skills every time a chat opens.

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8547,6 +8547,51 @@ final class ChatViewModelSendTests: XCTestCase {
 
     /// A `503 {"error": ...}` for `/api/tts` — the canonical "server TTS refused,
     /// use the on-device fallback" stimulus for Listen tests (#15).
+    // MARK: - Skill slash suggestions
+
+    /// The composer asks for the skill list from `.task` modifiers that SwiftUI
+    /// cancels on an unrelated view update — the chip warm-up for a restored
+    /// draft is keyed on the draft itself, so hydrating one cancels it. The
+    /// request used to run inside the caller, so that cancellation threw it away
+    /// and left a draft's `/skill` references drawn as plain text.
+    @MainActor
+    func testCancellingACallerDoesNotAbortTheSkillLoad() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/skills")
+            return apiTestJSONResponse(#"{"skills": [{"name": "handoff"}]}"#, for: request)
+        }
+
+        let caller = Task { await viewModel.loadSkillSlashSuggestions() }
+        caller.cancel()
+        await caller.value
+
+        XCTAssertEqual(viewModel.skillSlashSuggestions.map(\.slashName), ["handoff"])
+    }
+
+    /// A load that fails leaves nothing behind, so the next caller retries
+    /// rather than being told the list is already loaded.
+    @MainActor
+    func testAFailedSkillLoadIsRetriedByTheNextCaller() async throws {
+        var attempts = 0
+        let viewModel = try makeViewModel { request in
+            attempts += 1
+            guard attempts > 1 else {
+                return (
+                    HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!,
+                    Data()
+                )
+            }
+            return apiTestJSONResponse(#"{"skills": [{"name": "handoff"}]}"#, for: request)
+        }
+
+        await viewModel.loadSkillSlashSuggestions()
+        XCTAssertTrue(viewModel.skillSlashSuggestions.isEmpty)
+
+        await viewModel.loadSkillSlashSuggestions()
+        XCTAssertEqual(viewModel.skillSlashSuggestions.map(\.slashName), ["handoff"])
+        XCTAssertEqual(attempts, 2)
+    }
+
     private static func ttsUnavailableResponse(for request: URLRequest) -> (HTTPURLResponse, Data) {
         let response = HTTPURLResponse(
             url: request.url!,

--- a/HermesMobileTests/ComposerChipTests.swift
+++ b/HermesMobileTests/ComposerChipTests.swift
@@ -169,3 +169,38 @@ final class ComposerChipDocumentTests: XCTestCase {
         XCTAssertEqual(document.composerDisplayOffset(forSourceOffset: 99), 9)
     }
 }
+
+final class ComposerDropRouteTests: XCTestCase {
+    func testRoutesAMixOfFilesAndImages() throws {
+        let route = try XCTUnwrap(
+            ComposerDropRoute(providers: [fileProvider(), imageProvider(), fileProvider()])
+        )
+
+        XCTAssertEqual(route.files.count, 2)
+        XCTAssertEqual(route.images.count, 1)
+    }
+
+    func testRoutesAnImageOnlyDrop() throws {
+        let route = try XCTUnwrap(ComposerDropRoute(providers: [imageProvider()]))
+
+        XCTAssertTrue(route.files.isEmpty)
+        XCTAssertEqual(route.images.count, 1)
+    }
+
+    func testLeavesADropWithAnythingUnroutableToUIKit() {
+        XCTAssertNil(ComposerDropRoute(providers: [imageProvider(), NSItemProvider(object: "hello" as NSString)]))
+        XCTAssertNil(ComposerDropRoute(providers: []))
+    }
+
+    private func imageProvider() -> NSItemProvider {
+        NSItemProvider(object: UIImage(systemName: "star") ?? UIImage())
+    }
+
+    private func fileProvider() -> NSItemProvider {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).txt")
+        FileManager.default.createFile(atPath: url.path, contents: Data("hi".utf8))
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return NSItemProvider(contentsOf: url) ?? NSItemProvider()
+    }
+}

--- a/HermesMobileTests/ComposerChipTests.swift
+++ b/HermesMobileTests/ComposerChipTests.swift
@@ -1,0 +1,171 @@
+import UIKit
+import XCTest
+
+@testable import HermesMobile
+
+final class ComposerChipTokenizerTests: XCTestCase {
+    private let catalog = ComposerChipCatalog(skills: [
+        SkillSlashSuggestion(name: "ask-matt", category: nil, description: nil),
+        SkillSlashSuggestion(name: "babysit-pr", category: nil, description: nil)
+    ])
+
+    func testReferenceFollowedByASpaceBecomesAChip() {
+        let tokens = ComposerChipTokenizer.tokens(in: "/ask-matt what now", catalog: catalog)
+
+        XCTAssertEqual(tokens.count, 1)
+        XCTAssertEqual(tokens.first?.range, NSRange(location: 0, length: 9))
+        XCTAssertEqual(tokens.first?.source, "/ask-matt")
+        XCTAssertEqual(tokens.first?.label, "ask-matt")
+    }
+
+    func testHalfTypedReferenceStaysPlainText() {
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "/ask-ma", catalog: catalog).isEmpty)
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "/ask-matt", catalog: catalog).isEmpty)
+    }
+
+    func testUnknownSlugStaysPlainText() {
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "/unknown-skill hello", catalog: catalog).isEmpty)
+    }
+
+    func testBuiltInCommandIsNeverAChip() {
+        let catalog = ComposerChipCatalog(skills: [
+            SkillSlashSuggestion(name: "model", category: nil, description: nil)
+        ])
+
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "/model gpt-5 ", catalog: catalog).isEmpty)
+    }
+
+    func testReferenceGluedToPrecedingTextIsNotAChip() {
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "docs/ask-matt now", catalog: catalog).isEmpty)
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "~/proj/ask-matt now", catalog: catalog).isEmpty)
+    }
+
+    func testFindsEveryReferenceInTheDraft() {
+        let tokens = ComposerChipTokenizer.tokens(
+            in: "run /ask-matt then /babysit-pr please",
+            catalog: catalog
+        )
+
+        XCTAssertEqual(tokens.map(\.source), ["/ask-matt", "/babysit-pr"])
+        XCTAssertEqual(tokens.first?.range, NSRange(location: 4, length: 9))
+        XCTAssertEqual(tokens.last?.range, NSRange(location: 19, length: 11))
+    }
+
+    func testNewlineClosesAReference() {
+        let tokens = ComposerChipTokenizer.tokens(in: "/ask-matt\nwhat now", catalog: catalog)
+
+        XCTAssertEqual(tokens.map(\.source), ["/ask-matt"])
+    }
+
+    func testTrailingChipSurvivesDeletingTheSpaceAfterIt() {
+        let confirmed = ComposerChipTokenizer.tokens(in: "/ask-matt ", catalog: catalog)
+        XCTAssertEqual(confirmed.map(\.source), ["/ask-matt"])
+
+        let afterBackspace = ComposerChipTokenizer.tokens(
+            in: "/ask-matt",
+            catalog: catalog,
+            preservingTrailing: confirmed
+        )
+        XCTAssertEqual(afterBackspace.map(\.source), ["/ask-matt"])
+    }
+
+    func testPreservationOnlyAppliesToTheEndOfTheDraft() {
+        let confirmed = [
+            ComposerChipToken(
+                range: NSRange(location: 0, length: 9),
+                source: "/ask-matt",
+                label: "ask-matt"
+            )
+        ]
+
+        let tokens = ComposerChipTokenizer.tokens(
+            in: "/ask-mattress",
+            catalog: catalog,
+            preservingTrailing: confirmed
+        )
+        XCTAssertTrue(tokens.isEmpty)
+    }
+
+    func testAnEmptyCatalogDrawsNothing() {
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "/ask-matt hi", catalog: .empty).isEmpty)
+    }
+
+    func testMayContainReferenceSpotsACandidateWithoutTheCatalog() {
+        XCTAssertTrue(ComposerChipTokenizer.mayContainReference("/ask-matt hello"))
+        XCTAssertTrue(ComposerChipTokenizer.mayContainReference("please run /x"))
+        XCTAssertFalse(ComposerChipTokenizer.mayContainReference("no references here"))
+        XCTAssertFalse(ComposerChipTokenizer.mayContainReference("docs/ask-matt"))
+        XCTAssertFalse(ComposerChipTokenizer.mayContainReference(""))
+    }
+}
+
+final class ComposerChipDocumentTests: XCTestCase {
+    /// `run [/ask-matt] now`: 4 characters, one chip, 4 characters.
+    private func document() -> NSAttributedString {
+        let result = NSMutableAttributedString(string: "run ")
+        result.append(
+            NSAttributedString(
+                attachment: ComposerChipAttachment(
+                    source: "/ask-matt",
+                    label: "ask-matt",
+                    image: UIImage(),
+                    baselineOffset: 0
+                )
+            )
+        )
+        result.append(NSAttributedString(string: " now"))
+        return result
+    }
+
+    func testSerializesChipsBackToTheirSource() {
+        XCTAssertEqual(document().composerSourceText, "run /ask-matt now")
+    }
+
+    func testSerializesOnlyTheSelectedRange() {
+        // The chip plus the space after it.
+        XCTAssertEqual(
+            document().composerSourceText(in: NSRange(location: 4, length: 2)),
+            "/ask-matt "
+        )
+        XCTAssertEqual(document().composerSourceText(in: NSRange(location: 0, length: 0)), "")
+    }
+
+    func testMapsDisplayOffsetsOntoTheDraft() {
+        let document = document()
+
+        XCTAssertEqual(document.composerSourceOffset(forDisplayOffset: 0), 0)
+        XCTAssertEqual(document.composerSourceOffset(forDisplayOffset: 4), 4)
+        // Just after the chip.
+        XCTAssertEqual(document.composerSourceOffset(forDisplayOffset: 5), 13)
+        XCTAssertEqual(document.composerSourceOffset(forDisplayOffset: 9), 17)
+    }
+
+    func testMapsDraftOffsetsOntoTheDisplay() {
+        let document = document()
+
+        XCTAssertEqual(document.composerDisplayOffset(forSourceOffset: 0), 0)
+        XCTAssertEqual(document.composerDisplayOffset(forSourceOffset: 4), 4)
+        XCTAssertEqual(document.composerDisplayOffset(forSourceOffset: 13), 5)
+        XCTAssertEqual(document.composerDisplayOffset(forSourceOffset: 17), 9)
+    }
+
+    func testAnOffsetInsideAChipResolvesToJustAfterIt() {
+        XCTAssertEqual(document().composerDisplayOffset(forSourceOffset: 8), 5)
+    }
+
+    func testRangesRoundTripThroughBothCoordinateSpaces() {
+        let document = document()
+        let source = NSRange(location: 4, length: 10)
+
+        let display = document.composerDisplayRange(forSourceRange: source)
+        XCTAssertEqual(display, NSRange(location: 4, length: 2))
+        XCTAssertEqual(document.composerSourceRange(forDisplayRange: display), source)
+    }
+
+    func testAnOffsetPastTheEndClampsToTheEnd() {
+        let document = document()
+
+        XCTAssertEqual(document.composerSourceOffset(forDisplayOffset: 99), 17)
+        XCTAssertEqual(document.composerDisplayOffset(forSourceOffset: 99), 9)
+    }
+}

--- a/HermesMobileTests/ComposerChipTests.swift
+++ b/HermesMobileTests/ComposerChipTests.swift
@@ -99,6 +99,36 @@ final class ComposerChipTokenizerTests: XCTestCase {
     }
 }
 
+extension ComposerChipTokenizerTests {
+    // MARK: - Spoken form (the collapsed composer's VoiceOver label)
+
+    func testSpokenTextReadsChipsByTheirLabel() {
+        let draft = "Hello /ask-matt test"
+        let tokens = ComposerChipTokenizer.tokens(in: draft, catalog: catalog)
+
+        XCTAssertEqual(tokens.count, 1)
+        XCTAssertEqual(ComposerChipTokenizer.spokenText(in: draft, tokens: tokens), "Hello ask-matt test")
+    }
+
+    func testSpokenTextLeavesADraftWithoutChipsAlone() {
+        XCTAssertEqual(
+            ComposerChipTokenizer.spokenText(in: "check the /tmp folder", tokens: []),
+            "check the /tmp folder"
+        )
+    }
+
+    func testSpokenTextKeepsTextOnBothSidesOfEveryChip() {
+        let draft = "/ask-matt then /babysit-pr now"
+        let tokens = ComposerChipTokenizer.tokens(in: draft, catalog: catalog)
+
+        XCTAssertEqual(tokens.count, 2)
+        XCTAssertEqual(
+            ComposerChipTokenizer.spokenText(in: draft, tokens: tokens),
+            "ask-matt then babysit-pr now"
+        )
+    }
+}
+
 final class ComposerChipDocumentTests: XCTestCase {
     /// `run [/ask-matt] now`: 4 characters, one chip, 4 characters.
     private func document() -> NSAttributedString {


### PR DESCRIPTION
Replaces #385, which GitHub permanently sealed: its base branch was #384's, so merging #384 with `--delete-branch` auto-closed it, and it could not be reopened once its head branch had been force-pushed. Same work, rebased onto `master`, plus two fixes found in owner testing.

## What changed

Picking a skill out of the slash panel used to leave raw `/ask-matt ` sitting in the draft. Mid-sentence it read like typing noise, and backspacing through it chewed the name one letter at a time.

The composer now draws a skill reference as a single chip. Everything that leaves the editor — what is sent, copied, cut, and saved as a draft — is still the exact text you would have typed, so nothing about the message changes. Backspace next to a chip removes the whole reference. Copy and cut put the reference on the pasteboard, and pasting it back brings the chip with it, because chips are read out of the draft rather than stored beside it. Dropping images or files onto the editor on iPad now goes through the same attachment validation and upload as paste.

**How it works.** A chip is a picture of a substring, never a replacement for it. `ComposerChipTokenizer` finds the `/skill` references in the draft — a `/` at a word boundary, a slug the server knows, whitespace after it — and the editor swaps each one for an image attachment that remembers its source string. Every caret the editor reports and every range the composer asks for crosses a small mapping layer that reads the chips back out of the rendered document, so the slash trigger from #384 and the draft store both keep working in plain draft coordinates.

## Fixes since #385

**A restored draft came back as plain text.** The composer asks for the skill list from two `.task` modifiers — the chip warm-up and the autocomplete panel — and the warm-up is keyed on the draft, so hydrating the restored draft cancelled it. The request ran *inside* that caller, so it died with it: `CancellationError` went into `lastError`, `hasLoaded` stayed false, and the other caller had already returned on an "already loading" flag without awaiting a result. Nothing retried, so the chip only appeared once an unrelated interaction happened to load skills. The request now lives on a task the view model owns: a cancelled caller cannot take it down, a caller arriving mid-flight awaits that same result, and a failed load clears the handle so the next caller retries.

**The chip vanished when the composer collapsed.** The pill that stands in for the editor drew the draft as plain text. It now lays the same baked chip image inline, so the two composer states cannot drift apart. The renderer memoizes each picture, because the pill draws from `body` and would otherwise re-bake a chip on every parent update during a stream. VoiceOver reads a chip by its label rather than announcing an image.

## Rebase note

#384 was squash-merged while this branch was stacked on it, so this is `git rebase --onto master`. One conflict, in `ChatComposerTextInputView.swift`: this branch renames `text`/`selectedRange` to `sourceText`/`sourceSelection` for chip coordinates, while #384 gained a `generation` parameter for its IME fix. Resolved take-both — `applyBoundText` reads source text *and* carries the generation, and `textViewDidChange` publishes draft coordinates while bumping `publishGeneration`.

## Server contract

Verified against a live server rather than guessed: `GET /api/skills` returns names that are already slugs (`ask-matt`, `babysit-pr`), and upstream's own web UI inserts `/<slug>` for a skill row. There is no `$skill` syntax. Hermex already sends `/<slug> <message>`, so this PR changes only how that string is drawn. No endpoint, model, or request shape changed.

## Notes and trade-offs

- **A reference becomes a chip once it is closed by whitespace.** A half-typed `/ask-ma` stays ordinary editable text, which is what keeps the autocomplete panel usable. A chip at the very end of the draft survives deleting the space after it.
- **Chips only appear for skills the app has heard of.** The list is fetched lazily and warmed when a restored draft names a skill.
- **Rebuilding the document clears the editor's undo stack.** Only when the set of chips actually changes — never on ordinary typing. So `⌘Z` after accepting a *skill* row does nothing, while `⌘Z` after accepting a command row still restores what you typed.
- A slug that collides with a built-in command is never chipped: `/model` is the command, whatever a server calls its skills.

## How it was tested

Full XCTest suite on the iPhone 17 simulator: **2048 passed, 0 failed** (2 pre-existing photo-library skips).

New coverage: `ComposerChipTokenizerTests` (boundary rules, unknown slug, built-in collision, multiple references, newline close, trailing preservation, empty catalog, and the spoken form VoiceOver reads), `ComposerChipDocumentTests` (serialisation, both offset directions, an offset inside a chip, range round-trip, clamping), `ComposerDropRouteTests`, and two in `ChatViewModelSendTests` for the skill loader. The loader tests were checked against the unfixed code first and do fail there — an earlier attempt passed either way and was rewritten.

Owner-tested on the simulator against a live server: chip on pick, send producing `/<slug> <message>` unchanged, mid-sentence pick preserving the sentence, atomic backspace, copy/paste round-trip, draft restored across leaving and re-entering the session, and the chip in the collapsed pill.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (verified against a running server and upstream's web UI)

---

Written by Claude Opus 5 in Claude Code.