### PR TITLE
chore(chat): share one load across callers for personality suggestions

### DIFF
--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -463,7 +463,9 @@ final class ChatViewModel {
     private var isStreamConnectionSuspended: Bool { streamCoordinator.isConnectionSuspended }
     var isActiveStreamConnectionSuspended: Bool { streamCoordinator.isConnectionSuspended }
     private var hasLoadedPersonalitySuggestions = false
-    private var isLoadingPersonalitySuggestions = false
+    /// The in-flight personality list request, shared by every caller of
+    /// `loadPersonalitySuggestions()` so no view's cancellation can orphan it.
+    private var personalitySuggestionsLoad: Task<Void, Never>?
     /// Whether a skills list request has succeeded for this session, even when
     /// it returned no skills. Lets the composer tell "still loading" from
     /// "loaded, and the server has none".
@@ -978,23 +980,40 @@ final class ChatViewModel {
         }
     }
 
+    /// Loads the personality list once, sharing a single request between
+    /// callers.
+    ///
+    /// Same shape as `loadSkillSlashSuggestions()` and for the same reason: the
+    /// request lives on a task this view model owns, so a cancelled caller
+    /// cannot take the fetch down with it, and a caller arriving mid-flight
+    /// waits for that same result instead of racing past an "already loading"
+    /// flag and finding an empty list. A failed load clears the handle, so the
+    /// next caller retries.
     func loadPersonalitySuggestions() async {
         guard !hasLoadedPersonalitySuggestions else { return }
-        guard !isLoadingPersonalitySuggestions else { return }
 
-        isLoadingPersonalitySuggestions = true
-        defer { isLoadingPersonalitySuggestions = false }
-
-        do {
-            personalitySuggestions = (try await client.personalities()).slashAutocompleteNames
-            hasLoadedPersonalitySuggestions = true
-        } catch {
-            lastError = error
-            composerConfigurationErrorMessage = error.localizedDescription
-            if personalitySuggestions.isEmpty {
-                personalitySuggestions = ["none"]
+        let load: Task<Void, Never>
+        if let existing = personalitySuggestionsLoad {
+            load = existing
+        } else {
+            load = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    self.personalitySuggestions = (try await self.client.personalities()).slashAutocompleteNames
+                    self.hasLoadedPersonalitySuggestions = true
+                } catch {
+                    self.lastError = error
+                    self.composerConfigurationErrorMessage = error.localizedDescription
+                    if self.personalitySuggestions.isEmpty {
+                        self.personalitySuggestions = ["none"]
+                    }
+                }
+                self.personalitySuggestionsLoad = nil
             }
+            personalitySuggestionsLoad = load
         }
+
+        await load.value
     }
 
     /// Loads the skill list once, sharing a single request between callers.

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8636,6 +8636,39 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(attempts, 2)
     }
 
+    /// The point of the shared handle: a caller arriving mid-flight joins the
+    /// request already running instead of firing its own and returning early
+    /// with an empty list. The mock holds the response open until the second
+    /// caller has arrived, so it really does land on the in-flight branch.
+    @MainActor
+    func testAConcurrentCallerJoinsTheInFlightPersonalityLoad() async throws {
+        let requestStarted = XCTestExpectation(description: "personality request started")
+        let releaseResponse = DispatchSemaphore(value: 0)
+        var attempts = 0
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/personalities")
+            attempts += 1
+            requestStarted.fulfill()
+            // Bounded so a second, unshared request fails the count assertion
+            // below instead of hanging the test.
+            _ = releaseResponse.wait(timeout: .now() + 5)
+            return apiTestJSONResponse(#"{"personalities": [{"name": "mentor"}]}"#, for: request)
+        }
+
+        let first = Task { await viewModel.loadPersonalitySuggestions() }
+        await fulfillment(of: [requestStarted], timeout: 5)
+
+        let second = Task { await viewModel.loadPersonalitySuggestions() }
+        await Task.yield()
+        releaseResponse.signal()
+
+        await first.value
+        await second.value
+
+        XCTAssertEqual(viewModel.personalitySuggestions, ["none", "mentor"])
+        XCTAssertEqual(attempts, 1)
+    }
+
     /// Sent references become chips the moment the catalog lands, and a chip is
     /// not the size of the `/slug` it replaces, so the transcript has to be told
     /// it just re-laid out under the reader (#388).

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8592,6 +8592,50 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(attempts, 2)
     }
 
