### PR TITLE
feat(session): clear server-side history for /clear

### DIFF
--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -319,6 +319,10 @@ struct ChatView: View {
     @State private var transcriptMediaPreviewItem: TranscriptMediaPreviewItem?
     @State private var pendingProfileSelection: ProfileSummary?
     @State private var showProfileNewSessionConfirmation = false
+    /// Set while the destructive `/clear` confirmation is on screen. Holds the
+    /// submitted draft so a confirmed clear consumes it and a cancel leaves it
+    /// in the composer (#389).
+    @State private var pendingClearConfirmation: PendingClearConfirmation?
     @State private var goalDraft = ""
     @State private var showsGoalSheet = false
     @State private var activeGitSheet: ActiveGitSheet?
@@ -597,7 +601,39 @@ struct ChatView: View {
         "\(server.absoluteString)|\(transcriptMediaSessionID ?? "local:\(session.id)")"
     }
 
-    var body: some View {
+    /// Extracted from `body` so the view's single chained expression stays
+    /// inside the compiler's type-checking budget.
+    @ViewBuilder
+    private var approvalOverlay: some View {
+        if let approvalPrompt = viewModel.approvalPrompt {
+            ApprovalRequestOverlay(
+                prompt: approvalPrompt,
+                isResponding: viewModel.isRespondingToApproval,
+                errorMessage: viewModel.approvalErrorMessage,
+                onChoice: { choice in
+                    Task {
+                        let didRespond = await viewModel.respondToApproval(choice)
+                        if didRespond {
+                            ChatHaptics.approvalSubmitted(choice, isEnabled: isHapticsEnabled)
+                        }
+                    }
+                },
+                onSkipAll: {
+                    Task {
+                        let didSkip = await viewModel.skipApprovalsForCurrentSession()
+                        if didSkip {
+                            ChatHaptics.approvalBypassEnabled(isEnabled: isHapticsEnabled)
+                        }
+                    }
+                }
+            )
+            .zIndex(10)
+        }
+    }
+
+    /// The chat scaffold. Split from `body` so the confirmation-alert chain
+    /// below stays inside the compiler's type-checking budget.
+    private var chatContent: some View {
         ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
                 if viewModel.isViewingCachedData {
@@ -621,30 +657,7 @@ struct ChatView: View {
 
             messageComposer
 
-            if let approvalPrompt = viewModel.approvalPrompt {
-                ApprovalRequestOverlay(
-                    prompt: approvalPrompt,
-                    isResponding: viewModel.isRespondingToApproval,
-                    errorMessage: viewModel.approvalErrorMessage,
-                    onChoice: { choice in
-                        Task {
-                            let didRespond = await viewModel.respondToApproval(choice)
-                            if didRespond {
-                                ChatHaptics.approvalSubmitted(choice, isEnabled: isHapticsEnabled)
-                            }
-                        }
-                    },
-                    onSkipAll: {
-                        Task {
-                            let didSkip = await viewModel.skipApprovalsForCurrentSession()
-                            if didSkip {
-                                ChatHaptics.approvalBypassEnabled(isEnabled: isHapticsEnabled)
-                            }
-                        }
-                    }
-                )
-                .zIndex(10)
-            }
+            approvalOverlay
         }
         .overlay(alignment: .top) {
             GitActionToastOverlay(state: gitToastState)
@@ -792,6 +805,10 @@ struct ChatView: View {
                     }
                 )
             }
+    }
+
+    var body: some View {
+        chatContent
             .alert(
                 "Discard Later Messages?",
                 isPresented: $showEditDiscardConfirmation
@@ -838,6 +855,13 @@ struct ChatView: View {
             } message: {
                 Text(profileSwitchWarningMessage)
             }
+            .modifier(
+                ClearConversationAlertModifier(
+                    pending: $pendingClearConfirmation,
+                    isHapticsEnabled: isHapticsEnabled,
+                    onConfirm: confirmClearConversation
+                )
+            )
             .alert(
                 "Message Action Failed",
                 isPresented: Binding(
@@ -1672,6 +1696,24 @@ struct ChatView: View {
         }
     }
 
+    private func confirmClearConversation(_ pending: PendingClearConfirmation) {
+        Task { await clearConversation(pending) }
+    }
+
+    private func clearConversation(_ pending: PendingClearConfirmation) async {
+        let result = await viewModel.clearConversationFromSlashCommand(modelContext: modelContext)
+        handleSlashExecutionResult(
+            result,
+            parsedCommand: SlashCommandCatalog.command(named: "clear"),
+            submittedDraft: pending.draft,
+            submittedDraftRevision: pending.draftRevision
+        )
+
+        if let lastError = viewModel.lastError {
+            onAPIError(lastError)
+        }
+    }
+
     private func sendDraftMessage() async {
         let submittedDraft = draftMessage
         let submittedDraftRevision = draftRevision
@@ -1679,7 +1721,20 @@ struct ChatView: View {
 
         if submittedDraft.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/") {
             let parsedCommand = SlashCommandExecutor.parse(submittedDraft)?.command
-            let result = await SlashCommandExecutor.execute(text: submittedDraft, viewModel: viewModel)
+            // `/clear` wipes the conversation on the server, so it always asks
+            // first. The draft stays in the composer until the user confirms.
+            if parsedCommand?.handler == .clientSide(.clear) {
+                pendingClearConfirmation = PendingClearConfirmation(
+                    draft: submittedDraft,
+                    draftRevision: submittedDraftRevision
+                )
+                return
+            }
+            let result = await SlashCommandExecutor.execute(
+                text: submittedDraft,
+                viewModel: viewModel,
+                modelContext: modelContext
+            )
             handleSlashExecutionResult(
                 result,
                 parsedCommand: parsedCommand,
@@ -2896,6 +2951,47 @@ enum ChatToolbarSubtitleResolver {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+/// The draft that raised the destructive `/clear` confirmation, so confirming
+/// consumes exactly the text that was sent and cancelling leaves it alone.
+private struct PendingClearConfirmation: Equatable {
+    let draft: String
+    let draftRevision: Int
+}
+
+/// The `/clear` confirmation, in its own modifier so `ChatView.body`'s alert
+/// chain stays inside the compiler's type-checking budget.
+private struct ClearConversationAlertModifier: ViewModifier {
+    @Binding var pending: PendingClearConfirmation?
+    let isHapticsEnabled: Bool
+    let onConfirm: (PendingClearConfirmation) -> Void
+
+    func body(content: Content) -> some View {
+        content.alert(
+            "Clear Conversation?",
+            isPresented: Binding(
+                get: { pending != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        pending = nil
+                    }
+                }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                pending = nil
+            }
+            Button("Clear", role: .destructive) {
+                guard let confirmed = pending else { return }
+                ChatHaptics.destructiveConfirmationAccepted(isEnabled: isHapticsEnabled)
+                pending = nil
+                onConfirm(confirmed)
+            }
+        } message: {
+            Text("This deletes every message in this conversation on the server. It cannot be undone.")
+        }
     }
 }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1723,7 +1723,10 @@ struct ChatView: View {
             let parsedCommand = SlashCommandExecutor.parse(submittedDraft)?.command
             // `/clear` wipes the conversation on the server, so it always asks
             // first. The draft stays in the composer until the user confirms.
-            if parsedCommand?.handler == .clientSide(.clear) {
+            // A refusal the app already knows about (cached view, CLI session,
+            // live stream) skips the alert and falls through to the normal
+            // slash path, which surfaces it.
+            if parsedCommand?.handler == .clientSide(.clear), viewModel.clearConversationRefusal == nil {
                 pendingClearConfirmation = PendingClearConfirmation(
                     draft: submittedDraft,
                     draftRevision: submittedDraftRevision

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -2578,13 +2578,18 @@ final class ChatViewModel {
         sendErrorMessage = nil
     }
 
-    func executeSlashCommand(_ command: SlashCommand, args: String = "") async -> SlashCommandExecutionResult {
+    /// `modelContext` is only needed by commands that rewrite the offline cache
+    /// (`/clear`); every other command ignores it.
+    func executeSlashCommand(
+        _ command: SlashCommand,
+        args: String = "",
+        modelContext: ModelContext? = nil
+    ) async -> SlashCommandExecutionResult {
         switch command.handler {
         case .clientSide(let action):
             switch action {
             case .clear:
-                clearTranscript()
-                return .executed(message: nil)
+                return await clearConversationFromSlashCommand(modelContext: modelContext)
             case .stop:
                 await cancelActiveStream()
                 return .executed(message: nil)
@@ -3293,6 +3298,56 @@ final class ChatViewModel {
             }
 
             return .executed(message: String(localized: "Context compressed.\n\n\(details)"))
+        } catch {
+            lastError = error
+            return .unsupported(friendlyMessage: error.localizedDescription)
+        }
+    }
+
+    /// Clears the conversation on the server, then locally. Destructive and
+    /// irreversible, so `ChatView` confirms before calling this; the guards
+    /// below mirror `/undo` and refuse before any network call. Pass the
+    /// `ModelContext` so the offline cache is emptied too — otherwise a cold
+    /// open would repaint the history this just deleted.
+    func clearConversationFromSlashCommand(modelContext: ModelContext?) async -> SlashCommandExecutionResult {
+        guard !isViewingCachedData else {
+            return .unsupported(friendlyMessage: String(localized: "Reconnect to the server to clear the conversation."))
+        }
+
+        guard !isCLISession else {
+            return .unsupported(friendlyMessage: String(localized: "Clearing the conversation is available for WebUI sessions only."))
+        }
+
+        guard activeStreamID == nil else {
+            return .unsupported(friendlyMessage: String(localized: "Wait for the current response to finish before clearing the conversation."))
+        }
+
+        guard let sessionID else {
+            return .unsupported(friendlyMessage: String(localized: "The server did not provide a session ID."))
+        }
+
+        lastError = nil
+        sendErrorMessage = nil
+
+        do {
+            let response = try await client.clearSession(id: sessionID)
+            if let error = response.error {
+                return .unsupported(friendlyMessage: error)
+            }
+
+            clearTranscript()
+            displayTitle = Self.displayTitle(from: response.session?.title)
+            liveActivityManager.update(.sessionTitle(displayTitle))
+
+            if let modelContext {
+                do {
+                    try CacheStore.cacheMessages([], serverURL: server, sessionID: sessionID, in: modelContext)
+                } catch {
+                    cacheErrorMessage = error.localizedDescription
+                }
+            }
+
+            return .executed(message: nil)
         } catch {
             lastError = error
             return .unsupported(friendlyMessage: error.localizedDescription)
@@ -5253,7 +5308,7 @@ final class ChatViewModel {
     Available mobile commands:
 
     `/help` - Show this command list.
-    `/clear` - Clear the local transcript.
+    `/clear` - Clear this conversation on the server. Asks first.
     `/stop` - Stop the current response.
     `/new` - Open a fresh session.
     `/model <id>` - Switch this session's model.

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -233,6 +233,11 @@ final class ChatViewModel {
     @ObservationIgnored private var sendErrorIsFromStreamRecovery = false
     private(set) var messageActionErrorMessage: String?
     private(set) var cacheErrorMessage: String?
+
+    /// Set while `POST /api/session/clear` is in flight. A send or a second
+    /// `/clear` refuses while it is set, so the clear response cannot wipe a
+    /// message the user started inside that window (#389).
+    private(set) var isClearingConversation = false
     private(set) var lastError: Error?
     private(set) var displayTitle: String
     private(set) var listeningMessageID: String?
@@ -2223,6 +2228,11 @@ final class ChatViewModel {
             return false
         }
 
+        guard !isClearingConversation else {
+            sendErrorMessage = String(localized: "Wait for the conversation to finish clearing.")
+            return false
+        }
+
         let message = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return false }
 
@@ -3304,22 +3314,41 @@ final class ChatViewModel {
         }
     }
 
+    /// Why `/clear` cannot run right now, or `nil` when it can. These are the
+    /// same refusals `/undo` uses, and they never touch the network. `ChatView`
+    /// reads this before showing the destructive confirmation so a refusal is
+    /// never hidden behind an alert the user has to answer first.
+    var clearConversationRefusal: String? {
+        if isViewingCachedData {
+            return String(localized: "Reconnect to the server to clear the conversation.")
+        }
+
+        if isCLISession {
+            return String(localized: "Clearing the conversation is available for WebUI sessions only.")
+        }
+
+        if activeStreamID != nil {
+            return String(localized: "Wait for the current response to finish before clearing the conversation.")
+        }
+
+        if isClearingConversation {
+            return String(localized: "Wait for the conversation to finish clearing.")
+        }
+
+        if sessionID == nil {
+            return String(localized: "The server did not provide a session ID.")
+        }
+
+        return nil
+    }
+
     /// Clears the conversation on the server, then locally. Destructive and
-    /// irreversible, so `ChatView` confirms before calling this; the guards
-    /// below mirror `/undo` and refuse before any network call. Pass the
+    /// irreversible, so `ChatView` confirms before calling this. Pass the
     /// `ModelContext` so the offline cache is emptied too — otherwise a cold
     /// open would repaint the history this just deleted.
     func clearConversationFromSlashCommand(modelContext: ModelContext?) async -> SlashCommandExecutionResult {
-        guard !isViewingCachedData else {
-            return .unsupported(friendlyMessage: String(localized: "Reconnect to the server to clear the conversation."))
-        }
-
-        guard !isCLISession else {
-            return .unsupported(friendlyMessage: String(localized: "Clearing the conversation is available for WebUI sessions only."))
-        }
-
-        guard activeStreamID == nil else {
-            return .unsupported(friendlyMessage: String(localized: "Wait for the current response to finish before clearing the conversation."))
+        if let refusal = clearConversationRefusal {
+            return .unsupported(friendlyMessage: refusal)
         }
 
         guard let sessionID else {
@@ -3328,6 +3357,8 @@ final class ChatViewModel {
 
         lastError = nil
         sendErrorMessage = nil
+        isClearingConversation = true
+        defer { isClearingConversation = false }
 
         do {
             let response = try await client.clearSession(id: sessionID)
@@ -3343,7 +3374,11 @@ final class ChatViewModel {
                 do {
                     try CacheStore.cacheMessages([], serverURL: server, sessionID: sessionID, in: modelContext)
                 } catch {
+                    // The server history is gone but the offline copy still
+                    // holds it, so a later cold open would repaint messages the
+                    // user just deleted. Say so where they will see it.
                     cacheErrorMessage = error.localizedDescription
+                    sendErrorMessage = String(localized: "Cleared on the server, but the offline copy of this conversation could not be updated.")
                 }
             }
 

--- a/HermesMobile/Features/Chat/SlashCommandCatalog.swift
+++ b/HermesMobile/Features/Chat/SlashCommandCatalog.swift
@@ -10,7 +10,7 @@ enum SlashCommandCatalog {
         ),
         SlashCommand(
             name: "clear",
-            description: String(localized: "Clear the current conversation"),
+            description: String(localized: "Clear this conversation on the server"),
             noEcho: true,
             handler: .clientSide(.clear)
         ),

--- a/HermesMobile/Features/Chat/SlashCommandExecutor.swift
+++ b/HermesMobile/Features/Chat/SlashCommandExecutor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 
 struct ParsedSlashCommand: Equatable {
     let command: SlashCommand?
@@ -37,8 +38,14 @@ enum SlashCommandExecutor {
         )
     }
 
+    /// `modelContext` reaches the handful of commands that rewrite the offline
+    /// cache (`/clear`); callers with no SwiftData context can omit it.
     @MainActor
-    static func execute(text: String, viewModel: ChatViewModel) async -> SlashCommandExecutionResult {
+    static func execute(
+        text: String,
+        viewModel: ChatViewModel,
+        modelContext: ModelContext? = nil
+    ) async -> SlashCommandExecutionResult {
         guard let parsed = parse(text) else { return .sendAsMessage }
         guard !parsed.name.isEmpty else { return .needsSubArg }
 
@@ -57,10 +64,12 @@ enum SlashCommandExecutor {
         }
 
         switch command.handler {
-        case .clientSide:
-            return await viewModel.executeSlashCommand(command, args: parsed.args)
-        case .serverSide:
-            return await viewModel.executeSlashCommand(command, args: parsed.args)
+        case .clientSide, .serverSide:
+            return await viewModel.executeSlashCommand(
+                command,
+                args: parsed.args,
+                modelContext: modelContext
+            )
         case .unsupported:
             return .unsupported(friendlyMessage: unsupportedMessage(for: command.name))
         }

--- a/HermesMobile/Networking/APIClient+Sessions.swift
+++ b/HermesMobile/Networking/APIClient+Sessions.swift
@@ -131,6 +131,17 @@ extension APIClient {
         )
     }
 
+    /// Truncates the session to empty on the server and resets its title to
+    /// Untitled. Destructive and irreversible — only call it behind a
+    /// confirmation. Answers the same compact session shape as rename (#389).
+    func clearSession(id: String) async throws -> SessionMutationResponse {
+        try await send(
+            endpoint: .clearSession,
+            method: "POST",
+            body: SessionIDRequest(sessionId: id)
+        )
+    }
+
     func undoSession(id: String) async throws -> SessionUndoResponse {
         try await send(
             endpoint: .undoSession,

--- a/HermesMobile/Networking/Endpoints.swift
+++ b/HermesMobile/Networking/Endpoints.swift
@@ -20,6 +20,9 @@ enum Endpoint {
     /// fork lineage. `branchSession` means "fork a child from here" (#25).
     case duplicateSession
     case compressSession
+    /// Truncates the session to empty on the server, resetting the title.
+    /// Destructive and irreversible: always confirm before calling it (#389).
+    case clearSession
     case undoSession
     case retrySession
     case truncateSession
@@ -173,6 +176,8 @@ enum Endpoint {
             return "/api/session/duplicate"
         case .compressSession:
             return "/api/session/compress"
+        case .clearSession:
+            return "/api/session/clear"
         case .undoSession:
             return "/api/session/undo"
         case .retrySession:

--- a/HermesMobileTests/APIClientSessionMutationTests.swift
+++ b/HermesMobileTests/APIClientSessionMutationTests.swift
@@ -146,6 +146,53 @@ final class APIClientSessionMutationTests: APIClientTestCase {
         XCTAssertEqual(asciiSummary.compressedTokenEstimate, 320)
     }
 
+    func testClearSessionBuildsExpectedBodyAndDecodesResponse() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/session/clear")
+
+            let body = try XCTUnwrap(apiTestBodyData(from: request))
+            let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+            XCTAssertEqual(json?["session_id"] as? String, "abc123")
+            XCTAssertNil(json?["sessionId"])
+
+            return apiTestJSONResponse("""
+            {
+              "ok": true,
+              "session": {
+                "session_id": "abc123",
+                "title": "Untitled"
+              }
+            }
+            """, for: request)
+        }
+
+        let response = try await client.clearSession(id: "abc123")
+
+        XCTAssertEqual(response.ok, true)
+        XCTAssertEqual(response.session?.title, "Untitled")
+    }
+
+    /// Upstream answers a view-only subagent with 400 and a not-found session
+    /// with 404, so those surface as a thrown `APIError.http`, not a decoded
+    /// `error` field.
+    func testClearSessionThrowsOnUpstreamRejection() async throws {
+        let client = makeClient { request in
+            apiTestJSONResponse("""
+            {
+              "error": "Subagent sessions are view-only and cannot be modified from WebUI"
+            }
+            """, for: request, status: 400)
+        }
+
+        do {
+            _ = try await client.clearSession(id: "abc123")
+            XCTFail("Expected the 400 to throw.")
+        } catch let APIError.http(statusCode, body) {
+            XCTAssertEqual(statusCode, 400)
+            XCTAssertEqual(body?.contains("view-only"), true)
+        }
+    }
+
     func testUndoSessionBuildsExpectedBodyAndDecodesResponse() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/session/undo")

--- a/HermesMobileTests/APIEndpointContractTests.swift
+++ b/HermesMobileTests/APIEndpointContractTests.swift
@@ -64,6 +64,7 @@ final class ContractReadinessTests: XCTestCase {
             .init(name: "archive session", method: "POST", endpoint: .archiveSession, path: "/api/session/archive"),
             .init(name: "branch session", method: "POST", endpoint: .branchSession, path: "/api/session/branch"),
             .init(name: "compress session", method: "POST", endpoint: .compressSession, path: "/api/session/compress"),
+            .init(name: "clear session", method: "POST", endpoint: .clearSession, path: "/api/session/clear"),
             .init(name: "undo session", method: "POST", endpoint: .undoSession, path: "/api/session/undo"),
             .init(name: "retry session", method: "POST", endpoint: .retrySession, path: "/api/session/retry"),
             .init(name: "truncate session", method: "POST", endpoint: .truncateSession, path: "/api/session/truncate"),

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8156,6 +8156,66 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testSendIsRefusedWhileClearIsInFlight() async throws {
+        let clearRequestStarted = expectation(description: "clear request reached the server")
+        let releaseClearResponse = DispatchSemaphore(value: 0)
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/session/clear":
+                clearRequestStarted.fulfill()
+                releaseClearResponse.wait()
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "session": {"session_id": "session-abc", "title": "Untitled"}
+                }
+                """, for: request)
+            default:
+                XCTFail("A send during a clear must not reach \(request.url?.path ?? "unknown path").")
+                throw URLError(.badURL)
+            }
+        }
+
+        let clearTask = Task { await viewModel.clearConversationFromSlashCommand(modelContext: nil) }
+        await fulfillment(of: [clearRequestStarted], timeout: 5)
+
+        XCTAssertTrue(viewModel.isClearingConversation)
+        let didSend = await viewModel.sendMessage("Sneak this in")
+        XCTAssertFalse(didSend)
+        XCTAssertEqual(viewModel.sendErrorMessage, "Wait for the conversation to finish clearing.")
+
+        let secondClear = await viewModel.clearConversationFromSlashCommand(modelContext: nil)
+        XCTAssertEqual(secondClear, .unsupported(friendlyMessage: "Wait for the conversation to finish clearing."))
+
+        releaseClearResponse.signal()
+        let result = await clearTask.value
+
+        XCTAssertEqual(result, .executed(message: nil))
+        XCTAssertFalse(viewModel.isClearingConversation)
+    }
+
+    @MainActor
+    func testClearRefusalIsKnownBeforeConfirmingForCLISessions() async throws {
+        let webUIViewModel = try makeViewModel { request in
+            XCTFail("Reading the refusal must not call \(request.url?.path ?? "unknown path").")
+            throw URLError(.badURL)
+        }
+        XCTAssertNil(webUIViewModel.clearConversationRefusal)
+
+        let cliViewModel = try makeViewModel(
+            sessionSummary: SessionSummary(sessionId: "session-abc", title: "Planning", isCliSession: true)
+        ) { request in
+            XCTFail("Reading the refusal must not call \(request.url?.path ?? "unknown path").")
+            throw URLError(.badURL)
+        }
+
+        XCTAssertEqual(
+            cliViewModel.clearConversationRefusal,
+            "Clearing the conversation is available for WebUI sessions only."
+        )
+    }
+
+    @MainActor
     func testClearSlashCommandLeavesTranscriptIntactOnServerError() async throws {
         let viewModel = try makeViewModel { request in
             switch request.url?.path {

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8096,6 +8096,213 @@ final class ChatViewModelSendTests: XCTestCase {
     }
 
     @MainActor
+    func testClearSlashCommandEmptiesTranscriptTitleAndCacheAfterServerClear() async throws {
+        let context = try makeContext()
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
+        try CacheStore.cacheMessages(
+            [
+                ChatMessage(role: "user", content: "Cached question", timestamp: 1_770_000_001, messageId: "cached-user"),
+                ChatMessage(role: "assistant", content: "Cached answer", timestamp: 1_770_000_002, messageId: "cached-assistant")
+            ],
+            serverURL: serverURL,
+            sessionID: "session-abc",
+            in: context
+        )
+
+        var requestPaths: [String] = []
+        let viewModel = try makeViewModel { request in
+            requestPaths.append(request.url?.path ?? "")
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "messages": [
+                      {"role": "user", "content": "Old question", "timestamp": 1, "message_id": "u-1"}
+                    ]
+                  }
+                }
+                """, for: request)
+            case "/api/session/clear":
+                let body = try XCTUnwrap(apiTestJSONBody(from: request))
+                XCTAssertEqual(body["session_id"] as? String, "session-abc")
+                return apiTestJSONResponse("""
+                {
+                  "ok": true,
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Untitled"
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages(modelContext: context)
+        XCTAssertFalse(viewModel.messages.isEmpty)
+
+        let result = await viewModel.clearConversationFromSlashCommand(modelContext: context)
+
+        XCTAssertEqual(result, .executed(message: nil))
+        XCTAssertEqual(requestPaths, ["/api/session", "/api/session/clear"])
+        XCTAssertTrue(viewModel.messages.isEmpty)
+        XCTAssertEqual(viewModel.displayTitle, "Untitled")
+        XCTAssertTrue(try CacheStore.cachedMessages(serverURL: serverURL, sessionID: "session-abc", in: context).isEmpty)
+    }
+
+    @MainActor
+    func testClearSlashCommandLeavesTranscriptIntactOnServerError() async throws {
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "messages": [
+                      {"role": "user", "content": "Old question", "timestamp": 1, "message_id": "u-1"}
+                    ]
+                  }
+                }
+                """, for: request)
+            case "/api/session/clear":
+                return apiTestJSONResponse("""
+                {
+                  "error": "Session not found"
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        let result = await viewModel.clearConversationFromSlashCommand(modelContext: nil)
+
+        XCTAssertEqual(result, .unsupported(friendlyMessage: "Session not found"))
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), ["Old question"])
+        XCTAssertEqual(viewModel.displayTitle, "Planning")
+    }
+
+    @MainActor
+    func testClearSlashCommandLeavesTranscriptIntactWhenRequestThrows() async throws {
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "messages": [
+                      {"role": "user", "content": "Old question", "timestamp": 1, "message_id": "u-1"}
+                    ]
+                  }
+                }
+                """, for: request)
+            case "/api/session/clear":
+                throw URLError(.timedOut)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        let result = await viewModel.clearConversationFromSlashCommand(modelContext: nil)
+
+        guard case .unsupported = result else {
+            return XCTFail("Expected a thrown request to surface as .unsupported, got \(result).")
+        }
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), ["Old question"])
+        XCTAssertNotNil(viewModel.lastError)
+    }
+
+    @MainActor
+    func testClearSlashCommandRefusesWhileViewingCachedData() async throws {
+        let context = try makeContext()
+        let serverURL = try XCTUnwrap(URL(string: "https://example.test"))
+        try CacheStore.cacheMessages(
+            [ChatMessage(role: "user", content: "Cached question", timestamp: 1_770_000_001, messageId: "cached-user")],
+            serverURL: serverURL,
+            sessionID: "session-abc",
+            in: context
+        )
+
+        let viewModel = try makeViewModel { request in
+            guard request.url?.path == "/api/session" else {
+                XCTFail("Clear should not call the server while viewing cached data.")
+                throw URLError(.badURL)
+            }
+            throw URLError(.timedOut)
+        }
+
+        await viewModel.loadMessages(modelContext: context)
+        XCTAssertTrue(viewModel.isViewingCachedData)
+
+        let result = await viewModel.clearConversationFromSlashCommand(modelContext: context)
+
+        XCTAssertEqual(result, .unsupported(friendlyMessage: "Reconnect to the server to clear the conversation."))
+        XCTAssertEqual(viewModel.messages.compactMap(\.content), ["Cached question"])
+    }
+
+    @MainActor
+    func testClearSlashCommandRefusesForCLISessions() async throws {
+        let viewModel = try makeViewModel(
+            sessionSummary: SessionSummary(sessionId: "session-abc", title: "Planning", isCliSession: true)
+        ) { request in
+            XCTFail("Clear should not call the server for a CLI session: \(request.url?.path ?? "nil")")
+            throw URLError(.badURL)
+        }
+
+        let result = await viewModel.clearConversationFromSlashCommand(modelContext: nil)
+
+        XCTAssertEqual(
+            result,
+            .unsupported(friendlyMessage: "Clearing the conversation is available for WebUI sessions only.")
+        )
+    }
+
+    @MainActor
+    func testClearSlashCommandIsBlockedWhileStreaming() async throws {
+        let streamClient = SpySSEStreamingClient()
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/chat/start":
+                return apiTestJSONResponse("""
+                {
+                  "session_id": "session-abc",
+                  "stream_id": "stream-123"
+                }
+                """, for: request)
+            case "/api/session/clear":
+                XCTFail("Clear should not call the server while streaming.")
+                throw URLError(.badURL)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        let didStart = await viewModel.sendMessage("Keep working")
+        XCTAssertTrue(didStart)
+
+        let result = await viewModel.executeSlashCommand(try XCTUnwrap(SlashCommandCatalog.command(named: "clear")))
+
+        XCTAssertEqual(
+            result,
+            .unsupported(friendlyMessage: "Wait for the current response to finish before clearing the conversation.")
+        )
+    }
+
+    @MainActor
     func testUndoSlashCommandCallsServerThenReloadsMessages() async throws {
         var requestPaths: [String] = []
         let viewModel = try makeViewModel { request in
@@ -8277,38 +8484,6 @@ final class ChatViewModelSendTests: XCTestCase {
         )
         XCTAssertEqual(startCount, 1)
         XCTAssertNil(viewModel.activeStreamID)
-    }
-
-    @MainActor
-    func testClearSlashCommandClearsLocalTranscriptWithoutServerRequest() async throws {
-        var requestCount = 0
-        let viewModel = try makeViewModel { request in
-            requestCount += 1
-            switch request.url?.path {
-            case "/api/session":
-                return apiTestJSONResponse("""
-                {
-                  "session": {
-                    "session_id": "session-abc",
-                    "messages": [
-                      {"role": "user", "content": "Question", "timestamp": 1, "message_id": "u-1"},
-                      {"role": "assistant", "content": "Answer", "timestamp": 2, "message_id": "a-2"}
-                    ]
-                  }
-                }
-                """, for: request)
-            default:
-                XCTFail("Clear should not call \(request.url?.path ?? "unknown path").")
-                throw URLError(.badURL)
-            }
-        }
-
-        await viewModel.loadMessages()
-        let result = await viewModel.executeSlashCommand(try XCTUnwrap(SlashCommandCatalog.command(named: "clear")))
-
-        XCTAssertEqual(result, .executed(message: nil))
-        XCTAssertTrue(viewModel.messages.isEmpty)
-        XCTAssertEqual(requestCount, 1)
     }
 
     @MainActor

--- a/docs/agents/feature-gap-index.md
+++ b/docs/agents/feature-gap-index.md
@@ -71,7 +71,6 @@ sub-paths of a group. Do not reorder casually.
 | `/api/rollback/` | roadmap | P3 | write | Git Info & Rollback — checkpoint list/diff/restore |
 | `/api/crons/history` | roadmap | P2 | read | Cron History / Recent Runs |
 | `/api/session/usage` | roadmap | P2 | read | Session Token Usage — mostly covered by the context ring |
-| `/api/session/clear` | roadmap | P2 | write | Session Clear — destructive; needs confirmation |
 | `/api/session/import` | roadmap | P3 | — | Session Import (JSON / CLI) |
 | `/api/session/duplicate` | roadmap | P4 | — | Session Duplicate — branch-based duplicate already covers the need |
 | `/api/session/toolsets` | roadmap | P4 | write | Advanced Session Maintenance |


### PR DESCRIPTION
## Linked issue

Fixes #389

## What changed

`/clear` only emptied the transcript on screen. The server kept the whole conversation, so it came back on the next session load — the command's own description ("Clear the current conversation") was a lie.

Submitting `/clear` now asks first ("Clear Conversation?", Cancel / destructive Clear). On confirm the app POSTs `/api/session/clear`, empties the transcript, adopts the title the server returns (Untitled), and rewrites the offline cache as an empty list so a cold open doesn't repaint the history. No refetch; the session list picks up the new title on its next refresh, exactly like rename.

The guards match `/undo` and all short-circuit before any network call: viewing cached data, CLI sessions, and an active stream each refuse with copy that says why. A server `{error}` or a thrown request leaves the transcript untouched and surfaces through the existing slash `unsupported` path.

Two supporting notes:

- `ChatView.body` is split into `chatContent` plus its confirmation-alert chain, and the approval overlay moved to its own property. One more `.alert` pushed the single chained expression past the compiler's type-checking budget; the split is mechanical, no behavior change.
- `docs/agents/feature-gap-index.md` drops the `/api/session/clear` roadmap row — `implemented` is derived from `Endpoints.swift`, so the row would otherwise contradict the code. The issue also asked for a block in `docs/agents/upstream-smoke-checklist.md`, but that doc was deleted from the repo in #305 and only exists as an untracked local file, so it's left alone rather than re-added here.

## How it was tested

Full XCTest suite via XcodeBuildMCP `test_sim` (scheme `HermesMobile`, iPhone 17) on `5beca9e`: **2074 passed, 0 failed, 2 skipped**.

New focused tests:

- `APIClientSessionMutationTests` — `/api/session/clear` path, snake_case `session_id` body, tolerant decode of `{ok, session}`, and the upstream 400 (view-only subagent) surfacing as a thrown `APIError.http`.
- `ContractReadinessTests` — endpoint contract row for `.clearSession`.
- `ChatViewModelSendTests` — success empties the transcript, adopts the returned title, and empties the SwiftData cache; a `{error}` body and a thrown request both leave messages intact; cached-view, CLI-session, and streaming guards each refuse with no request recorded.

The stale `testClearSlashCommandClearsLocalTranscriptWithoutServerRequest` was removed — it asserted the bug this PR fixes.

Endpoint verified against the pinned upstream handler in `.codex-tmp/hermes-webui/api/routes.py` (`/api/session/clear` → truncate-to-empty, watermark sentinel, title reset, `{"ok": true, "session": s.compact()}`). No live-server smoke has been run yet.

### Owner checks

Needs `needs-manual-validation`, on a real server:

1. Open a session with history, type `/clear`, **Cancel** → transcript unchanged, `/clear` still in the composer.
2. Repeat and **Clear** → transcript empties, nav title reads Untitled, no navigation away.
3. Kill and relaunch → session still empty (cache check).
4. Back out to the session list → row title updates after refresh.
5. While a response is streaming, and on a CLI session → refusal copy, nothing cleared.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (reuses `SessionMutationResponse`)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (verified against the pinned upstream handler)

---

Implemented by Claude Opus 5 (1M context) in Claude Code.