### PR TITLE
feat(git): review every changed file in one diff surface

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		1D1FF0000000000000000B0A /* ReviewWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0A /* ReviewWordDiffTests.swift */; };
 		1D1FF0000000000000000B0B /* ReviewDiffLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */; };
 		1D1FF0000000000000000B0C /* ReviewDiffSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */; };
+		1D1FF0000000000000000B21 /* ReviewDiffCanvasViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F21 /* ReviewDiffCanvasViewTests.swift */; };
 		C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */; };
 		C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */; };
 		C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */; };
@@ -664,6 +665,7 @@
 		1D1FF0000000000000000F0A /* ReviewWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWordDiffTests.swift; sourceTree = "<group>"; };
 		1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffLayoutTests.swift; sourceTree = "<group>"; };
 		1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffSelectionTests.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F21 /* ReviewDiffCanvasViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffCanvasViewTests.swift; sourceTree = "<group>"; };
 		C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeAggregatorTests.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatterTests.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFoldingTests.swift; sourceTree = "<group>"; };
@@ -988,6 +990,7 @@
 				1D1FF0000000000000000F0A /* ReviewWordDiffTests.swift */,
 				1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */,
 				1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */,
+				1D1FF0000000000000000F21 /* ReviewDiffCanvasViewTests.swift */,
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */,
@@ -1988,6 +1991,7 @@
 				1D1FF0000000000000000B0A /* ReviewWordDiffTests.swift in Sources */,
 				1D1FF0000000000000000B0B /* ReviewDiffLayoutTests.swift in Sources */,
 				1D1FF0000000000000000B0C /* ReviewDiffSelectionTests.swift in Sources */,
+				1D1FF0000000000000000B21 /* ReviewDiffCanvasViewTests.swift in Sources */,
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */,

--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -235,6 +235,20 @@
 		C03180000000000000B004 /* GitCommitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F004 /* GitCommitView.swift */; };
 		C03180000000000000B005 /* TurnFileChangeSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F005 /* TurnFileChangeSummary.swift */; };
 		C03180000000000000B007 /* GitTurnChangesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03180000000000000F007 /* GitTurnChangesCard.swift */; };
+		1D1FF0000000000000000B00 /* ReviewDiffRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F00 /* ReviewDiffRow.swift */; };
+		1D1FF0000000000000000B01 /* ReviewWordDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F01 /* ReviewWordDiff.swift */; };
+		1D1FF0000000000000000B02 /* ReviewDiffLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F02 /* ReviewDiffLayout.swift */; };
+		1D1FF0000000000000000B03 /* ReviewDiffSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F03 /* ReviewDiffSelection.swift */; };
+		1D1FF0000000000000000B04 /* ReviewDiffStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F04 /* ReviewDiffStyle.swift */; };
+		1D1FF0000000000000000B05 /* ReviewDiffCanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F05 /* ReviewDiffCanvasView.swift */; };
+		1D1FF0000000000000000B06 /* ReviewDiffCanvasView+Drawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F06 /* ReviewDiffCanvasView+Drawing.swift */; };
+		1D1FF0000000000000000B20 /* ReviewDiffCanvasView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F20 /* ReviewDiffCanvasView+Accessibility.swift */; };
+		1D1FF0000000000000000B07 /* ReviewDiffSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F07 /* ReviewDiffSurfaceView.swift */; };
+		1D1FF0000000000000000B08 /* ReviewDiffSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F08 /* ReviewDiffSurface.swift */; };
+		1D1FF0000000000000000B09 /* ReviewDiffRowBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F09 /* ReviewDiffRowBuilderTests.swift */; };
+		1D1FF0000000000000000B0A /* ReviewWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0A /* ReviewWordDiffTests.swift */; };
+		1D1FF0000000000000000B0B /* ReviewDiffLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */; };
+		1D1FF0000000000000000B0C /* ReviewDiffSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */; };
 		C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */; };
 		C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */; };
 		C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */; };
@@ -636,6 +650,20 @@
 		C03180000000000000F004 /* GitCommitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitCommitView.swift; sourceTree = "<group>"; };
 		C03180000000000000F005 /* TurnFileChangeSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeSummary.swift; sourceTree = "<group>"; };
 		C03180000000000000F007 /* GitTurnChangesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTurnChangesCard.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F00 /* ReviewDiffRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffRow.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F01 /* ReviewWordDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWordDiff.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F02 /* ReviewDiffLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffLayout.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F03 /* ReviewDiffSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffSelection.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F04 /* ReviewDiffStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffStyle.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F05 /* ReviewDiffCanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffCanvasView.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F06 /* ReviewDiffCanvasView+Drawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReviewDiffCanvasView+Drawing.swift"; sourceTree = "<group>"; };
+		1D1FF0000000000000000F20 /* ReviewDiffCanvasView+Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReviewDiffCanvasView+Accessibility.swift"; sourceTree = "<group>"; };
+		1D1FF0000000000000000F07 /* ReviewDiffSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffSurfaceView.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F08 /* ReviewDiffSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffSurface.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F09 /* ReviewDiffRowBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffRowBuilderTests.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F0A /* ReviewWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWordDiffTests.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffLayoutTests.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffSelectionTests.swift; sourceTree = "<group>"; };
 		C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeAggregatorTests.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatterTests.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFoldingTests.swift; sourceTree = "<group>"; };
@@ -956,6 +984,10 @@
 				C012400000000000000005 /* AppIconChoiceTests.swift */,
 				C03120000000000000F006 /* APIClientGitTests.swift */,
 				C03120000000000000F007 /* GitWorkspaceViewModelTests.swift */,
+				1D1FF0000000000000000F09 /* ReviewDiffRowBuilderTests.swift */,
+				1D1FF0000000000000000F0A /* ReviewWordDiffTests.swift */,
+				1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */,
+				1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */,
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */,
@@ -1238,6 +1270,23 @@
 			path = Chat;
 			sourceTree = "<group>";
 		};
