### PR TITLE
feat(tasks): show recent runs across all tasks on the Tasks list

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -334,8 +334,10 @@
 		36CD9EF0B0734E5F8C28BB92 /* SlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA59130ED4141049177576C /* SlashCommand.swift */; };
 		D600000000000000000022 /* TaskConfigurationFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600000000000000000021 /* TaskConfigurationFields.swift */; };
 		D600000000000000000002 /* CronRunHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600000000000000000001 /* CronRunHistory.swift */; };
+		D6000000000000000000A2 /* CronRecentCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6000000000000000000A1 /* CronRecentCompletion.swift */; };
 		D500000000000000000012 /* TaskDetailHeaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000011 /* TaskDetailHeaderCard.swift */; };
 		D500000000000000000022 /* TaskRunHistorySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000021 /* TaskRunHistorySection.swift */; };
+		D5000000000000000000A2 /* TaskRecentRunRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5000000000000000000A1 /* TaskRecentRunRowView.swift */; };
 		D500000000000000000032 /* TaskRunOutputSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D500000000000000000031 /* TaskRunOutputSheet.swift */; };
 		3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F91D2A54B9A4F66A2C01011 /* Cron.swift */; };
 		D100000000000000000002 /* ANSIEscapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000000000001 /* ANSIEscapes.swift */; };
@@ -685,8 +687,10 @@
 		A82A2A58F08883E396B94B1C /* SlashAutocompleteRanking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashAutocompleteRanking.swift; sourceTree = "<group>"; };
 		D600000000000000000021 /* TaskConfigurationFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskConfigurationFields.swift; sourceTree = "<group>"; };
 		D600000000000000000001 /* CronRunHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronRunHistory.swift; sourceTree = "<group>"; };
+		D6000000000000000000A1 /* CronRecentCompletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronRecentCompletion.swift; sourceTree = "<group>"; };
 		D500000000000000000011 /* TaskDetailHeaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailHeaderCard.swift; sourceTree = "<group>"; };
 		D500000000000000000021 /* TaskRunHistorySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunHistorySection.swift; sourceTree = "<group>"; };
+		D5000000000000000000A1 /* TaskRecentRunRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRecentRunRowView.swift; sourceTree = "<group>"; };
 		D500000000000000000031 /* TaskRunOutputSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRunOutputSheet.swift; sourceTree = "<group>"; };
 		3F91D2A54B9A4F66A2C01011 /* Cron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cron.swift; sourceTree = "<group>"; };
 		D100000000000000000001 /* ANSIEscapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIEscapes.swift; sourceTree = "<group>"; };
@@ -1061,6 +1065,7 @@
 				A02400000000000000000002 /* Goal.swift */,
 				3F91D2A54B9A4F66A2C01011 /* Cron.swift */,
 				D600000000000000000001 /* CronRunHistory.swift */,
+				D6000000000000000000A1 /* CronRecentCompletion.swift */,
 				D100000000000000000001 /* ANSIEscapes.swift */,
 				1A2B3C4D5E6F70000000201 /* Memory.swift */,
 				1A2B3C4D5E6F70000000211 /* Skills.swift */,
@@ -1393,6 +1398,7 @@
 				D500000000000000000031 /* TaskRunOutputSheet.swift */,
 				D600000000000000000021 /* TaskConfigurationFields.swift */,
 				D500000000000000000021 /* TaskRunHistorySection.swift */,
+				D5000000000000000000A1 /* TaskRecentRunRowView.swift */,
 				D500000000000000000011 /* TaskDetailHeaderCard.swift */,
 				C0369000000000000000002 /* CronJobEditorConfigurationLoader.swift */,
 				C0369000000000000000008 /* CronJobEditorSheet.swift */,
@@ -1798,9 +1804,11 @@
 				C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */,
 				A02400000000000000000001 /* Goal.swift in Sources */,
 				D600000000000000000002 /* CronRunHistory.swift in Sources */,
+				D6000000000000000000A2 /* CronRecentCompletion.swift in Sources */,
 				D600000000000000000022 /* TaskConfigurationFields.swift in Sources */,
 				D500000000000000000012 /* TaskDetailHeaderCard.swift in Sources */,
 				D500000000000000000022 /* TaskRunHistorySection.swift in Sources */,
