### PR TITLE
fix(sessions): refresh the session list when returning from a chat

### DIFF
--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -277,7 +277,7 @@ struct SessionListView: View {
                 selectedProjectID = nil
             }
             .onChange(of: navigationState.destination) { oldValue, newValue in
-                SessionListNewChatReturn.run(
+                SessionListDestinationReturn.run(
                     from: oldValue,
                     to: newValue,
                     suppressEmptyPlaceholders: viewModel.removeEmptySidebarPlaceholders,
@@ -1363,20 +1363,31 @@ enum SessionListInitialLoad {
     }
 }
 
-enum SessionListNewChatReturn {
+/// Refreshes the session list whenever the user leaves one destination for
+/// another, so a row reflects whatever just happened in the chat it opened
+/// (a rename, a `/clear`, new messages). Driven from the `destination`
+/// `onChange` in `SessionListView`.
+enum SessionListDestinationReturn {
     static func run(
         from oldValue: SessionNavigationDestination?,
         to newValue: SessionNavigationDestination?,
         suppressEmptyPlaceholders: () -> Void,
         refreshSessions: () -> Void
     ) {
-        guard case .newChat = oldValue else { return }
-        if case .newChat = newValue { return }
+        // Nothing to refresh against before the first destination, and a
+        // destination that re-emits itself has no new server state to adopt.
+        guard let oldValue, oldValue != newValue else { return }
+        // Replacing one pending new-chat route with another stays on the same
+        // screen, so it is not a return.
+        if case .newChat = oldValue, case .newChat = newValue { return }
 
-        // Keep this synchronous so an empty Untitled placeholder cannot flash
-        // during the navigation transition. The refresh then adopts the server's
-        // latest metadata for a new chat that has become contentful.
-        suppressEmptyPlaceholders()
+        if case .newChat = oldValue {
+            // Keep this synchronous so an empty Untitled placeholder cannot
+            // flash during the navigation transition. The refresh then adopts
+            // the server's latest metadata for a new chat that became
+            // contentful.
+            suppressEmptyPlaceholders()
+        }
         refreshSessions()
     }
 }

--- a/HermesMobileTests/SessionNavigationStateTests.swift
+++ b/HermesMobileTests/SessionNavigationStateTests.swift
@@ -161,9 +161,9 @@ final class SessionNavigationStateTests: XCTestCase {
         state.remember(SessionSummary(sessionId: "created-session"))
         let oldDestination = state.destination
         state.clearDestination()
-        var events: [NewChatReturnEvent] = []
+        var events: [DestinationReturnEvent] = []
 
-        SessionListNewChatReturn.run(
+        SessionListDestinationReturn.run(
             from: oldDestination,
             to: state.destination,
             suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
@@ -179,9 +179,9 @@ final class SessionNavigationStateTests: XCTestCase {
         state.select(route)
         let oldDestination = state.destination
         state.clearDestination()
-        var events: [NewChatReturnEvent] = []
+        var events: [DestinationReturnEvent] = []
 
-        SessionListNewChatReturn.run(
+        SessionListDestinationReturn.run(
             from: oldDestination,
             to: state.destination,
             suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
@@ -194,11 +194,85 @@ final class SessionNavigationStateTests: XCTestCase {
     func testReplacingNewChatRouteDoesNotRefreshSessions() {
         let firstRoute = PendingNewChatRoute()
         let secondRoute = PendingNewChatRoute()
-        var events: [NewChatReturnEvent] = []
+        var events: [DestinationReturnEvent] = []
 
-        SessionListNewChatReturn.run(
+        SessionListDestinationReturn.run(
             from: .newChat(firstRoute),
             to: .newChat(secondRoute),
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testReturningFromSessionRefreshesSessionsWithoutSuppressingPlaceholders() {
+        var state = SessionNavigationState()
+        state.select(SessionSummary(sessionId: "session-1"))
+        let oldDestination = state.destination
+        state.clearDestination()
+        var events: [DestinationReturnEvent] = []
+
+        SessionListDestinationReturn.run(
+            from: oldDestination,
+            to: state.destination,
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertEqual(events, [.refreshedSessions])
+    }
+
+    func testSwitchingBetweenSessionsRefreshesSessions() {
+        var events: [DestinationReturnEvent] = []
+
+        SessionListDestinationReturn.run(
+            from: .session(SessionSummary(sessionId: "session-1")),
+            to: .session(SessionSummary(sessionId: "session-2")),
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertEqual(events, [.refreshedSessions])
+    }
+
+    func testReturningFromUtilityDestinationRefreshesSessions() {
+        var state = SessionNavigationState()
+        state.select(SessionListUtilityDestination.archived)
+        let oldDestination = state.destination
+        state.clearDestination()
+        var events: [DestinationReturnEvent] = []
+
+        SessionListDestinationReturn.run(
+            from: oldDestination,
+            to: state.destination,
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertEqual(events, [.refreshedSessions])
+    }
+
+    func testOpeningTheFirstDestinationRefreshesNothing() {
+        var events: [DestinationReturnEvent] = []
+
+        SessionListDestinationReturn.run(
+            from: nil,
+            to: .session(SessionSummary(sessionId: "session-1")),
+            suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
+            refreshSessions: { events.append(.refreshedSessions) }
+        )
+
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testUnchangedDestinationRefreshesNothing() {
+        let destination = SessionNavigationDestination.session(SessionSummary(sessionId: "session-1"))
+        var events: [DestinationReturnEvent] = []
+
+        SessionListDestinationReturn.run(
+            from: destination,
+            to: destination,
             suppressEmptyPlaceholders: { events.append(.suppressedPlaceholders) },
             refreshSessions: { events.append(.refreshedSessions) }
         )
@@ -287,7 +361,7 @@ final class SessionNavigationStateTests: XCTestCase {
     }
 }
 
-private enum NewChatReturnEvent: Equatable {
+private enum DestinationReturnEvent: Equatable {
     case suppressedPlaceholders
     case refreshedSessions
 }


### PR DESCRIPTION
## Linked issue

Fixes #397

## What changed

Renaming or `/clear`ing a session from inside its chat and then going back left the row showing the stale title, message count, and timestamp until you pulled to refresh, hit an active-stream poll, or cold-started the app. Only the *new chat* return path refreshed the list.

The fix widens the existing pure seam rather than adding a new one. `SessionListNewChatReturn` becomes `SessionListDestinationReturn` and refreshes whenever the destination changes away from a previous one, instead of bailing out unless you came from a new chat. The synchronous `suppressEmptyPlaceholders()` call still runs first, and still only when the old destination was a new chat, so the empty-Untitled flash stays suppressed exactly as before. Replacing one pending new-chat route with another still does nothing, and there is no refresh when there was no previous destination.

On regular width this also fires when switching between sessions in the sidebar, which is the intended freshness win.

Error handling is unchanged: the refresh goes through `refreshAfterReturningIfNeeded()` → `loadSessions()` → `handleLastError()`, so a failed refresh on return behaves exactly like a failed pull-to-refresh.

## How it was tested

Full XCTest suite via XcodeBuildMCP `test_sim` (scheme `HermesMobile`, iPhone 17): **2081 passed, 0 failed, 2 skipped**.

Six new cases in `SessionNavigationStateTests` cover the widened seam:

- `.session` → `nil` refreshes without suppressing placeholders
- `.session` → `.session` refreshes (iPad sidebar switch)
- `.utility` → `nil` refreshes
- `nil` → `.session` refreshes nothing
- an unchanged destination refreshes nothing
- the existing `.newChat` → `.newChat` and both `.newChat` → `nil` cases still behave as before

Owner manual pass still outstanding (issue is `needs-manual-validation`): `/clear` and `/title` inside a session then back out, plus watching for an Untitled flash when backing out of an unused new chat, and an iPad two-session switch.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no wire changes)

---

Implemented by Claude Opus 5 (1M context) in Claude Code.