+		1D1FF00000000000000000C0 /* ReviewDiff */ = {
+			isa = PBXGroup;
+			children = (
+				1D1FF0000000000000000F00 /* ReviewDiffRow.swift */,
+				1D1FF0000000000000000F01 /* ReviewWordDiff.swift */,
+				1D1FF0000000000000000F02 /* ReviewDiffLayout.swift */,
+				1D1FF0000000000000000F03 /* ReviewDiffSelection.swift */,
+				1D1FF0000000000000000F04 /* ReviewDiffStyle.swift */,
+				1D1FF0000000000000000F05 /* ReviewDiffCanvasView.swift */,
+				1D1FF0000000000000000F06 /* ReviewDiffCanvasView+Drawing.swift */,
+				1D1FF0000000000000000F20 /* ReviewDiffCanvasView+Accessibility.swift */,
+				1D1FF0000000000000000F07 /* ReviewDiffSurfaceView.swift */,
+				1D1FF0000000000000000F08 /* ReviewDiffSurface.swift */,
+			);
+			path = ReviewDiff;
+			sourceTree = "<group>";
+		};
 		1A2B3C4D5E6F7000000000C7 /* Workspace */ = {
 			isa = PBXGroup;
 			children = (
@@ -1254,6 +1303,7 @@
 				C03180000000000000F003 /* GitInlineCommitButton.swift */,
 				C03180000000000000F004 /* GitCommitView.swift */,
 				C03180000000000000F007 /* GitTurnChangesCard.swift */,
+				1D1FF00000000000000000C0 /* ReviewDiff */,
 				C03140000000000000F001 /* GitBranchPickerView.swift */,
 				22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */,
 				22AB000000000000000000F2 /* WorkspaceManagerView.swift */,
@@ -1642,6 +1692,16 @@
 				C03180000000000000B004 /* GitCommitView.swift in Sources */,
 				C03180000000000000B005 /* TurnFileChangeSummary.swift in Sources */,
 				C03180000000000000B007 /* GitTurnChangesCard.swift in Sources */,
+				1D1FF0000000000000000B00 /* ReviewDiffRow.swift in Sources */,
+				1D1FF0000000000000000B01 /* ReviewWordDiff.swift in Sources */,
+				1D1FF0000000000000000B02 /* ReviewDiffLayout.swift in Sources */,
+				1D1FF0000000000000000B03 /* ReviewDiffSelection.swift in Sources */,
+				1D1FF0000000000000000B04 /* ReviewDiffStyle.swift in Sources */,
+				1D1FF0000000000000000B05 /* ReviewDiffCanvasView.swift in Sources */,
+				1D1FF0000000000000000B06 /* ReviewDiffCanvasView+Drawing.swift in Sources */,
+				1D1FF0000000000000000B20 /* ReviewDiffCanvasView+Accessibility.swift in Sources */,
+				1D1FF0000000000000000B07 /* ReviewDiffSurfaceView.swift in Sources */,
+				1D1FF0000000000000000B08 /* ReviewDiffSurface.swift in Sources */,
 				C03140000000000000B001 /* GitBranchPickerView.swift in Sources */,
 				C04000000000000000000005 /* APIClient+ServerPanels.swift in Sources */,
 				C04000000000000000000006 /* APIClient+Cron.swift in Sources */,
@@ -1924,6 +1984,10 @@
 				C012400000000000000006 /* AppIconChoiceTests.swift in Sources */,
 				C03120000000000000B006 /* APIClientGitTests.swift in Sources */,
 				C03120000000000000B007 /* GitWorkspaceViewModelTests.swift in Sources */,
+				1D1FF0000000000000000B09 /* ReviewDiffRowBuilderTests.swift in Sources */,
+				1D1FF0000000000000000B0A /* ReviewWordDiffTests.swift in Sources */,
+				1D1FF0000000000000000B0B /* ReviewDiffLayoutTests.swift in Sources */,
+				1D1FF0000000000000000B0C /* ReviewDiffSelectionTests.swift in Sources */,
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatHaptics.swift
+++ b/HermesMobile/Features/Chat/ChatHaptics.swift
@@ -70,6 +70,16 @@ enum ChatHaptics {
         emit(succeeded ? .success : .warning, isEnabled: isEnabled, performer: performer)
     }
 
+    /// A line tapped or long-pressed on the review diff surface.
+    static func diffLineSelected(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.selection, isEnabled: isEnabled, performer: performer)
+    }
+
+    /// Selected diff lines dropped into the composer draft.
+    static func addedToPrompt(isEnabled: Bool, performer: Performer? = nil) {
+        emit(.lightImpact, isEnabled: isEnabled, performer: performer)
+    }
+
     /// One tick of the opt-in pulse while assistant text streams. Callers throttle
     /// with `StreamingPulseThrottle`; this only honors the enabled flag.
     static func streamingPulse(isEnabled: Bool, performer: Performer? = nil) {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -25,16 +25,15 @@ private enum ActiveGitSheet: Identifiable {
     var id: Self { self }
 }
 
-/// What the per-turn diff sheet shows (issue #316): every changed file in the turn, or a
-/// single file's diff (a recap-card row tap).
+/// What the per-turn diff sheet shows (issue #316): every changed file in the turn,
+/// opened at one of them for a recap-card row tap.
 private enum TurnDiffPresentation: Identifiable {
-    case turnFiles([GitFile])
-    case file(GitFile)
+    case turnFiles([GitFile], initial: GitFile?)
 
     var id: String {
         switch self {
-        case .turnFiles(let files): return "turn:" + files.map(\.id).joined(separator: "|")
-        case .file(let file): return "file:" + file.id
+        case .turnFiles(let files, let initial):
+            return "turn:" + files.map(\.id).joined(separator: "|") + ":" + (initial?.id ?? "")
         }
     }
 }
@@ -920,7 +919,12 @@ struct ChatView: View {
     private func gitSheet(_ sheet: ActiveGitSheet) -> some View {
         switch sheet {
         case .changes:
-            GitWorkspaceView(session: session, server: server, onAPIError: onAPIError)
+            GitWorkspaceView(
+                session: session,
+                server: server,
+                onAPIError: onAPIError,
+                onAddToPrompt: addDiffSelectionToDraft
+            )
         case .commit:
             GitCommitView(
                 session: session,
@@ -937,11 +941,24 @@ struct ChatView: View {
     @ViewBuilder
     private func turnDiffSheet(_ presentation: TurnDiffPresentation) -> some View {
         switch presentation {
-        case .turnFiles(let files):
-            GitTurnDiffSheet(session: session, server: server, files: files, onAPIError: onAPIError)
-        case .file(let file):
-            GitDiffView(session: session, server: server, file: file, onAPIError: onAPIError)
+        case .turnFiles(let files, let initial):
+            GitDiffView(
+                session: session,
+                server: server,
+                files: files,
+                initialFile: initial,
+                onAPIError: onAPIError,
+                onAddToPrompt: addDiffSelectionToDraft
+            )
         }
+    }
+
+    /// Drops a diff selection from a Git sheet into the composer and closes the sheet.
+    private func addDiffSelectionToDraft(_ snippet: String) {
+        let separator = draftMessage.isEmpty ? "" : (draftMessage.hasSuffix("\n") ? "\n" : "\n\n")
+        persistedDraftBinding.wrappedValue = draftMessage + separator + snippet + "\n"
+        activeGitSheet = nil
+        turnDiffPresentation = nil
     }
 
     private var gitActionsMenu: some View {
@@ -1024,7 +1041,7 @@ struct ChatView: View {
     private func presentTurnDiff(for summary: TurnFileChangeSummary?) {
         let files = summary?.diffFiles ?? []
         guard !files.isEmpty else { return }
-        turnDiffPresentation = .turnFiles(files)
+        turnDiffPresentation = .turnFiles(files, initial: nil)
     }
 
     @MainActor
@@ -1338,7 +1355,7 @@ struct ChatView: View {
                 presentTurnDiff(for: turnChangesRecapSummary)
             },
             onOpenTurnFileDiff: { file in
-                turnDiffPresentation = .file(file)
+                turnDiffPresentation = .turnFiles(turnChangesRecapSummary?.diffFiles ?? [file], initial: file)
             }
         )
         // Off the main body chain, which is at the type-checker's limit.

--- a/HermesMobile/Features/Workspace/GitDiffView.swift
+++ b/HermesMobile/Features/Workspace/GitDiffView.swift
@@ -184,7 +184,7 @@ struct GitDiffView: View {
             ordered.insert(initialFile, at: 0)
         }
         var reportedError = false
-        await withTaskGroup(of: FileDiffResult.self) { group in
+        await withTaskGroup(of: FileDiffResult?.self) { group in
             var pending = ordered.makeIterator()
             func enqueueNext() {
                 guard let file = pending.next() else { return }
@@ -193,10 +193,13 @@ struct GitDiffView: View {
             }
             for _ in 0..<Self.maxConcurrentDiffLoads { enqueueNext() }
             for await result in group {
-                guard generation == loadGeneration else {
+                // A dismissed sheet or a newer load owns the rest; stop fetching and
+                // leave the state alone.
+                guard !Task.isCancelled, generation == loadGeneration else {
                     group.cancelAll()
                     return
                 }
+                guard let result else { continue }
                 statesByFileID[result.fileID] = result.state
                 if let error = result.error, !reportedError {
                     reportedError = true
@@ -214,7 +217,8 @@ struct GitDiffView: View {
         let error: Error?
     }
 
-    private static func fetchDiff(for file: GitFile, sessionID: String, apiClient: APIClient) async -> FileDiffResult {
+    /// Nil when the request was cancelled: not a failure to show or report.
+    private static func fetchDiff(for file: GitFile, sessionID: String, apiClient: APIClient) async -> FileDiffResult? {
         do {
             let diff = try await apiClient.gitDiff(
                 sessionID: sessionID,
@@ -226,8 +230,20 @@ struct GitDiffView: View {
             }
             return FileDiffResult(fileID: file.id, state: .loaded(diff), error: nil)
         } catch {
+            if isCancellation(error) { return nil }
             return FileDiffResult(fileID: file.id, state: .failed(error.localizedDescription), error: error)
         }
+    }
+
+    private static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        let underlying: Error
+        if case APIError.network(let wrapped) = error {
+            underlying = wrapped
+        } else {
+            underlying = error
+        }
+        return (underlying as? URLError)?.code == .cancelled
     }
 
     /// Rows build off the main thread; a newer build supersedes an older one.

--- a/HermesMobile/Features/Workspace/GitDiffView.swift
+++ b/HermesMobile/Features/Workspace/GitDiffView.swift
@@ -1,33 +1,71 @@
 import SwiftUI
 
+/// Every changed file in one scroll: sticky file headers, per-file collapse and viewed
+/// state, word-level highlights, and line selection that feeds the composer. Diffs
+/// load one file at a time (a few in flight) so the first file paints before the rest
+/// arrive; rows rebuild off the main thread as each answer lands.
 struct GitDiffView: View {
     let onAPIError: (Error) -> Void
+    /// Receives the selected lines as Markdown. Nil hides "Add to prompt", for hosts
+    /// with no composer to add to.
+    let onAddToPrompt: ((String) -> Void)?
 
     private let session: SessionSummary
-    private let file: GitFile
+    private let files: [GitFile]
+    private let initialFile: GitFile?
     private let apiClient: APIClient
-    @State private var diff: GitDiff?
-    @State private var isLoading = false
-    @State private var errorMessage: String?
+
+    @State private var statesByFileID: [String: ReviewDiffFileState] = [:]
+    @State private var rows: [ReviewDiffRow] = []
+    @State private var rowsVersion = 0
+    @State private var rowsBuildGeneration = 0
+    @State private var loadGeneration = 0
     @State private var hasLoaded = false
-    @State private var collapsedHunks: Set<Int> = []
+    @State private var isRefreshing = false
+    @State private var collapsedFileIDs: Set<String> = []
+    @State private var viewedFileIDs: Set<String> = []
+    @State private var selection = ReviewDiffSelection()
+    @State private var scrollTarget: ReviewDiffScrollTarget?
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
     @Environment(\.dismiss) private var dismiss
 
-    init(session: SessionSummary, server: URL, file: GitFile, onAPIError: @escaping (Error) -> Void) {
+    private static let maxConcurrentDiffLoads = 4
+
+    init(
+        session: SessionSummary,
+        server: URL,
+        files: [GitFile],
+        initialFile: GitFile? = nil,
+        onAPIError: @escaping (Error) -> Void,
+        onAddToPrompt: ((String) -> Void)? = nil
+    ) {
         self.session = session
-        self.file = file
+        self.files = files
+        self.initialFile = initialFile
         self.apiClient = APIClient(baseURL: server)
         self.onAPIError = onAPIError
+        self.onAddToPrompt = onAddToPrompt
+        _scrollTarget = State(initialValue: initialFile.map { ReviewDiffScrollTarget(fileID: $0.id, token: UUID()) })
     }
+
+    private var title: String {
+        if files.count == 1, let file = files.first { return file.displayPath }
+        return String(localized: "\(files.count) files changed")
+    }
+
+    private var selectedRowIDs: Set<String> { selection.selectedRowIDs(in: rows) }
 
     var body: some View {
         NavigationStack {
             content
-                .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
-                .navigationTitle(file.displayPath)
+                .navigationTitle(title)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) { Button("Done") { dismiss() } }
+                }
+                .safeAreaInset(edge: .bottom) {
+                    let selected = selectedRowIDs
+                    if !selected.isEmpty { selectionBar(count: selected.count) }
                 }
                 .task {
                     guard !hasLoaded else { return }
@@ -41,148 +79,170 @@ struct GitDiffView: View {
 
     @ViewBuilder
     private var content: some View {
-        if isLoading && diff == nil {
-            ProgressView("Loading…").frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if errorMessage != nil && diff == nil {
-            ContentUnavailableView {
-                Label("Could Not Load Changes", systemImage: "exclamationmark.triangle")
-            } description: {
-                if let errorMessage { Text(errorMessage) }
-            } actions: {
-                Button("Try Again") { Task { await load() } }
-            }
-        } else if let diff {
-            diffBody(diff)
+        if files.isEmpty {
+            ContentUnavailableView("No Changes", systemImage: "checkmark.circle")
         } else {
-            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-
-    @ViewBuilder
-    private func diffBody(_ diff: GitDiff) -> some View {
-        if diff.binary == true {
-            ContentUnavailableView("Binary file changed", systemImage: "doc.badge.gearshape")
-        } else if diff.tooLarge == true {
-            ContentUnavailableView("Diff too large to show.", systemImage: "doc.badge.exclamationmark")
-        } else {
-            let hunks = DiffHunk.parse(diff.diff ?? "")
-            if hunks.isEmpty {
-                ContentUnavailableView("No Changes", systemImage: "checkmark.circle")
-            } else {
-                VStack(spacing: 0) {
-                    summary(diff: diff, hunks: hunks)
-                    GeometryReader { proxy in
-                        ScrollView([.horizontal, .vertical]) {
-                            LazyVStack(alignment: .leading, spacing: 0) {
-                                ForEach(hunks) { hunk in
-                                    hunkHeader(hunk)
-                                    if !collapsedHunks.contains(hunk.id) {
-                                        ForEach(hunk.lines) { DiffLineRow(line: $0) }
-                                    }
-                                }
-                            }
-                            // Pin the content to at least the viewport width so short lines
-                            // still get full-width row backgrounds; longer lines scroll.
-                            .frame(minWidth: proxy.size.width, alignment: .leading)
-                            .textSelection(.enabled)
-                        }
-                        .environment(\.layoutDirection, .leftToRight)
-                    }
-                }
-            }
-        }
-    }
-
-    private func summary(diff: GitDiff, hunks: [DiffHunk]) -> some View {
-        HStack(spacing: 10) {
-            Text("1 file changed").font(AppFont.subheadline(weight: .semibold))
-            DiffCountsLabel(
-                additions: diff.additions ?? hunks.reduce(0) { $0 + $1.additions },
-                deletions: diff.deletions ?? hunks.reduce(0) { $0 + $1.deletions }
+            ReviewDiffSurface(
+                rows: rows,
+                rowsVersion: rowsVersion,
+                collapsedFileIDs: collapsedFileIDs,
+                viewedFileIDs: viewedFileIDs,
+                selectedRowIDs: selectedRowIDs,
+                isRefreshing: isRefreshing,
+                scrollTarget: scrollTarget,
+                onToggleFile: toggleFile,
+                onToggleViewed: toggleViewed,
+                onLinePress: handleLinePress,
+                onRefresh: { Task { await refresh() } }
             )
-            Spacer()
-            Button(collapsedHunks.count == hunks.count ? "Expand All" : "Collapse All") {
-                withAnimation(.easeInOut(duration: 0.18)) {
-                    if collapsedHunks.count == hunks.count {
-                        collapsedHunks.removeAll()
-                    } else {
-                        collapsedHunks = Set(hunks.map(\.id))
-                    }
-                }
-            }
-            .font(AppFont.mono(style: .caption))
-            .foregroundStyle(.blue)
         }
-        .padding(12)
-        .background(Color(.systemBackground))
     }
 
-    private func hunkHeader(_ hunk: DiffHunk) -> some View {
-        let collapsed = collapsedHunks.contains(hunk.id)
-        return Button {
-            withAnimation(.easeInOut(duration: 0.18)) {
-                if collapsed { collapsedHunks.remove(hunk.id) } else { collapsedHunks.insert(hunk.id) }
+    private func selectionBar(count: Int) -> some View {
+        HStack(spacing: 12) {
+            Text(count == 1 ? String(localized: "1 line selected") : String(localized: "\(count) lines selected"))
+                .font(AppFont.footnote(weight: .semibold))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            Button("Clear") { selection.clear() }
+                .font(AppFont.footnote())
+            if onAddToPrompt != nil {
+                Button("Add to prompt", action: addToPrompt)
+                    .font(AppFont.footnote(weight: .semibold))
+                    .buttonStyle(.borderedProminent)
             }
-        } label: {
-            HStack(spacing: 7) {
-                Image(systemName: collapsed ? "chevron.right" : "chevron.down")
-                    .font(.caption2.weight(.semibold))
-                Text(hunk.displayLabel)
-                    .font(AppFont.mono(style: .caption))
-                DiffCountsLabel(additions: hunk.additions, deletions: hunk.deletions)
-                Spacer(minLength: 0)
-            }
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 7)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(.tertiarySystemBackground))
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(Text(hunk.displayLabel))
-        .accessibilityHint(Text(collapsed ? "Expand section" : "Collapse section"))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.bar)
+        .accessibilityElement(children: .contain)
     }
 
+    // MARK: - Interaction
+
+    private func toggleFile(_ fileID: String) {
+        if collapsedFileIDs.contains(fileID) {
+            collapsedFileIDs.remove(fileID)
+        } else {
+            collapsedFileIDs.insert(fileID)
+        }
+        ChatHaptics.disclosureToggled(isEnabled: isHapticsEnabled)
+    }
+
+    /// Marking a file viewed also collapses it; un-viewing leaves it collapsed.
+    private func toggleViewed(_ fileID: String) {
+        if viewedFileIDs.contains(fileID) {
+            viewedFileIDs.remove(fileID)
+        } else {
+            viewedFileIDs.insert(fileID)
+            collapsedFileIDs.insert(fileID)
+        }
+        ChatHaptics.disclosureToggled(isEnabled: isHapticsEnabled)
+    }
+
+    private func handleLinePress(_ press: ReviewDiffLinePress) {
+        switch press.gesture {
+        case .tap: selection.tap(rowID: press.rowID, fileID: press.fileID)
+        case .longPress: selection.longPress(rowID: press.rowID, fileID: press.fileID)
+        }
+        ChatHaptics.diffLineSelected(isEnabled: isHapticsEnabled)
+    }
+
+    private func addToPrompt() {
+        guard let snippet = selection.snippet(in: rows) else { return }
+        onAddToPrompt?(snippet)
+        ChatHaptics.addedToPrompt(isEnabled: isHapticsEnabled)
+        selection.clear()
+    }
+
+    // MARK: - Loading
+
+    private func refresh() async {
+        isRefreshing = true
+        selection.clear()
+        await load()
+        isRefreshing = false
+    }
+
+    @MainActor
     private func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
         guard let sessionID = session.sessionId else {
-            errorMessage = String(localized: "Session ID is missing.")
+            let message = String(localized: "Session ID is missing.")
+            for file in files { statesByFileID[file.id] = .failed(message) }
+            rebuildRows()
             return
         }
-        isLoading = true
-        errorMessage = nil
+        for file in files { statesByFileID[file.id] = .loading }
+        rebuildRows()
+
+        // The file the reader asked for loads first; the rest follow a few at a time.
+        var ordered = files
+        if let initialFile, let index = ordered.firstIndex(of: initialFile) {
+            ordered.remove(at: index)
+            ordered.insert(initialFile, at: 0)
+        }
+        var reportedError = false
+        await withTaskGroup(of: FileDiffResult.self) { group in
+            var pending = ordered.makeIterator()
+            func enqueueNext() {
+                guard let file = pending.next() else { return }
+                let client = apiClient
+                group.addTask { await Self.fetchDiff(for: file, sessionID: sessionID, apiClient: client) }
+            }
+            for _ in 0..<Self.maxConcurrentDiffLoads { enqueueNext() }
+            for await result in group {
+                guard generation == loadGeneration else {
+                    group.cancelAll()
+                    return
+                }
+                statesByFileID[result.fileID] = result.state
+                if let error = result.error, !reportedError {
+                    reportedError = true
+                    onAPIError(error)
+                }
+                rebuildRows()
+                enqueueNext()
+            }
+        }
+    }
+
+    private struct FileDiffResult {
+        let fileID: String
+        let state: ReviewDiffFileState
+        let error: Error?
+    }
+
+    private static func fetchDiff(for file: GitFile, sessionID: String, apiClient: APIClient) async -> FileDiffResult {
         do {
-            diff = try await apiClient.gitDiff(
+            let diff = try await apiClient.gitDiff(
                 sessionID: sessionID,
                 path: file.displayPath,
                 kind: file.preferredDiffKind
             ).diff
+            guard let diff else {
+                return FileDiffResult(fileID: file.id, state: .failed(String(localized: "Could Not Load Changes")), error: nil)
+            }
+            return FileDiffResult(fileID: file.id, state: .loaded(diff), error: nil)
         } catch {
-            errorMessage = error.localizedDescription
-            onAPIError(error)
+            return FileDiffResult(fileID: file.id, state: .failed(error.localizedDescription), error: error)
         }
-        isLoading = false
     }
-}
 
-private struct DiffLineRow: View {
-    let line: DiffLine
-
-    var body: some View {
-        HStack(spacing: 0) {
-            Text(line.gutterLabel)
-                .font(AppFont.mono(style: .caption))
-                .foregroundStyle(.secondary)
-                .frame(width: 48, alignment: .trailing)
-                .padding(.trailing, 8)
-                .background(line.kind.gutterBackground)
-            Text(line.text.isEmpty ? " " : line.text)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(line.kind == .context ? .secondary : .primary)
-                .padding(.horizontal, 8)
-                .frame(maxWidth: .infinity, alignment: .leading)
+    /// Rows build off the main thread; a newer build supersedes an older one.
+    private func rebuildRows() {
+        rowsBuildGeneration += 1
+        let generation = rowsBuildGeneration
+        let inputs = files.map { ReviewDiffFileInput(file: $0, state: statesByFileID[$0.id] ?? .loading) }
+        Task.detached(priority: .userInitiated) {
+            let built = ReviewDiffRowBuilder.rows(for: inputs)
+            await MainActor.run {
+                guard generation == rowsBuildGeneration else { return }
+                rows = built
+                rowsVersion += 1
+            }
         }
-        .frame(minHeight: 19)
-        .background(line.kind.rowBackground)
     }
 }
 
@@ -318,22 +378,6 @@ struct DiffLine: Identifiable, Equatable {
             default: self = .context
             }
         }
-
-        var rowBackground: Color {
-            switch self {
-            case .addition: return Color(red: 0.20, green: 0.78, blue: 0.35).opacity(0.16)
-            case .deletion: return Color(red: 0.95, green: 0.25, blue: 0.25).opacity(0.16)
-            case .context: return Color(.systemBackground)
-            }
-        }
-
-        var gutterBackground: Color {
-            switch self {
-            case .addition: return Color(red: 0.20, green: 0.68, blue: 0.32).opacity(0.24)
-            case .deletion: return Color(red: 0.86, green: 0.20, blue: 0.20).opacity(0.24)
-            case .context: return Color(.secondarySystemBackground)
-            }
-        }
     }
 
     let id: Int
@@ -341,9 +385,4 @@ struct DiffLine: Identifiable, Equatable {
     let text: String
     let oldLineNumber: Int?
     let newLineNumber: Int?
-
-    var gutterLabel: String {
-        let value = kind == .deletion ? oldLineNumber : newLineNumber
-        return value.map(String.init) ?? ""
-    }
 }

--- a/HermesMobile/Features/Workspace/GitTurnChangesCard.swift
+++ b/HermesMobile/Features/Workspace/GitTurnChangesCard.swift
@@ -3,8 +3,9 @@ import SwiftUI
 /// Turn-end "File changes" recap card shown under the latest assistant turn for git
 /// workspaces (issue #316, Slice D, surface B). The per-file list is derived from the
 /// turn's tool-call metadata and joined to `git/status` for counts/chips. The card is
-/// collapsible (default expanded); the header "Open diff" opens the per-turn diff sheet
-/// and each file row opens that file's diff. The host owns the actual sheet presentation.
+/// collapsible (default expanded); the header "Open diff" opens the turn's files in the
+/// diff surface and each file row opens that surface at the file. The host owns the
+/// actual sheet presentation.
 struct GitTurnChangesCard: View {
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
@@ -128,65 +129,5 @@ struct GitTurnChangesCard: View {
 
     private var divider: some View {
         Rectangle().fill(dividerColor).frame(height: 0.5)
-    }
-}
-
-/// Per-turn diff sheet: lists the turn's changed files and drills into each file's diff
-/// (reusing the restyled #318 `GitDiffView`). Presented for the composer capsule tap and
-/// the recap card's "Open diff" button.
-struct GitTurnDiffSheet: View {
-    let session: SessionSummary
-    let server: URL
-    let files: [GitFile]
-    let onAPIError: (Error) -> Void
-
-    @State private var selectedFile: GitFile?
-    @Environment(\.dismiss) private var dismiss
-
-    private var title: String {
-        files.count == 1
-            ? String(localized: "1 file changed")
-            : String(localized: "\(files.count) files changed")
-    }
-
-    var body: some View {
-        NavigationStack {
-            content
-                .navigationTitle(title)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) { Button("Done") { dismiss() } }
-                }
-        }
-        .presentationDetents([.medium, .large])
-        .adaptivePagePresentation()
-        .sheet(item: $selectedFile) { file in
-            GitDiffView(session: session, server: server, file: file, onAPIError: onAPIError)
-        }
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        if files.isEmpty {
-            ContentUnavailableView(
-                "No File Diffs",
-                systemImage: "doc.text.magnifyingglass",
-                description: Text("Diffs for this turn aren't available yet.")
-            )
-        } else {
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 12) {
-                    ForEach(files) { file in
-                        Button {
-                            selectedFile = file
-                        } label: {
-                            GitFileCard(file: file)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(16)
-            }
-        }
     }
 }

--- a/HermesMobile/Features/Workspace/GitWorkspaceView.swift
+++ b/HermesMobile/Features/Workspace/GitWorkspaceView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct GitWorkspaceView: View {
     let onAPIError: (Error) -> Void
+    /// Forwarded to the diff surface so a line selection can land in the composer.
+    let onAddToPrompt: ((String) -> Void)?
 
     private let session: SessionSummary
     private let server: URL
@@ -9,10 +11,16 @@ struct GitWorkspaceView: View {
     @State private var selectedFile: GitFile?
     @Environment(\.dismiss) private var dismiss
 
-    init(session: SessionSummary, server: URL, onAPIError: @escaping (Error) -> Void) {
+    init(
+        session: SessionSummary,
+        server: URL,
+        onAPIError: @escaping (Error) -> Void,
+        onAddToPrompt: ((String) -> Void)? = nil
+    ) {
         self.session = session
         self.server = server
         self.onAPIError = onAPIError
+        self.onAddToPrompt = onAddToPrompt
         _viewModel = State(initialValue: GitWorkspaceViewModel(session: session, server: server))
     }
 
@@ -35,7 +43,15 @@ struct GitWorkspaceView: View {
         .presentationDetents([.medium, .large])
         .adaptivePagePresentation()
         .sheet(item: $selectedFile) { file in
-            GitDiffView(session: session, server: server, file: file, onAPIError: onAPIError)
+            // Every changed file in one surface, opened at the tapped one.
+            GitDiffView(
+                session: session,
+                server: server,
+                files: viewModel.status?.trackedFiles ?? [file],
+                initialFile: file,
+                onAPIError: onAPIError,
+                onAddToPrompt: onAddToPrompt
+            )
         }
     }
 

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Accessibility.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Accessibility.swift
@@ -1,0 +1,170 @@
+import UIKit
+
+/// VoiceOver for the drawn rows. The canvas is an accessibility container whose
+/// elements are created on demand for the visible (non-collapsed) rows, so a 5,000-line
+/// diff never materialises 5,000 objects. Labels read line number, change type, and
+/// text; headers expose collapse and viewed as actions.
+extension ReviewDiffCanvasView {
+    // MARK: - Accessibility
+
+    override var isAccessibilityElement: Bool {
+        get { false }
+        set {}
+    }
+
+    override func accessibilityElementCount() -> Int {
+        layout.visibleRowIndices.count
+    }
+
+    override func accessibilityElement(at index: Int) -> Any? {
+        guard layout.visibleRowIndices.indices.contains(index) else { return nil }
+        let rowIndex = layout.visibleRowIndices[index]
+        if let element = accessibilityElementsByRowIndex[rowIndex] { return element }
+        let element = ReviewDiffRowAccessibilityElement(canvas: self, rowIndex: rowIndex)
+        accessibilityElementsByRowIndex[rowIndex] = element
+        return element
+    }
+
+    override func index(ofAccessibilityElement element: Any) -> Int {
+        guard let element = element as? ReviewDiffRowAccessibilityElement else { return NSNotFound }
+        let indices = layout.visibleRowIndices
+        var lower = 0
+        var upper = indices.count
+        while lower < upper {
+            let middle = (lower + upper) / 2
+            if indices[middle] < element.rowIndex { lower = middle + 1 } else { upper = middle }
+        }
+        return lower < indices.count && indices[lower] == element.rowIndex ? lower : NSNotFound
+    }
+
+    func accessibilityLabel(forRowAt rowIndex: Int) -> String {
+        let row = rows[rowIndex]
+        switch row.kind {
+        case .file(let header):
+            var parts = [header.displayPath]
+            parts.append(String(localized: "\(header.additions) added"))
+            parts.append(String(localized: "\(header.deletions) removed"))
+            parts.append(
+                collapsedFileIDs.contains(row.fileID)
+                    ? String(localized: "Collapsed")
+                    : String(localized: "Expanded")
+            )
+            if viewedFileIDs.contains(row.fileID) { parts.append(String(localized: "Viewed")) }
+            return parts.joined(separator: ", ")
+        case .hunk(let text), .notice(let text):
+            return text
+        case .line(let line):
+            var parts: [String] = []
+            if let number = line.displayLineNumber { parts.append(String(localized: "Line \(number)")) }
+            switch line.change {
+            case .addition: parts.append(String(localized: "added"))
+            case .deletion: parts.append(String(localized: "removed"))
+            case .context: break
+            }
+            parts.append(line.content.isEmpty ? String(localized: "blank") : line.content)
+            return parts.joined(separator: ", ")
+        }
+    }
+
+    func accessibilityTraits(forRowAt rowIndex: Int) -> UIAccessibilityTraits {
+        let row = rows[rowIndex]
+        switch row.kind {
+        case .file: return [.header, .button]
+        case .hunk, .notice: return .staticText
+        case .line: return selectedRowIDs.contains(row.id) ? [.staticText, .selected] : .staticText
+        }
+    }
+
+    func accessibilityCustomActions(forRowAt rowIndex: Int) -> [UIAccessibilityCustomAction] {
+        let row = rows[rowIndex]
+        switch row.kind {
+        case .file:
+            let isViewed = viewedFileIDs.contains(row.fileID)
+            return [
+                UIAccessibilityCustomAction(
+                    name: isViewed ? String(localized: "Mark as not viewed") : String(localized: "Mark as viewed")
+                ) { [weak self] _ in
+                    self?.onToggleViewed?(row.fileID)
+                    return true
+                }
+            ]
+        case .line:
+            return [
+                UIAccessibilityCustomAction(name: String(localized: "Select line")) { [weak self] _ in
+                    self?.onLinePress?(ReviewDiffLinePress(rowID: row.id, fileID: row.fileID, gesture: .tap))
+                    return true
+                },
+                UIAccessibilityCustomAction(name: String(localized: "Start selection here")) { [weak self] _ in
+                    self?.onLinePress?(ReviewDiffLinePress(rowID: row.id, fileID: row.fileID, gesture: .longPress))
+                    return true
+                }
+            ]
+        case .hunk, .notice:
+            return []
+        }
+    }
+
+    func accessibilityActivate(rowAt rowIndex: Int) -> Bool {
+        guard rows.indices.contains(rowIndex) else { return false }
+        switch rows[rowIndex].kind {
+        case .file, .line:
+            activateRow(at: rowIndex, point: nil)
+            return true
+        case .hunk, .notice:
+            return false
+        }
+    }
+
+    func accessibilityScreenFrame(forRowAt rowIndex: Int) -> CGRect {
+        guard let frame = frame(forRowAt: rowIndex) else { return .null }
+        return UIAccessibility.convertToScreenCoordinates(frame, in: self)
+    }
+
+    func revealRowForAccessibility(_ rowIndex: Int) {
+        guard let frame = frame(forRowAt: rowIndex) else { return }
+        if frame.minY < 0 || frame.maxY > bounds.height {
+            onRevealRow?(rowIndex)
+        }
+    }
+}
+
+/// One VoiceOver element per visible row, created on demand. Every property reads
+/// the canvas so collapse, viewed, and selection state are never stale.
+final class ReviewDiffRowAccessibilityElement: UIAccessibilityElement {
+    let rowIndex: Int
+    private weak var canvas: ReviewDiffCanvasView?
+
+    init(canvas: ReviewDiffCanvasView, rowIndex: Int) {
+        self.canvas = canvas
+        self.rowIndex = rowIndex
+        super.init(accessibilityContainer: canvas)
+    }
+
+    override var accessibilityLabel: String? {
+        get { canvas?.accessibilityLabel(forRowAt: rowIndex) }
+        set {}
+    }
+
+    override var accessibilityTraits: UIAccessibilityTraits {
+        get { canvas?.accessibilityTraits(forRowAt: rowIndex) ?? .none }
+        set {}
+    }
+
+    override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
+        get { canvas?.accessibilityCustomActions(forRowAt: rowIndex) }
+        set {}
+    }
+
+    override var accessibilityFrame: CGRect {
+        get { canvas?.accessibilityScreenFrame(forRowAt: rowIndex) ?? .null }
+        set {}
+    }
+
+    override func accessibilityActivate() -> Bool {
+        canvas?.accessibilityActivate(rowAt: rowIndex) ?? false
+    }
+
+    override func accessibilityElementDidBecomeFocused() {
+        canvas?.revealRowForAccessibility(rowIndex)
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Accessibility.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Accessibility.swift
@@ -37,7 +37,11 @@ extension ReviewDiffCanvasView {
         return lower < indices.count && indices[lower] == element.rowIndex ? lower : NSNotFound
     }
 
+    // VoiceOver can hold an element from before a rows rebuild, so every accessor
+    // treats an out-of-range index as an empty row instead of trapping.
+
     func accessibilityLabel(forRowAt rowIndex: Int) -> String {
+        guard rows.indices.contains(rowIndex) else { return "" }
         let row = rows[rowIndex]
         switch row.kind {
         case .file(let header):
@@ -67,6 +71,7 @@ extension ReviewDiffCanvasView {
     }
 
     func accessibilityTraits(forRowAt rowIndex: Int) -> UIAccessibilityTraits {
+        guard rows.indices.contains(rowIndex) else { return .none }
         let row = rows[rowIndex]
         switch row.kind {
         case .file: return [.header, .button]
@@ -76,6 +81,7 @@ extension ReviewDiffCanvasView {
     }
 
     func accessibilityCustomActions(forRowAt rowIndex: Int) -> [UIAccessibilityCustomAction] {
+        guard rows.indices.contains(rowIndex) else { return [] }
         let row = rows[rowIndex]
         switch row.kind {
         case .file:
@@ -116,12 +122,14 @@ extension ReviewDiffCanvasView {
     }
 
     func accessibilityScreenFrame(forRowAt rowIndex: Int) -> CGRect {
-        guard let frame = frame(forRowAt: rowIndex) else { return .null }
+        guard let frame = drawnFrame(forRowAt: rowIndex) else { return .null }
         return UIAccessibility.convertToScreenCoordinates(frame, in: self)
     }
 
+    /// Scrolls a focused row into view unless it is already drawn on screen, which
+    /// includes the pinned sticky header.
     func revealRowForAccessibility(_ rowIndex: Int) {
-        guard let frame = frame(forRowAt: rowIndex) else { return }
+        guard let frame = drawnFrame(forRowAt: rowIndex) else { return }
         if frame.minY < 0 || frame.maxY > bounds.height {
             onRevealRow?(rowIndex)
         }

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Drawing.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Drawing.swift
@@ -1,0 +1,434 @@
+import UIKit
+
+/// Drawing for `ReviewDiffCanvasView`. Everything is CoreGraphics on the character
+/// grid of the resolved monospaced font: row backgrounds, the solid add bar and striped
+/// delete bar, word-diff highlights, the selection overlay, and the file header card.
+extension ReviewDiffCanvasView {
+    struct FileHeaderInteractiveRects {
+        let chevron: CGRect
+        let icon: CGRect
+        let checkbox: CGRect
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+        let signpost = reviewDiffSignposter.beginInterval("Draw")
+        defer { reviewDiffSignposter.endInterval("Draw", signpost) }
+
+        theme.background.setFill()
+        context.fill(rect)
+        guard !rows.isEmpty else { return }
+
+        let visibleMinY = verticalOffset + rect.minY
+        let visibleMaxY = verticalOffset + rect.maxY
+        let overscan = max(style.metrics.rowHeight, style.metrics.fileHeaderHeight) * 4
+        guard let range = layout.rowRange(intersecting: max(0, visibleMinY - overscan), visibleMaxY + overscan) else {
+            return
+        }
+
+        for rowIndex in range {
+            guard let frame = frame(forRowAt: rowIndex), frame.height > 0 else { continue }
+            let rowStart = frame.minY + verticalOffset
+            if rowStart + frame.height < visibleMinY || rowStart > visibleMaxY { continue }
+            drawRow(rows[rowIndex], rect: frame, context: context)
+        }
+
+        if let sticky = stickyHeaderTarget() {
+            drawFileRow(rows[sticky.rowIndex], rect: sticky.rect, context: context)
+        }
+    }
+
+    private func drawRow(_ row: ReviewDiffRow, rect: CGRect, context: CGContext) {
+        switch row.kind {
+        case .file:
+            drawFileRow(row, rect: rect, context: context)
+        case .hunk(let text):
+            drawHunkRow(text, fileID: row.fileID, rect: rect, context: context)
+        case .notice(let text):
+            drawNoticeRow(text, rect: rect, context: context)
+        case .line(let line):
+            drawCodeRow(row, line: line, rect: rect, context: context)
+        }
+    }
+
+    // MARK: - File header
+
+    func fileHeaderInteractiveRects(cardRect: CGRect) -> FileHeaderInteractiveRects {
+        let centerY = cardRect.midY
+        let padding = style.fileHeaderHorizontalPadding
+        let chevron = CGRect(x: cardRect.minX + padding, y: centerY - 10, width: 20, height: 20)
+        let icon = CGRect(x: chevron.maxX + 8, y: centerY - 10, width: 20, height: 20)
+        // The checkbox hit target is generous; the drawn box is inset from it.
+        let checkbox = CGRect(x: cardRect.maxX - padding - 32, y: centerY - 22, width: 44, height: 44)
+        return FileHeaderInteractiveRects(chevron: chevron, icon: icon, checkbox: checkbox)
+    }
+
+    private func countsText(for header: ReviewDiffFileHeader) -> (add: String, delete: String) {
+        ("+\(header.additions)", "−\(header.deletions)")
+    }
+
+    func fileHeaderPathRect(for header: ReviewDiffFileHeader, cardRect: CGRect) -> CGRect {
+        let rects = fileHeaderInteractiveRects(cardRect: cardRect)
+        let counts = countsText(for: header)
+        let countsWidth = textWidth(counts.add, font: style.fileHeaderMetaFont)
+            + 4 + textWidth(counts.delete, font: style.fileHeaderMetaFont)
+        let countsX = checkboxDrawRect(in: rects.checkbox).minX - 10 - countsWidth
+        let pathX = rects.icon.maxX + 10
+        let height = ceil(style.fileHeaderFont.lineHeight) + 2
+        return CGRect(x: pathX, y: cardRect.midY - height / 2, width: max(24, countsX - pathX - 12), height: height)
+    }
+
+    private func checkboxDrawRect(in hitRect: CGRect) -> CGRect {
+        CGRect(x: hitRect.midX - 10, y: hitRect.midY - 10, width: 20, height: 20)
+    }
+
+    func drawFileRow(_ row: ReviewDiffRow, rect: CGRect, context: CGContext) {
+        guard let header = row.fileHeader else { return }
+        theme.headerBackground.setFill()
+        context.fill(rect)
+
+        let hairline = 1 / max(traitCollection.displayScale, 1)
+        theme.border.setFill()
+        context.fill(CGRect(x: rect.minX, y: rect.maxY - hairline, width: rect.width, height: hairline))
+
+        let rects = fileHeaderInteractiveRects(cardRect: rect)
+        let isCollapsed = collapsedFileIDs.contains(row.fileID)
+        drawDisclosureChevron(rect: rects.chevron, color: theme.mutedText, collapsed: isCollapsed, context: context)
+        drawFileIcon(rect: rects.icon, changeKind: header.changeKind, context: context)
+        drawViewedCheckbox(rect: checkboxDrawRect(in: rects.checkbox), checked: viewedFileIDs.contains(row.fileID), context: context)
+
+        let counts = countsText(for: header)
+        let addWidth = textWidth(counts.add, font: style.fileHeaderMetaFont)
+        let deleteWidth = textWidth(counts.delete, font: style.fileHeaderMetaFont)
+        let countsX = checkboxDrawRect(in: rects.checkbox).minX - 10 - (addWidth + 4 + deleteWidth)
+        let metaHeight = ceil(style.fileHeaderMetaFont.lineHeight)
+        drawSingleLineText(
+            counts.add,
+            rect: CGRect(x: countsX, y: rect.midY - metaHeight / 2, width: addWidth, height: metaHeight),
+            color: theme.addTint,
+            font: style.fileHeaderMetaFont,
+            context: context
+        )
+        drawSingleLineText(
+            counts.delete,
+            rect: CGRect(x: countsX + addWidth + 4, y: rect.midY - metaHeight / 2, width: deleteWidth, height: metaHeight),
+            color: theme.deleteTint,
+            font: style.fileHeaderMetaFont,
+            context: context
+        )
+
+        let pathRect = fileHeaderPathRect(for: header, cardRect: rect)
+        let pathOffset = horizontalOffset(for: row.fileID, kind: .fileHeaderPath)
+        drawSingleLineText(
+            header.displayPath,
+            rect: pathRect,
+            color: theme.text,
+            font: style.fileHeaderFont,
+            horizontalOffset: pathOffset,
+            context: context
+        )
+        drawPathScrollFade(header, pathRect: pathRect, horizontalOffset: pathOffset, context: context)
+    }
+
+    private func drawPathScrollFade(
+        _ header: ReviewDiffFileHeader,
+        pathRect: CGRect,
+        horizontalOffset: CGFloat,
+        context: CGContext
+    ) {
+        let maxOffset = maxHeaderPathOffset(for: header)
+        guard maxOffset > 0, pathRect.width > 0 else { return }
+        let fadeWidth = min(28, pathRect.width / 3)
+        if horizontalOffset > 0.5 {
+            drawHorizontalFade(
+                rect: CGRect(x: pathRect.minX, y: pathRect.minY, width: fadeWidth, height: pathRect.height),
+                fadesToRight: false,
+                context: context
+            )
+        }
+        if horizontalOffset < maxOffset - 0.5 {
+            drawHorizontalFade(
+                rect: CGRect(x: pathRect.maxX - fadeWidth, y: pathRect.minY, width: fadeWidth, height: pathRect.height),
+                fadesToRight: true,
+                context: context
+            )
+        }
+    }
+
+    private func drawHorizontalFade(rect: CGRect, fadesToRight: Bool, context: CGContext) {
+        let color = theme.headerBackground.resolvedColor(with: traitCollection)
+        guard rect.width > 0,
+              let gradient = CGGradient(
+                  colorsSpace: CGColorSpaceCreateDeviceRGB(),
+                  colors: [
+                      color.withAlphaComponent(fadesToRight ? 0 : 1).cgColor,
+                      color.withAlphaComponent(fadesToRight ? 1 : 0).cgColor
+                  ] as CFArray,
+                  locations: [0, 1]
+              ) else { return }
+        context.saveGState()
+        context.clip(to: rect)
+        context.drawLinearGradient(
+            gradient,
+            start: CGPoint(x: rect.minX, y: rect.midY),
+            end: CGPoint(x: rect.maxX, y: rect.midY),
+            options: []
+        )
+        context.restoreGState()
+    }
+
+    // MARK: - Hunk, notice, code rows
+
+    private func drawHunkRow(_ text: String, fileID: String, rect: CGRect, context: CGContext) {
+        theme.hunkBackground.setFill()
+        context.fill(rect)
+        context.saveGState()
+        context.clip(to: CGRect(x: style.stickyWidth, y: rect.minY, width: max(0, viewportWidth - style.stickyWidth), height: rect.height))
+        drawText(
+            text,
+            at: CGPoint(x: style.codeStartX - horizontalOffset(for: fileID), y: rect.midY - style.hunkFont.lineHeight / 2),
+            color: theme.accent,
+            font: style.hunkFont
+        )
+        context.restoreGState()
+    }
+
+    private func drawNoticeRow(_ text: String, rect: CGRect, context: CGContext) {
+        theme.background.setFill()
+        context.fill(rect)
+        let hairline = 1 / max(traitCollection.displayScale, 1)
+        theme.border.withAlphaComponent(0.65).setFill()
+        context.fill(CGRect(x: 0, y: rect.maxY - hairline, width: rect.width, height: hairline))
+
+        let iconSize: CGFloat = 16
+        let iconRect = CGRect(x: style.fileHeaderHorizontalPadding + 2, y: rect.midY - iconSize / 2, width: iconSize, height: iconSize)
+        drawNoticeIcon(rect: iconRect, color: theme.mutedText, context: context)
+        let textHeight = ceil(style.noticeFont.lineHeight)
+        drawSingleLineText(
+            text,
+            rect: CGRect(
+                x: iconRect.maxX + 10,
+                y: rect.midY - textHeight / 2,
+                width: max(24, viewportWidth - iconRect.maxX - 10 - style.fileHeaderHorizontalPadding),
+                height: textHeight
+            ),
+            color: theme.mutedText,
+            font: style.noticeFont,
+            context: context
+        )
+    }
+
+    private func drawCodeRow(_ row: ReviewDiffRow, line: ReviewDiffLine, rect: CGRect, context: CGContext) {
+        let horizontalOffset = horizontalOffset(for: row.fileID)
+        rowBackground(for: line.change).setFill()
+        context.fill(rect)
+
+        let barRect = CGRect(x: 0, y: rect.minY, width: style.changeBarWidth, height: rect.height)
+        switch line.change {
+        case .addition:
+            theme.addTint.setFill()
+            context.fill(barRect)
+        case .deletion:
+            drawDeleteStripes(rect: barRect, context: context)
+        case .context:
+            break
+        }
+
+        if selectedRowIDs.contains(row.id) {
+            theme.accent.withAlphaComponent(0.22).setFill()
+            context.fill(rect)
+            theme.accent.withAlphaComponent(0.95).setFill()
+            context.fill(barRect)
+        }
+
+        if let number = line.displayLineNumber {
+            drawRightAlignedText(
+                "\(number)",
+                rect: CGRect(
+                    x: style.changeBarWidth,
+                    y: rect.midY - style.lineNumberFont.lineHeight / 2,
+                    width: style.gutterWidth - style.codePadding,
+                    height: style.lineNumberFont.lineHeight
+                ),
+                color: lineNumberColor(for: line.change),
+                font: style.lineNumberFont
+            )
+        }
+
+        context.saveGState()
+        context.clip(to: CGRect(x: style.stickyWidth, y: rect.minY, width: max(0, viewportWidth - style.stickyWidth), height: rect.height))
+        drawWordDiffRanges(line, rowRect: rect, horizontalOffset: horizontalOffset)
+        drawText(
+            line.content,
+            at: CGPoint(x: style.codeStartX - horizontalOffset, y: rect.midY - style.codeFont.lineHeight / 2),
+            color: line.change == .context ? theme.text.withAlphaComponent(0.85) : theme.text,
+            font: style.codeFont
+        )
+        context.restoreGState()
+    }
+
+    private func drawWordDiffRanges(_ line: ReviewDiffLine, rowRect: CGRect, horizontalOffset: CGFloat) {
+        guard !line.wordDiffRanges.isEmpty else { return }
+        let fill: UIColor
+        switch line.change {
+        case .addition: fill = theme.addTint.withAlphaComponent(0.28)
+        case .deletion: fill = theme.deleteTint.withAlphaComponent(0.28)
+        case .context: return
+        }
+        let height = max(4, min(rowRect.height - 4, style.codeFont.lineHeight))
+        let y = rowRect.midY - height / 2
+        fill.setFill()
+        for range in line.wordDiffRanges where !range.isEmpty {
+            let x = style.codeStartX - horizontalOffset + CGFloat(range.lowerBound) * style.codeCharacterWidth
+            let width = max(2, CGFloat(range.count) * style.codeCharacterWidth)
+            UIBezierPath(roundedRect: CGRect(x: x, y: y, width: width, height: height), cornerRadius: 3).fill()
+        }
+    }
+
+    private func rowBackground(for change: DiffLine.Kind) -> UIColor {
+        switch change {
+        case .addition: return theme.addBackground
+        case .deletion: return theme.deleteBackground
+        case .context: return theme.background
+        }
+    }
+
+    private func lineNumberColor(for change: DiffLine.Kind) -> UIColor {
+        switch change {
+        case .addition: return theme.addTint
+        case .deletion: return theme.deleteTint
+        case .context: return theme.mutedText
+        }
+    }
+
+    /// Alternating 1 pt stripes so a deletion reads without relying on red alone.
+    private func drawDeleteStripes(rect: CGRect, context: CGContext) {
+        theme.deleteTint.setFill()
+        var y = rect.minY
+        while y < rect.maxY {
+            context.fill(CGRect(x: rect.minX, y: y, width: rect.width, height: 1))
+            y += 2
+        }
+    }
+
+    // MARK: - Glyphs
+
+    private func drawDisclosureChevron(rect: CGRect, color: UIColor, collapsed: Bool, context: CGContext) {
+        context.saveGState()
+        context.setStrokeColor(color.cgColor)
+        context.setLineWidth(2)
+        context.setLineCap(.round)
+        context.setLineJoin(.round)
+        if collapsed {
+            context.move(to: CGPoint(x: rect.minX + rect.width * 0.40, y: rect.minY + rect.height * 0.28))
+            context.addLine(to: CGPoint(x: rect.minX + rect.width * 0.60, y: rect.midY))
+            context.addLine(to: CGPoint(x: rect.minX + rect.width * 0.40, y: rect.maxY - rect.height * 0.28))
+        } else {
+            context.move(to: CGPoint(x: rect.minX + rect.width * 0.28, y: rect.minY + rect.height * 0.42))
+            context.addLine(to: CGPoint(x: rect.midX, y: rect.minY + rect.height * 0.62))
+            context.addLine(to: CGPoint(x: rect.maxX - rect.width * 0.28, y: rect.minY + rect.height * 0.42))
+        }
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    private func drawFileIcon(rect: CGRect, changeKind: GitFile.ChangeKind, context: CGContext) {
+        let color = theme.tint(for: changeKind)
+        let outline = UIBezierPath(roundedRect: rect, cornerRadius: 6)
+        color.setStroke()
+        outline.lineWidth = 2
+        outline.stroke()
+
+        if changeKind == .renamed {
+            drawRenameChevrons(rect: rect.insetBy(dx: 4.5, dy: 5), color: color, context: context)
+            return
+        }
+        color.setFill()
+        UIBezierPath(ovalIn: CGRect(x: rect.midX - 3, y: rect.midY - 3, width: 6, height: 6)).fill()
+    }
+
+    private func drawRenameChevrons(rect: CGRect, color: UIColor, context: CGContext) {
+        context.saveGState()
+        context.setStrokeColor(color.cgColor)
+        context.setLineWidth(1.8)
+        context.setLineCap(.round)
+        context.setLineJoin(.round)
+        let chevronWidth = min(rect.width * 0.28, 3.6)
+        let chevronHeight = min(rect.height, 8)
+        let gap = min(rect.width * 0.18, 2.4)
+        let startX = rect.midX - (chevronWidth * 2 + gap) / 2
+        for x in [startX, startX + chevronWidth + gap] {
+            context.move(to: CGPoint(x: x, y: rect.midY - chevronHeight / 2))
+            context.addLine(to: CGPoint(x: x + chevronWidth, y: rect.midY))
+            context.addLine(to: CGPoint(x: x, y: rect.midY + chevronHeight / 2))
+        }
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    private func drawViewedCheckbox(rect: CGRect, checked: Bool, context: CGContext) {
+        let path = UIBezierPath(roundedRect: rect, cornerRadius: 6)
+        if checked {
+            theme.accent.setFill()
+            path.fill()
+        }
+        (checked ? theme.accent : theme.mutedText).setStroke()
+        path.lineWidth = 1.8
+        path.stroke()
+        guard checked else { return }
+
+        context.saveGState()
+        context.setStrokeColor(theme.background.cgColor)
+        context.setLineWidth(2)
+        context.setLineCap(.round)
+        context.setLineJoin(.round)
+        context.move(to: CGPoint(x: rect.minX + rect.width * 0.28, y: rect.midY))
+        context.addLine(to: CGPoint(x: rect.minX + rect.width * 0.44, y: rect.maxY - rect.height * 0.30))
+        context.addLine(to: CGPoint(x: rect.maxX - rect.width * 0.25, y: rect.minY + rect.height * 0.30))
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    private func drawNoticeIcon(rect: CGRect, color: UIColor, context: CGContext) {
+        context.saveGState()
+        context.setStrokeColor(color.cgColor)
+        context.setLineWidth(1.7)
+        context.setLineCap(.round)
+        context.strokeEllipse(in: rect.insetBy(dx: 1, dy: 1))
+        context.move(to: CGPoint(x: rect.midX, y: rect.minY + rect.height * 0.30))
+        context.addLine(to: CGPoint(x: rect.midX, y: rect.minY + rect.height * 0.58))
+        context.strokePath()
+        color.setFill()
+        context.fillEllipse(in: CGRect(x: rect.midX - 1, y: rect.maxY - rect.height * 0.30, width: 2, height: 2))
+        context.restoreGState()
+    }
+
+    // MARK: - Text
+
+    private func drawText(_ text: String, at point: CGPoint, color: UIColor, font: UIFont) {
+        (text as NSString).draw(at: point, withAttributes: [.font: font, .foregroundColor: color, .ligature: 0])
+    }
+
+    private func drawSingleLineText(
+        _ text: String,
+        rect: CGRect,
+        color: UIColor,
+        font: UIFont,
+        horizontalOffset: CGFloat = 0,
+        context: CGContext
+    ) {
+        context.saveGState()
+        context.clip(to: rect)
+        (text as NSString).draw(
+            at: CGPoint(x: rect.minX - horizontalOffset, y: rect.midY - font.lineHeight / 2),
+            withAttributes: [.font: font, .foregroundColor: color, .ligature: 0]
+        )
+        context.restoreGState()
+    }
+
+    private func drawRightAlignedText(_ text: String, rect: CGRect, color: UIColor, font: UIFont) {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .right
+        (text as NSString).draw(in: rect, withAttributes: [.font: font, .foregroundColor: color, .paragraphStyle: paragraph])
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
@@ -1,0 +1,414 @@
+// Ported from t3code's `T3ReviewDiffView.swift` (apps/mobile/modules/t3-review-diff).
+//
+// MIT License
+//
+// Copyright (c) 2026 T3 Tools Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import OSLog
+import UIKit
+
+struct ReviewDiffLinePress: Equatable {
+    enum Gesture: Equatable {
+        case tap
+        case longPress
+    }
+
+    let rowID: String
+    let fileID: String
+    let gesture: Gesture
+}
+
+let reviewDiffSignposter = OSSignposter(
+    subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile",
+    category: "ReviewDiff"
+)
+
+/// The drawing surface. It is sized to the viewport and slid along with the scroll
+/// offset by `ReviewDiffSurfaceView`, so every draw pass paints only the rows that
+/// intersect the visible bounds (plus a four-row overscan). Rows are never views:
+/// a 5,000-line diff is one `draw(_:)` of ~40 rows.
+///
+/// Owns hit testing and the per-file horizontal pan with display-link deceleration.
+/// Drawing lives in `ReviewDiffCanvasView+Drawing`, VoiceOver in `+Accessibility`.
+final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
+    enum HorizontalPanKind {
+        case code
+        case fileHeaderPath
+    }
+
+    private(set) var layout: ReviewDiffLayout
+    private(set) var style: ReviewDiffStyle
+    let theme = ReviewDiffTheme()
+
+    var viewedFileIDs: Set<String> = [] {
+        didSet { setNeedsDisplay() }
+    }
+    var selectedRowIDs: Set<String> = [] {
+        didSet { setNeedsDisplay() }
+    }
+    var viewportWidth: CGFloat = 0 {
+        didSet {
+            clampHorizontalOffsets()
+            setNeedsDisplay()
+        }
+    }
+    /// Scroll offset of the host; row `y` in canvas coordinates is `offset - verticalOffset`.
+    var verticalOffset: CGFloat = 0
+
+    var onToggleFile: ((String) -> Void)?
+    var onToggleViewed: ((String) -> Void)?
+    var onLinePress: ((ReviewDiffLinePress) -> Void)?
+    /// The layout height changed (rows, collapse, Dynamic Type); the host resizes content.
+    var onContentHeightChange: (() -> Void)?
+    /// VoiceOver focused a row that is off screen; the host scrolls it into view.
+    var onRevealRow: ((Int) -> Void)?
+
+    private(set) var contentWidthsByFileID: [String: CGFloat] = [:]
+    private var horizontalOffsetsByFileID: [String: CGFloat] = [:]
+    private var headerPathOffsetsByFileID: [String: CGFloat] = [:]
+    private var panStartHorizontalOffset: CGFloat = 0
+    private var activePanFileID: String?
+    private var activePanKind: HorizontalPanKind?
+    private var decelerationDisplayLink: CADisplayLink?
+    private var deceleratingFileID: String?
+    private var horizontalVelocity: CGFloat = 0
+    private var lastDecelerationTimestamp: CFTimeInterval = 0
+    /// VoiceOver elements created on demand; cleared whenever the layout rebuilds.
+    var accessibilityElementsByRowIndex: [Int: ReviewDiffRowAccessibilityElement] = [:]
+
+    var rows: [ReviewDiffRow] { layout.rows }
+    var collapsedFileIDs: Set<String> { layout.collapsedFileIDs }
+    var contentHeight: CGFloat { layout.contentHeight }
+
+    private lazy var horizontalPanGesture: UIPanGestureRecognizer = {
+        let gesture = UIPanGestureRecognizer(target: self, action: #selector(handleHorizontalPan(_:)))
+        gesture.delegate = self
+        gesture.cancelsTouchesInView = false
+        return gesture
+    }()
+
+    private lazy var tapGesture: UITapGestureRecognizer = {
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        gesture.delegate = self
+        gesture.cancelsTouchesInView = false
+        return gesture
+    }()
+
+    private lazy var longPressGesture: UILongPressGestureRecognizer = {
+        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
+        gesture.delegate = self
+        gesture.cancelsTouchesInView = false
+        gesture.minimumPressDuration = 0.28
+        return gesture
+    }()
+
+    override init(frame: CGRect) {
+        let style = ReviewDiffStyle.resolve(for: UITraitCollection.current)
+        self.style = style
+        layout = ReviewDiffLayout(rows: [], collapsedFileIDs: [], metrics: style.metrics)
+        super.init(frame: frame)
+        isOpaque = true
+        contentMode = .redraw
+        backgroundColor = theme.background
+        addGestureRecognizer(horizontalPanGesture)
+        addGestureRecognizer(tapGesture)
+        addGestureRecognizer(longPressGesture)
+        tapGesture.require(toFail: longPressGesture)
+
+        // Dynamic Type resizes every row; appearance changes only need a repaint.
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: Self, _) in
+            view.style = ReviewDiffStyle.resolve(for: view.traitCollection)
+            view.rebuildLayout(rows: view.layout.rows, collapsedFileIDs: view.layout.collapsedFileIDs)
+        }
+        registerForTraitChanges([UITraitUserInterfaceStyle.self, UITraitAccessibilityContrast.self]) { (view: Self, _) in
+            view.setNeedsDisplay()
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    deinit {
+        stopHorizontalDeceleration()
+    }
+
+    // MARK: - Inputs
+
+    func setRows(_ rows: [ReviewDiffRow]) {
+        stopHorizontalDeceleration()
+        horizontalOffsetsByFileID.removeAll()
+        headerPathOffsetsByFileID.removeAll()
+        activePanFileID = nil
+        activePanKind = nil
+        rebuildLayout(rows: rows, collapsedFileIDs: layout.collapsedFileIDs)
+    }
+
+    func setCollapsedFileIDs(_ collapsedFileIDs: Set<String>) {
+        guard collapsedFileIDs != layout.collapsedFileIDs else { return }
+        rebuildLayout(rows: layout.rows, collapsedFileIDs: collapsedFileIDs)
+    }
+
+    private func rebuildLayout(rows: [ReviewDiffRow], collapsedFileIDs: Set<String>) {
+        let state = reviewDiffSignposter.beginInterval("RebuildLayout")
+        layout = ReviewDiffLayout(rows: rows, collapsedFileIDs: collapsedFileIDs, metrics: style.metrics)
+        contentWidthsByFileID = layout.maxColumnCountsByFileID.mapValues { columns in
+            let measured = ceil(CGFloat(columns) * style.codeCharacterWidth) + style.codePadding * 2
+            return max(0, min(style.maxContentWidth, measured))
+        }
+        accessibilityElementsByRowIndex.removeAll()
+        clampHorizontalOffsets()
+        reviewDiffSignposter.endInterval("RebuildLayout", state, "rows=\(rows.count)")
+        onContentHeightChange?()
+        setNeedsDisplay()
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+    }
+
+    // MARK: - Geometry
+
+    /// Row frame in canvas coordinates (viewport space).
+    func frame(forRowAt index: Int) -> CGRect? {
+        guard let frame = layout.frame(forRowAt: index) else { return nil }
+        return CGRect(x: 0, y: frame.minY - verticalOffset, width: max(bounds.width, viewportWidth), height: frame.height)
+    }
+
+    func stickyHeaderTarget() -> (rowIndex: Int, rect: CGRect)? {
+        guard let sticky = layout.stickyHeader(atVerticalOffset: verticalOffset) else { return nil }
+        let rect = CGRect(x: 0, y: sticky.y, width: max(bounds.width, viewportWidth), height: style.metrics.fileHeaderHeight)
+        return (sticky.rowIndex, rect)
+    }
+
+    private func rowIndex(atCanvasPoint point: CGPoint) -> Int? {
+        layout.rowIndex(at: verticalOffset + point.y)
+    }
+
+    /// Where the header is currently drawn: pinned at the top when sticky, in place otherwise.
+    func scrollAnchorScreenY(forFileID fileID: String) -> CGFloat? {
+        if let sticky = stickyHeaderTarget(), rows[sticky.rowIndex].fileID == fileID {
+            return 0
+        }
+        return layout.fileHeaderOffset(forFileID: fileID).map { $0 - verticalOffset }
+    }
+
+    // MARK: - Gestures
+
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === horizontalPanGesture else { return true }
+
+        let velocity = horizontalPanGesture.velocity(in: self)
+        guard abs(velocity.x) > abs(velocity.y) * 1.25 else { return false }
+        guard let target = horizontalPanTarget(at: horizontalPanGesture.location(in: self)) else { return false }
+
+        let currentOffset = horizontalOffset(for: target.fileID, kind: target.kind)
+        if velocity.x > 0, currentOffset <= 0.5 { return false }
+        return maxHorizontalOffset(for: target.fileID, kind: target.kind) > 0
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        false
+    }
+
+    @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        let point = gesture.location(in: self)
+        if let sticky = stickyHeaderTarget(), sticky.rect.contains(point) {
+            handleFileHeaderTap(rowIndex: sticky.rowIndex, rect: sticky.rect, point: point)
+            return
+        }
+        guard let rowIndex = rowIndex(atCanvasPoint: point) else { return }
+        activateRow(at: rowIndex, point: point)
+    }
+
+    /// Tap behaviour for a row, shared with VoiceOver activation (no point).
+    func activateRow(at rowIndex: Int, point: CGPoint?) {
+        let row = rows[rowIndex]
+        switch row.kind {
+        case .line:
+            onLinePress?(ReviewDiffLinePress(rowID: row.id, fileID: row.fileID, gesture: .tap))
+        case .file:
+            guard let rect = frame(forRowAt: rowIndex) else { return }
+            handleFileHeaderTap(rowIndex: rowIndex, rect: rect, point: point)
+        case .hunk, .notice:
+            break
+        }
+    }
+
+    @objc private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began else { return }
+        let point = gesture.location(in: self)
+        if let sticky = stickyHeaderTarget(), sticky.rect.contains(point) { return }
+        guard let rowIndex = rowIndex(atCanvasPoint: point), let row = rows[safe: rowIndex], row.line != nil else { return }
+        onLinePress?(ReviewDiffLinePress(rowID: row.id, fileID: row.fileID, gesture: .longPress))
+    }
+
+    /// The checkbox toggles viewed; anywhere else on the header toggles collapse.
+    private func handleFileHeaderTap(rowIndex: Int, rect: CGRect, point: CGPoint?) {
+        let fileID = rows[rowIndex].fileID
+        if let point, fileHeaderInteractiveRects(cardRect: rect).checkbox.contains(point) {
+            onToggleViewed?(fileID)
+            return
+        }
+        onToggleFile?(fileID)
+    }
+
+    @objc private func handleHorizontalPan(_ gesture: UIPanGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            stopHorizontalDeceleration()
+            let target = horizontalPanTarget(at: gesture.location(in: self))
+            activePanFileID = target?.fileID
+            activePanKind = target?.kind
+            panStartHorizontalOffset = horizontalOffset(for: target?.fileID, kind: target?.kind ?? .code)
+        case .changed, .ended, .cancelled:
+            guard let fileID = activePanFileID, let kind = activePanKind else { return }
+            let translation = gesture.translation(in: self)
+            setHorizontalOffset(
+                min(max(panStartHorizontalOffset - translation.x, 0), maxHorizontalOffset(for: fileID, kind: kind)),
+                for: fileID,
+                kind: kind
+            )
+            guard gesture.state != .changed else { return }
+            activePanFileID = nil
+            activePanKind = nil
+            if gesture.state == .ended, kind == .code {
+                startHorizontalDeceleration(fileID: fileID, velocity: -gesture.velocity(in: self).x)
+            }
+        default:
+            break
+        }
+    }
+
+    private func horizontalPanTarget(at point: CGPoint) -> (fileID: String, kind: HorizontalPanKind)? {
+        if let sticky = stickyHeaderTarget(), sticky.rect.contains(point) {
+            return (rows[sticky.rowIndex].fileID, .fileHeaderPath)
+        }
+        guard let rowIndex = rowIndex(atCanvasPoint: point) else { return nil }
+        let row = rows[rowIndex]
+        return (row.fileID, row.isFileHeader ? .fileHeaderPath : .code)
+    }
+
+    // MARK: - Horizontal offsets
+
+    func horizontalOffset(for fileID: String?, kind: HorizontalPanKind = .code) -> CGFloat {
+        guard let fileID else { return 0 }
+        switch kind {
+        case .code: return horizontalOffsetsByFileID[fileID] ?? 0
+        case .fileHeaderPath: return headerPathOffsetsByFileID[fileID] ?? 0
+        }
+    }
+
+    private func setHorizontalOffset(_ offset: CGFloat, for fileID: String, kind: HorizontalPanKind) {
+        switch kind {
+        case .code: horizontalOffsetsByFileID[fileID] = offset
+        case .fileHeaderPath: headerPathOffsetsByFileID[fileID] = offset
+        }
+        setNeedsDisplay()
+    }
+
+    private func clampHorizontalOffsets() {
+        for (fileID, offset) in horizontalOffsetsByFileID {
+            horizontalOffsetsByFileID[fileID] = min(offset, maxHorizontalOffset(for: fileID, kind: .code))
+        }
+        for (fileID, offset) in headerPathOffsetsByFileID {
+            headerPathOffsetsByFileID[fileID] = min(offset, maxHorizontalOffset(for: fileID, kind: .fileHeaderPath))
+        }
+    }
+
+    func contentWidth(for fileID: String) -> CGFloat {
+        contentWidthsByFileID[fileID] ?? min(style.maxContentWidth, max(viewportWidth, 0))
+    }
+
+    func maxHorizontalOffset(for fileID: String, kind: HorizontalPanKind) -> CGFloat {
+        switch kind {
+        case .fileHeaderPath:
+            guard let header = rows.first(where: { $0.fileID == fileID && $0.isFileHeader })?.fileHeader else { return 0 }
+            return maxHeaderPathOffset(for: header)
+        case .code:
+            return max(0, contentWidth(for: fileID) - max(0, viewportWidth - style.codeStartX))
+        }
+    }
+
+    func maxHeaderPathOffset(for header: ReviewDiffFileHeader) -> CGFloat {
+        let cardRect = CGRect(x: 0, y: 0, width: max(bounds.width, viewportWidth), height: style.metrics.fileHeaderHeight)
+        let pathRect = fileHeaderPathRect(for: header, cardRect: cardRect)
+        return max(0, textWidth(header.displayPath, font: style.fileHeaderFont) - pathRect.width)
+    }
+
+    private func startHorizontalDeceleration(fileID: String, velocity: CGFloat) {
+        guard abs(velocity) > 80 else { return }
+        let currentOffset = horizontalOffset(for: fileID)
+        let maxOffset = maxHorizontalOffset(for: fileID, kind: .code)
+        if (currentOffset <= 0 && velocity < 0) || (currentOffset >= maxOffset && velocity > 0) { return }
+
+        stopHorizontalDeceleration()
+        deceleratingFileID = fileID
+        horizontalVelocity = velocity
+        lastDecelerationTimestamp = 0
+        let displayLink = CADisplayLink(target: self, selector: #selector(stepHorizontalDeceleration(_:)))
+        displayLink.add(to: .main, forMode: .common)
+        decelerationDisplayLink = displayLink
+    }
+
+    @objc private func stepHorizontalDeceleration(_ displayLink: CADisplayLink) {
+        guard let fileID = deceleratingFileID else {
+            stopHorizontalDeceleration()
+            return
+        }
+        if lastDecelerationTimestamp == 0 {
+            lastDecelerationTimestamp = displayLink.timestamp
+            return
+        }
+        let dt = max(0, displayLink.timestamp - lastDecelerationTimestamp)
+        lastDecelerationTimestamp = displayLink.timestamp
+
+        let maxOffset = maxHorizontalOffset(for: fileID, kind: .code)
+        let next = min(max(horizontalOffset(for: fileID) + horizontalVelocity * CGFloat(dt), 0), maxOffset)
+        setHorizontalOffset(next, for: fileID, kind: .code)
+
+        // UIScrollView deceleration rates are expressed per millisecond.
+        horizontalVelocity *= CGFloat(pow(Double(UIScrollView.DecelerationRate.normal.rawValue), dt * 1000))
+        if abs(horizontalVelocity) < 20 || next <= 0 || next >= maxOffset {
+            stopHorizontalDeceleration()
+        }
+    }
+
+    private func stopHorizontalDeceleration() {
+        decelerationDisplayLink?.invalidate()
+        decelerationDisplayLink = nil
+        deceleratingFileID = nil
+        horizontalVelocity = 0
+        lastDecelerationTimestamp = 0
+    }
+
+    func textWidth(_ text: String, font: UIFont) -> CGFloat {
+        ceil((text as NSString).size(withAttributes: [.font: font, .ligature: 0]).width)
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
@@ -154,10 +154,10 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
 
     // MARK: - Inputs
 
+    /// Rows arrive file by file while loading, so a pan the reader already made on a
+    /// loaded file survives the rebuild; offsets are clamped to the new widths.
     func setRows(_ rows: [ReviewDiffRow]) {
         stopHorizontalDeceleration()
-        horizontalOffsetsByFileID.removeAll()
-        headerPathOffsetsByFileID.removeAll()
         activePanFileID = nil
         activePanKind = nil
         rebuildLayout(rows: rows, collapsedFileIDs: layout.collapsedFileIDs)
@@ -189,6 +189,15 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
     func frame(forRowAt index: Int) -> CGRect? {
         guard let frame = layout.frame(forRowAt: index) else { return nil }
         return CGRect(x: 0, y: frame.minY - verticalOffset, width: max(bounds.width, viewportWidth), height: frame.height)
+    }
+
+    /// Where a row is drawn right now: the pinned rect for the sticky header, the
+    /// scrolled position for everything else. VoiceOver frames use this.
+    func drawnFrame(forRowAt index: Int) -> CGRect? {
+        if let sticky = stickyHeaderTarget(), sticky.rowIndex == index {
+            return sticky.rect
+        }
+        return frame(forRowAt: index)
     }
 
     func stickyHeaderTarget() -> (rowIndex: Int, rect: CGRect)? {

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffLayout.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffLayout.swift
@@ -1,0 +1,177 @@
+import CoreGraphics
+import Foundation
+
+/// Row heights the layout needs. The canvas derives them from the resolved fonts so
+/// Dynamic Type changes rebuild the layout instead of clipping text.
+struct ReviewDiffMetrics: Equatable {
+    var rowHeight: CGFloat
+    var fileHeaderHeight: CGFloat
+    var noticeHeight: CGFloat
+}
+
+/// Vertical geometry of the row list: prefix-sum offsets, binary-search hit testing,
+/// and the sticky header the next file header pushes off screen. Pure and cheap to
+/// rebuild, so collapse and Dynamic Type just build a new one.
+struct ReviewDiffLayout {
+    struct StickyHeader: Equatable {
+        let rowIndex: Int
+        /// Top of the header in viewport coordinates, zero or negative while the
+        /// next file header pushes it up.
+        let y: CGFloat
+    }
+
+    let rows: [ReviewDiffRow]
+    let collapsedFileIDs: Set<String>
+    let metrics: ReviewDiffMetrics
+    private(set) var rowOffsets: [CGFloat] = []
+    private(set) var fileHeaderRowIndices: [Int] = []
+    /// Rows with a non-zero height, in order; the accessibility element list.
+    private(set) var visibleRowIndices: [Int] = []
+    private(set) var contentHeight: CGFloat = 0
+    /// Longest line per file, in characters; the canvas turns it into a content width.
+    private(set) var maxColumnCountsByFileID: [String: Int] = [:]
+
+    init(rows: [ReviewDiffRow], collapsedFileIDs: Set<String>, metrics: ReviewDiffMetrics) {
+        self.rows = rows
+        self.collapsedFileIDs = collapsedFileIDs
+        self.metrics = metrics
+
+        rowOffsets.reserveCapacity(rows.count)
+        var offset: CGFloat = 0
+        for (index, row) in rows.enumerated() {
+            rowOffsets.append(offset)
+            if row.isFileHeader { fileHeaderRowIndices.append(index) }
+            let height = height(forRowAt: index)
+            if height > 0 { visibleRowIndices.append(index) }
+            offset += height
+            let columns = row.columnCount
+            if columns > 0 {
+                maxColumnCountsByFileID[row.fileID] = max(maxColumnCountsByFileID[row.fileID] ?? 0, columns)
+            }
+        }
+        contentHeight = offset
+    }
+
+    func height(forRowAt index: Int) -> CGFloat {
+        let row = rows[index]
+        switch row.kind {
+        case .file:
+            return metrics.fileHeaderHeight
+        case .hunk, .line:
+            return collapsedFileIDs.contains(row.fileID) ? 0 : metrics.rowHeight
+        case .notice:
+            return collapsedFileIDs.contains(row.fileID) ? 0 : metrics.noticeHeight
+        }
+    }
+
+    /// Vertical extent of a row in content coordinates.
+    func frame(forRowAt index: Int) -> (minY: CGFloat, height: CGFloat)? {
+        guard rows.indices.contains(index) else { return nil }
+        return (rowOffsets[index], height(forRowAt: index))
+    }
+
+    /// The row containing `absoluteY`, skipping collapsed (zero-height) rows.
+    func rowIndex(at absoluteY: CGFloat) -> Int? {
+        guard !rows.isEmpty else { return nil }
+        var lower = 0
+        var upper = rows.count - 1
+        while lower <= upper {
+            let middle = (lower + upper) / 2
+            let start = rowOffsets[middle]
+            let end = start + height(forRowAt: middle)
+            if absoluteY < start {
+                upper = middle - 1
+            } else if absoluteY >= end {
+                lower = middle + 1
+            } else {
+                return middle
+            }
+        }
+        return nil
+    }
+
+    func firstRowIndex(endingAtOrAfter absoluteY: CGFloat) -> Int? {
+        guard !rows.isEmpty else { return nil }
+        var lower = 0
+        var upper = rows.count
+        while lower < upper {
+            let middle = (lower + upper) / 2
+            if rowOffsets[middle] + height(forRowAt: middle) < absoluteY {
+                lower = middle + 1
+            } else {
+                upper = middle
+            }
+        }
+        return lower < rows.count ? lower : nil
+    }
+
+    func lastRowIndex(startingAtOrBefore absoluteY: CGFloat) -> Int? {
+        guard !rows.isEmpty else { return nil }
+        var lower = 0
+        var upper = rows.count
+        while lower < upper {
+            let middle = (lower + upper) / 2
+            if rowOffsets[middle] <= absoluteY {
+                lower = middle + 1
+            } else {
+                upper = middle
+            }
+        }
+        return lower > 0 ? lower - 1 : nil
+    }
+
+    /// Rows that intersect `minY...maxY` in content coordinates.
+    func rowRange(intersecting minY: CGFloat, _ maxY: CGFloat) -> ClosedRange<Int>? {
+        guard let first = firstRowIndex(endingAtOrAfter: minY),
+              let last = lastRowIndex(startingAtOrBefore: maxY),
+              first <= last else { return nil }
+        return first...last
+    }
+
+    func fileHeaderRowIndex(forFileID fileID: String) -> Int? {
+        fileHeaderRowIndices.first { rows[$0].fileID == fileID }
+    }
+
+    func fileHeaderOffset(forFileID fileID: String) -> CGFloat? {
+        fileHeaderRowIndex(forFileID: fileID).map { rowOffsets[$0] }
+    }
+
+    /// Position (in `fileHeaderRowIndices`) of the last header at or above `absoluteY`.
+    private func lastHeaderPosition(atOrAbove absoluteY: CGFloat) -> Int? {
+        var lower = 0
+        var upper = fileHeaderRowIndices.count
+        while lower < upper {
+            let middle = (lower + upper) / 2
+            if rowOffsets[fileHeaderRowIndices[middle]] <= absoluteY {
+                lower = middle + 1
+            } else {
+                upper = middle
+            }
+        }
+        return lower > 0 ? lower - 1 : nil
+    }
+
+    /// The file whose header is at or above the viewport top, or the first file.
+    func visibleFileID(atVerticalOffset verticalOffset: CGFloat) -> String? {
+        guard let firstHeader = fileHeaderRowIndices.first else { return nil }
+        let position = lastHeaderPosition(atOrAbove: verticalOffset + 0.5)
+        let rowIndex = position.map { fileHeaderRowIndices[$0] } ?? firstHeader
+        return rows[rowIndex].fileID
+    }
+
+    /// The header pinned at the top once its own row has scrolled past, pushed up by
+    /// the next file's header until it is fully off screen.
+    func stickyHeader(atVerticalOffset verticalOffset: CGFloat) -> StickyHeader? {
+        guard let position = lastHeaderPosition(atOrAbove: verticalOffset) else { return nil }
+        let rowIndex = fileHeaderRowIndices[position]
+        guard rowOffsets[rowIndex] < verticalOffset else { return nil }
+
+        var pushedY: CGFloat = 0
+        if fileHeaderRowIndices.indices.contains(position + 1) {
+            let nextTop = rowOffsets[fileHeaderRowIndices[position + 1]]
+            pushedY = min(0, nextTop - verticalOffset - metrics.fileHeaderHeight)
+        }
+        guard pushedY > -metrics.fileHeaderHeight else { return nil }
+        return StickyHeader(rowIndex: rowIndex, y: pushedY)
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffRow.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffRow.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// One drawn row of the review surface. The surface is a flat list, so layout is a
+/// prefix sum over row heights and hit testing is a binary search over offsets.
+struct ReviewDiffRow: Equatable, Identifiable {
+    enum Kind: Equatable {
+        case file(ReviewDiffFileHeader)
+        case hunk(String)
+        case line(ReviewDiffLine)
+        case notice(String)
+    }
+
+    let id: String
+    let fileID: String
+    let kind: Kind
+
+    var fileHeader: ReviewDiffFileHeader? {
+        if case .file(let header) = kind { return header }
+        return nil
+    }
+
+    var line: ReviewDiffLine? {
+        if case .line(let line) = kind { return line }
+        return nil
+    }
+
+    var isFileHeader: Bool { fileHeader != nil }
+
+    /// The text a row contributes to its file's horizontal content width.
+    var columnCount: Int {
+        switch kind {
+        case .hunk(let text): return text.count
+        case .line(let line): return line.content.count
+        case .file, .notice: return 0
+        }
+    }
+}
+
+struct ReviewDiffFileHeader: Equatable {
+    let path: String
+    /// Set for renames when the old path differs from `path`.
+    let previousPath: String?
+    let changeKind: GitFile.ChangeKind
+    let additions: Int
+    let deletions: Int
+
+    var displayPath: String {
+        guard let previousPath else { return path }
+        return "\(previousPath) → \(path)"
+    }
+}
+
+struct ReviewDiffLine: Equatable {
+    /// Display text without the unified-diff prefix character, tabs expanded so the
+    /// monospaced character grid the word highlights sit on stays honest.
+    let content: String
+    let change: DiffLine.Kind
+    let oldLineNumber: Int?
+    let newLineNumber: Int?
+    /// Character offsets into `content` to highlight as the changed words.
+    var wordDiffRanges: [Range<Int>] = []
+
+    var displayLineNumber: Int? { newLineNumber ?? oldLineNumber }
+}
+
+/// What the host knows about one file's diff while the surface is on screen.
+enum ReviewDiffFileState: Equatable {
+    case loading
+    case loaded(GitDiff)
+    case failed(String)
+}
+
+struct ReviewDiffFileInput: Equatable {
+    let file: GitFile
+    let state: ReviewDiffFileState
+}
+
+/// Turns the per-file `git/diff` results into the flat row list the surface draws.
+/// Row ids are stable across reloads (file id, hunk index, line index) so collapse,
+/// viewed, and selection state survive a rows rebuild.
+enum ReviewDiffRowBuilder {
+    static func rows(for inputs: [ReviewDiffFileInput]) -> [ReviewDiffRow] {
+        inputs.flatMap(rows(for:))
+    }
+
+    static func rows(for input: ReviewDiffFileInput) -> [ReviewDiffRow] {
+        let file = input.file
+        let fileID = file.id
+        let hunks: [DiffHunk]
+        let notice: String?
+        switch input.state {
+        case .loading:
+            hunks = []
+            notice = String(localized: "Loading…")
+        case .failed(let message):
+            hunks = []
+            notice = message
+        case .loaded(let diff):
+            if diff.binary == true {
+                hunks = []
+                notice = String(localized: "Binary file changed")
+            } else if diff.tooLarge == true {
+                hunks = []
+                notice = String(localized: "Diff too large to show.")
+            } else {
+                hunks = DiffHunk.parse(diff.diff ?? "")
+                notice = hunks.isEmpty ? String(localized: "No Changes") : nil
+            }
+        }
+
+        let header = ReviewDiffFileHeader(
+            path: file.displayPath,
+            previousPath: previousPath(for: file),
+            changeKind: file.changeKind,
+            additions: file.additions ?? hunks.reduce(0) { $0 + $1.additions },
+            deletions: file.deletions ?? hunks.reduce(0) { $0 + $1.deletions }
+        )
+
+        var rows: [ReviewDiffRow] = [ReviewDiffRow(id: "\(fileID):header", fileID: fileID, kind: .file(header))]
+        if let notice {
+            rows.append(ReviewDiffRow(id: "\(fileID):notice", fileID: fileID, kind: .notice(notice)))
+            return rows
+        }
+
+        for (hunkIndex, hunk) in hunks.enumerated() {
+            rows.append(ReviewDiffRow(id: "\(fileID):hunk:\(hunkIndex)", fileID: fileID, kind: .hunk(hunk.displayLabel)))
+            for (lineIndex, line) in hunk.lines.enumerated() {
+                rows.append(
+                    ReviewDiffRow(
+                        id: "\(fileID):line:\(hunkIndex):\(lineIndex)",
+                        fileID: fileID,
+                        kind: .line(reviewLine(for: line))
+                    )
+                )
+            }
+        }
+        ReviewWordDiff.annotate(&rows)
+        return rows
+    }
+
+    private static func previousPath(for file: GitFile) -> String? {
+        guard let oldPath = file.oldPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !oldPath.isEmpty, oldPath != file.displayPath else { return nil }
+        return oldPath
+    }
+
+    private static func reviewLine(for line: DiffLine) -> ReviewDiffLine {
+        // "\ No newline at end of file" markers keep their text; real lines drop the
+        // +/-/space prefix.
+        let raw = line.text.hasPrefix("\\") ? line.text : String(line.text.dropFirst())
+        return ReviewDiffLine(
+            content: raw.replacingOccurrences(of: "\t", with: "    "),
+            change: line.kind,
+            oldLineNumber: line.oldLineNumber,
+            newLineNumber: line.newLineNumber
+        )
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSelection.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSelection.swift
@@ -56,7 +56,9 @@ struct ReviewDiffSelection: Equatable {
     }
 
     /// Plain Markdown for the composer: path and line range, then the selected lines
-    /// as a fenced diff so the agent sees what was added, removed, or unchanged.
+    /// as a fenced diff so the agent sees what was added, removed, or unchanged. The
+    /// fence is one backtick longer than any run inside the lines, so selecting a
+    /// Markdown code block cannot close it early.
     func snippet(in rows: [ReviewDiffRow]) -> String? {
         let selected = selectedRows(in: rows)
         guard let fileID, !selected.isEmpty else { return nil }
@@ -76,6 +78,19 @@ struct ReviewDiffSelection: Equatable {
             }
             return prefix + line.content
         }
-        return "\(heading)\n```diff\n\(body.joined(separator: "\n"))\n```"
+        let fence = String(repeating: "`", count: max(3, Self.longestBacktickRun(in: body) + 1))
+        return "\(heading)\n\(fence)diff\n\(body.joined(separator: "\n"))\n\(fence)"
+    }
+
+    private static func longestBacktickRun(in lines: [String]) -> Int {
+        var longest = 0
+        for line in lines {
+            var run = 0
+            for character in line {
+                run = character == "`" ? run + 1 : 0
+                longest = max(longest, run)
+            }
+        }
+        return longest
     }
 }

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSelection.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSelection.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Line selection on the review surface. A tap selects one line (tapping it again
+/// clears), a long press anchors a range and the next tap in the same file ends it.
+/// The selection is a pair of row ids so it survives a rows rebuild with stable ids.
+struct ReviewDiffSelection: Equatable {
+    private(set) var fileID: String?
+    private(set) var anchorRowID: String?
+    private(set) var endRowID: String?
+    /// True between a long press and the tap that ends the range.
+    private(set) var isAwaitingRangeEnd = false
+
+    var isEmpty: Bool { anchorRowID == nil }
+
+    mutating func longPress(rowID: String, fileID: String) {
+        self.fileID = fileID
+        anchorRowID = rowID
+        endRowID = rowID
+        isAwaitingRangeEnd = true
+    }
+
+    mutating func tap(rowID: String, fileID: String) {
+        if isAwaitingRangeEnd, self.fileID == fileID {
+            endRowID = rowID
+            isAwaitingRangeEnd = false
+            return
+        }
+        if anchorRowID == rowID, endRowID == rowID {
+            clear()
+            return
+        }
+        self.fileID = fileID
+        anchorRowID = rowID
+        endRowID = rowID
+        isAwaitingRangeEnd = false
+    }
+
+    mutating func clear() {
+        fileID = nil
+        anchorRowID = nil
+        endRowID = nil
+        isAwaitingRangeEnd = false
+    }
+
+    /// The line rows between anchor and end, inclusive, in either direction.
+    func selectedRows(in rows: [ReviewDiffRow]) -> [ReviewDiffRow] {
+        guard let anchorRowID, let endRowID,
+              let anchorIndex = rows.firstIndex(where: { $0.id == anchorRowID }),
+              let endIndex = rows.firstIndex(where: { $0.id == endRowID }) else { return [] }
+        let range = min(anchorIndex, endIndex)...max(anchorIndex, endIndex)
+        return rows[range].filter { $0.line != nil && $0.fileID == fileID }
+    }
+
+    func selectedRowIDs(in rows: [ReviewDiffRow]) -> Set<String> {
+        Set(selectedRows(in: rows).map(\.id))
+    }
+
+    /// Plain Markdown for the composer: path and line range, then the selected lines
+    /// as a fenced diff so the agent sees what was added, removed, or unchanged.
+    func snippet(in rows: [ReviewDiffRow]) -> String? {
+        let selected = selectedRows(in: rows)
+        guard let fileID, !selected.isEmpty else { return nil }
+        let path = rows.first { $0.fileID == fileID && $0.isFileHeader }?.fileHeader?.path ?? fileID
+        let numbers = selected.compactMap { $0.line?.displayLineNumber }
+        var heading = path
+        if let first = numbers.first, let last = numbers.last {
+            heading += first == last ? " L\(first)" : " L\(first)-L\(last)"
+        }
+        let body = selected.compactMap { row -> String? in
+            guard let line = row.line else { return nil }
+            let prefix: String
+            switch line.change {
+            case .addition: prefix = "+"
+            case .deletion: prefix = "-"
+            case .context: prefix = " "
+            }
+            return prefix + line.content
+        }
+        return "\(heading)\n```diff\n\(body.joined(separator: "\n"))\n```"
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffStyle.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffStyle.swift
@@ -1,0 +1,94 @@
+import UIKit
+
+/// Semantic colours for the surface. Every colour is dynamic, so a draw pass resolves
+/// light or dark from the current trait collection with no theme plumbing.
+struct ReviewDiffTheme {
+    let background = UIColor.systemBackground
+    let text = UIColor.label
+    let mutedText = UIColor.secondaryLabel
+    let headerBackground = UIColor.secondarySystemBackground
+    let border = UIColor.separator
+    let accent = UIColor.systemBlue
+    let hunkBackground = UIColor.systemBlue.withAlphaComponent(0.10)
+    let addBackground = UIColor.systemGreen.withAlphaComponent(0.14)
+    let deleteBackground = UIColor.systemRed.withAlphaComponent(0.14)
+    let addTint = UIColor.systemGreen
+    let deleteTint = UIColor.systemRed
+    let conflictTint = UIColor.systemOrange
+
+    func tint(for changeKind: GitFile.ChangeKind) -> UIColor {
+        switch changeKind {
+        case .added, .untracked: return addTint
+        case .deleted: return deleteTint
+        case .conflict: return conflictTint
+        case .renamed, .modified, .ignored, .unknown: return accent
+        }
+    }
+}
+
+/// Fonts and fixed geometry, resolved once per trait collection. Row heights follow
+/// the scaled code font so Dynamic Type grows rows instead of clipping them.
+struct ReviewDiffStyle {
+    let codeFont: UIFont
+    let lineNumberFont: UIFont
+    let hunkFont: UIFont
+    let fileHeaderFont: UIFont
+    let fileHeaderMetaFont: UIFont
+    let noticeFont: UIFont
+    let metrics: ReviewDiffMetrics
+    /// Advance of one character in `codeFont`; the word highlights sit on this grid.
+    let codeCharacterWidth: CGFloat
+    let gutterWidth: CGFloat
+    let changeBarWidth: CGFloat = 4
+    let codePadding: CGFloat = 8
+    let maxContentWidth: CGFloat = 2800
+    let fileHeaderHorizontalPadding: CGFloat = 12
+
+    /// Change bar plus gutter: the part of a row that never scrolls horizontally.
+    var stickyWidth: CGFloat { changeBarWidth + gutterWidth }
+    var codeStartX: CGFloat { stickyWidth + codePadding }
+
+    static func resolve(for traits: UITraitCollection) -> ReviewDiffStyle {
+        let metrics = UIFontMetrics(forTextStyle: .body)
+        func mono(_ size: CGFloat, _ weight: UIFont.Weight) -> UIFont {
+            metrics.scaledFont(
+                for: .monospacedSystemFont(ofSize: size, weight: weight),
+                maximumPointSize: size * 2.2,
+                compatibleWith: traits
+            )
+        }
+        let codeFont = mono(12, .regular)
+        let lineNumberFont = mono(11, .regular)
+        let fileHeaderFont = UIFont.preferredFont(forTextStyle: .subheadline, compatibleWith: traits).withWeight(.semibold)
+        let noticeFont = UIFont.preferredFont(forTextStyle: .footnote, compatibleWith: traits)
+
+        let sample = String(repeating: "M", count: 64)
+        let characterWidth = (sample as NSString).size(withAttributes: [.font: codeFont, .ligature: 0]).width / 64
+        let gutterSample = ("00000" as NSString).size(withAttributes: [.font: lineNumberFont]).width
+
+        return ReviewDiffStyle(
+            codeFont: codeFont,
+            lineNumberFont: lineNumberFont,
+            hunkFont: mono(12, .semibold),
+            fileHeaderFont: fileHeaderFont,
+            fileHeaderMetaFont: mono(12, .semibold),
+            noticeFont: noticeFont,
+            metrics: ReviewDiffMetrics(
+                rowHeight: ceil(codeFont.lineHeight) + 6,
+                fileHeaderHeight: ceil(fileHeaderFont.lineHeight) + 30,
+                noticeHeight: max(44, ceil(noticeFont.lineHeight) + 24)
+            ),
+            codeCharacterWidth: characterWidth,
+            gutterWidth: ceil(gutterSample) + 14
+        )
+    }
+}
+
+private extension UIFont {
+    func withWeight(_ weight: UIFont.Weight) -> UIFont {
+        let descriptor = fontDescriptor.addingAttributes([
+            .traits: [UIFontDescriptor.TraitKey.weight: weight]
+        ])
+        return UIFont(descriptor: descriptor, size: pointSize)
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurface.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurface.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// One-shot scroll request; a new token scrolls again even to the same file.
+struct ReviewDiffScrollTarget: Equatable {
+    let fileID: String
+    let token: UUID
+}
+
+/// SwiftUI face of the review surface. The host owns every piece of state (rows,
+/// collapse, viewed, selection, refresh) and this bridge pushes only what changed.
+struct ReviewDiffSurface: UIViewRepresentable {
+    let rows: [ReviewDiffRow]
+    /// Bumped by the host whenever `rows` is replaced, so the bridge never compares
+    /// thousands of rows to notice a change.
+    let rowsVersion: Int
+    let collapsedFileIDs: Set<String>
+    let viewedFileIDs: Set<String>
+    let selectedRowIDs: Set<String>
+    let isRefreshing: Bool
+    let scrollTarget: ReviewDiffScrollTarget?
+    let onToggleFile: (String) -> Void
+    let onToggleViewed: (String) -> Void
+    let onLinePress: (ReviewDiffLinePress) -> Void
+    let onRefresh: () -> Void
+
+    final class Coordinator {
+        var onToggleFile: (String) -> Void = { _ in }
+        var onToggleViewed: (String) -> Void = { _ in }
+        var onLinePress: (ReviewDiffLinePress) -> Void = { _ in }
+        var onRefresh: () -> Void = {}
+        var appliedRowsVersion = -1
+        var appliedScrollToken: UUID?
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> ReviewDiffSurfaceView {
+        let view = ReviewDiffSurfaceView()
+        let coordinator = context.coordinator
+        view.onToggleFile = { coordinator.onToggleFile($0) }
+        view.onToggleViewed = { coordinator.onToggleViewed($0) }
+        view.onLinePress = { coordinator.onLinePress($0) }
+        view.onPullToRefresh = { coordinator.onRefresh() }
+        return view
+    }
+
+    func updateUIView(_ view: ReviewDiffSurfaceView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.onToggleFile = onToggleFile
+        coordinator.onToggleViewed = onToggleViewed
+        coordinator.onLinePress = onLinePress
+        coordinator.onRefresh = onRefresh
+
+        if coordinator.appliedRowsVersion != rowsVersion {
+            coordinator.appliedRowsVersion = rowsVersion
+            view.setRows(rows)
+        }
+        view.setCollapsedFileIDs(collapsedFileIDs)
+        if view.viewedFileIDs != viewedFileIDs { view.viewedFileIDs = viewedFileIDs }
+        if view.selectedRowIDs != selectedRowIDs { view.selectedRowIDs = selectedRowIDs }
+        view.setRefreshing(isRefreshing)
+
+        if let scrollTarget, coordinator.appliedScrollToken != scrollTarget.token {
+            coordinator.appliedScrollToken = scrollTarget.token
+            view.scrollToFile(scrollTarget.fileID, animated: false)
+        }
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurfaceView.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurfaceView.swift
@@ -1,0 +1,183 @@
+import UIKit
+
+/// Scroll host for `ReviewDiffCanvasView`. The canvas is exactly one viewport tall and
+/// rides along with the content offset, so scrolling repaints rows instead of laying
+/// out views. Also owns pull-to-refresh, scroll-to-file, and the scroll anchor that
+/// keeps the file under the reader still when rows above it change height.
+final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
+    private let scrollView = UIScrollView()
+    private let canvas = ReviewDiffCanvasView()
+    private let refreshControl = UIRefreshControl()
+    private var pendingScrollFileID: String?
+    private var pendingScrollAnimated = false
+
+    var onPullToRefresh: (() -> Void)?
+    var onToggleFile: ((String) -> Void)? {
+        get { canvas.onToggleFile }
+        set { canvas.onToggleFile = newValue }
+    }
+    var onToggleViewed: ((String) -> Void)? {
+        get { canvas.onToggleViewed }
+        set { canvas.onToggleViewed = newValue }
+    }
+    var onLinePress: ((ReviewDiffLinePress) -> Void)? {
+        get { canvas.onLinePress }
+        set { canvas.onLinePress = newValue }
+    }
+
+    var rows: [ReviewDiffRow] { canvas.rows }
+    var collapsedFileIDs: Set<String> { canvas.collapsedFileIDs }
+    var viewedFileIDs: Set<String> {
+        get { canvas.viewedFileIDs }
+        set { canvas.viewedFileIDs = newValue }
+    }
+    var selectedRowIDs: Set<String> {
+        get { canvas.selectedRowIDs }
+        set { canvas.selectedRowIDs = newValue }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        clipsToBounds = true
+        backgroundColor = canvas.theme.background
+
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.delegate = self
+        scrollView.clipsToBounds = true
+        scrollView.alwaysBounceVertical = true
+        scrollView.alwaysBounceHorizontal = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.backgroundColor = canvas.theme.background
+        refreshControl.addTarget(self, action: #selector(handlePullToRefresh), for: .valueChanged)
+        scrollView.refreshControl = refreshControl
+        addSubview(scrollView)
+        scrollView.addSubview(canvas)
+
+        canvas.onContentHeightChange = { [weak self] in self?.updateContentMetrics() }
+        canvas.onRevealRow = { [weak self] rowIndex in self?.revealRow(at: rowIndex) }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        scrollView.frame = bounds
+        if canvas.viewportWidth != bounds.width {
+            canvas.viewportWidth = bounds.width
+        }
+        updateContentMetrics()
+    }
+
+    // MARK: - Inputs
+
+    /// Replaces the rows, keeping the file at the top of the viewport where it was.
+    func setRows(_ rows: [ReviewDiffRow]) {
+        let anchor = currentAnchor()
+        canvas.setRows(rows)
+        restore(anchor)
+        applyPendingScrollIfNeeded()
+    }
+
+    /// Collapsing one file keeps its header where it is drawn (pinned at the top when
+    /// sticky), so the reader is not thrown to a different file.
+    func setCollapsedFileIDs(_ collapsedFileIDs: Set<String>) {
+        let changed = canvas.collapsedFileIDs.symmetricDifference(collapsedFileIDs)
+        var anchor: Anchor?
+        if changed.count == 1, let fileID = changed.first, let screenY = canvas.scrollAnchorScreenY(forFileID: fileID) {
+            anchor = Anchor(fileID: fileID, screenY: screenY)
+        }
+        canvas.setCollapsedFileIDs(collapsedFileIDs)
+        restore(anchor)
+    }
+
+    func scrollToFile(_ fileID: String, animated: Bool) {
+        pendingScrollFileID = fileID
+        pendingScrollAnimated = animated
+        applyPendingScrollIfNeeded()
+    }
+
+    /// The host owns the spinner: it stays until the reload finishes, not until the
+    /// gesture ends.
+    func setRefreshing(_ refreshing: Bool) {
+        if refreshing {
+            if !refreshControl.isRefreshing { refreshControl.beginRefreshing() }
+        } else if refreshControl.isRefreshing {
+            refreshControl.endRefreshing()
+        }
+    }
+
+    @objc private func handlePullToRefresh() {
+        onPullToRefresh?()
+    }
+
+    // MARK: - Scroll anchoring
+
+    private struct Anchor {
+        let fileID: String
+        /// Header top relative to the viewport top; negative while scrolled into the file.
+        let screenY: CGFloat
+    }
+
+    private func currentAnchor() -> Anchor? {
+        let offset = scrollView.contentOffset.y
+        guard offset > 0.5,
+              let fileID = canvas.layout.visibleFileID(atVerticalOffset: offset),
+              let headerOffset = canvas.layout.fileHeaderOffset(forFileID: fileID) else { return nil }
+        return Anchor(fileID: fileID, screenY: headerOffset - offset)
+    }
+
+    private func restore(_ anchor: Anchor?) {
+        guard let anchor, let headerOffset = canvas.layout.fileHeaderOffset(forFileID: anchor.fileID) else { return }
+        setVerticalOffset(headerOffset - anchor.screenY, animated: false)
+    }
+
+    private func applyPendingScrollIfNeeded() {
+        guard let fileID = pendingScrollFileID, bounds.height > 0 else { return }
+        guard let headerOffset = canvas.layout.fileHeaderOffset(forFileID: fileID) else {
+            if !rows.isEmpty { pendingScrollFileID = nil }
+            return
+        }
+        pendingScrollFileID = nil
+        setVerticalOffset(headerOffset, animated: pendingScrollAnimated)
+    }
+
+    private func setVerticalOffset(_ target: CGFloat, animated: Bool) {
+        let maxOffset = max(scrollView.contentSize.height - scrollView.bounds.height, 0)
+        let clamped = min(max(target, 0), maxOffset)
+        let shouldAnimate = animated && abs(scrollView.contentOffset.y - clamped) > 0.5
+        scrollView.setContentOffset(CGPoint(x: 0, y: clamped), animated: shouldAnimate)
+        if !shouldAnimate { updateViewportFrame() }
+    }
+
+    private func revealRow(at rowIndex: Int) {
+        guard let frame = canvas.layout.frame(forRowAt: rowIndex) else { return }
+        scrollView.scrollRectToVisible(CGRect(x: 0, y: frame.minY, width: 1, height: frame.height), animated: false)
+        updateViewportFrame()
+    }
+
+    // MARK: - Viewport
+
+    private func updateContentMetrics() {
+        scrollView.contentSize = CGSize(width: bounds.width, height: max(bounds.height, canvas.contentHeight))
+        updateViewportFrame()
+        applyPendingScrollIfNeeded()
+    }
+
+    private func updateViewportFrame() {
+        canvas.frame = CGRect(
+            x: 0,
+            y: scrollView.contentOffset.y,
+            width: max(bounds.width, 1),
+            height: max(bounds.height, 1)
+        )
+        canvas.verticalOffset = scrollView.contentOffset.y
+        canvas.setNeedsDisplay()
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        updateViewportFrame()
+    }
+}

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewWordDiff.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewWordDiff.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+/// Word-level highlights for paired deleted/added lines. A run of deletions followed by
+/// a run of additions is paired index by index; each pair is diffed by word and the
+/// changed words become highlight ranges, subject to gates that keep noisy lines plain.
+enum ReviewWordDiff {
+    /// Lines longer than this are never word-diffed.
+    static let maxLineLength = 1000
+    /// More ranges than this reads as noise, so the line stays plain.
+    static let maxRangeCount = 4
+    /// Highlights covering more than this share of the non-whitespace text mean the
+    /// line was rewritten, not edited; the line stays plain.
+    static let maxCoverage = 0.45
+
+    struct Pair: Equatable {
+        var deletion: [Range<Int>]
+        var addition: [Range<Int>]
+    }
+
+    /// Adds word-diff ranges to every paired deletion/addition line in `rows`.
+    /// Pairs never cross a file or hunk boundary because those rows break the run.
+    static func annotate(_ rows: inout [ReviewDiffRow]) {
+        var index = 0
+        while index < rows.count {
+            var deleted: [Int] = []
+            var added: [Int] = []
+            while index < rows.count, rows[index].line?.change == .deletion {
+                deleted.append(index)
+                index += 1
+            }
+            while index < rows.count, rows[index].line?.change == .addition {
+                added.append(index)
+                index += 1
+            }
+            if deleted.isEmpty, added.isEmpty {
+                index += 1
+                continue
+            }
+            for (deletedIndex, addedIndex) in zip(deleted, added) {
+                guard let deletedLine = rows[deletedIndex].line, let addedLine = rows[addedIndex].line,
+                      !deletedLine.content.isEmpty, !addedLine.content.isEmpty else { continue }
+                let pair = ranges(deletion: deletedLine.content, addition: addedLine.content)
+                if !pair.deletion.isEmpty {
+                    rows[deletedIndex] = rows[deletedIndex].replacingWordDiffRanges(pair.deletion)
+                }
+                if !pair.addition.isEmpty {
+                    rows[addedIndex] = rows[addedIndex].replacingWordDiffRanges(pair.addition)
+                }
+            }
+        }
+    }
+
+    /// Ranges are Character offsets. Either side is empty when its gates fail.
+    static func ranges(deletion: String, addition: String) -> Pair {
+        guard !(deletion.isEmpty && addition.isEmpty),
+              deletion.count <= maxLineLength, addition.count <= maxLineLength else {
+            return Pair(deletion: [], addition: [])
+        }
+
+        let deletionTokens = tokenize(deletion)
+        let additionTokens = tokenize(addition)
+        let operations = diff(deletionTokens, additionTokens)
+
+        var deletionSpans: [Span] = []
+        var additionSpans: [Span] = []
+        for (offset, operation) in operations.enumerated() {
+            let isLast = offset == operations.count - 1
+            switch operation {
+            case .equal(let token):
+                pushOrJoin(Span(isChanged: false, text: token), into: &deletionSpans, isLast: isLast)
+                pushOrJoin(Span(isChanged: false, text: token), into: &additionSpans, isLast: isLast)
+            case .removed(let token):
+                pushOrJoin(Span(isChanged: true, text: token), into: &deletionSpans, isLast: isLast)
+            case .added(let token):
+                pushOrJoin(Span(isChanged: true, text: token), into: &additionSpans, isLast: isLast)
+            }
+        }
+
+        let deletionRanges = trimmed(mergeNearby(ranges(from: deletionSpans)), in: deletion)
+        let additionRanges = trimmed(mergeNearby(ranges(from: additionSpans)), in: addition)
+        return Pair(
+            deletion: passesGates(deletionRanges, in: deletion) ? deletionRanges : [],
+            addition: passesGates(additionRanges, in: addition) ? additionRanges : []
+        )
+    }
+
+    // MARK: - Spans
+
+    private struct Span {
+        var isChanged: Bool
+        var text: String
+    }
+
+    /// Consecutive spans of one kind merge. A single neutral character (a dot, a
+    /// bracket) between two changed words joins the change so the highlight reads as
+    /// one edit instead of a stutter. The last operation never joins, so a trailing
+    /// unchanged run stays unhighlighted.
+    private static func pushOrJoin(_ span: Span, into spans: inout [Span], isLast: Bool) {
+        guard let last = spans.last, !isLast else {
+            spans.append(span)
+            return
+        }
+        let joinsSameKind = span.isChanged == last.isChanged
+        let joinsSingleNeutral = !span.isChanged && span.text.count == 1 && last.isChanged
+        if joinsSameKind || joinsSingleNeutral {
+            spans[spans.count - 1].text += span.text
+            return
+        }
+        spans.append(span)
+    }
+
+    private static func ranges(from spans: [Span]) -> [Range<Int>] {
+        var ranges: [Range<Int>] = []
+        var offset = 0
+        for span in spans {
+            let next = offset + span.text.count
+            if span.isChanged, next > offset {
+                ranges.append(offset..<next)
+            }
+            offset = next
+        }
+        return ranges
+    }
+
+    private static func mergeNearby(_ ranges: [Range<Int>]) -> [Range<Int>] {
+        var merged: [Range<Int>] = []
+        for range in ranges {
+            if let previous = merged.last, range.lowerBound - previous.upperBound <= 1 {
+                merged[merged.count - 1] = previous.lowerBound..<range.upperBound
+            } else {
+                merged.append(range)
+            }
+        }
+        return merged
+    }
+
+    private static func trimmed(_ ranges: [Range<Int>], in content: String) -> [Range<Int>] {
+        let characters = Array(content)
+        return ranges.compactMap { range in
+            var start = max(0, range.lowerBound)
+            var end = min(characters.count, range.upperBound)
+            while start < end, characters[start].isWhitespace { start += 1 }
+            while end > start, characters[end - 1].isWhitespace { end -= 1 }
+            return end > start ? start..<end : nil
+        }
+    }
+
+    private static func passesGates(_ ranges: [Range<Int>], in content: String) -> Bool {
+        guard !ranges.isEmpty, ranges.count <= maxRangeCount else { return false }
+        let characters = Array(content)
+        let meaningful = characters.filter { !$0.isWhitespace }.count
+        guard meaningful > 0 else { return false }
+        let highlighted = ranges.reduce(0) { total, range in
+            total + characters[range].filter { !$0.isWhitespace }.count
+        }
+        return Double(highlighted) / Double(meaningful) <= maxCoverage
+    }
+
+    // MARK: - Token diff
+
+    /// Runs of word characters, whitespace, and other characters, so "foo.bar" diffs as
+    /// three tokens and an edit inside a word highlights just that word.
+    static func tokenize(_ text: String) -> [String] {
+        enum Run { case word, space, other }
+        var tokens: [String] = []
+        var current = ""
+        var currentRun: Run?
+        for character in text {
+            let run: Run
+            if character.isLetter || character.isNumber || character == "_" {
+                run = .word
+            } else if character.isWhitespace {
+                run = .space
+            } else {
+                run = .other
+            }
+            if run != currentRun, !current.isEmpty {
+                tokens.append(current)
+                current = ""
+            }
+            current.append(character)
+            currentRun = run
+        }
+        if !current.isEmpty { tokens.append(current) }
+        return tokens
+    }
+
+    private enum Operation {
+        case equal(String)
+        case removed(String)
+        case added(String)
+    }
+
+    /// Longest-common-subsequence diff over tokens. Lines are capped at
+    /// `maxLineLength`, so the table stays small.
+    private static func diff(_ old: [String], _ new: [String]) -> [Operation] {
+        let rows = old.count
+        let columns = new.count
+        var table = [Int](repeating: 0, count: (rows + 1) * (columns + 1))
+        let stride = columns + 1
+        if rows > 0, columns > 0 {
+            // Suffix table: cell (row, column) is the LCS length of the tails.
+            for row in (0..<rows).reversed() {
+                for column in (0..<columns).reversed() {
+                    if old[row] == new[column] {
+                        table[(row) * stride + column] = table[(row + 1) * stride + column + 1] + 1
+                    } else {
+                        table[(row) * stride + column] = max(
+                            table[(row + 1) * stride + column],
+                            table[(row) * stride + column + 1]
+                        )
+                    }
+                }
+            }
+        }
+
+        var operations: [Operation] = []
+        var row = 0
+        var column = 0
+        while row < rows, column < columns {
+            if old[row] == new[column] {
+                operations.append(.equal(old[row]))
+                row += 1
+                column += 1
+            } else if table[(row + 1) * stride + column] >= table[row * stride + column + 1] {
+                operations.append(.removed(old[row]))
+                row += 1
+            } else {
+                operations.append(.added(new[column]))
+                column += 1
+            }
+        }
+        while row < rows {
+            operations.append(.removed(old[row]))
+            row += 1
+        }
+        while column < columns {
+            operations.append(.added(new[column]))
+            column += 1
+        }
+        return operations
+    }
+}
+
+private extension ReviewDiffRow {
+    func replacingWordDiffRanges(_ ranges: [Range<Int>]) -> ReviewDiffRow {
+        guard var line else { return self }
+        line.wordDiffRanges = ranges
+        return ReviewDiffRow(id: id, fileID: fileID, kind: .line(line))
+    }
+}

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -128300,6 +128300,1278 @@
           }
         }
       }
+    },
+    "Add to prompt" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "إضافة إلى الموجّه"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zum Prompt hinzufügen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Añadir al prompt"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajouter au prompt"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הוספה להנחיה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aggiungi al prompt"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プロンプトに追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "프롬프트에 추가"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aan prompt toevoegen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dodaj do promptu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adicionar ao prompt"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Добавить в промпт"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Prompt'a ekle"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "پرامپٹ میں شامل کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "加入提示"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "添加到提示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "加入提示"
+          }
+        }
+      }
+    },
+    "1 line selected" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم تحديد سطر واحد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 Zeile ausgewählt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 línea seleccionada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 ligne sélectionnée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נבחרה שורה אחת"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 riga selezionata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1行を選択中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1줄 선택됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 regel geselecteerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zaznaczono 1 wiersz"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 linha selecionada"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Выбрана 1 строка"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 satır seçildi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 لائن منتخب"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已選取 1 行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已选择 1 行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已選取 1 行"
+          }
+        }
+      }
+    },
+    "%lld lines selected" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تم تحديد %lld سطور"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld Zeilen ausgewählt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld líneas seleccionadas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld lignes sélectionnées"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נבחרו %lld שורות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld righe selezionate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld行を選択中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld줄 선택됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld regels geselecteerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zaznaczono %lld wierszy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld linhas selecionadas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Выбрано строк: %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld satır seçildi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld لائنیں منتخب"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已選取 %lld 行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已选择 %lld 行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已選取 %lld 行"
+          }
+        }
+      }
+    },
+    "Viewed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تمت المراجعة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Angesehen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Visto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vu"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נצפה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Visto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "確認済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "확인함"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bekeken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Przejrzany"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Visto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Просмотрено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Görüntülendi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "دیکھا گیا"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已檢視"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已查看"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已檢視"
+          }
+        }
+      }
+    },
+    "Mark as viewed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "وضع علامة كتمت المراجعة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Als angesehen markieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Marcar como visto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Marquer comme vu"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "סימון כנצפה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Segna come visto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "確認済みにする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "확인함으로 표시"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Markeren als bekeken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oznacz jako przejrzany"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Marcar como visto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Отметить как просмотренное"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Görüntülendi olarak işaretle"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "دیکھا گیا کے طور پر نشان زد کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "標記為已檢視"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "标记为已查看"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "標記為已檢視"
+          }
+        }
+      }
+    },
+    "Mark as not viewed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "وضع علامة كغير مراجَع"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Als nicht angesehen markieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Marcar como no visto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Marquer comme non vu"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "סימון כלא נצפה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Segna come non visto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未確認にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "확인 안 함으로 표시"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Markeren als niet bekeken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oznacz jako nieprzejrzany"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Marcar como não visto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Отметить как непросмотренное"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Görüntülenmedi olarak işaretle"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نہیں دیکھا گیا کے طور پر نشان زد کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "標記為未檢視"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "标记为未查看"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "標記為未檢視"
+          }
+        }
+      }
+    },
+    "Select line" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "تحديد السطر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zeile auswählen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seleccionar línea"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sélectionner la ligne"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "בחירת שורה"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seleziona riga"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行を選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "줄 선택"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Regel selecteren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zaznacz wiersz"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Selecionar linha"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Выбрать строку"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Satırı seç"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لائن منتخب کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "選取行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "选择行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "選取行"
+          }
+        }
+      }
+    },
+    "Start selection here" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "بدء التحديد هنا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Auswahl hier beginnen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Iniciar selección aquí"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Commencer la sélection ici"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "התחלת הבחירה כאן"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Inizia la selezione qui"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ここから選択を開始"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "여기서 선택 시작"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Selectie hier starten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rozpocznij zaznaczenie tutaj"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Iniciar seleção aqui"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Начать выделение здесь"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seçimi burada başlat"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "یہاں سے انتخاب شروع کریں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "從此處開始選取"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "从此处开始选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "從此處開始選取"
+          }
+        }
+      }
+    },
+    "Line %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "السطر %lld"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zeile %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Línea %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ligne %lld"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "שורה %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Riga %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld行目"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld번째 줄"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Regel %lld"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wiersz %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Linha %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Строка %lld"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Satır %lld"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لائن %lld"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "第 %lld 行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "第 %lld 行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "第 %lld 行"
+          }
+        }
+      }
+    },
+    "added" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "مضاف"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "hinzugefügt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "añadida"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ajoutée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נוסף"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "aggiunta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "추가됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "toegevoegd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "dodano"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "adicionada"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "добавлено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "eklendi"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "شامل کی گئی"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新增"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新增"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新增"
+          }
+        }
+      }
+    },
+    "removed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "محذوف"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "entfernt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "eliminada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "supprimée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "הוסר"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "rimossa"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "삭제됨"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "verwijderd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "usunięto"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "removida"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "удалено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "kaldırıldı"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ہٹائی گئی"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "刪除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "删除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "刪除"
+          }
+        }
+      }
+    },
+    "blank" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فارغ"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "leer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "vacía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "vide"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ריק"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "vuota"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "空行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "빈 줄"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "leeg"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "pusty"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "vazia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "пусто"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "boş"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "خالی"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "空行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "空行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "空行"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ReviewDiffCanvasViewTests.swift
+++ b/HermesMobileTests/ReviewDiffCanvasViewTests.swift
@@ -1,0 +1,58 @@
+import UIKit
+import XCTest
+@testable import HermesMobile
+
+@MainActor
+final class ReviewDiffCanvasViewTests: XCTestCase {
+    private func header(_ fileID: String) -> ReviewDiffRow {
+        ReviewDiffRow(
+            id: "\(fileID):header",
+            fileID: fileID,
+            kind: .file(ReviewDiffFileHeader(path: fileID, previousPath: nil, changeKind: .modified, additions: 1, deletions: 0))
+        )
+    }
+
+    private func line(_ fileID: String, _ index: Int) -> ReviewDiffRow {
+        ReviewDiffRow(
+            id: "\(fileID):line:\(index)",
+            fileID: fileID,
+            kind: .line(ReviewDiffLine(content: "line \(index)", change: .addition, oldLineNumber: nil, newLineNumber: index))
+        )
+    }
+
+    private func makeCanvas(rows: [ReviewDiffRow]) -> ReviewDiffCanvasView {
+        let canvas = ReviewDiffCanvasView(frame: CGRect(x: 0, y: 0, width: 390, height: 300))
+        canvas.viewportWidth = 390
+        canvas.setRows(rows)
+        return canvas
+    }
+
+    func testStaleAccessibilityElementSurvivesARowsRebuild() throws {
+        let canvas = makeCanvas(rows: [header("a")] + (0..<20).map { line("a", $0) })
+        let element = try XCTUnwrap(canvas.accessibilityElement(at: 15) as? ReviewDiffRowAccessibilityElement)
+        XCTAssertEqual(element.accessibilityLabel, "Line 14, added, line 14")
+
+        canvas.setRows([header("a"), line("a", 0)])
+
+        XCTAssertEqual(element.accessibilityLabel, "")
+        XCTAssertEqual(element.accessibilityTraits, .none)
+        XCTAssertEqual(element.accessibilityCustomActions?.count, 0)
+        XCTAssertFalse(element.accessibilityActivate())
+        XCTAssertEqual(canvas.index(ofAccessibilityElement: element), NSNotFound)
+    }
+
+    func testStickyHeaderReportsItsPinnedFrame() {
+        let rows = [header("a")] + (0..<40).map { line("a", $0) } + [header("b")] + (0..<5).map { line("b", $0) }
+        let canvas = makeCanvas(rows: rows)
+        let headerHeight = canvas.style.metrics.fileHeaderHeight
+
+        canvas.verticalOffset = 200
+        XCTAssertEqual(canvas.drawnFrame(forRowAt: 0)?.minY, 0, "Scrolled past, the header pins to the top.")
+        XCTAssertEqual(canvas.drawnFrame(forRowAt: 0)?.height, headerHeight)
+        XCTAssertEqual(canvas.frame(forRowAt: 0)?.minY, -200, "Its row position is still where it scrolled to.")
+
+        canvas.verticalOffset = 0
+        XCTAssertEqual(canvas.drawnFrame(forRowAt: 0)?.minY, 0)
+        XCTAssertEqual(canvas.drawnFrame(forRowAt: 1)?.minY, headerHeight, "Other rows use their scrolled position.")
+    }
+}

--- a/HermesMobileTests/ReviewDiffLayoutTests.swift
+++ b/HermesMobileTests/ReviewDiffLayoutTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import HermesMobile
+
+final class ReviewDiffLayoutTests: XCTestCase {
+    private let metrics = ReviewDiffMetrics(rowHeight: 20, fileHeaderHeight: 50, noticeHeight: 44)
+
+    private func header(_ fileID: String) -> ReviewDiffRow {
+        ReviewDiffRow(
+            id: "\(fileID):header",
+            fileID: fileID,
+            kind: .file(ReviewDiffFileHeader(path: fileID, previousPath: nil, changeKind: .modified, additions: 0, deletions: 0))
+        )
+    }
+
+    private func line(_ fileID: String, _ index: Int, _ content: String = "x") -> ReviewDiffRow {
+        ReviewDiffRow(
+            id: "\(fileID):line:\(index)",
+            fileID: fileID,
+            kind: .line(ReviewDiffLine(content: content, change: .context, oldLineNumber: index, newLineNumber: index))
+        )
+    }
+
+    /// Two files: a header and three lines each.
+    private var rows: [ReviewDiffRow] {
+        [header("a"), line("a", 0, "short"), line("a", 1, "a much longer line"), line("a", 2),
+         header("b"), line("b", 0), line("b", 1), line("b", 2)]
+    }
+
+    func testOffsetsArePrefixSumsAndCollapsedRowsHaveNoHeight() {
+        let open = ReviewDiffLayout(rows: rows, collapsedFileIDs: [], metrics: metrics)
+        XCTAssertEqual(open.rowOffsets, [0, 50, 70, 90, 110, 160, 180, 200])
+        XCTAssertEqual(open.contentHeight, 220)
+        XCTAssertEqual(open.fileHeaderRowIndices, [0, 4])
+        XCTAssertEqual(open.visibleRowIndices, Array(0..<8))
+        XCTAssertEqual(open.maxColumnCountsByFileID, ["a": 18, "b": 1])
+
+        let collapsed = ReviewDiffLayout(rows: rows, collapsedFileIDs: ["a"], metrics: metrics)
+        XCTAssertEqual(collapsed.rowOffsets, [0, 50, 50, 50, 50, 100, 120, 140])
+        XCTAssertEqual(collapsed.contentHeight, 160)
+        XCTAssertEqual(collapsed.visibleRowIndices, [0, 4, 5, 6, 7])
+        XCTAssertEqual(collapsed.fileHeaderOffset(forFileID: "b"), 50)
+    }
+
+    func testHitTestingFindsRowsAndSkipsCollapsedOnes() {
+        let open = ReviewDiffLayout(rows: rows, collapsedFileIDs: [], metrics: metrics)
+        XCTAssertEqual(open.rowIndex(at: 0), 0)
+        XCTAssertEqual(open.rowIndex(at: 49.9), 0)
+        XCTAssertEqual(open.rowIndex(at: 50), 1)
+        XCTAssertEqual(open.rowIndex(at: 219), 7)
+        XCTAssertNil(open.rowIndex(at: 220))
+        XCTAssertNil(open.rowIndex(at: -1))
+
+        let collapsed = ReviewDiffLayout(rows: rows, collapsedFileIDs: ["a"], metrics: metrics)
+        XCTAssertEqual(collapsed.rowIndex(at: 50), 4, "Collapsed rows are invisible to hit testing.")
+    }
+
+    func testRowRangeCoversIntersectingRowsOnly() {
+        let layout = ReviewDiffLayout(rows: rows, collapsedFileIDs: [], metrics: metrics)
+        XCTAssertEqual(layout.rowRange(intersecting: 60, 165), 1...5)
+        XCTAssertEqual(layout.rowRange(intersecting: 0, 10), 0...0)
+        XCTAssertEqual(layout.rowRange(intersecting: 300, 400), nil)
+    }
+
+    func testStickyHeaderPinsThenIsPushedOffByTheNextHeader() {
+        let layout = ReviewDiffLayout(rows: rows, collapsedFileIDs: [], metrics: metrics)
+        XCTAssertNil(layout.stickyHeader(atVerticalOffset: 0), "The header is in place, nothing to pin.")
+        XCTAssertEqual(layout.stickyHeader(atVerticalOffset: 30), .init(rowIndex: 0, y: 0))
+        // File b's header starts at 110; with 50 pt of header it starts pushing at offset 60.
+        XCTAssertEqual(layout.stickyHeader(atVerticalOffset: 60), .init(rowIndex: 0, y: 0))
+        XCTAssertEqual(layout.stickyHeader(atVerticalOffset: 80), .init(rowIndex: 0, y: -20))
+        XCTAssertNil(layout.stickyHeader(atVerticalOffset: 110), "Fully pushed off, and b is in place.")
+        XCTAssertEqual(layout.stickyHeader(atVerticalOffset: 150), .init(rowIndex: 4, y: 0), "The last file never gets pushed.")
+    }
+
+    func testVisibleFileFollowsTheScrollOffset() {
+        let layout = ReviewDiffLayout(rows: rows, collapsedFileIDs: [], metrics: metrics)
+        XCTAssertEqual(layout.visibleFileID(atVerticalOffset: 0), "a")
+        XCTAssertEqual(layout.visibleFileID(atVerticalOffset: 109), "a")
+        XCTAssertEqual(layout.visibleFileID(atVerticalOffset: 110), "b")
+        XCTAssertNil(ReviewDiffLayout(rows: [], collapsedFileIDs: [], metrics: metrics).visibleFileID(atVerticalOffset: 0))
+    }
+}

--- a/HermesMobileTests/ReviewDiffRowBuilderTests.swift
+++ b/HermesMobileTests/ReviewDiffRowBuilderTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import HermesMobile
+
+final class ReviewDiffRowBuilderTests: XCTestCase {
+    private func file(_ path: String, oldPath: String? = nil, status: String = "M", additions: Int? = nil) throws -> GitFile {
+        var json: [String: Any] = ["path": path, "status": status, "unstaged": true]
+        if let oldPath { json["old_path"] = oldPath }
+        if let additions { json["additions"] = additions }
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(GitFile.self, from: data)
+    }
+
+    private func diff(_ text: String, binary: Bool? = nil, tooLarge: Bool? = nil) throws -> GitDiff {
+        var json: [String: Any] = ["diff": text]
+        if let binary { json["binary"] = binary }
+        if let tooLarge { json["too_large"] = tooLarge }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(GitDiff.self, from: JSONSerialization.data(withJSONObject: json))
+    }
+
+    func testLoadedDiffBuildsHeaderHunkAndLineRowsWithStableIDs() throws {
+        let raw = "@@ -1,3 +1,3 @@\n context\n-old value\n+new value\n\\ No newline at end of file"
+        let rows = ReviewDiffRowBuilder.rows(for: ReviewDiffFileInput(file: try file("a/b.swift"), state: .loaded(try diff(raw))))
+
+        XCTAssertEqual(rows.map(\.id), ["a/b.swift:header", "a/b.swift:hunk:0", "a/b.swift:line:0:0", "a/b.swift:line:0:1", "a/b.swift:line:0:2", "a/b.swift:line:0:3"])
+        XCTAssertEqual(rows.map(\.fileID), Array(repeating: "a/b.swift", count: 6))
+
+        let header = try XCTUnwrap(rows[0].fileHeader)
+        XCTAssertEqual(header.path, "a/b.swift")
+        XCTAssertNil(header.previousPath)
+        XCTAssertEqual(header.additions, 1, "Counts fall back to the hunk when the file has none.")
+        XCTAssertEqual(header.deletions, 1)
+
+        XCTAssertEqual(rows[1].kind, .hunk("Lines 1-3"))
+        let context = try XCTUnwrap(rows[2].line)
+        XCTAssertEqual(context.change, .context)
+        XCTAssertEqual(context.content, "context", "The diff prefix character is dropped.")
+        XCTAssertEqual(context.oldLineNumber, 1)
+        XCTAssertEqual(context.newLineNumber, 1)
+        XCTAssertEqual(rows[3].line?.change, .deletion)
+        XCTAssertEqual(rows[4].line?.change, .addition)
+        XCTAssertEqual(rows[5].line?.content, "\\ No newline at end of file", "Markers keep their text.")
+    }
+
+    func testPairedLinesCarryWordDiffRanges() throws {
+        let raw = "@@ -1,1 +1,1 @@\n-let value = compute(alpha)\n+let value = compute(beta)"
+        let rows = ReviewDiffRowBuilder.rows(for: ReviewDiffFileInput(file: try file("x.swift"), state: .loaded(try diff(raw))))
+
+        XCTAssertEqual(rows[2].line?.wordDiffRanges, [20..<25])
+        XCTAssertEqual(rows[3].line?.wordDiffRanges, [20..<24])
+    }
+
+    func testTabsExpandToSpacesForTheCharacterGrid() throws {
+        let raw = "@@ -1,1 +1,1 @@\n+\tindented"
+        let rows = ReviewDiffRowBuilder.rows(for: ReviewDiffFileInput(file: try file("x.swift"), state: .loaded(try diff(raw))))
+        XCTAssertEqual(rows[2].line?.content, "    indented")
+    }
+
+    func testRenameShowsPreviousPathAndFileCountsWin() throws {
+        let renamed = try file("new.swift", oldPath: "old.swift", status: "R", additions: 7)
+        let rows = ReviewDiffRowBuilder.rows(for: ReviewDiffFileInput(file: renamed, state: .loaded(try diff("@@ -1 +1 @@\n-a\n+b"))))
+        let header = try XCTUnwrap(rows[0].fileHeader)
+        XCTAssertEqual(header.previousPath, "old.swift")
+        XCTAssertEqual(header.displayPath, "old.swift → new.swift")
+        XCTAssertEqual(header.changeKind, .renamed)
+        XCTAssertEqual(header.additions, 7, "Server counts win over the parsed hunk.")
+    }
+
+    func testNonRenderableStatesBecomeOneNoticeRow() throws {
+        let plain = try file("x.swift")
+        let cases: [(ReviewDiffFileState, String)] = [
+            (.loading, "Loading…"),
+            (.failed("Boom"), "Boom"),
+            (.loaded(try diff("", binary: true)), "Binary file changed"),
+            (.loaded(try diff("", tooLarge: true)), "Diff too large to show."),
+            (.loaded(try diff("")), "No Changes")
+        ]
+        for (state, notice) in cases {
+            let rows = ReviewDiffRowBuilder.rows(for: ReviewDiffFileInput(file: plain, state: state))
+            XCTAssertEqual(rows.count, 2)
+            XCTAssertEqual(rows[1].id, "x.swift:notice")
+            XCTAssertEqual(rows[1].kind, .notice(notice))
+        }
+    }
+
+    func testMultipleFilesConcatenateInOrder() throws {
+        let rows = ReviewDiffRowBuilder.rows(for: [
+            ReviewDiffFileInput(file: try file("one.swift"), state: .loading),
+            ReviewDiffFileInput(file: try file("two.swift"), state: .loaded(try diff("@@ -1 +1 @@\n-a\n+b")))
+        ])
+        XCTAssertEqual(rows.filter(\.isFileHeader).map(\.fileID), ["one.swift", "two.swift"])
+        XCTAssertEqual(rows.count, 2 + 4)
+    }
+}

--- a/HermesMobileTests/ReviewDiffSelectionTests.swift
+++ b/HermesMobileTests/ReviewDiffSelectionTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import HermesMobile
+
+final class ReviewDiffSelectionTests: XCTestCase {
+    private let rows: [ReviewDiffRow] = [
+        ReviewDiffRow(id: "f:header", fileID: "f", kind: .file(ReviewDiffFileHeader(path: "Sources/App.swift", previousPath: nil, changeKind: .modified, additions: 1, deletions: 1))),
+        ReviewDiffRow(id: "f:hunk:0", fileID: "f", kind: .hunk("Lines 10-12")),
+        ReviewDiffRow(id: "f:line:0", fileID: "f", kind: .line(ReviewDiffLine(content: "let a = 1", change: .context, oldLineNumber: 10, newLineNumber: 10))),
+        ReviewDiffRow(id: "f:line:1", fileID: "f", kind: .line(ReviewDiffLine(content: "old()", change: .deletion, oldLineNumber: 11, newLineNumber: nil))),
+        ReviewDiffRow(id: "f:line:2", fileID: "f", kind: .line(ReviewDiffLine(content: "new()", change: .addition, oldLineNumber: nil, newLineNumber: 11))),
+        ReviewDiffRow(id: "f:line:3", fileID: "f", kind: .line(ReviewDiffLine(content: "}", change: .context, oldLineNumber: 12, newLineNumber: 12))),
+        ReviewDiffRow(id: "g:header", fileID: "g", kind: .file(ReviewDiffFileHeader(path: "Other.swift", previousPath: nil, changeKind: .added, additions: 1, deletions: 0))),
+        ReviewDiffRow(id: "g:line:0", fileID: "g", kind: .line(ReviewDiffLine(content: "x", change: .addition, oldLineNumber: nil, newLineNumber: 1)))
+    ]
+
+    func testTapSelectsOneLineAndTappingItAgainClears() {
+        var selection = ReviewDiffSelection()
+        selection.tap(rowID: "f:line:1", fileID: "f")
+        XCTAssertEqual(selection.selectedRowIDs(in: rows), ["f:line:1"])
+        selection.tap(rowID: "f:line:1", fileID: "f")
+        XCTAssertTrue(selection.isEmpty)
+    }
+
+    func testLongPressThenTapSelectsTheRangeInEitherDirection() {
+        var selection = ReviewDiffSelection()
+        selection.longPress(rowID: "f:line:3", fileID: "f")
+        XCTAssertTrue(selection.isAwaitingRangeEnd)
+        XCTAssertEqual(selection.selectedRowIDs(in: rows), ["f:line:3"], "The anchor shows as selected while waiting.")
+        selection.tap(rowID: "f:line:0", fileID: "f")
+        XCTAssertFalse(selection.isAwaitingRangeEnd)
+        XCTAssertEqual(selection.selectedRowIDs(in: rows), ["f:line:0", "f:line:1", "f:line:2", "f:line:3"])
+
+        selection.tap(rowID: "f:line:2", fileID: "f")
+        XCTAssertEqual(selection.selectedRowIDs(in: rows), ["f:line:2"], "A plain tap after a range starts over.")
+    }
+
+    func testTapInAnotherFileWhileAwaitingStartsFresh() {
+        var selection = ReviewDiffSelection()
+        selection.longPress(rowID: "f:line:0", fileID: "f")
+        selection.tap(rowID: "g:line:0", fileID: "g")
+        XCTAssertEqual(selection.selectedRowIDs(in: rows), ["g:line:0"])
+        XCTAssertFalse(selection.isAwaitingRangeEnd)
+    }
+
+    func testSnippetIsPathLineRangeAndFencedDiff() {
+        var selection = ReviewDiffSelection()
+        selection.longPress(rowID: "f:line:0", fileID: "f")
+        selection.tap(rowID: "f:line:3", fileID: "f")
+        XCTAssertEqual(
+            selection.snippet(in: rows),
+            """
+            Sources/App.swift L10-L12
+            ```diff
+             let a = 1
+            -old()
+            +new()
+             }
+            ```
+            """
+        )
+
+        selection.tap(rowID: "g:line:0", fileID: "g")
+        XCTAssertEqual(selection.snippet(in: rows), "Other.swift L1\n```diff\n+x\n```")
+        selection.clear()
+        XCTAssertNil(selection.snippet(in: rows))
+    }
+}

--- a/HermesMobileTests/ReviewDiffSelectionTests.swift
+++ b/HermesMobileTests/ReviewDiffSelectionTests.swift
@@ -64,4 +64,16 @@ final class ReviewDiffSelectionTests: XCTestCase {
         selection.clear()
         XCTAssertNil(selection.snippet(in: rows))
     }
+
+    func testFenceOutgrowsBackticksInsideTheSelection() {
+        let markdown = [
+            ReviewDiffRow(id: "m:header", fileID: "m", kind: .file(ReviewDiffFileHeader(path: "README.md", previousPath: nil, changeKind: .modified, additions: 1, deletions: 0))),
+            ReviewDiffRow(id: "m:line:0", fileID: "m", kind: .line(ReviewDiffLine(content: "```swift", change: .addition, oldLineNumber: nil, newLineNumber: 4))),
+            ReviewDiffRow(id: "m:line:1", fileID: "m", kind: .line(ReviewDiffLine(content: "let x = `y`", change: .addition, oldLineNumber: nil, newLineNumber: 5)))
+        ]
+        var selection = ReviewDiffSelection()
+        selection.longPress(rowID: "m:line:0", fileID: "m")
+        selection.tap(rowID: "m:line:1", fileID: "m")
+        XCTAssertEqual(selection.snippet(in: markdown), "README.md L4-L5\n````diff\n+```swift\n+let x = `y`\n````")
+    }
 }

--- a/HermesMobileTests/ReviewWordDiffTests.swift
+++ b/HermesMobileTests/ReviewWordDiffTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import HermesMobile
+
+final class ReviewWordDiffTests: XCTestCase {
+    func testHighlightsOnlyTheChangedWord() {
+        let pair = ReviewWordDiff.ranges(deletion: "let total = price * count", addition: "let total = price * quantity")
+        XCTAssertEqual(pair.deletion, [20..<25])
+        XCTAssertEqual(pair.addition, [20..<28])
+    }
+
+    func testAdjacentChangesMergeAcrossASingleNeutralCharacter() {
+        let pair = ReviewWordDiff.ranges(
+            deletion: "let value = foo.bar ?? fallback",
+            addition: "let value = baz.qux ?? fallback"
+        )
+        XCTAssertEqual(pair.deletion, [12..<19], "foo, the dot, and bar read as one edit.")
+        XCTAssertEqual(pair.addition, [12..<19])
+    }
+
+    func testWhitespaceIsTrimmedFromRangeEdges() {
+        let pair = ReviewWordDiff.ranges(deletion: "a  b c", addition: "a  x c")
+        XCTAssertEqual(pair.deletion, [3..<4])
+        XCTAssertEqual(pair.addition, [3..<4])
+    }
+
+    func testRewrittenLinesStayPlainAboveTheCoverageGate() {
+        let pair = ReviewWordDiff.ranges(deletion: "alpha beta gamma delta", addition: "one two three four")
+        XCTAssertEqual(pair.deletion, [])
+        XCTAssertEqual(pair.addition, [])
+    }
+
+    func testTooManyRangesStayPlain() {
+        let pair = ReviewWordDiff.ranges(
+            deletion: "a1 keep b1 keep c1 keep d1 keep e1 keep keep keep keep keep keep keep keep",
+            addition: "a2 keep b2 keep c2 keep d2 keep e2 keep keep keep keep keep keep keep keep"
+        )
+        XCTAssertEqual(pair.deletion, [], "Five separate edits are noise, not a word diff.")
+        XCTAssertEqual(pair.addition, [])
+    }
+
+    func testLongLinesAreSkipped() {
+        let long = String(repeating: "x", count: ReviewWordDiff.maxLineLength + 1)
+        let pair = ReviewWordDiff.ranges(deletion: long, addition: long + "y")
+        XCTAssertEqual(pair.deletion, [])
+        XCTAssertEqual(pair.addition, [])
+    }
+
+    func testAnnotatePairsRunsIndexByIndexAndStopsAtHunkRows() {
+        func line(_ id: String, _ change: DiffLine.Kind, _ content: String) -> ReviewDiffRow {
+            ReviewDiffRow(id: id, fileID: "f", kind: .line(ReviewDiffLine(content: content, change: change, oldLineNumber: nil, newLineNumber: nil)))
+        }
+        var rows = [
+            line("d1", .deletion, "let a = one"),
+            line("d2", .deletion, "let b = two"),
+            line("a1", .addition, "let a = uno"),
+            ReviewDiffRow(id: "h", fileID: "f", kind: .hunk("Line 9")),
+            line("a2", .addition, "let b = dos")
+        ]
+        ReviewWordDiff.annotate(&rows)
+
+        XCTAssertEqual(rows[0].line?.wordDiffRanges, [8..<11])
+        XCTAssertEqual(rows[2].line?.wordDiffRanges, [8..<11])
+        XCTAssertEqual(rows[1].line?.wordDiffRanges, [], "The second deletion has no partner before the hunk row.")
+        XCTAssertEqual(rows[4].line?.wordDiffRanges, [])
+    }
+}


### PR DESCRIPTION
## Linked issue

Maintainer-scoped Git review work; no tracking issue.

## What changed

Opening a Git diff gave you one file per sheet as a SwiftUI list: no word-level highlights, no sticky file headers, no way to mark a file as reviewed, and no way to hand a few lines to the agent.

Now the Git changes sheet, the turn recap's "Open diff", and its file rows all open one surface with every changed file:

- **Sticky file headers** that the next file's header pushes off.
- **Collapse and viewed** per file. Tapping the checkbox marks the file viewed and collapses it; un-viewing leaves it collapsed. Collapsing keeps the header where it is drawn, so you are not thrown to another file.
- **Word-level highlights** on paired deleted/added lines, gated so rewrites stay plain (max 4 ranges, ≤ 45 % coverage, lines ≤ 1000 chars, gaps ≤ 1 merged).
- **Striped delete bar** next to the solid add bar, so deletions read without relying on red alone.
- **Per-file horizontal pan** with display-link deceleration; the line-number gutter stays put.
- **Line selection**: tap selects one line, long-press then tap selects a range. **Add to prompt** appends the path, line range, and a fenced diff to the composer draft and closes the sheet.
- **Pull-to-refresh** with a spinner the reload owns.

How: `ReviewDiffCanvasView` is a UIKit canvas sized to the viewport that slides with the scroll offset and draws only the rows intersecting it (four-row overscan) from a flat `ReviewDiffRow` list; `ReviewDiffLayout` is the prefix-sum layout with binary-search hit testing. The canvas is a port of an MIT-licensed native diff view; the notice is kept in the file header. `GitDiffView` is now the multi-file host: it fetches `git/diff` per file, four in flight, starting with the file you tapped, and rebuilds rows off the main thread as each answer lands while the surface keeps the file under the reader anchored. The existing `DiffHunk` parser is unchanged and feeds the row model.

VoiceOver sees the canvas as a container whose elements are created on demand for visible rows (line number, change type, text; headers expose collapse and viewed as actions). Fonts scale with Dynamic Type and rebuild the layout. Colours are system semantic colours, so light and dark resolve at draw time. Draw and layout passes emit `ReviewDiff` signposts.

## How it was tested

- Full XCTest suite on the iPhone 17 simulator via XcodeBuildMCP `test_sim`: **2103 passed, 0 failed, 2 skipped** on the final head.
- New focused tests: `ReviewDiffRowBuilderTests` (row ids, notices for loading/failed/binary/too-large/empty, renames, tab expansion, server counts win), `ReviewWordDiffTests` (changed-word ranges, single-character joins, whitespace trim, coverage and count gates, long-line skip, pairing stops at hunk rows), `ReviewDiffLayoutTests` (prefix sums, collapsed heights, hit testing, sticky push-off, visible file), `ReviewDiffSelectionTests` (tap/long-press state machine, Markdown snippet).
- Manual pass by the maintainer on the simulator against the live server: multi-file surface, word highlight, striped delete bar, line selection, and Add to prompt confirmed. Screenshots to follow as a comment.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (no model changes)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (reuses the existing `GET /api/git/diff` per file)

---

Built by Claude Fable 5.1 via Claude Code.