+				D5000000000000000000A2 /* TaskRecentRunRowView.swift in Sources */,
 				D500000000000000000032 /* TaskRunOutputSheet.swift in Sources */,
 				3F91D2A54B9A4F66A2C01001 /* Cron.swift in Sources */,
 				D100000000000000000002 /* ANSIEscapes.swift in Sources */,

--- a/HermesMobile/Features/Tasks/TaskRecentRunRowView.swift
+++ b/HermesMobile/Features/Tasks/TaskRecentRunRowView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// One row of the Tasks list's "Ran Recently" group: an ok/failed dot, the
+/// job's name, and how long ago it finished. The list decides whether the row
+/// links to Task Detail; this view only draws it.
+struct TaskRecentRunRowView: View {
+    let completion: CronRecentCompletion
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Circle()
+                .fill(completion.didFail ? Color.red : Color.green)
+                .frame(width: 8, height: 8)
+                .accessibilityHidden(true)
+
+            Text(completion.displayName)
+                .font(.subheadline)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 1)
+
+            Spacer(minLength: 8)
+
+            Text(relativeTime)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(verbatim: [completion.displayName, statusWord, relativeTime].joined(separator: ", ")))
+    }
+
+    /// Re-evaluated whenever the row is redrawn, which a refresh forces by
+    /// replacing the feed.
+    private var relativeTime: String {
+        completion.completedAt.formatted(.relative(presentation: .numeric, unitsStyle: .abbreviated))
+    }
+
+    private var statusWord: String {
+        completion.didFail ? String(localized: "Failed") : String(localized: "Completed")
+    }
+}

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -110,15 +110,20 @@ struct TasksView: View {
     @ViewBuilder
     private var agenda: some View {
         Group {
-            if sections.isEmpty {
-                ContentUnavailableView {
-                    Label("No Matching Tasks", systemImage: "line.3.horizontal.decrease.circle")
-                } description: {
-                    Text("No tasks match this filter.")
-                }
+            if sections.isEmpty && viewModel.recentRuns.isEmpty {
+                noMatchingTasks
             } else {
+                // The list stays mounted while the feed has rows, so switching
+                // to a filter with no tasks does not take "Ran Recently" away.
                 List {
                     recentRunsSection
+
+                    if sections.isEmpty {
+                        Section {
+                            noMatchingTasks
+                                .listRowBackground(Color.clear)
+                        }
+                    }
 
                     ForEach(sections) { section in
                         Section(section.group.title) {
@@ -135,6 +140,14 @@ struct TasksView: View {
         }
         .safeAreaInset(edge: .top, spacing: 0) {
             filterPicker
+        }
+    }
+
+    private var noMatchingTasks: some View {
+        ContentUnavailableView {
+            Label("No Matching Tasks", systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+            Text("No tasks match this filter.")
         }
     }
 

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -7,6 +7,12 @@ struct TasksView: View {
     @State private var viewModel: TasksViewModel
     @State private var isPresentingCreateTask = false
     @State private var jobPendingDeletion: CronJob?
+    /// "Ran Recently" shows a few rows until the user asks for the rest. View
+    /// state only: every fresh visit starts compact.
+    @State private var isShowingAllRecentRuns = false
+
+    /// Rows "Ran Recently" shows before it needs a "Show all" row.
+    private static let compactRecentRunCount = 3
 
     init(server: URL, onAPIError: @escaping (Error) -> Void) {
         self.server = server
@@ -167,9 +173,13 @@ struct TasksView: View {
     /// Absent until the feed answers and whenever it is empty or failed.
     @ViewBuilder
     private var recentRunsSection: some View {
-        if !viewModel.recentRuns.isEmpty {
+        let recentRuns = viewModel.recentRuns
+        if !recentRuns.isEmpty {
+            let isTruncated = recentRuns.count > Self.compactRecentRunCount && !isShowingAllRecentRuns
+            let visibleRuns = isTruncated ? Array(recentRuns.prefix(Self.compactRecentRunCount)) : recentRuns
+
             Section("Ran Recently") {
-                ForEach(viewModel.recentRuns) { completion in
+                ForEach(visibleRuns) { completion in
                     if let job = viewModel.job(for: completion) {
                         NavigationLink {
                             detail(for: job)
@@ -180,6 +190,15 @@ struct TasksView: View {
                         // The feed named a job the list does not have: no link,
                         // no chevron, and nothing that reads as a button.
                         TaskRecentRunRowView(completion: completion)
+                    }
+                }
+
+                if recentRuns.count > Self.compactRecentRunCount {
+                    Button {
+                        isShowingAllRecentRuns.toggle()
+                    } label: {
+                        Text(isTruncated ? "Show All (\(recentRuns.count))" : "Show Less")
+                            .font(.subheadline)
                     }
                 }
             }

--- a/HermesMobile/Features/Tasks/TasksView.swift
+++ b/HermesMobile/Features/Tasks/TasksView.swift
@@ -118,6 +118,8 @@ struct TasksView: View {
                 }
             } else {
                 List {
+                    recentRunsSection
+
                     ForEach(sections) { section in
                         Section(section.group.title) {
                             ForEach(section.jobs) { job in
@@ -148,17 +150,44 @@ struct TasksView: View {
         .background(.bar)
     }
 
+    /// Cross-task recent completions, above the agenda and outside the filter.
+    /// Absent until the feed answers and whenever it is empty or failed.
+    @ViewBuilder
+    private var recentRunsSection: some View {
+        if !viewModel.recentRuns.isEmpty {
+            Section("Ran Recently") {
+                ForEach(viewModel.recentRuns) { completion in
+                    if let job = viewModel.job(for: completion) {
+                        NavigationLink {
+                            detail(for: job)
+                        } label: {
+                            TaskRecentRunRowView(completion: completion)
+                        }
+                    } else {
+                        // The feed named a job the list does not have: no link,
+                        // no chevron, and nothing that reads as a button.
+                        TaskRecentRunRowView(completion: completion)
+                    }
+                }
+            }
+        }
+    }
+
+    private func detail(for job: CronJob) -> some View {
+        TaskDetailView(
+            job: job,
+            runningElapsed: viewModel.runningElapsed(for: job),
+            server: server,
+            onAPIError: onAPIError,
+            onMutation: { mutation in
+                viewModel.apply(mutation)
+            }
+        )
+    }
+
     private func row(for job: CronJob, in group: TaskAgendaGroup) -> some View {
         NavigationLink {
-            TaskDetailView(
-                job: job,
-                runningElapsed: viewModel.runningElapsed(for: job),
-                server: server,
-                onAPIError: onAPIError,
-                onMutation: { mutation in
-                    viewModel.apply(mutation)
-                }
-            )
+            detail(for: job)
         } label: {
             CronJobRowView(
                 job: job,

--- a/HermesMobile/Features/Tasks/TasksViewModel.swift
+++ b/HermesMobile/Features/Tasks/TasksViewModel.swift
@@ -14,6 +14,12 @@ final class TasksViewModel {
     /// Server-provided deliver targets; `nil` while unknown or when the
     /// endpoint is unavailable (the editor then falls back to free text).
     private(set) var deliveryOptions: [CronDeliveryOption]?
+    /// Newest-first recent completions across every job. Empty until the feed
+    /// answers, and stays empty on any feed failure; never gates `isLoading`.
+    private(set) var recentRuns: [CronRecentCompletion] = []
+    /// The in-flight feed request, so a reload cancels the one before it and
+    /// tests can wait for the feed without polling.
+    private(set) var recentRunsTask: Task<Void, Never>?
     private(set) var isLoading = false
     private(set) var isMutating = false
     private(set) var errorMessage: String?
@@ -42,6 +48,8 @@ final class TasksViewModel {
         lastError = nil
         defer { isLoading = false }
 
+        refreshRecentRuns()
+
         do {
             async let jobsResponse = client.crons()
             async let statusResponse = client.cronStatus()
@@ -57,6 +65,29 @@ final class TasksViewModel {
             lastError = error
             errorMessage = error.localizedDescription
         }
+    }
+
+    /// Fetches the recent-runs feed on its own task so a slow or missing
+    /// endpoint never holds the task list in its loading state. A reload
+    /// cancels the previous fetch, so a late answer cannot overwrite a newer one.
+    private func refreshRecentRuns() {
+        recentRunsTask?.cancel()
+        recentRunsTask = Task { [client] in
+            let response = try? await client.cronRecent()
+            guard !Task.isCancelled, let response else { return }
+            recentRuns = CronRecentCompletion.newestFirst(response.completions ?? [])
+        }
+    }
+
+    /// The loaded job a recent run belongs to, or `nil` when the feed names a
+    /// job the list does not have. Matches on id first; `/api/crons` has shipped
+    /// with `id` null before, in which case the name is all there is.
+    func job(for completion: CronRecentCompletion) -> CronJob? {
+        if let jobID = completion.jobId, let job = jobs.first(where: { $0.jobId == jobID }) {
+            return job
+        }
+        guard let name = completion.name, !name.isEmpty else { return nil }
+        return jobs.first { $0.name == name }
     }
 
     func runningElapsed(for job: CronJob) -> Double? {

--- a/HermesMobile/Features/Tasks/TasksViewModel.swift
+++ b/HermesMobile/Features/Tasks/TasksViewModel.swift
@@ -69,12 +69,16 @@ final class TasksViewModel {
 
     /// Fetches the recent-runs feed on its own task so a slow or missing
     /// endpoint never holds the task list in its loading state. A reload
-    /// cancels the previous fetch, so a late answer cannot overwrite a newer one.
+    /// cancels the previous fetch, so a late answer cannot overwrite a newer
+    /// one, and a failed refresh keeps the last good feed, the same way the
+    /// task list keeps its jobs when its own reload fails. The task holds
+    /// `self` weakly, so a screen that is gone by the time the feed answers
+    /// is never written to.
     private func refreshRecentRuns() {
         recentRunsTask?.cancel()
-        recentRunsTask = Task { [client] in
+        recentRunsTask = Task { [weak self, client] in
             let response = try? await client.cronRecent()
-            guard !Task.isCancelled, let response else { return }
+            guard let self, !Task.isCancelled, let response else { return }
             recentRuns = CronRecentCompletion.newestFirst(response.completions ?? [])
         }
     }

--- a/HermesMobile/Models/CronRecentCompletion.swift
+++ b/HermesMobile/Models/CronRecentCompletion.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// `GET /api/crons/recent`: one entry per job that has ever run, built from
+/// each job's `last_run_at` and `last_status`. Upstream emits them in job
+/// order, not by time, so the Tasks list sorts `completions` itself.
+struct CronRecentCompletionsResponse: Decodable, Equatable {
+    let completions: [CronRecentCompletion]?
+
+    enum CodingKeys: String, CodingKey {
+        case completions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        completions = ((try? container.decodeIfPresent([LossyCronRecentCompletion].self, forKey: .completions)) ?? nil)?
+            .compactMap(\.completion)
+    }
+}
+
+/// One job's latest finished run, as the recent-runs group shows it.
+struct CronRecentCompletion: Decodable, Equatable, Identifiable {
+    /// One completion per job on the wire, so the job is the identity; a
+    /// nameless, idless entry falls back to its timestamp.
+    var id: String {
+        jobId ?? name ?? String(completedAt.timeIntervalSince1970)
+    }
+
+    let jobId: String?
+    let name: String?
+    let status: String?
+    let completedAt: Date
+    let sessionId: String?
+    let messageCount: Int?
+
+    var didFail: Bool {
+        status == "error"
+    }
+
+    var displayName: String {
+        if let name, !name.isEmpty {
+            return name
+        }
+        return String(localized: "Untitled Task")
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case jobId
+        case name
+        case status
+        case completedAt
+        case sessionId
+        case messageCount
+    }
+
+    init(jobId: String?, name: String?, status: String?, completedAt: Date, sessionId: String? = nil, messageCount: Int? = nil) {
+        self.jobId = jobId
+        self.name = name
+        self.status = status
+        self.completedAt = completedAt
+        self.sessionId = sessionId
+        self.messageCount = messageCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Without a time the row has nothing to sort or show, so it is dropped
+        // by `LossyCronRecentCompletion` rather than rendered.
+        guard let completedAt = (try? container.decodeIfPresent(CronDateValue.self, forKey: .completedAt)) ?? nil else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .completedAt,
+                in: container,
+                debugDescription: "Recent completion has no usable completed_at"
+            )
+        }
+
+        self.completedAt = completedAt.date
+        jobId = container.decodeLossyStringIfPresent(forKey: .jobId)
+        name = container.decodeLossyStringIfPresent(forKey: .name)
+        status = container.decodeLossyStringIfPresent(forKey: .status)
+        sessionId = container.decodeLossyStringIfPresent(forKey: .sessionId)
+        messageCount = container.decodeLossyIntIfPresent(forKey: .messageCount)
+    }
+
+    /// Newest first, which is the only order the group is shown in.
+    static func newestFirst(_ completions: [CronRecentCompletion]) -> [CronRecentCompletion] {
+        completions.sorted { $0.completedAt > $1.completedAt }
+    }
+}
+
+/// Wraps one array element so a single malformed completion is skipped
+/// instead of failing the whole feed.
+private struct LossyCronRecentCompletion: Decodable {
+    let completion: CronRecentCompletion?
+
+    init(from decoder: Decoder) throws {
+        completion = try? CronRecentCompletion(from: decoder)
+    }
+}

--- a/HermesMobile/Networking/APIClient+Cron.swift
+++ b/HermesMobile/Networking/APIClient+Cron.swift
@@ -67,6 +67,12 @@ extension APIClient {
         try await send(endpoint: .cronDeliveryOptions, method: "GET")
     }
 
+    /// Each job's most recent completion. Unordered on the wire; see
+    /// `CronRecentCompletionsResponse.completions`.
+    func cronRecent() async throws -> CronRecentCompletionsResponse {
+        try await send(endpoint: .cronRecent, method: "GET")
+    }
+
     func deleteCron(jobID: String) async throws -> CronMutationResponse {
         try await send(
             endpoint: .cronDelete,

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -102,6 +102,9 @@ enum Endpoint {
     case cronStatus(jobID: String?)
     case cronOutput(jobID: String, limit: Int?)
     case cronDeliveryOptions
+    /// GET: every job's latest completion, for the Tasks list's recent-runs
+    /// group. Upstream also accepts `since` for polling; this app does not poll.
+    case cronRecent
     case kanbanConfig
     case kanbanBoards
     case kanbanCreateBoard
@@ -326,6 +329,8 @@ enum Endpoint {
             return "/api/crons/output"
         case .cronDeliveryOptions:
             return "/api/crons/delivery-options"
+        case .cronRecent:
+            return "/api/crons/recent"
         case .kanbanConfig:
             return "/api/kanban/config"
         case .kanbanBoards, .kanbanCreateBoard:

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -128088,6 +128088,218 @@
           }
         }
       }
+    },
+    "Show All (%lld)" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "عرض الكل (%lld)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle anzeigen (%lld)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar todo (%lld)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tout afficher (%lld)"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הצג הכל (%lld)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra tutto (%lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "すべて表示 (%lld)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모두 보기 (%lld)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alles tonen (%lld)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pokaż wszystkie (%lld)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar tudo (%lld)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показать все (%lld)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tümünü göster (%lld)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سب دکھائیں (%lld)"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示全部 (%lld)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "显示全部 (%lld)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示全部 (%lld)"
+          }
+        }
+      }
+    },
+    "Show Less" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "عرض أقل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Weniger anzeigen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar menos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Afficher moins"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הצג פחות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra meno"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "表示を減らす"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "간략히 보기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Minder tonen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pokaż mniej"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar menos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показать меньше"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Daha az göster"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کم دکھائیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示較少"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "收起"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示較少"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -127982,6 +127982,112 @@
           }
         }
       }
+    },
+    "Ran Recently" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم التشغيل مؤخرًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kürzlich ausgeführt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ejecutadas recientemente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exécutées récemment"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הופעלו לאחרונה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eseguite di recente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "最近実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "최근 실행됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Onlangs uitgevoerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ostatnio uruchomione"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Executadas recentemente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Недавно выполнены"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Son çalıştırılanlar"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "حال ہی میں چلائے گئے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "最近執行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "最近运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "最近執行"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -261,6 +261,7 @@ final class ContractReadinessTests: XCTestCase {
                 endpoint: .cronDeliveryOptions,
                 path: "/api/crons/delivery-options"
             ),
+            .init(name: "cron recent", method: "GET", endpoint: .cronRecent, path: "/api/crons/recent"),
             .init(name: "memory", method: "GET", endpoint: .memory, path: "/api/memory"),
             .init(name: "memory write", method: "POST", endpoint: .memoryWrite, path: "/api/memory/write"),
             .init(name: "skills", method: "GET", endpoint: .skills, path: "/api/skills"),

--- a/HermesMobileTests/CronManagementTests.swift
+++ b/HermesMobileTests/CronManagementTests.swift
@@ -248,6 +248,8 @@ final class CronManagementViewModelTests: XCTestCase {
                     #"{"platforms": [{"value": "local", "label": "Local (save output only)"}]}"#,
                     for: request
                 )
+            case "/api/crons/recent":
+                return apiTestJSONResponse(#"{"completions": []}"#, for: request)
             default:
                 XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
                 return apiTestJSONResponse("{}", for: request)
@@ -278,6 +280,8 @@ final class CronManagementViewModelTests: XCTestCase {
                     headerFields: ["Content-Type": "application/json"]
                 )!
                 return (response, Data(#"{"error": "not found"}"#.utf8))
+            case "/api/crons/recent":
+                return apiTestJSONResponse(#"{"completions": []}"#, for: request)
             default:
                 XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
                 return apiTestJSONResponse("{}", for: request)
@@ -290,6 +294,114 @@ final class CronManagementViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.deliveryOptions, "Endpoint failure must fall back to free-text deliver entry.")
         XCTAssertEqual(viewModel.jobs.map(\.jobId), ["job123"], "Jobs must still load when delivery options fail.")
         XCTAssertNil(viewModel.errorMessage)
+    }
+
+    // MARK: - Recent runs feed
+
+    private static let jobsJSON = #"{"jobs": [{"id": "job-a", "name": "Digest"}, {"id": null, "name": "Backup"}]}"#
+
+    @MainActor
+    func testTasksViewModelLoadsRecentRunsNewestFirstAndMatchesJobs() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons":
+                return apiTestJSONResponse(Self.jobsJSON, for: request)
+            case "/api/crons/status":
+                return apiTestJSONResponse(#"{"running": {}}"#, for: request)
+            case "/api/crons/delivery-options":
+                return apiTestJSONResponse(#"{"platforms": []}"#, for: request)
+            case "/api/crons/recent":
+                return apiTestJSONResponse("""
+                {
+                  "completions": [
+                    {"job_id": "job-a", "name": "Renamed", "status": "ok", "completed_at": 100.5},
+                    {"job_id": "job-gone", "name": "Deleted", "status": "error", "completed_at": 300, "message_count": 1e30},
+                    {"job_id": "b-id", "name": "Backup", "status": "ok", "completed_at": "200", "message_count": "4"},
+                    {"job_id": "no-time", "name": "Broken", "status": "ok", "completed_at": "soon"}
+                  ],
+                  "since": 0
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TasksViewModel(server: try XCTUnwrap(URL(string: "https://example.test")), client: client)
+
+        await viewModel.load()
+        await viewModel.recentRunsTask?.value
+
+        XCTAssertEqual(viewModel.recentRuns.map(\.jobId), ["job-gone", "b-id", "job-a"], "Newest first; the entry without a usable time is dropped.")
+        XCTAssertEqual(viewModel.recentRuns.map(\.didFail), [true, false, false])
+        XCTAssertEqual(viewModel.recentRuns.map(\.messageCount), [nil, 4, nil], "Out-of-range and string counts decode without trapping.")
+
+        XCTAssertEqual(viewModel.job(for: viewModel.recentRuns[2])?.name, "Digest", "Id wins over a stale name.")
+        XCTAssertEqual(viewModel.job(for: viewModel.recentRuns[1])?.name, "Backup", "Name is the fallback when the list has no id.")
+        XCTAssertNil(viewModel.job(for: viewModel.recentRuns[0]), "A job missing from the list stays display-only.")
+    }
+
+    @MainActor
+    func testTasksViewModelLoadFinishesWhileRecentRunsAreStillInFlight() async throws {
+        let releaseFeed = DispatchSemaphore(value: 0)
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons":
+                return apiTestJSONResponse(Self.jobsJSON, for: request)
+            case "/api/crons/status":
+                return apiTestJSONResponse(#"{"running": {}}"#, for: request)
+            case "/api/crons/delivery-options":
+                return apiTestJSONResponse(#"{"platforms": []}"#, for: request)
+            case "/api/crons/recent":
+                releaseFeed.wait()
+                return apiTestJSONResponse(
+                    #"{"completions": [{"job_id": "job-a", "name": "Digest", "status": "ok", "completed_at": 1}]}"#,
+                    for: request
+                )
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TasksViewModel(server: try XCTUnwrap(URL(string: "https://example.test")), client: client)
+
+        await viewModel.load()
+
+        XCTAssertFalse(viewModel.isLoading, "A pending feed must not hold the list in its loading state.")
+        XCTAssertEqual(viewModel.jobs.map(\.name), ["Digest", "Backup"])
+        XCTAssertTrue(viewModel.recentRuns.isEmpty, "The group stays absent until the feed answers.")
+
+        releaseFeed.signal()
+        await viewModel.recentRunsTask?.value
+
+        XCTAssertEqual(viewModel.recentRuns.map(\.jobId), ["job-a"])
+    }
+
+    @MainActor
+    func testTasksViewModelLoadToleratesRecentRunsFailure() async throws {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/crons":
+                return apiTestJSONResponse(Self.jobsJSON, for: request)
+            case "/api/crons/status":
+                return apiTestJSONResponse(#"{"running": {}}"#, for: request)
+            case "/api/crons/delivery-options":
+                return apiTestJSONResponse(#"{"platforms": []}"#, for: request)
+            case "/api/crons/recent":
+                return apiTestJSONResponse(#"{"error": "not found"}"#, for: request, status: 404)
+            default:
+                XCTFail("Unexpected request: \(request.url?.path ?? "nil")")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+        let viewModel = TasksViewModel(server: try XCTUnwrap(URL(string: "https://example.test")), client: client)
+
+        await viewModel.load()
+        await viewModel.recentRunsTask?.value
+
+        XCTAssertTrue(viewModel.recentRuns.isEmpty, "An older server without the endpoint leaves the group absent.")
+        XCTAssertEqual(viewModel.jobs.count, 2, "The task list is untouched by a feed failure.")
+        XCTAssertNil(viewModel.errorMessage, "No error surfaces for the optional feed.")
     }
 
     @MainActor


### PR DESCRIPTION
## Linked issue

Fixes #378

## What changed

The Tasks list said what was scheduled but not what actually ran; you had to open each task to find out. Now a **Ran Recently** group sits at the top of the list showing every task's last run, newest first, with a green/red dot and a relative time. Tapping a row opens that task's detail. Rows for tasks the list does not have are display-only, with no chevron and no button trait.

How: `TasksViewModel.load()` kicks off `GET /api/crons/recent` on its own task, so the list renders as soon as `/api/crons` answers and the feed fills in when it arrives, or quietly stays absent on any failure (including a 404 from an older server). A reload cancels the previous feed fetch so a late answer cannot overwrite a newer one. Rows match a job by id first, falling back to name.

Contract verified against the live server on 2026-09-04: `/api/crons/recent` returns `{completions: [{job_id, name, status, completed_at, toast_notifications, session_id, message_count}], since}`, unordered, so the client sorts. `/api/crons` returns real ids under `id` (only the `job_id` key is null), which the app already reads, so id matching does resolve; name stays as the fallback the issue asks for.

## How it was tested

- Full XCTest suite via XcodeBuildMCP `test_sim` on iPhone 17: 2067 passed, 0 failed, 2 skipped.
- New tests in `CronManagementViewModelTests`: feed loads newest-first and matches jobs by id then name, a malformed `message_count` / `completed_at` decodes without trapping, a slow feed does not hold `isLoading`, and a 404 feed leaves the list and error state untouched. `APIEndpointContractTests` covers the new endpoint path.
- Manual simulator check pending from the maintainer (see below).

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (verified against a running server and `routes.py`)

---
Built by Claude Fable 5.1 via Claude Code.