### PR TITLE
feat(chat): draw a sent skill reference as a chip in the bubble

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -126,56 +126,12 @@ private struct ComposerCollapsedDraft: View {
     /// it draws, so a set that no longer fits the text the pill was handed is
     /// dropped rather than drawn in the wrong place.
     private var tokens: [ComposerChipToken] {
-        let text = draft as NSString
-        guard chips.allSatisfy({
-            $0.range.upperBound <= text.length && text.substring(with: $0.range) == $0.source
-        }) else {
-            return []
-        }
-        return chips
+        ComposerChipTextLine.validTokens(chips, in: draft)
     }
 
     private var line: Text {
         guard !draft.isEmpty else { return Text(placeholder) }
-
-        let tokens = tokens
-        guard !tokens.isEmpty else { return Text(draft) }
-
-
-        let metrics = ComposerChipMetrics(editorFont: editorFont)
-        // Every trait the chip resolves a colour from, or the pill asks the
-        // cache for a picture drawn for someone else's settings.
-        let traits = UITraitCollection { traits in
-            traits.userInterfaceStyle = colorScheme == .dark ? .dark : .light
-            traits.accessibilityContrast = colorSchemeContrast == .increased ? .high : .normal
-        }
-        let isRightToLeft = layoutDirection == .rightToLeft
-        let text = draft as NSString
-
-        var line = Text(verbatim: "")
-        var cursor = 0
-
-        for token in tokens where token.range.location >= cursor {
-            if token.range.location > cursor {
-                let plain = text.substring(with: NSRange(location: cursor, length: token.range.location - cursor))
-                line = line + Text(verbatim: plain)
-            }
-
-            let chip = ComposerChipRenderer.image(
-                label: token.label,
-                metrics: metrics,
-                traits: traits,
-                isRightToLeft: isRightToLeft
-            )
-            line = line + Text(Image(uiImage: chip))
-            cursor = token.range.upperBound
-        }
-
-        if cursor < text.length {
-            line = line + Text(verbatim: text.substring(from: cursor))
-        }
-
-        return line
+        return ComposerChipTextLine.text(draft, tokens: tokens, style: chipStyle)
     }
 
     /// VoiceOver reads a chip by its label, the way the editor's attachment does,
@@ -184,12 +140,15 @@ private struct ComposerCollapsedDraft: View {
         draft.isEmpty ? placeholder : ComposerChipTokenizer.spokenText(in: draft, tokens: tokens)
     }
 
-    /// Reading `dynamicTypeSize` is what makes SwiftUI re-evaluate — and so
-    /// re-measure the chips — when the user changes their text size; the size
-    /// itself comes from the same body font the editor uses.
-    private var editorFont: UIFont {
-        _ = dynamicTypeSize
-        return .preferredFont(forTextStyle: .body)
+    /// Every trait a chip resolves a colour or a size from, or the pill asks the
+    /// cache for a picture drawn for someone else's settings.
+    private var chipStyle: ComposerChipTextStyle {
+        ComposerChipTextStyle(
+            colorScheme: colorScheme,
+            contrast: colorSchemeContrast,
+            layoutDirection: layoutDirection,
+            dynamicTypeSize: dynamicTypeSize
+        )
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -193,9 +193,13 @@ struct ChatTranscriptView: View {
                 .onChange(of: transcriptRelayoutScrollToken) {
                     // The transcript just changed height without gaining a message —
                     // the server render replacing the cache-first one (#289), or sent
-                    // references becoming chips (#388). Snap back to the bottom (no
-                    // animation) unless the reader has scrolled away in the meantime.
-                    guard isFollowingLatestContent else { return }
+                    // references becoming chips (#388). A reader at the live edge is
+                    // put back there (no animation); a reader up in history keeps the
+                    // offset they were reading at, the way a disclosure toggle does.
+                    guard isFollowingLatestContent else {
+                        pinReader(proxy: proxy)
+                        return
+                    }
                     releasingHold { onScrollToLatestContent(proxy, false) }
                 }
                 .onChange(of: clarificationPromptID) {

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -36,7 +36,7 @@ struct ChatTranscriptView: View {
     let isScrolledNearBottom: Bool
     let activeStreamID: String?
     let streamingScrollTrigger: Int
-    let cacheFirstReconcileScrollToken: Int
+    let transcriptRelayoutScrollToken: Int
     let bottomAnchorID: String
     let transcriptSpacing: CGFloat
     let transcriptBottomInsetHeight: CGFloat
@@ -190,9 +190,10 @@ struct ChatTranscriptView: View {
                         releasingHold { onScrollToLatestContent(proxy, true) }
                     }
                 }
-                .onChange(of: cacheFirstReconcileScrollToken) {
-                    // Cache-first reconcile (#289): the server transcript just replaced
-                    // the lighter cached render, so snap back to the bottom (no
+                .onChange(of: transcriptRelayoutScrollToken) {
+                    // The transcript just changed height without gaining a message —
+                    // the server render replacing the cache-first one (#289), or sent
+                    // references becoming chips (#388). Snap back to the bottom (no
                     // animation) unless the reader has scrolled away in the meantime.
                     guard isFollowingLatestContent else { return }
                     releasingHold { onScrollToLatestContent(proxy, false) }

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1317,6 +1317,24 @@ struct ChatView: View {
         .onChange(of: viewModel.latestRunOutcome) {
             handleLatestRunOutcomeChange(viewModel.latestRunOutcome)
         }
+        .environment(\.skillChipCatalog, viewModel.skillChipCatalog)
+        .task(id: viewModel.messages.count) {
+            await loadSkillSuggestionsForTranscriptChipsIfNeeded()
+        }
+    }
+
+    /// A sent message draws its skill reference as a chip only for skills the
+    /// app has heard of, so a transcript that names one warms the skill list the
+    /// way a restored draft does — and a chat that never mentions a skill still
+    /// costs no skills request.
+    private func loadSkillSuggestionsForTranscriptChipsIfNeeded() async {
+        guard !viewModel.hasLoadedSkillSlashSuggestions,
+              viewModel.messages.contains(where: {
+                  $0.role == "user" && ComposerChipTokenizer.mayContainReference($0.content ?? "")
+              })
+        else { return }
+
+        await viewModel.loadSkillSlashSuggestions()
     }
 
     /// The chat-canvas layout direction. Driven by the manual Settings → Chat

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -333,6 +333,10 @@ struct ChatView: View {
     @State private var clarificationBarHeight: CGFloat = 0
     @State private var composerIsFocused = false
     @State private var didHydrateDraft = false
+    /// Whether this chat has already asked the server for its skills on the
+    /// transcript's behalf, so a request that failed does not repeat with every
+    /// later transcript update.
+    @State private var hasRequestedSkillsForTranscriptChips = false
     /// True from the moment hydration finds persisted attachment records until
     /// their restore pass finishes. It gates `syncDraftAttachments` across the
     /// whole window, so the not-yet-rebuilt composer strip can never overwrite
@@ -657,7 +661,7 @@ struct ChatView: View {
             .onChange(of: viewModel.activeStreamID) {
                 handleActiveStreamChange()
             }
-            .onChange(of: viewModel.cacheFirstReconcileScrollToken) {
+            .onChange(of: viewModel.transcriptRelayoutScrollToken) {
                 // Open a brief snap window so the cache-first reconcile re-pin (and any
                 // message-count auto-follow racing it) lands without an animated jump (#289).
                 cacheFirstSnapUntil = Date().addingTimeInterval(0.35)
@@ -1227,7 +1231,7 @@ struct ChatView: View {
             isScrolledNearBottom: isScrolledNearBottom,
             activeStreamID: viewModel.activeStreamID,
             streamingScrollTrigger: viewModel.streamingScrollTrigger,
-            cacheFirstReconcileScrollToken: viewModel.cacheFirstReconcileScrollToken,
+            transcriptRelayoutScrollToken: viewModel.transcriptRelayoutScrollToken,
             bottomAnchorID: bottomAnchorID,
             transcriptSpacing: transcriptSpacing,
             transcriptBottomInsetHeight: transcriptBottomInsetHeight,
@@ -1318,8 +1322,28 @@ struct ChatView: View {
             handleLatestRunOutcomeChange(viewModel.latestRunOutcome)
         }
         .environment(\.skillChipCatalog, viewModel.skillChipCatalog)
-        .task(id: viewModel.messages.count) {
+        .task(id: transcriptSkillReferenceCount) {
             await loadSkillSuggestionsForTranscriptChipsIfNeeded()
+        }
+    }
+
+    /// How many sent messages look like they name a skill.
+    ///
+    /// It is both the trigger and the task's identity, so a cache-first
+    /// transcript that swaps in the server's messages still warms the list when
+    /// the count of messages did not change but their text did. Zero once the
+    /// list has loaded or this chat has already asked, which is what keeps the
+    /// scan off the streaming path.
+    private var transcriptSkillReferenceCount: Int {
+        guard !hasRequestedSkillsForTranscriptChips, !viewModel.hasLoadedSkillSlashSuggestions else {
+            return 0
+        }
+
+        return viewModel.messages.reduce(into: 0) { count, message in
+            guard message.role == "user",
+                  ComposerChipTokenizer.mayContainReference(message.content ?? "")
+            else { return }
+            count += 1
         }
     }
 
@@ -1328,13 +1352,15 @@ struct ChatView: View {
     /// way a restored draft does — and a chat that never mentions a skill still
     /// costs no skills request.
     private func loadSkillSuggestionsForTranscriptChipsIfNeeded() async {
-        guard !viewModel.hasLoadedSkillSlashSuggestions,
-              viewModel.messages.contains(where: {
-                  $0.role == "user" && ComposerChipTokenizer.mayContainReference($0.content ?? "")
-              })
-        else { return }
+        guard transcriptSkillReferenceCount > 0 else { return }
 
         await viewModel.loadSkillSlashSuggestions()
+
+        // One ask per chat. A skills request that failed must not turn every
+        // later transcript update into another one; typing `/` in the composer
+        // still retries on the reader's behalf. Set after the wait so a
+        // cancelled task leaves the chat free to ask again.
+        hasRequestedSkillsForTranscriptChips = true
     }
 
     /// The chat-canvas layout direction. Driven by the manual Settings → Chat

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -242,7 +242,11 @@ final class ChatViewModel {
     /// (tool-call / reasoning cards, content parts) is taller than the lighter cached
     /// render, so the view re-pins to the bottom on this token *without* animation —
     /// otherwise the height growth produces a visible scroll jump.
-    private(set) var cacheFirstReconcileScrollToken = 0
+    /// Bumped whenever something re-lays out the transcript under the reader
+    /// without adding a message: the server transcript replacing the lighter
+    /// cache-first render, or the skill catalog turning sent `/slug` text into
+    /// chips. A reader who was pinned to the bottom is put back there.
+    private(set) var transcriptRelayoutScrollToken = 0
     private var hasPrimedInitialCachedMessages = false
     @ObservationIgnored private var pendingStreamingScrollTriggerTask: Task<Void, Never>?
     @ObservationIgnored private var pendingAssistantTokenChunks: [String] = []
@@ -1407,7 +1411,7 @@ final class ChatViewModel {
             if renderedCacheFirst {
                 // The taller server transcript has now replaced the lighter cache-first
                 // render; signal the view to re-pin to the bottom without a visible jump.
-                cacheFirstReconcileScrollToken += 1
+                transcriptRelayoutScrollToken += 1
             }
             latestServerLoadHadAssistantResponseAfterLatestUser = Self.hasAssistantResponseAfterLatestUser(
                 in: messages
@@ -3088,8 +3092,16 @@ final class ChatViewModel {
     /// The one way the skill list changes, so the chip catalog can never fall
     /// out of step with it.
     private func applySkillSlashSuggestions(_ suggestions: [SkillSlashSuggestion]) {
+        let wasEmpty = skillChipCatalog.isEmpty
         skillSlashSuggestions = suggestions
         skillChipCatalog = ComposerChipCatalog(skills: suggestions)
+
+        // The first catalog turns sent `/slug` text into chips, and a chip is
+        // not the size of the text it replaces. Signal the relayout so a reader
+        // pinned to the bottom stays there.
+        if wasEmpty, !skillChipCatalog.isEmpty {
+            transcriptRelayoutScrollToken += 1
+        }
     }
 
     private func branchSessionFromSlashCommand(_ args: String) async -> SlashCommandExecutionResult {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -348,6 +348,10 @@ final class ChatViewModel {
     private(set) var workspaceSuggestions: [String] = []
     private(set) var personalitySuggestions: [String] = ["none"]
     private(set) var skillSlashSuggestions: [SkillSlashSuggestion] = []
+    /// The same skills in the shape the chip tokenizer needs, kept beside the
+    /// list so the transcript's `body` never rebuilds it. Always assigned
+    /// through `applySkillSlashSuggestions(_:)`.
+    private(set) var skillChipCatalog: ComposerChipCatalog = .empty
     private(set) var profileOptions: [ProfileSummary] = []
     private(set) var isSingleProfileMode = false
     private(set) var selectedProfileName: String?
@@ -1009,7 +1013,9 @@ final class ChatViewModel {
                 guard let self else { return }
                 do {
                     let response = try await self.client.skills()
-                    self.skillSlashSuggestions = SlashSkillFormatter.suggestions(from: response.skills ?? [])
+                    self.applySkillSlashSuggestions(
+                        SlashSkillFormatter.suggestions(from: response.skills ?? [])
+                    )
                     self.hasLoadedSkillSlashSuggestions = true
                 } catch {
                     self.lastError = error
@@ -3074,9 +3080,16 @@ final class ChatViewModel {
 
         let response = try await client.skills()
         let suggestions = SlashSkillFormatter.suggestions(from: response.skills ?? [])
-        skillSlashSuggestions = suggestions
+        applySkillSlashSuggestions(suggestions)
         hasLoadedSkillSlashSuggestions = true
         return suggestions
+    }
+
+    /// The one way the skill list changes, so the chip catalog can never fall
+    /// out of step with it.
+    private func applySkillSlashSuggestions(_ suggestions: [SkillSlashSuggestion]) {
+        skillSlashSuggestions = suggestions
+        skillChipCatalog = ComposerChipCatalog(skills: suggestions)
     }
 
     private func branchSessionFromSlashCommand(_ args: String) async -> SlashCommandExecutionResult {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -3092,14 +3092,15 @@ final class ChatViewModel {
     /// The one way the skill list changes, so the chip catalog can never fall
     /// out of step with it.
     private func applySkillSlashSuggestions(_ suggestions: [SkillSlashSuggestion]) {
-        let wasEmpty = skillChipCatalog.isEmpty
+        let previousCatalog = skillChipCatalog
         skillSlashSuggestions = suggestions
         skillChipCatalog = ComposerChipCatalog(skills: suggestions)
 
-        // The first catalog turns sent `/slug` text into chips, and a chip is
-        // not the size of the text it replaces. Signal the relayout so a reader
-        // pinned to the bottom stays there.
-        if wasEmpty, !skillChipCatalog.isEmpty {
+        // A catalog that draws differently redraws the transcript: sent `/slug`
+        // text becomes a chip, or an existing chip changes size or goes away.
+        // Signal the relayout so a reader pinned to the bottom stays there. A
+        // list that came back the same changes nothing and says nothing.
+        if skillChipCatalog != previousCatalog {
             transcriptRelayoutScrollToken += 1
         }
     }

--- a/HermesMobile/Features/Chat/ComposerChipRendering.swift
+++ b/HermesMobile/Features/Chat/ComposerChipRendering.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 
 /// The chip a skill reference is drawn as: one attachment glyph that stands for
@@ -164,6 +165,89 @@ enum ComposerChipRenderer {
                 withAttributes: attributes
             )
         }
+    }
+}
+
+/// Everything about the current environment that changes a chip's picture.
+///
+/// Built inside a view's `body` so SwiftUI re-evaluates — and the chips
+/// re-measure — when appearance, contrast, direction, or text size moves.
+struct ComposerChipTextStyle {
+    let metrics: ComposerChipMetrics
+    let traits: UITraitCollection
+    let isRightToLeft: Bool
+
+    init(
+        colorScheme: ColorScheme,
+        contrast: ColorSchemeContrast,
+        layoutDirection: LayoutDirection,
+        dynamicTypeSize: DynamicTypeSize
+    ) {
+        // Reading the size is what ties this value to Dynamic Type; the font
+        // itself comes from the same body style the editor uses.
+        _ = dynamicTypeSize
+        metrics = ComposerChipMetrics(editorFont: .preferredFont(forTextStyle: .body))
+        traits = UITraitCollection { traits in
+            traits.userInterfaceStyle = colorScheme == .dark ? .dark : .light
+            traits.accessibilityContrast = contrast == .increased ? .high : .normal
+        }
+        isRightToLeft = layoutDirection == .rightToLeft
+    }
+}
+
+/// A run of text with its skill references drawn as chips, for the two places
+/// SwiftUI does the drawing: the collapsed composer pill and the sent user
+/// bubble. The expanded editor is a `UITextView` with real attachments instead,
+/// but every chip is the same picture, so one reference cannot look like two
+/// different things on either side of the send.
+enum ComposerChipTextLine {
+    /// The tokens that still describe `text`. A caller whose chips were
+    /// computed a beat earlier can hand over a set the text has since outgrown;
+    /// drawing none is better than drawing one in the wrong place.
+    static func validTokens(_ tokens: [ComposerChipToken], in text: String) -> [ComposerChipToken] {
+        let string = text as NSString
+        guard tokens.allSatisfy({
+            $0.range.upperBound <= string.length && string.substring(with: $0.range) == $0.source
+        }) else {
+            return []
+        }
+        return tokens
+    }
+
+    /// `text` with every token replaced by its chip picture and the rest left
+    /// verbatim, so nothing in a message is read as markdown or a format string.
+    static func text(
+        _ text: String,
+        tokens: [ComposerChipToken],
+        style: ComposerChipTextStyle
+    ) -> Text {
+        guard !tokens.isEmpty else { return Text(verbatim: text) }
+
+        let string = text as NSString
+        var line = Text(verbatim: "")
+        var cursor = 0
+
+        for token in tokens where token.range.location >= cursor {
+            if token.range.location > cursor {
+                let plain = string.substring(with: NSRange(location: cursor, length: token.range.location - cursor))
+                line = line + Text(verbatim: plain)
+            }
+
+            let chip = ComposerChipRenderer.image(
+                label: token.label,
+                metrics: style.metrics,
+                traits: style.traits,
+                isRightToLeft: style.isRightToLeft
+            )
+            line = line + Text(Image(uiImage: chip))
+            cursor = token.range.upperBound
+        }
+
+        if cursor < string.length {
+            line = line + Text(verbatim: string.substring(from: cursor))
+        }
+
+        return line
     }
 }
 

--- a/HermesMobile/Features/Chat/ComposerChipToken.swift
+++ b/HermesMobile/Features/Chat/ComposerChipToken.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// A skill reference in the draft that the composer draws as one atomic chip.
 ///
@@ -61,10 +62,16 @@ enum ComposerChipTokenizer {
     /// stays ordinary editable text. `previous` keeps a chip at the very end of
     /// the draft drawn after its trailing space is deleted, so backspacing the
     /// space a completion added does not flicker the chip back into text.
+    ///
+    /// `isComplete` says the text is finished rather than being typed, which is
+    /// what a sent message is: a reference that ends the message is a whole
+    /// reference, so the transcript draws the chip the composer was still
+    /// waiting for a space to confirm.
     static func tokens(
         in draft: String,
         catalog: ComposerChipCatalog,
-        preservingTrailing previous: [ComposerChipToken] = []
+        preservingTrailing previous: [ComposerChipToken] = [],
+        isComplete: Bool = false
     ) -> [ComposerChipToken] {
         guard !catalog.isEmpty else { return [] }
 
@@ -98,7 +105,7 @@ enum ComposerChipTokenizer {
 
             let isClosed = end < text.length && isWhitespaceOrNewline(text.character(at: end))
             let isPreservedTail = end == text.length
-                && previous.contains { $0.range == range && $0.source == source }
+                && (isComplete || previous.contains { $0.range == range && $0.source == source })
             guard isClosed || isPreservedTail else { continue }
 
             tokens.append(ComposerChipToken(range: range, source: source, label: label))
@@ -167,5 +174,23 @@ enum ComposerChipTokenizer {
     private static func isWhitespaceOrNewline(_ unit: UInt16) -> Bool {
         guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
         return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+}
+
+private struct SkillChipCatalogKey: EnvironmentKey {
+    static let defaultValue = ComposerChipCatalog.empty
+}
+
+extension EnvironmentValues {
+    /// The skills a transcript may draw as chips.
+    ///
+    /// Sent messages carry no marker for a reference, so the bubble has to look
+    /// the slug up the same way the composer does. It travels in the
+    /// environment because it belongs to the chat, not to any one bubble, and
+    /// the rows in between are `Equatable` blocks that should not have to
+    /// forward it.
+    var skillChipCatalog: ComposerChipCatalog {
+        get { self[SkillChipCatalogKey.self] }
+        set { self[SkillChipCatalogKey.self] = newValue }
     }
 }

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -2,8 +2,12 @@ import SwiftUI
 
 struct MessageBubbleView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @Environment(\.layoutDirection) private var layoutDirection
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// The skills this chat can draw as chips, published by `ChatView`.
+    @Environment(\.skillChipCatalog) private var skillChipCatalog
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
 
@@ -212,8 +216,17 @@ struct MessageBubbleView: View {
         .padding(.vertical, 4)
     }
 
+    /// The sent message, with any skill reference drawn as the same chip the
+    /// composer showed before the send.
+    ///
+    /// A chip is a picture, so dragging a selection across one leaves its
+    /// `/slug` out of what is copied; the message's own Copy and Select Text
+    /// actions read `message.content`, which is always the exact text.
     private var userBubble: some View {
-        Text(verbatim: userBubbleText)
+        let text = userBubbleText
+        let chips = userBubbleChips(in: text)
+
+        return ComposerChipTextLine.text(text, tokens: chips, style: chipStyle)
             .font(.body)
             .textSelection(.enabled)
             .padding(.horizontal, 14)
@@ -224,6 +237,32 @@ struct MessageBubbleView: View {
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .stroke(userBubbleBorder, lineWidth: 0.5)
             )
+            // VoiceOver reads a chip by its skill's name rather than announcing
+            // an image, the way both composer states already do.
+            .accessibilityLabel(
+                chips.isEmpty
+                    ? Text(verbatim: text)
+                    : Text(verbatim: ComposerChipTokenizer.spokenText(in: text, tokens: chips))
+            )
+    }
+
+    /// The references in a sent message. `isComplete` is what a send means: the
+    /// text will not grow, so a reference that ends the message is finished and
+    /// draws as a chip even though the composer was still waiting for a space.
+    /// A slug the server no longer knows resolves to nothing and stays plain
+    /// text, which is the same rule the composer follows.
+    private func userBubbleChips(in text: String) -> [ComposerChipToken] {
+        guard !skillChipCatalog.isEmpty else { return [] }
+        return ComposerChipTokenizer.tokens(in: text, catalog: skillChipCatalog, isComplete: true)
+    }
+
+    private var chipStyle: ComposerChipTextStyle {
+        ComposerChipTextStyle(
+            colorScheme: colorScheme,
+            contrast: colorSchemeContrast,
+            layoutDirection: layoutDirection,
+            dynamicTypeSize: dynamicTypeSize
+        )
     }
 
     @ViewBuilder

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8612,13 +8612,15 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     /// A server with no skills leaves the transcript exactly as it was drawn, so
-    /// it must not claim a relayout.
+    /// it must not claim a relayout. Covers the general rule too: a catalog that
+    /// came back unchanged says nothing.
     @MainActor
     func testAnEmptySkillListDoesNotSignalARelayout() async throws {
         let viewModel = try makeViewModel { request in
             apiTestJSONResponse(#"{"skills": []}"#, for: request)
         }
 
+        await viewModel.loadSkillSlashSuggestions()
         await viewModel.loadSkillSlashSuggestions()
 
         XCTAssertTrue(viewModel.skillChipCatalog.isEmpty)

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -3700,12 +3700,12 @@ final class ChatViewModelSendTests: XCTestCase {
             """, for: request)
         }
 
-        XCTAssertEqual(viewModel.cacheFirstReconcileScrollToken, 0)
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 0)
         await viewModel.loadMessages(modelContext: context)
 
         // The cache-first reconcile fired exactly once so the view can snap back to the
         // bottom as the taller server transcript replaces the lighter cached render.
-        XCTAssertEqual(viewModel.cacheFirstReconcileScrollToken, 1)
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 1)
     }
 
     @MainActor
@@ -3734,7 +3734,7 @@ final class ChatViewModelSendTests: XCTestCase {
         await viewModel.loadMessages(modelContext: context)
 
         // No cache was rendered first, so there is nothing to re-pin and the token stays put.
-        XCTAssertEqual(viewModel.cacheFirstReconcileScrollToken, 0)
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 0)
     }
 
     @MainActor
@@ -8590,6 +8590,39 @@ final class ChatViewModelSendTests: XCTestCase {
         await viewModel.loadSkillSlashSuggestions()
         XCTAssertEqual(viewModel.skillSlashSuggestions.map(\.slashName), ["handoff"])
         XCTAssertEqual(attempts, 2)
+    }
+
+    /// Sent references become chips the moment the catalog lands, and a chip is
+    /// not the size of the `/slug` it replaces, so the transcript has to be told
+    /// it just re-laid out under the reader (#388).
+    @MainActor
+    func testTheFirstSkillCatalogSignalsATranscriptRelayout() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/skills")
+            return apiTestJSONResponse(#"{"skills": [{"name": "handoff"}]}"#, for: request)
+        }
+
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 0)
+        XCTAssertTrue(viewModel.skillChipCatalog.isEmpty)
+
+        await viewModel.loadSkillSlashSuggestions()
+
+        XCTAssertEqual(viewModel.skillChipCatalog.label(forSlug: "handoff"), "handoff")
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 1)
+    }
+
+    /// A server with no skills leaves the transcript exactly as it was drawn, so
+    /// it must not claim a relayout.
+    @MainActor
+    func testAnEmptySkillListDoesNotSignalARelayout() async throws {
+        let viewModel = try makeViewModel { request in
+            apiTestJSONResponse(#"{"skills": []}"#, for: request)
+        }
+
+        await viewModel.loadSkillSlashSuggestions()
+
+        XCTAssertTrue(viewModel.skillChipCatalog.isEmpty)
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 0)
     }
 
     private static func ttsUnavailableResponse(for request: URLRequest) -> (HTTPURLResponse, Data) {

--- a/HermesMobileTests/ComposerChipTests.swift
+++ b/HermesMobileTests/ComposerChipTests.swift
@@ -100,6 +100,42 @@ final class ComposerChipTokenizerTests: XCTestCase {
 }
 
 extension ComposerChipTokenizerTests {
+    // MARK: - Sent messages (the transcript bubble, issue #388)
+
+    func testSentMessageEndingInAReferenceDrawsAChip() {
+        let tokens = ComposerChipTokenizer.tokens(in: "please run /ask-matt", catalog: catalog, isComplete: true)
+
+        XCTAssertEqual(tokens.map(\.source), ["/ask-matt"])
+        XCTAssertEqual(tokens.first?.range, NSRange(location: 11, length: 9))
+    }
+
+    func testSentMessageStillNeedsAKnownSlug() {
+        XCTAssertTrue(
+            ComposerChipTokenizer.tokens(in: "please run /ask-mat", catalog: catalog, isComplete: true).isEmpty
+        )
+        XCTAssertTrue(
+            ComposerChipTokenizer.tokens(in: "please run /ask-matt", catalog: .empty, isComplete: true).isEmpty
+        )
+    }
+
+    func testSentMessageKeepsTheMidSentenceRules() {
+        XCTAssertTrue(
+            ComposerChipTokenizer.tokens(in: "see docs/ask-matt", catalog: catalog, isComplete: true).isEmpty
+        )
+    }
+
+    // MARK: - Drawing the line (shared by the collapsed pill and the bubble)
+
+    func testStaleChipsAreDroppedRatherThanDrawnInTheWrongPlace() {
+        let tokens = ComposerChipTokenizer.tokens(in: "/ask-matt now", catalog: catalog)
+
+        XCTAssertEqual(ComposerChipTextLine.validTokens(tokens, in: "/ask-matt now"), tokens)
+        XCTAssertTrue(ComposerChipTextLine.validTokens(tokens, in: "hi").isEmpty)
+        XCTAssertTrue(ComposerChipTextLine.validTokens(tokens, in: "/babysit-pr now").isEmpty)
+    }
+}
+
+extension ComposerChipTokenizerTests {
     // MARK: - Spoken form (the collapsed composer's VoiceOver label)
 
     func testSpokenTextReadsChipsByTheirLabel() {


### PR DESCRIPTION
## Linked issue

Fixes #388

## What changed

You pick a skill and the composer draws it as a neat chip — then you hit send and it turns back into raw `/ask-matt` text in the bubble. Same reference, two looks, one send apart. The sent bubble now draws the same chip.

The bubble is a plain SwiftUI `Text`, not the markdown pipeline (the issue assumed otherwise), and the collapsed composer pill already built exactly the line we need: plain runs concatenated with baked chip pictures. That is lifted into a shared `ComposerChipTextLine` and reused by both, so the two can't drift apart.

Rules the bubble follows, all inherited from the composer:

- **A deleted or renamed skill stays plain text.** The chip is drawn only when the slug still resolves against the server's skill list, so nothing is stored beside the message and a sent message never lies about what exists today.
- **A reference that ends the message is complete.** The composer waits for a trailing space to know you finished typing the name; a sent message won't grow, so `isComplete` closes it.
- **`docs/ask-matt` is still a path, not a chip.** Same tokenizer, same mid-word rules.
- **VoiceOver reads the skill's name**, not "image", matching both composer states.

Wiring: the catalog reaches the bubble through `EnvironmentValues.skillChipCatalog` rather than being threaded through the `Equatable` transcript blocks, and it's derived once in `ChatViewModel` so no `body` rebuilds it. A transcript that names a skill warms the skill list the way a restored draft already does — a chat that never mentions one still costs no `/api/skills` request.

**Known trade-off:** a chip is a picture, so dragging a text selection across one leaves its `/slug` out of what gets copied. The message's own **Copy** and **Select Text** actions read `message.content` and are unaffected, so the exact-text path is intact.

## How it was tested

- Full XCTest suite on iPhone 17 simulator via XcodeBuildMCP `test_sim`: **2059 passed, 0 failed, 2 skipped** on `77ead9e`.
- Six new focused tests in `ComposerChipTests`: a reference ending a sent message becomes a chip, an unknown/half-typed slug and an empty catalog do not, `docs/ask-matt` is still a path, and a stale chip set is dropped rather than drawn in the wrong place.
- Integrated pass: signed Debug build installed and launched on the iPhone 17 simulator (`build_run_sim`), clean launch.
- Before/after images are pending — capturing them needs a session on the maintainer's live server that already references a skill.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no wire changes; reuses the existing `GET /api/skills` load)

---

Implemented by Claude Opus 5 (1M context) in Claude Code.