+    // MARK: - Personality slash suggestions
+
+    /// The personality list is loaded from the same kind of `.task` modifier as
+    /// the skill list, so it needs the same protection (#387): a caller SwiftUI
+    /// cancels must not take the shared fetch down with it and leave the
+    /// personality picker permanently empty.
+    @MainActor
+    func testCancellingACallerDoesNotAbortThePersonalityLoad() async throws {
+        let viewModel = try makeViewModel { request in
+            XCTAssertEqual(request.url?.path, "/api/personalities")
+            return apiTestJSONResponse(#"{"personalities": [{"name": "mentor"}]}"#, for: request)
+        }
+
+        let caller = Task { await viewModel.loadPersonalitySuggestions() }
+        caller.cancel()
+        await caller.value
+
+        XCTAssertEqual(viewModel.personalitySuggestions, ["none", "mentor"])
+    }
+
+    /// A load that fails leaves nothing behind, so the next caller retries
+    /// rather than awaiting the finished, empty-handed task.
+    @MainActor
+    func testAFailedPersonalityLoadIsRetriedByTheNextCaller() async throws {
+        var attempts = 0
+        let viewModel = try makeViewModel { request in
+            attempts += 1
+            guard attempts > 1 else {
+                return (
+                    HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!,
+                    Data()
+                )
+            }
+            return apiTestJSONResponse(#"{"personalities": [{"name": "mentor"}]}"#, for: request)
+        }
+
+        await viewModel.loadPersonalitySuggestions()
+        XCTAssertEqual(viewModel.personalitySuggestions, ["none"])
+
+        await viewModel.loadPersonalitySuggestions()
+        XCTAssertEqual(viewModel.personalitySuggestions, ["none", "mentor"])
+        XCTAssertEqual(attempts, 2)
+    }
+
     /// Sent references become chips the moment the catalog lands, and a chip is
     /// not the size of the `/slug` it replaces, so the transcript has to be told
     /// it just re-laid out under the reader (#388).


### PR DESCRIPTION
## Linked issue

Fixes #387

## What changed

`loadPersonalitySuggestions()` had the same shape — and the same latent defect — as the skill loader that caused the chip bug in #386. A caller arriving while a load was in flight hit `guard !isLoadingPersonalitySuggestions else { return }`, returned without awaiting anything, and found an empty list. Worse, the caller that owned the flag ran the request inside itself: if SwiftUI cancelled that `.task`, the request threw `CancellationError`, the `catch` swallowed it into `lastError`, `hasLoaded` stayed `false`, and nothing retried — the personality picker would sit empty with no visible sign.

The fix is the shape #386 gave the skill loader: the request lives on a `Task` the view model owns. A caller arriving mid-flight awaits that same task instead of racing past a flag, a cancelled caller can no longer take the shared fetch down with it, and a failed load clears the handle so the next caller retries. The failure path keeps its existing behaviour (`lastError`, `composerConfigurationErrorMessage`, and the `["none"]` fallback).

This was prevention rather than a live bug — nothing currently warms personalities off a restored draft the way the chip code warms skills — but the cancellation regression test fails against the unfixed loader, so the hazard was real.

## How it was tested

- Confirmed the new cancellation test is **red** against the unfixed loader (stashed the `ChatViewModel` change): `XCTAssertEqual failed: ("["none"]") is not equal to ("["none", "mentor"]")`.
- Two new tests in `ChatViewModelSendTests`, mirroring the skill loader's: `testCancellingACallerDoesNotAbortThePersonalityLoad` and `testAFailedPersonalityLoadIsRetriedByTheNextCaller`.
- Full XCTest suite on the simulator (iPhone 17, scheme `HermesMobile`) via XcodeBuildMCP `test_sim`: **2063 passed, 0 failed, 2 skipped**.

No UI change, so no before/after images.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename) — no model changes
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server) — no contract change; `/api/personalities` untouched

---

Implemented by Claude Opus 5 (1M context) in Claude Code.