### PR TITLE
feat(workspace): view source files on the review surface with syntax colour

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -250,6 +250,13 @@
 		1D1FF0000000000000000B0B /* ReviewDiffLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */; };
 		1D1FF0000000000000000B0C /* ReviewDiffSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */; };
 		1D1FF0000000000000000B21 /* ReviewDiffCanvasViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F21 /* ReviewDiffCanvasViewTests.swift */; };
+		1D1FF0000000000000000B30 /* SourceHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F30 /* SourceHighlighter.swift */; };
+		1D1FF0000000000000000B31 /* SourceFileRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F31 /* SourceFileRows.swift */; };
+		1D1FF0000000000000000B32 /* SourceFileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F32 /* SourceFileViewModel.swift */; };
+		1D1FF0000000000000000B33 /* SourceFileSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F33 /* SourceFileSurface.swift */; };
+		1D1FF0000000000000000B34 /* SourceFileRowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F34 /* SourceFileRowsTests.swift */; };
+		1D1FF0000000000000000B35 /* SourceHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F35 /* SourceHighlighterTests.swift */; };
+		1D1FF0000000000000000B36 /* SourceFileViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FF0000000000000000F36 /* SourceFileViewModelTests.swift */; };
 		C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */; };
 		C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */; };
 		C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */; };
@@ -666,6 +673,13 @@
 		1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffLayoutTests.swift; sourceTree = "<group>"; };
 		1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffSelectionTests.swift; sourceTree = "<group>"; };
 		1D1FF0000000000000000F21 /* ReviewDiffCanvasViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffCanvasViewTests.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F30 /* SourceHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceHighlighter.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F31 /* SourceFileRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceFileRows.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F32 /* SourceFileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceFileViewModel.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F33 /* SourceFileSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceFileSurface.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F34 /* SourceFileRowsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceFileRowsTests.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F35 /* SourceHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceHighlighterTests.swift; sourceTree = "<group>"; };
+		1D1FF0000000000000000F36 /* SourceFileViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceFileViewModelTests.swift; sourceTree = "<group>"; };
 		C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnFileChangeAggregatorTests.swift; sourceTree = "<group>"; };
 		C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallSummaryFormatterTests.swift; sourceTree = "<group>"; };
 		C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTurnFoldingTests.swift; sourceTree = "<group>"; };
@@ -991,6 +1005,9 @@
 				1D1FF0000000000000000F0B /* ReviewDiffLayoutTests.swift */,
 				1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */,
 				1D1FF0000000000000000F21 /* ReviewDiffCanvasViewTests.swift */,
+				1D1FF0000000000000000F34 /* SourceFileRowsTests.swift */,
+				1D1FF0000000000000000F35 /* SourceHighlighterTests.swift */,
+				1D1FF0000000000000000F36 /* SourceFileViewModelTests.swift */,
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */,
@@ -1273,6 +1290,17 @@
 			path = Chat;
 			sourceTree = "<group>";
 		};
+		1D1FF00000000000000000C1 /* SourceViewer */ = {
+			isa = PBXGroup;
+			children = (
+				1D1FF0000000000000000F30 /* SourceHighlighter.swift */,
+				1D1FF0000000000000000F31 /* SourceFileRows.swift */,
+				1D1FF0000000000000000F32 /* SourceFileViewModel.swift */,
+				1D1FF0000000000000000F33 /* SourceFileSurface.swift */,
+			);
+			path = SourceViewer;
+			sourceTree = "<group>";
+		};
 		1D1FF00000000000000000C0 /* ReviewDiff */ = {
 			isa = PBXGroup;
 			children = (
@@ -1307,6 +1335,7 @@
 				C03180000000000000F004 /* GitCommitView.swift */,
 				C03180000000000000F007 /* GitTurnChangesCard.swift */,
 				1D1FF00000000000000000C0 /* ReviewDiff */,
+				1D1FF00000000000000000C1 /* SourceViewer */,
 				C03140000000000000F001 /* GitBranchPickerView.swift */,
 				22AB000000000000000000F1 /* WorkspaceRegistryViewModel.swift */,
 				22AB000000000000000000F2 /* WorkspaceManagerView.swift */,
@@ -1705,6 +1734,10 @@
 				1D1FF0000000000000000B20 /* ReviewDiffCanvasView+Accessibility.swift in Sources */,
 				1D1FF0000000000000000B07 /* ReviewDiffSurfaceView.swift in Sources */,
 				1D1FF0000000000000000B08 /* ReviewDiffSurface.swift in Sources */,
+				1D1FF0000000000000000B30 /* SourceHighlighter.swift in Sources */,
+				1D1FF0000000000000000B31 /* SourceFileRows.swift in Sources */,
+				1D1FF0000000000000000B32 /* SourceFileViewModel.swift in Sources */,
+				1D1FF0000000000000000B33 /* SourceFileSurface.swift in Sources */,
 				C03140000000000000B001 /* GitBranchPickerView.swift in Sources */,
 				C04000000000000000000005 /* APIClient+ServerPanels.swift in Sources */,
 				C04000000000000000000006 /* APIClient+Cron.swift in Sources */,
@@ -1992,6 +2025,9 @@
 				1D1FF0000000000000000B0B /* ReviewDiffLayoutTests.swift in Sources */,
 				1D1FF0000000000000000B0C /* ReviewDiffSelectionTests.swift in Sources */,
 				1D1FF0000000000000000B21 /* ReviewDiffCanvasViewTests.swift in Sources */,
+				1D1FF0000000000000000B34 /* SourceFileRowsTests.swift in Sources */,
+				1D1FF0000000000000000B35 /* SourceHighlighterTests.swift in Sources */,
+				1D1FF0000000000000000B36 /* SourceFileViewModelTests.swift in Sources */,
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/MarkdownRenderer.swift
+++ b/HermesMobile/Features/Chat/MarkdownRenderer.swift
@@ -876,7 +876,7 @@ enum MarkdownHighlightPolicy {
         "text",
         "txt"
     ]
-    private static let highlightrLanguages: Set<String> = [
+    static let highlightrLanguages: Set<String> = [
         "bash",
         "c",
         "cpp",

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -2,10 +2,14 @@ import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
 
+/// One workspace file. Markdown keeps the chat renderer; every other text file
+/// draws on the source surface with a gutter, syntax colour, and an optional
+/// starting line. Images and binaries keep their own previews.
 struct FilePreviewView: View {
     let onAPIError: (Error) -> Void
 
     private let entry: WorkspaceEntry
+    private let initialLine: Int?
     @State private var viewModel: FilePreviewViewModel
     @State private var selectableText: SelectableTextPresentation?
     @State private var exportDocument = ExportedFileDocument(data: Data())
@@ -16,9 +20,18 @@ struct FilePreviewView: View {
     @State private var saveConfirmationMessage: String?
     @State private var isSavingToPhotos = false
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @AppStorage(SourceFileSurface.wrapsLinesKey) private var wrapsLines = false
 
-    init(session: SessionSummary, server: URL, entry: WorkspaceEntry, onAPIError: @escaping (Error) -> Void) {
+    /// `initialLine` is one-based; the source surface scrolls to it and highlights it.
+    init(
+        session: SessionSummary,
+        server: URL,
+        entry: WorkspaceEntry,
+        initialLine: Int? = nil,
+        onAPIError: @escaping (Error) -> Void
+    ) {
         self.entry = entry
+        self.initialLine = initialLine
         self.onAPIError = onAPIError
         _viewModel = State(initialValue: FilePreviewViewModel(session: session, server: server, path: entry.path ?? ""))
     }
@@ -53,6 +66,10 @@ struct FilePreviewView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
+                if case let .text(file) = viewModel.preview, !isMarkdownFile {
+                    sourceActionsMenu(content: file.content ?? "")
+                }
+
                 if viewModel.canSaveImageToPhotos {
                     Button {
                         Task { await saveImageToPhotos() }
@@ -129,11 +146,35 @@ struct FilePreviewView: View {
         }
     }
 
+    /// Wrap, Copy, and Select Text for source files. The drawn surface owns long
+    /// press for line selection, so these live in the toolbar instead of a context menu.
+    private func sourceActionsMenu(content: String) -> some View {
+        Menu {
+            Toggle("Wrap Lines", systemImage: "text.justify.leading", isOn: $wrapsLines)
+            Button {
+                UIPasteboard.general.string = content
+                ChatHaptics.copied(isEnabled: isHapticsEnabled)
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+            Button {
+                selectableText = SelectableTextPresentation(id: "file-preview:\(displayPath)", text: content)
+            } label: {
+                Label("Select Text", systemImage: "text.cursor")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .accessibilityLabel("File actions")
+    }
+
     @ViewBuilder
     private func previewContent(_ preview: FilePreviewContent) -> some View {
         switch preview {
+        case let .text(file) where isMarkdownFile:
+            markdownContent(file.content ?? "")
         case let .text(file):
-            fileContent(file.content ?? "")
+            sourceContent(file)
         case let .image(file):
             imageContent(file.data)
         case .audio:
@@ -159,20 +200,31 @@ struct FilePreviewView: View {
         }
     }
 
-    private func fileContent(_ content: String) -> some View {
-        ScrollView(isMarkdownFile ? .vertical : [.vertical, .horizontal]) {
+    private func sourceContent(_ file: FileResponse) -> some View {
+        VStack(spacing: 0) {
+            fileHeader
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+            Divider()
+            SourceFileSurface(
+                content: file.content ?? "",
+                path: displayPath,
+                serverLanguage: file.language,
+                targetLine: initialLine,
+                isRefreshing: viewModel.isLoading,
+                onRefresh: { Task { await loadFile() } }
+            )
+        }
+        .background(Color(.systemBackground))
+    }
+
+    private func markdownContent(_ content: String) -> some View {
+        ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 fileHeader
-
-                if isMarkdownFile {
-                    MarkdownRenderer(content: content, isStreaming: false)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    Text(content)
-                        .font(.system(.body, design: .monospaced))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                MarkdownRenderer(content: content, isStreaming: false)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding()
         }

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Drawing.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Drawing.swift
@@ -241,12 +241,13 @@ extension ReviewDiffCanvasView {
             context.fill(barRect)
         }
 
+        // The number sits on the first visual line, so a wrapped row keeps it at the top.
         if let number = line.displayLineNumber {
             drawRightAlignedText(
                 "\(number)",
                 rect: CGRect(
                     x: style.changeBarWidth,
-                    y: rect.midY - style.lineNumberFont.lineHeight / 2,
+                    y: rect.minY + (style.metrics.rowHeight - style.lineNumberFont.lineHeight) / 2,
                     width: style.gutterWidth - style.codePadding,
                     height: style.lineNumberFont.lineHeight
                 ),

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Drawing.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView+Drawing.swift
@@ -258,13 +258,48 @@ extension ReviewDiffCanvasView {
         context.saveGState()
         context.clip(to: CGRect(x: style.stickyWidth, y: rect.minY, width: max(0, viewportWidth - style.stickyWidth), height: rect.height))
         drawWordDiffRanges(line, rowRect: rect, horizontalOffset: horizontalOffset)
-        drawText(
+        drawCodeText(
             line.content,
-            at: CGPoint(x: style.codeStartX - horizontalOffset, y: rect.midY - style.codeFont.lineHeight / 2),
-            color: line.change == .context ? theme.text.withAlphaComponent(0.85) : theme.text,
-            font: style.codeFont
+            runs: tokensByRowID[row.id] ?? [],
+            origin: CGPoint(x: style.codeStartX - horizontalOffset, y: rect.minY + (style.metrics.rowHeight - style.codeFont.lineHeight) / 2),
+            color: line.change == .context ? theme.text.withAlphaComponent(0.85) : theme.text
         )
         context.restoreGState()
+    }
+
+    /// Code text with optional syntax colour runs, split into visual lines of
+    /// `wrapColumns` characters when the layout wraps. The plain, unwrapped case stays
+    /// a single string draw so diff rows cost what they did before.
+    private func drawCodeText(_ text: String, runs: [SourceHighlightRun], origin: CGPoint, color: UIColor) {
+        let wrapColumns = layout.wrapColumns
+        if runs.isEmpty, wrapColumns == nil || text.count <= wrapColumns! {
+            drawText(text, at: origin, color: color, font: style.codeFont)
+            return
+        }
+
+        let attributed = NSMutableAttributedString(
+            string: text,
+            attributes: [.font: style.codeFont, .foregroundColor: color, .ligature: 0]
+        )
+        let bounds = NSRange(location: 0, length: attributed.length)
+        for run in runs {
+            let clamped = NSIntersectionRange(run.range, bounds)
+            guard clamped.length > 0 else { continue }
+            attributed.addAttribute(.foregroundColor, value: run.color, range: clamped)
+        }
+
+        guard let wrapColumns, text.count > wrapColumns else {
+            attributed.draw(at: origin)
+            return
+        }
+        var y = origin.y
+        var start = text.startIndex
+        while start < text.endIndex {
+            let end = text.index(start, offsetBy: wrapColumns, limitedBy: text.endIndex) ?? text.endIndex
+            attributed.attributedSubstring(from: NSRange(start..<end, in: text)).draw(at: CGPoint(x: origin.x, y: y))
+            y += style.metrics.wrappedLineHeight
+            start = end
+        }
     }
 
     private func drawWordDiffRanges(_ line: ReviewDiffLine, rowRect: CGRect, horizontalOffset: CGFloat) {

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
@@ -57,6 +57,7 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
     private(set) var layout: ReviewDiffLayout
     private(set) var style: ReviewDiffStyle
     let theme = ReviewDiffTheme()
+    let presentation: ReviewDiffPresentation
 
     var viewedFileIDs: Set<String> = [] {
         didSet { setNeedsDisplay() }
@@ -66,9 +67,26 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
     }
     var viewportWidth: CGFloat = 0 {
         didSet {
-            clampHorizontalOffsets()
-            setNeedsDisplay()
+            guard viewportWidth != oldValue else { return }
+            if wrapsLines {
+                rebuildLayout(rows: layout.rows, collapsedFileIDs: layout.collapsedFileIDs)
+            } else {
+                clampHorizontalOffsets()
+                setNeedsDisplay()
+            }
         }
+    }
+    /// Wrap long lines on the character grid instead of panning them horizontally.
+    var wrapsLines = false {
+        didSet {
+            guard wrapsLines != oldValue else { return }
+            rebuildLayout(rows: layout.rows, collapsedFileIDs: layout.collapsedFileIDs)
+        }
+    }
+    /// Syntax colour runs by row id, filled in for visible rows as the highlighter
+    /// answers; rows without an entry draw in the plain text colour.
+    var tokensByRowID: [String: [SourceHighlightRun]] = [:] {
+        didSet { setNeedsDisplay() }
     }
     /// Scroll offset of the host; row `y` in canvas coordinates is `offset - verticalOffset`.
     var verticalOffset: CGFloat = 0
@@ -120,9 +138,10 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
         return gesture
     }()
 
-    override init(frame: CGRect) {
-        let style = ReviewDiffStyle.resolve(for: UITraitCollection.current)
+    init(frame: CGRect, presentation: ReviewDiffPresentation = .diff) {
+        let style = ReviewDiffStyle.resolve(for: UITraitCollection.current, presentation: presentation)
         self.style = style
+        self.presentation = presentation
         layout = ReviewDiffLayout(rows: [], collapsedFileIDs: [], metrics: style.metrics)
         super.init(frame: frame)
         isOpaque = true
@@ -135,7 +154,7 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
 
         // Dynamic Type resizes every row; appearance changes only need a repaint.
         registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: Self, _) in
-            view.style = ReviewDiffStyle.resolve(for: view.traitCollection)
+            view.style = ReviewDiffStyle.resolve(for: view.traitCollection, presentation: view.presentation)
             view.rebuildLayout(rows: view.layout.rows, collapsedFileIDs: view.layout.collapsedFileIDs)
         }
         registerForTraitChanges([UITraitUserInterfaceStyle.self, UITraitAccessibilityContrast.self]) { (view: Self, _) in
@@ -170,7 +189,7 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
 
     private func rebuildLayout(rows: [ReviewDiffRow], collapsedFileIDs: Set<String>) {
         let state = reviewDiffSignposter.beginInterval("RebuildLayout")
-        layout = ReviewDiffLayout(rows: rows, collapsedFileIDs: collapsedFileIDs, metrics: style.metrics)
+        layout = ReviewDiffLayout(rows: rows, collapsedFileIDs: collapsedFileIDs, metrics: style.metrics, wrapColumns: wrapColumns)
         contentWidthsByFileID = layout.maxColumnCountsByFileID.mapValues { columns in
             let measured = ceil(CGFloat(columns) * style.codeCharacterWidth) + style.codePadding * 2
             return max(0, min(style.maxContentWidth, measured))
@@ -181,6 +200,13 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
         onContentHeightChange?()
         setNeedsDisplay()
         UIAccessibility.post(notification: .layoutChanged, argument: nil)
+    }
+
+    /// Characters that fit between the gutter and the viewport edge, when wrapping.
+    private var wrapColumns: Int? {
+        guard wrapsLines else { return nil }
+        let available = viewportWidth - style.codeStartX - style.codePadding
+        return max(8, Int(available / max(style.codeCharacterWidth, 1)))
     }
 
     // MARK: - Geometry

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffCanvasView.swift
@@ -381,6 +381,7 @@ final class ReviewDiffCanvasView: UIView, UIGestureRecognizerDelegate {
             guard let header = rows.first(where: { $0.fileID == fileID && $0.isFileHeader })?.fileHeader else { return 0 }
             return maxHeaderPathOffset(for: header)
         case .code:
+            guard !wrapsLines else { return 0 }
             return max(0, contentWidth(for: fileID) - max(0, viewportWidth - style.codeStartX))
         }
     }

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffLayout.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffLayout.swift
@@ -7,6 +7,8 @@ struct ReviewDiffMetrics: Equatable {
     var rowHeight: CGFloat
     var fileHeaderHeight: CGFloat
     var noticeHeight: CGFloat
+    /// Height of each extra visual line when a wrapped row spans more than one.
+    var wrappedLineHeight: CGFloat = 0
 }
 
 /// Vertical geometry of the row list: prefix-sum offsets, binary-search hit testing,
@@ -23,6 +25,8 @@ struct ReviewDiffLayout {
     let rows: [ReviewDiffRow]
     let collapsedFileIDs: Set<String>
     let metrics: ReviewDiffMetrics
+    /// Characters per visual line when lines wrap; nil scrolls horizontally instead.
+    let wrapColumns: Int?
     private(set) var rowOffsets: [CGFloat] = []
     private(set) var fileHeaderRowIndices: [Int] = []
     /// Rows with a non-zero height, in order; the accessibility element list.
@@ -31,10 +35,11 @@ struct ReviewDiffLayout {
     /// Longest line per file, in characters; the canvas turns it into a content width.
     private(set) var maxColumnCountsByFileID: [String: Int] = [:]
 
-    init(rows: [ReviewDiffRow], collapsedFileIDs: Set<String>, metrics: ReviewDiffMetrics) {
+    init(rows: [ReviewDiffRow], collapsedFileIDs: Set<String>, metrics: ReviewDiffMetrics, wrapColumns: Int? = nil) {
         self.rows = rows
         self.collapsedFileIDs = collapsedFileIDs
         self.metrics = metrics
+        self.wrapColumns = wrapColumns.map { max(1, $0) }
 
         rowOffsets.reserveCapacity(rows.count)
         var offset: CGFloat = 0
@@ -44,7 +49,7 @@ struct ReviewDiffLayout {
             let height = height(forRowAt: index)
             if height > 0 { visibleRowIndices.append(index) }
             offset += height
-            let columns = row.columnCount
+            let columns = min(row.columnCount, self.wrapColumns ?? Int.max)
             if columns > 0 {
                 maxColumnCountsByFileID[row.fileID] = max(maxColumnCountsByFileID[row.fileID] ?? 0, columns)
             }
@@ -57,11 +62,21 @@ struct ReviewDiffLayout {
         switch row.kind {
         case .file:
             return metrics.fileHeaderHeight
-        case .hunk, .line:
+        case .hunk:
             return collapsedFileIDs.contains(row.fileID) ? 0 : metrics.rowHeight
+        case .line:
+            guard !collapsedFileIDs.contains(row.fileID) else { return 0 }
+            return metrics.rowHeight + CGFloat(visualLineCount(forRowAt: index) - 1) * metrics.wrappedLineHeight
         case .notice:
             return collapsedFileIDs.contains(row.fileID) ? 0 : metrics.noticeHeight
         }
+    }
+
+    /// How many visual lines a line row occupies: one unless wrapping splits it.
+    func visualLineCount(forRowAt index: Int) -> Int {
+        guard let wrapColumns else { return 1 }
+        let columns = rows[index].columnCount
+        return max(1, (columns + wrapColumns - 1) / wrapColumns)
     }
 
     /// Vertical extent of a row in content coordinates.

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffStyle.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffStyle.swift
@@ -26,6 +26,20 @@ struct ReviewDiffTheme {
     }
 }
 
+/// What the surface is showing. A diff keeps the change bar beside the gutter; a
+/// source file drops it so every row reads as plain context.
+enum ReviewDiffPresentation: Equatable {
+    case diff
+    case source
+
+    var changeBarWidth: CGFloat {
+        switch self {
+        case .diff: return 4
+        case .source: return 0
+        }
+    }
+}
+
 /// Fonts and fixed geometry, resolved once per trait collection. Row heights follow
 /// the scaled code font so Dynamic Type grows rows instead of clipping them.
 struct ReviewDiffStyle {
@@ -39,7 +53,7 @@ struct ReviewDiffStyle {
     /// Advance of one character in `codeFont`; the word highlights sit on this grid.
     let codeCharacterWidth: CGFloat
     let gutterWidth: CGFloat
-    let changeBarWidth: CGFloat = 4
+    let changeBarWidth: CGFloat
     let codePadding: CGFloat = 8
     let maxContentWidth: CGFloat = 2800
     let fileHeaderHorizontalPadding: CGFloat = 12
@@ -48,7 +62,7 @@ struct ReviewDiffStyle {
     var stickyWidth: CGFloat { changeBarWidth + gutterWidth }
     var codeStartX: CGFloat { stickyWidth + codePadding }
 
-    static func resolve(for traits: UITraitCollection) -> ReviewDiffStyle {
+    static func resolve(for traits: UITraitCollection, presentation: ReviewDiffPresentation = .diff) -> ReviewDiffStyle {
         let metrics = UIFontMetrics(forTextStyle: .body)
         func mono(_ size: CGFloat, _ weight: UIFont.Weight) -> UIFont {
             metrics.scaledFont(
@@ -76,10 +90,12 @@ struct ReviewDiffStyle {
             metrics: ReviewDiffMetrics(
                 rowHeight: ceil(codeFont.lineHeight) + 6,
                 fileHeaderHeight: ceil(fileHeaderFont.lineHeight) + 30,
-                noticeHeight: max(44, ceil(noticeFont.lineHeight) + 24)
+                noticeHeight: max(44, ceil(noticeFont.lineHeight) + 24),
+                wrappedLineHeight: ceil(codeFont.lineHeight)
             ),
             codeCharacterWidth: characterWidth,
-            gutterWidth: ceil(gutterSample) + 14
+            gutterWidth: ceil(gutterSample) + 14,
+            changeBarWidth: presentation.changeBarWidth
         )
     }
 }

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurface.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurface.swift
@@ -1,9 +1,25 @@
 import SwiftUI
 
-/// One-shot scroll request; a new token scrolls again even to the same file.
+/// One-shot scroll request; a new token scrolls again even to the same place.
 struct ReviewDiffScrollTarget: Equatable {
-    let fileID: String
+    enum Anchor: Equatable {
+        /// The file header lands at the top of the viewport.
+        case fileHeader(String)
+        /// The row lands 30 % down the viewport.
+        case row(String)
+    }
+
+    let anchor: Anchor
     let token: UUID
+
+    init(anchor: Anchor, token: UUID) {
+        self.anchor = anchor
+        self.token = token
+    }
+
+    init(fileID: String, token: UUID) {
+        self.init(anchor: .fileHeader(fileID), token: token)
+    }
 }
 
 /// SwiftUI face of the review surface. The host owns every piece of state (rows,
@@ -18,6 +34,12 @@ struct ReviewDiffSurface: UIViewRepresentable {
     let selectedRowIDs: Set<String>
     let isRefreshing: Bool
     let scrollTarget: ReviewDiffScrollTarget?
+    var presentation: ReviewDiffPresentation = .diff
+    var wrapsLines = false
+    /// Syntax colour runs by row id, replaced whenever `tokensVersion` changes.
+    var tokensByRowID: [String: [SourceHighlightRun]] = [:]
+    var tokensVersion = 0
+    var onVisibleRowRangeChange: ((ClosedRange<Int>?) -> Void)? = nil
     let onToggleFile: (String) -> Void
     let onToggleViewed: (String) -> Void
     let onLinePress: (ReviewDiffLinePress) -> Void
@@ -28,7 +50,9 @@ struct ReviewDiffSurface: UIViewRepresentable {
         var onToggleViewed: (String) -> Void = { _ in }
         var onLinePress: (ReviewDiffLinePress) -> Void = { _ in }
         var onRefresh: () -> Void = {}
+        var onVisibleRowRangeChange: ((ClosedRange<Int>?) -> Void)?
         var appliedRowsVersion = -1
+        var appliedTokensVersion = -1
         var appliedScrollToken: UUID?
     }
 
@@ -37,12 +61,13 @@ struct ReviewDiffSurface: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> ReviewDiffSurfaceView {
-        let view = ReviewDiffSurfaceView()
+        let view = ReviewDiffSurfaceView(presentation: presentation)
         let coordinator = context.coordinator
         view.onToggleFile = { coordinator.onToggleFile($0) }
         view.onToggleViewed = { coordinator.onToggleViewed($0) }
         view.onLinePress = { coordinator.onLinePress($0) }
         view.onPullToRefresh = { coordinator.onRefresh() }
+        view.onVisibleRowRangeChange = { coordinator.onVisibleRowRangeChange?($0) }
         return view
     }
 
@@ -52,10 +77,16 @@ struct ReviewDiffSurface: UIViewRepresentable {
         coordinator.onToggleViewed = onToggleViewed
         coordinator.onLinePress = onLinePress
         coordinator.onRefresh = onRefresh
+        coordinator.onVisibleRowRangeChange = onVisibleRowRangeChange
 
         if coordinator.appliedRowsVersion != rowsVersion {
             coordinator.appliedRowsVersion = rowsVersion
             view.setRows(rows)
+        }
+        if view.wrapsLines != wrapsLines { view.wrapsLines = wrapsLines }
+        if coordinator.appliedTokensVersion != tokensVersion {
+            coordinator.appliedTokensVersion = tokensVersion
+            view.tokensByRowID = tokensByRowID
         }
         view.setCollapsedFileIDs(collapsedFileIDs)
         if view.viewedFileIDs != viewedFileIDs { view.viewedFileIDs = viewedFileIDs }
@@ -64,7 +95,7 @@ struct ReviewDiffSurface: UIViewRepresentable {
 
         if let scrollTarget, coordinator.appliedScrollToken != scrollTarget.token {
             coordinator.appliedScrollToken = scrollTarget.token
-            view.scrollToFile(scrollTarget.fileID, animated: false)
+            view.scroll(to: scrollTarget.anchor, animated: false)
         }
     }
 }

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurfaceView.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurfaceView.swift
@@ -39,9 +39,23 @@ final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
         get { canvas.selectedRowIDs }
         set { canvas.selectedRowIDs = newValue }
     }
+    /// Toggling wrap changes row heights above the viewport, so the row at the top
+    /// is kept where it is drawn.
     var wrapsLines: Bool {
         get { canvas.wrapsLines }
-        set { canvas.wrapsLines = newValue }
+        set {
+            guard newValue != canvas.wrapsLines else { return }
+            let anchor = currentRowAnchor()
+            canvas.wrapsLines = newValue
+            restore(anchor)
+        }
+    }
+    /// Current scroll position; tests read it.
+    var verticalOffset: CGFloat { scrollView.contentOffset.y }
+
+    /// Vertical extent of a row in content coordinates.
+    func frame(forRowID rowID: String) -> (minY: CGFloat, height: CGFloat)? {
+        rows.firstIndex { $0.id == rowID }.flatMap { canvas.layout.frame(forRowAt: $0) }
     }
     var tokensByRowID: [String: [SourceHighlightRun]] {
         get { canvas.tokensByRowID }
@@ -153,6 +167,23 @@ final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
         setVerticalOffset(headerOffset - anchor.screenY, animated: false)
     }
 
+    private struct RowAnchor {
+        let rowIndex: Int
+        let screenY: CGFloat
+    }
+
+    private func currentRowAnchor() -> RowAnchor? {
+        let offset = scrollView.contentOffset.y
+        guard offset > 0.5, let rowIndex = canvas.layout.rowIndex(at: offset),
+              let frame = canvas.layout.frame(forRowAt: rowIndex) else { return nil }
+        return RowAnchor(rowIndex: rowIndex, screenY: frame.minY - offset)
+    }
+
+    private func restore(_ anchor: RowAnchor?) {
+        guard let anchor, let frame = canvas.layout.frame(forRowAt: anchor.rowIndex) else { return }
+        setVerticalOffset(frame.minY - anchor.screenY, animated: false)
+    }
+
     private func applyPendingScrollIfNeeded() {
         guard let anchor = pendingScroll, bounds.height > 0 else { return }
         let target: CGFloat?
@@ -160,9 +191,7 @@ final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
         case .fileHeader(let fileID):
             target = canvas.layout.fileHeaderOffset(forFileID: fileID)
         case .row(let rowID):
-            target = rows.firstIndex { $0.id == rowID }
-                .flatMap { canvas.layout.frame(forRowAt: $0) }
-                .map { $0.minY - max(0, (bounds.height - $0.height) * 0.3) }
+            target = frame(forRowID: rowID).map { $0.minY - max(0, (bounds.height - $0.height) * 0.3) }
         }
         guard let target else {
             if !rows.isEmpty { pendingScroll = nil }

--- a/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurfaceView.swift
+++ b/HermesMobile/Features/Workspace/ReviewDiff/ReviewDiffSurfaceView.swift
@@ -6,12 +6,16 @@ import UIKit
 /// keeps the file under the reader still when rows above it change height.
 final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
     private let scrollView = UIScrollView()
-    private let canvas = ReviewDiffCanvasView()
+    private let canvas: ReviewDiffCanvasView
     private let refreshControl = UIRefreshControl()
-    private var pendingScrollFileID: String?
+    private var pendingScroll: ReviewDiffScrollTarget.Anchor?
     private var pendingScrollAnimated = false
+    private var reportedVisibleRowRange: ClosedRange<Int>?
 
     var onPullToRefresh: (() -> Void)?
+    /// Rows intersecting the viewport changed; the host uses it to highlight only
+    /// what is on screen.
+    var onVisibleRowRangeChange: ((ClosedRange<Int>?) -> Void)?
     var onToggleFile: ((String) -> Void)? {
         get { canvas.onToggleFile }
         set { canvas.onToggleFile = newValue }
@@ -35,9 +39,18 @@ final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
         get { canvas.selectedRowIDs }
         set { canvas.selectedRowIDs = newValue }
     }
+    var wrapsLines: Bool {
+        get { canvas.wrapsLines }
+        set { canvas.wrapsLines = newValue }
+    }
+    var tokensByRowID: [String: [SourceHighlightRun]] {
+        get { canvas.tokensByRowID }
+        set { canvas.tokensByRowID = newValue }
+    }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(presentation: ReviewDiffPresentation = .diff) {
+        canvas = ReviewDiffCanvasView(frame: .zero, presentation: presentation)
+        super.init(frame: .zero)
         clipsToBounds = true
         backgroundColor = canvas.theme.background
 
@@ -93,10 +106,16 @@ final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
         restore(anchor)
     }
 
-    func scrollToFile(_ fileID: String, animated: Bool) {
-        pendingScrollFileID = fileID
+    /// A file header lands at the top; a row lands 30 % down the viewport so the
+    /// reader sees what leads into it. Applied once the layout can place it.
+    func scroll(to anchor: ReviewDiffScrollTarget.Anchor, animated: Bool) {
+        pendingScroll = anchor
         pendingScrollAnimated = animated
         applyPendingScrollIfNeeded()
+    }
+
+    func scrollToFile(_ fileID: String, animated: Bool) {
+        scroll(to: .fileHeader(fileID), animated: animated)
     }
 
     /// The host owns the spinner: it stays until the reload finishes, not until the
@@ -135,13 +154,22 @@ final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
     }
 
     private func applyPendingScrollIfNeeded() {
-        guard let fileID = pendingScrollFileID, bounds.height > 0 else { return }
-        guard let headerOffset = canvas.layout.fileHeaderOffset(forFileID: fileID) else {
-            if !rows.isEmpty { pendingScrollFileID = nil }
+        guard let anchor = pendingScroll, bounds.height > 0 else { return }
+        let target: CGFloat?
+        switch anchor {
+        case .fileHeader(let fileID):
+            target = canvas.layout.fileHeaderOffset(forFileID: fileID)
+        case .row(let rowID):
+            target = rows.firstIndex { $0.id == rowID }
+                .flatMap { canvas.layout.frame(forRowAt: $0) }
+                .map { $0.minY - max(0, (bounds.height - $0.height) * 0.3) }
+        }
+        guard let target else {
+            if !rows.isEmpty { pendingScroll = nil }
             return
         }
-        pendingScrollFileID = nil
-        setVerticalOffset(headerOffset, animated: pendingScrollAnimated)
+        pendingScroll = nil
+        setVerticalOffset(target, animated: pendingScrollAnimated)
     }
 
     private func setVerticalOffset(_ target: CGFloat, animated: Bool) {
@@ -175,6 +203,15 @@ final class ReviewDiffSurfaceView: UIView, UIScrollViewDelegate {
         )
         canvas.verticalOffset = scrollView.contentOffset.y
         canvas.setNeedsDisplay()
+        reportVisibleRowRangeIfChanged()
+    }
+
+    private func reportVisibleRowRangeIfChanged() {
+        let offset = scrollView.contentOffset.y
+        let range = canvas.layout.rowRange(intersecting: max(0, offset), offset + bounds.height)
+        guard range != reportedVisibleRowRange else { return }
+        reportedVisibleRowRange = range
+        onVisibleRowRangeChange?(range)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/HermesMobile/Features/Workspace/SourceViewer/SourceFileRows.swift
+++ b/HermesMobile/Features/Workspace/SourceViewer/SourceFileRows.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Turns file text into the flat rows the review surface draws: one context row per
+/// line, numbered from one, tabs expanded to four spaces so the character grid holds.
+enum SourceFileRows {
+    static let fileID = "source"
+
+    static func rowID(forLineIndex index: Int) -> String {
+        "source:line:\(index)"
+    }
+
+    /// Lines as they will be drawn. A trailing newline does not add an empty last line.
+    static func lines(in content: String) -> [String] {
+        var lines = content.components(separatedBy: "\n").map { line -> String in
+            var line = line.replacingOccurrences(of: "\t", with: "    ")
+            if line.hasSuffix("\r") { line.removeLast() }
+            return line
+        }
+        if lines.count > 1, lines.last?.isEmpty == true { lines.removeLast() }
+        return lines
+    }
+
+    static func rows(for lines: [String]) -> [ReviewDiffRow] {
+        lines.enumerated().map { index, line in
+            ReviewDiffRow(
+                id: rowID(forLineIndex: index),
+                fileID: fileID,
+                kind: .line(ReviewDiffLine(content: line, change: .context, oldLineNumber: nil, newLineNumber: index + 1))
+            )
+        }
+    }
+}

--- a/HermesMobile/Features/Workspace/SourceViewer/SourceFileSurface.swift
+++ b/HermesMobile/Features/Workspace/SourceViewer/SourceFileSurface.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import UIKit
+
+/// A workspace file on the review surface: line gutter, optional wrap, syntax colour
+/// for the rows on screen, tap-to-select with Copy, and an initial line placed 30 %
+/// down the viewport and highlighted.
+struct SourceFileSurface: View {
+    static let wrapsLinesKey = "workspace.sourceViewer.wrapsLines"
+
+    let content: String
+    let targetLine: Int?
+    let isRefreshing: Bool
+    let onRefresh: () -> Void
+
+    @State private var viewModel: SourceFileViewModel
+    @State private var selection = ReviewDiffSelection()
+    @State private var scrollTarget: ReviewDiffScrollTarget?
+    @AppStorage(SourceFileSurface.wrapsLinesKey) private var wrapsLines = false
+    @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(
+        content: String,
+        path: String,
+        serverLanguage: String?,
+        targetLine: Int? = nil,
+        isRefreshing: Bool = false,
+        onRefresh: @escaping () -> Void = {}
+    ) {
+        self.content = content
+        self.targetLine = targetLine
+        self.isRefreshing = isRefreshing
+        self.onRefresh = onRefresh
+        _viewModel = State(initialValue: SourceFileViewModel(path: path, serverLanguage: serverLanguage))
+    }
+
+    private var selectedRowIDs: Set<String> { selection.selectedRowIDs(in: viewModel.rows) }
+
+    var body: some View {
+        ReviewDiffSurface(
+            rows: viewModel.rows,
+            rowsVersion: viewModel.rowsVersion,
+            collapsedFileIDs: [],
+            viewedFileIDs: [],
+            selectedRowIDs: selectedRowIDs,
+            isRefreshing: isRefreshing,
+            scrollTarget: scrollTarget,
+            presentation: .source,
+            wrapsLines: wrapsLines,
+            tokensByRowID: viewModel.tokensByRowID,
+            tokensVersion: viewModel.tokensVersion,
+            onVisibleRowRangeChange: { viewModel.visibleRowRangeChanged($0) },
+            onToggleFile: { _ in },
+            onToggleViewed: { _ in },
+            onLinePress: handleLinePress,
+            onRefresh: onRefresh
+        )
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if viewModel.isPlainText { plainTextChip }
+        }
+        .safeAreaInset(edge: .bottom) {
+            let selected = selectedRowIDs
+            if !selected.isEmpty { selectionBar(count: selected.count) }
+        }
+        .task(id: content) {
+            await viewModel.load(content: content)
+            seedTargetLineIfNeeded()
+        }
+        .onChange(of: colorScheme, initial: true) {
+            viewModel.setColorScheme(isDark: colorScheme == .dark)
+        }
+    }
+
+    /// Quiet notice that this file has no syntax colour; sits in the surface's top inset.
+    private var plainTextChip: some View {
+        HStack {
+            Spacer()
+            Text("Plain text")
+                .font(AppFont.caption2(weight: .medium))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .background(Color(.secondarySystemBackground))
+    }
+
+    private func selectionBar(count: Int) -> some View {
+        HStack(spacing: 12) {
+            Text(count == 1 ? String(localized: "1 line selected") : String(localized: "\(count) lines selected"))
+                .font(AppFont.footnote(weight: .semibold))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            Button("Clear") { selection.clear() }
+                .font(AppFont.footnote())
+            // A label-coloured pill needs a background-coloured title, or dark mode
+            // draws white on white.
+            Button(action: copySelection) {
+                Text("Copy")
+                    .font(AppFont.footnote(weight: .semibold))
+                    .foregroundStyle(Color(.systemBackground))
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .tint(.primary)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.bar)
+        .accessibilityElement(children: .contain)
+    }
+
+    /// The requested line is selected and scrolled to once, when the rows first exist.
+    private func seedTargetLineIfNeeded() {
+        guard let targetLine, scrollTarget == nil, selection.isEmpty,
+              targetLine >= 1, targetLine <= viewModel.rows.count else { return }
+        let rowID = SourceFileRows.rowID(forLineIndex: targetLine - 1)
+        selection.tap(rowID: rowID, fileID: SourceFileRows.fileID)
+        scrollTarget = ReviewDiffScrollTarget(anchor: .row(rowID), token: UUID())
+    }
+
+    private func handleLinePress(_ press: ReviewDiffLinePress) {
+        switch press.gesture {
+        case .tap: selection.tap(rowID: press.rowID, fileID: press.fileID)
+        case .longPress: selection.longPress(rowID: press.rowID, fileID: press.fileID)
+        }
+        ChatHaptics.diffLineSelected(isEnabled: isHapticsEnabled)
+    }
+
+    private func copySelection() {
+        let text = selection.selectedRows(in: viewModel.rows).compactMap { $0.line?.content }.joined(separator: "\n")
+        guard !text.isEmpty else { return }
+        UIPasteboard.general.string = text
+        ChatHaptics.copied(isEnabled: isHapticsEnabled)
+        selection.clear()
+    }
+}

--- a/HermesMobile/Features/Workspace/SourceViewer/SourceFileSurface.swift
+++ b/HermesMobile/Features/Workspace/SourceViewer/SourceFileSurface.swift
@@ -126,10 +126,11 @@ struct SourceFileSurface: View {
         ChatHaptics.diffLineSelected(isEnabled: isHapticsEnabled)
     }
 
+    /// Copies the selected lines, blank ones included, so a selection always answers.
     private func copySelection() {
-        let text = selection.selectedRows(in: viewModel.rows).compactMap { $0.line?.content }.joined(separator: "\n")
-        guard !text.isEmpty else { return }
-        UIPasteboard.general.string = text
+        let selected = selection.selectedRows(in: viewModel.rows)
+        guard !selected.isEmpty else { return }
+        UIPasteboard.general.string = selected.compactMap { $0.line?.content }.joined(separator: "\n")
         ChatHaptics.copied(isEnabled: isHapticsEnabled)
         selection.clear()
     }

--- a/HermesMobile/Features/Workspace/SourceViewer/SourceFileViewModel.swift
+++ b/HermesMobile/Features/Workspace/SourceViewer/SourceFileViewModel.swift
@@ -2,9 +2,9 @@ import Foundation
 import OSLog
 
 /// Rows and syntax colour for one workspace file. Rows build off the main actor;
-/// colour arrives per visible window from `SourceHighlighter`, a row is never
-/// tokenized twice, and a new window is requested only once the viewport has moved
-/// twenty rows past the last request.
+/// colour arrives per visible window from `SourceHighlighter`, one contiguous
+/// uncoloured run at a time so a row is never tokenized twice, and a new window is
+/// requested only once the viewport has moved twenty rows past the last request.
 @MainActor
 @Observable
 final class SourceFileViewModel {
@@ -31,7 +31,6 @@ final class SourceFileViewModel {
     /// Bumped whenever colour must start over (new rows, new appearance); a
     /// highlight result from an older generation is dropped.
     private var highlightGeneration = 0
-    private var needsAnotherPass = false
     /// The request in flight, if any; tests await it.
     private(set) var highlightTask: Task<Void, Never>?
 
@@ -54,7 +53,7 @@ final class SourceFileViewModel {
             reviewDiffSignposter.endInterval("BuildSourceRows", state, "rows=\(rows.count)")
             return (lines, rows)
         }.value
-        guard buildGeneration == loadGeneration else { return }
+        guard buildGeneration == loadGeneration, !Task.isCancelled else { return }
         lines = built.0
         rows = built.1
         rowsVersion += 1
@@ -86,23 +85,23 @@ final class SourceFileViewModel {
         tokensVersion += 1
         highlightedLines = Array(repeating: false, count: lines.count)
         requestedRange = nil
-        needsAnotherPass = false
         requestHighlight()
     }
 
     private func requestHighlight() {
         guard let language, let visibleRange, !lines.isEmpty else { return }
         requestedRange = visibleRange
-        if highlightTask != nil {
-            needsAnotherPass = true
-            return
-        }
+        // One request at a time; the answer re-runs this for whatever is still uncoloured.
+        guard highlightTask == nil else { return }
 
+        // The first uncoloured run inside the padded window. Rows already coloured
+        // (an earlier window the reader scrolled past) are never sent again.
         var lower = max(0, visibleRange.lowerBound - Self.highlightOverscan)
-        var upper = min(lines.count - 1, visibleRange.upperBound + Self.highlightOverscan)
-        while lower <= upper, highlightedLines[lower] { lower += 1 }
-        while upper >= lower, highlightedLines[upper] { upper -= 1 }
-        guard lower <= upper else { return }
+        let windowEnd = min(lines.count - 1, visibleRange.upperBound + Self.highlightOverscan)
+        while lower <= windowEnd, highlightedLines[lower] { lower += 1 }
+        guard lower <= windowEnd else { return }
+        var upper = lower
+        while upper < windowEnd, !highlightedLines[upper + 1] { upper += 1 }
 
         let slice = Array(lines[lower...upper])
         let requestGeneration = highlightGeneration
@@ -115,12 +114,8 @@ final class SourceFileViewModel {
 
     private func finishHighlight(_ result: [[SourceHighlightRun]]?, range: ClosedRange<Int>, generation: Int) {
         highlightTask = nil
-        defer {
-            if needsAnotherPass {
-                needsAnotherPass = false
-                requestHighlight()
-            }
-        }
+        // Whatever the viewport shows now (it may have moved mid-request) gets the next pass.
+        defer { requestHighlight() }
         guard generation == highlightGeneration else { return }
         guard let result else {
             language = nil

--- a/HermesMobile/Features/Workspace/SourceViewer/SourceFileViewModel.swift
+++ b/HermesMobile/Features/Workspace/SourceViewer/SourceFileViewModel.swift
@@ -1,0 +1,139 @@
+import Foundation
+import OSLog
+
+/// Rows and syntax colour for one workspace file. Rows build off the main actor;
+/// colour arrives per visible window from `SourceHighlighter`, a row is never
+/// tokenized twice, and a new window is requested only once the viewport has moved
+/// twenty rows past the last request.
+@MainActor
+@Observable
+final class SourceFileViewModel {
+    private(set) var rows: [ReviewDiffRow] = []
+    private(set) var rowsVersion = 0
+    private(set) var tokensByRowID: [String: [SourceHighlightRun]] = [:]
+    private(set) var tokensVersion = 0
+    /// True when this file draws without colour: no grammar, or Highlightr gave up.
+    private(set) var isPlainText: Bool
+
+    /// Rows either side of the viewport tokenized along with it.
+    static let highlightOverscan = 40
+    static let rerequestThreshold = 20
+
+    private let highlighter: SourceHighlighter
+    private var language: String?
+    private var lines: [String] = []
+    private var highlightedLines: [Bool] = []
+    private var visibleRange: ClosedRange<Int>?
+    private var requestedRange: ClosedRange<Int>?
+    private var isDark = false
+    /// Bumped per `load`; a slower, older build never replaces newer rows.
+    private var loadGeneration = 0
+    /// Bumped whenever colour must start over (new rows, new appearance); a
+    /// highlight result from an older generation is dropped.
+    private var highlightGeneration = 0
+    private var needsAnotherPass = false
+    /// The request in flight, if any; tests await it.
+    private(set) var highlightTask: Task<Void, Never>?
+
+    init(path: String, serverLanguage: String?, highlighter: SourceHighlighter = .shared) {
+        self.highlighter = highlighter
+        let language = SourceHighlightLanguage.resolve(path: path, serverLanguage: serverLanguage)
+        self.language = language
+        isPlainText = language == nil
+    }
+
+    /// Replaces the file text. Rows build off the main actor; an older build that
+    /// lands after a newer one is dropped.
+    func load(content: String) async {
+        loadGeneration += 1
+        let buildGeneration = loadGeneration
+        let built = await Task.detached(priority: .userInitiated) {
+            let state = reviewDiffSignposter.beginInterval("BuildSourceRows")
+            let lines = SourceFileRows.lines(in: content)
+            let rows = SourceFileRows.rows(for: lines)
+            reviewDiffSignposter.endInterval("BuildSourceRows", state, "rows=\(rows.count)")
+            return (lines, rows)
+        }.value
+        guard buildGeneration == loadGeneration else { return }
+        lines = built.0
+        rows = built.1
+        rowsVersion += 1
+        resetHighlighting()
+    }
+
+    func setColorScheme(isDark: Bool) {
+        guard isDark != self.isDark else { return }
+        self.isDark = isDark
+        resetHighlighting()
+    }
+
+    /// Called by the surface as the viewport moves. Only bookkeeping the view does
+    /// not observe changes synchronously, so a report made mid-layout is safe.
+    func visibleRowRangeChanged(_ range: ClosedRange<Int>?) {
+        visibleRange = range
+        guard let range, language != nil else { return }
+        if let requestedRange,
+           abs(range.lowerBound - requestedRange.lowerBound) + abs(range.upperBound - requestedRange.upperBound)
+               < Self.rerequestThreshold {
+            return
+        }
+        requestHighlight()
+    }
+
+    private func resetHighlighting() {
+        highlightGeneration += 1
+        tokensByRowID = [:]
+        tokensVersion += 1
+        highlightedLines = Array(repeating: false, count: lines.count)
+        requestedRange = nil
+        needsAnotherPass = false
+        requestHighlight()
+    }
+
+    private func requestHighlight() {
+        guard let language, let visibleRange, !lines.isEmpty else { return }
+        requestedRange = visibleRange
+        if highlightTask != nil {
+            needsAnotherPass = true
+            return
+        }
+
+        var lower = max(0, visibleRange.lowerBound - Self.highlightOverscan)
+        var upper = min(lines.count - 1, visibleRange.upperBound + Self.highlightOverscan)
+        while lower <= upper, highlightedLines[lower] { lower += 1 }
+        while upper >= lower, highlightedLines[upper] { upper -= 1 }
+        guard lower <= upper else { return }
+
+        let slice = Array(lines[lower...upper])
+        let requestGeneration = highlightGeneration
+        let isDark = isDark
+        highlightTask = Task {
+            let result = await highlighter.highlight(lines: slice, language: language, isDark: isDark)
+            finishHighlight(result, range: lower...upper, generation: requestGeneration)
+        }
+    }
+
+    private func finishHighlight(_ result: [[SourceHighlightRun]]?, range: ClosedRange<Int>, generation: Int) {
+        highlightTask = nil
+        defer {
+            if needsAnotherPass {
+                needsAnotherPass = false
+                requestHighlight()
+            }
+        }
+        guard generation == highlightGeneration else { return }
+        guard let result else {
+            language = nil
+            isPlainText = true
+            return
+        }
+        for (offset, runs) in result.enumerated() {
+            let index = range.lowerBound + offset
+            highlightedLines[index] = true
+            if !runs.isEmpty {
+                tokensByRowID[SourceFileRows.rowID(forLineIndex: index)] = runs
+            }
+        }
+        tokensVersion += 1
+    }
+}

--- a/HermesMobile/Features/Workspace/SourceViewer/SourceHighlighter.swift
+++ b/HermesMobile/Features/Workspace/SourceViewer/SourceHighlighter.swift
@@ -1,0 +1,107 @@
+import Highlightr
+import UIKit
+
+/// One syntax colour run inside a row's text, in UTF-16 units of the row content.
+struct SourceHighlightRun: Equatable {
+    let range: NSRange
+    let color: UIColor
+}
+
+/// Which Highlightr grammar, if any, a workspace file gets.
+enum SourceHighlightLanguage {
+    /// Extensions Markdown fences never use, mapped onto grammar names.
+    private static let extensionAliases: [String: String] = [
+        "bash": "bash",
+        "cc": "cpp",
+        "cjs": "javascript",
+        "cxx": "cpp",
+        "h": "c",
+        "hpp": "cpp",
+        "mjs": "javascript",
+        "plist": "xml"
+    ]
+
+    /// The chat renderer's Highlightr list plus Swift, which it routes to Splash instead.
+    static let supported: Set<String> = MarkdownHighlightPolicy.highlightrLanguages.union(["swift"])
+
+    /// The server's `language` wins when Highlightr knows it; the path extension is the fallback.
+    static func resolve(path: String, serverLanguage: String?) -> String? {
+        let candidates = [serverLanguage, (path as NSString).pathExtension].compactMap { $0 }
+        for candidate in candidates {
+            let lowered = candidate.lowercased()
+            let normalized = extensionAliases[lowered] ?? MarkdownHighlightPolicy.normalizedLanguage(from: lowered)
+            if let normalized, supported.contains(normalized) { return normalized }
+        }
+        return nil
+    }
+}
+
+/// Runs Highlightr off the main actor. One request colours a contiguous slice of
+/// lines; the caller keeps the runs per row and asks only for rows on screen.
+actor SourceHighlighter {
+    static let shared = SourceHighlighter()
+    /// Lines longer than this are blanked before tokenizing; they draw plain.
+    static let maxLineLength = 1_000
+
+    private var highlightrsByAppearance: [Bool: Highlightr] = [:]
+
+    /// Colour runs per line, or nil when Highlightr is unavailable, rejects the
+    /// language, or hands back text that no longer matches the input.
+    func highlight(lines: [String], language: String, isDark: Bool) -> [[SourceHighlightRun]]? {
+        guard let highlightr = highlightr(isDark: isDark) else { return nil }
+        let source = lines.map { $0.count > Self.maxLineLength ? "" : $0 }
+        let joined = source.joined(separator: "\n")
+        guard let attributed = highlightr.highlight(joined, as: language, fastRender: true),
+              attributed.string == joined else { return nil }
+        return Self.runsByLine(in: attributed, lineCount: lines.count)
+    }
+
+    private func highlightr(isDark: Bool) -> Highlightr? {
+        if let cached = highlightrsByAppearance[isDark] { return cached }
+        guard let highlightr = Highlightr() else { return nil }
+        highlightr.setTheme(to: isDark ? "github-dark" : "xcode")
+        highlightrsByAppearance[isDark] = highlightr
+        return highlightr
+    }
+
+    /// Splits whole-string foreground colour runs into per-line runs with line-local
+    /// offsets. Text Highlightr left uncoloured has no run and draws in the label colour.
+    static func runsByLine(in attributed: NSAttributedString, lineCount: Int) -> [[SourceHighlightRun]] {
+        var runs = Array(repeating: [SourceHighlightRun](), count: lineCount)
+        let string = attributed.string as NSString
+        var colorRuns: [(range: NSRange, color: UIColor)] = []
+        attributed.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: string.length)) { value, range, _ in
+            if let color = value as? UIColor { colorRuns.append((range, color)) }
+        }
+
+        var lineStart = 0
+        var runCursor = 0
+        for lineIndex in 0..<lineCount {
+            guard lineStart <= string.length else { break }
+            let remaining = NSRange(location: lineStart, length: string.length - lineStart)
+            let newline = string.range(of: "\n", options: [], range: remaining)
+            let lineEnd = newline.location == NSNotFound ? string.length : newline.location
+            let lineRange = NSRange(location: lineStart, length: lineEnd - lineStart)
+
+            while runCursor < colorRuns.count, NSMaxRange(colorRuns[runCursor].range) <= lineStart {
+                runCursor += 1
+            }
+            var index = runCursor
+            while index < colorRuns.count, colorRuns[index].range.location < lineEnd {
+                let overlap = NSIntersectionRange(colorRuns[index].range, lineRange)
+                if overlap.length > 0 {
+                    runs[lineIndex].append(
+                        SourceHighlightRun(
+                            range: NSRange(location: overlap.location - lineStart, length: overlap.length),
+                            color: colorRuns[index].color
+                        )
+                    )
+                }
+                index += 1
+            }
+            guard newline.location != NSNotFound else { break }
+            lineStart = lineEnd + 1
+        }
+        return runs
+    }
+}

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -129572,6 +129572,324 @@
           }
         }
       }
+    },
+    "Plain text" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "نص عادي"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nur Text"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Texto sin formato"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Texte brut"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "טקסט רגיל"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Testo semplice"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "プレーンテキスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "일반 텍스트"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Platte tekst"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zwykły tekst"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Texto simples"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Обычный текст"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Düz metin"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "سادہ متن"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "純文字"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "纯文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "純文字"
+          }
+        }
+      }
+    },
+    "Wrap Lines" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "التفاف الأسطر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zeilen umbrechen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajustar líneas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Renvoyer les lignes"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "גלישת שורות"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vai a capo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行を折り返す"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "줄 바꿈"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Regels afbreken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zawijaj wiersze"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Quebrar linhas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Переносить строки"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Satırları kaydır"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لائنیں لپیٹیں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自動換行"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自动换行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自動換行"
+          }
+        }
+      }
+    },
+    "File actions" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "إجراءات الملف"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dateiaktionen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Acciones del archivo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Actions du fichier"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "פעולות קובץ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Azioni file"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ファイル操作"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "파일 동작"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bestandsacties"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Działania na pliku"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ações do arquivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Действия с файлом"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dosya işlemleri"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فائل کی کارروائیاں"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "檔案操作"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "文件操作"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "檔案操作"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ReviewDiffCanvasViewTests.swift
+++ b/HermesMobileTests/ReviewDiffCanvasViewTests.swift
@@ -41,6 +41,54 @@ final class ReviewDiffCanvasViewTests: XCTestCase {
         XCTAssertEqual(canvas.index(ofAccessibilityElement: element), NSNotFound)
     }
 
+    func testWrappingDisablesHorizontalPan() {
+        let long = ReviewDiffRow(
+            id: "s:0",
+            fileID: "s",
+            kind: .line(ReviewDiffLine(content: String(repeating: "x", count: 400), change: .context, oldLineNumber: nil, newLineNumber: 1))
+        )
+        let canvas = ReviewDiffCanvasView(frame: CGRect(x: 0, y: 0, width: 390, height: 300), presentation: .source)
+        canvas.viewportWidth = 390
+        canvas.setRows([long])
+        XCTAssertGreaterThan(canvas.maxHorizontalOffset(for: "s", kind: .code), 0)
+        XCTAssertEqual(canvas.style.changeBarWidth, 0, "Source files have no change bar.")
+
+        canvas.wrapsLines = true
+        XCTAssertEqual(canvas.maxHorizontalOffset(for: "s", kind: .code), 0)
+        XCTAssertGreaterThan(canvas.layout.visualLineCount(forRowAt: 0), 1)
+    }
+
+    /// Toggling wrap grows the rows above the viewport; the row at the top must stay put.
+    func testWrapToggleKeepsTheTopRowWhereItIs() throws {
+        let rows = (0..<60).map { index in
+            ReviewDiffRow(
+                id: "s:\(index)",
+                fileID: "s",
+                kind: .line(ReviewDiffLine(content: String(repeating: "x", count: 200), change: .context, oldLineNumber: nil, newLineNumber: index + 1))
+            )
+        }
+        let view = ReviewDiffSurfaceView(presentation: .source)
+        view.frame = CGRect(x: 0, y: 0, width: 390, height: 300)
+        view.layoutIfNeeded()
+        view.setRows(rows)
+        view.scroll(to: .row("s:30"), animated: false)
+        let before = view.verticalOffset
+        XCTAssertGreaterThan(before, 0)
+        // The row under the top edge is the one that must not move.
+        let topRow = try XCTUnwrap(view.rows.first { row in
+            guard let frame = view.frame(forRowID: row.id) else { return false }
+            return frame.minY <= before && before < frame.minY + frame.height
+        })
+        XCTAssertNotEqual(topRow.id, "s:30", "The target sits 30 % down, so the top row is above it.")
+        let screenYBefore = try XCTUnwrap(view.frame(forRowID: topRow.id)).minY - before
+
+        view.wrapsLines = true
+
+        XCTAssertGreaterThan(view.verticalOffset, before, "Wrapped rows above pushed the content down.")
+        let screenYAfter = try XCTUnwrap(view.frame(forRowID: topRow.id)).minY - view.verticalOffset
+        XCTAssertEqual(screenYAfter, screenYBefore, accuracy: 0.5)
+    }
+
     func testStickyHeaderReportsItsPinnedFrame() {
         let rows = [header("a")] + (0..<40).map { line("a", $0) } + [header("b")] + (0..<5).map { line("b", $0) }
         let canvas = makeCanvas(rows: rows)

--- a/HermesMobileTests/ReviewDiffLayoutTests.swift
+++ b/HermesMobileTests/ReviewDiffLayoutTests.swift
@@ -80,3 +80,28 @@ final class ReviewDiffLayoutTests: XCTestCase {
         XCTAssertNil(ReviewDiffLayout(rows: [], collapsedFileIDs: [], metrics: metrics).visibleFileID(atVerticalOffset: 0))
     }
 }
+
+extension ReviewDiffLayoutTests {
+    func testWrappedRowsGrowByVisualLineAndCapTheContentWidth() {
+        let metrics = ReviewDiffMetrics(rowHeight: 20, fileHeaderHeight: 50, noticeHeight: 44, wrappedLineHeight: 14)
+        let rows = [
+            ReviewDiffRow(id: "s:0", fileID: "s", kind: .line(ReviewDiffLine(content: String(repeating: "x", count: 25), change: .context, oldLineNumber: nil, newLineNumber: 1))),
+            ReviewDiffRow(id: "s:1", fileID: "s", kind: .line(ReviewDiffLine(content: "short", change: .context, oldLineNumber: nil, newLineNumber: 2))),
+            ReviewDiffRow(id: "s:2", fileID: "s", kind: .line(ReviewDiffLine(content: String(repeating: "y", count: 20), change: .context, oldLineNumber: nil, newLineNumber: 3)))
+        ]
+
+        let wrapped = ReviewDiffLayout(rows: rows, collapsedFileIDs: [], metrics: metrics, wrapColumns: 10)
+        XCTAssertEqual(wrapped.visualLineCount(forRowAt: 0), 3)
+        XCTAssertEqual(wrapped.visualLineCount(forRowAt: 1), 1)
+        XCTAssertEqual(wrapped.visualLineCount(forRowAt: 2), 2, "An exact multiple does not add an empty visual line.")
+        XCTAssertEqual(wrapped.rowOffsets, [0, 48, 68])
+        XCTAssertEqual(wrapped.contentHeight, 102)
+        XCTAssertEqual(wrapped.maxColumnCountsByFileID, ["s": 10], "Wrapped files never pan wider than one visual line.")
+        XCTAssertEqual(wrapped.rowIndex(at: 47), 0)
+        XCTAssertEqual(wrapped.rowIndex(at: 48), 1)
+
+        let unwrapped = ReviewDiffLayout(rows: rows, collapsedFileIDs: [], metrics: metrics)
+        XCTAssertEqual(unwrapped.rowOffsets, [0, 20, 40])
+        XCTAssertEqual(unwrapped.maxColumnCountsByFileID, ["s": 25])
+    }
+}

--- a/HermesMobileTests/SourceFileRowsTests.swift
+++ b/HermesMobileTests/SourceFileRowsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import HermesMobile
+
+final class SourceFileRowsTests: XCTestCase {
+    func testLinesDropTheTrailingNewlineStripCarriageReturnsAndExpandTabs() {
+        XCTAssertEqual(SourceFileRows.lines(in: "a\n\tb\r\nc\n"), ["a", "    b", "c"])
+        XCTAssertEqual(SourceFileRows.lines(in: ""), [""], "An empty file is one blank line, not none.")
+        XCTAssertEqual(SourceFileRows.lines(in: "\n"), [""], "A lone newline is one blank line.")
+        XCTAssertEqual(SourceFileRows.lines(in: "a\n\n"), ["a", ""], "Only the final newline is dropped.")
+    }
+
+    func testRowsAreContextLinesNumberedFromOneWithStableIDs() throws {
+        let rows = SourceFileRows.rows(for: ["let x = 1", ""])
+        XCTAssertEqual(rows.map(\.id), ["source:line:0", "source:line:1"])
+        XCTAssertEqual(Set(rows.map(\.fileID)), [SourceFileRows.fileID])
+        let first = try XCTUnwrap(rows[0].line)
+        XCTAssertEqual(first.content, "let x = 1")
+        XCTAssertEqual(first.change, .context)
+        XCTAssertEqual(first.displayLineNumber, 1)
+        XCTAssertEqual(rows[1].line?.displayLineNumber, 2)
+        XCTAssertTrue(first.wordDiffRanges.isEmpty)
+    }
+}

--- a/HermesMobileTests/SourceFileViewModelTests.swift
+++ b/HermesMobileTests/SourceFileViewModelTests.swift
@@ -59,6 +59,30 @@ final class SourceFileViewModelTests: XCTestCase {
         XCTAssertGreaterThan(model.tokensVersion, version)
     }
 
+    /// A coloured island inside a later window is skipped: the request covers the
+    /// uncoloured run before it, then the run after it, never the island itself.
+    func testHighlightedIslandInsideAWindowIsNotSentAgain() async {
+        let model = await loadedModel(lineCount: 400)
+        model.visibleRowRangeChanged(100...100)
+        await model.highlightTask?.value
+        XCTAssertNotNil(model.tokensByRowID["source:line:60"])
+        XCTAssertNotNil(model.tokensByRowID["source:line:140"])
+        let islandRun = model.tokensByRowID["source:line:100"]
+
+        model.visibleRowRangeChanged(50...200)
+        var passes = 0
+        while let task = model.highlightTask {
+            await task.value
+            passes += 1
+        }
+
+        XCTAssertEqual(passes, 2, "One pass below the island, one above it.")
+        XCTAssertNotNil(model.tokensByRowID["source:line:10"])
+        XCTAssertNotNil(model.tokensByRowID["source:line:240"])
+        XCTAssertNil(model.tokensByRowID["source:line:241"])
+        XCTAssertEqual(model.tokensByRowID["source:line:100"], islandRun, "The island keeps its first colouring.")
+    }
+
     func testAppearanceChangeDropsColourAndRecoloursTheViewport() async {
         let model = await loadedModel(lineCount: 50)
         model.visibleRowRangeChanged(0...10)

--- a/HermesMobileTests/SourceFileViewModelTests.swift
+++ b/HermesMobileTests/SourceFileViewModelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import HermesMobile
+
+@MainActor
+final class SourceFileViewModelTests: XCTestCase {
+    private func loadedModel(lineCount: Int, path: String = "data.json") async -> SourceFileViewModel {
+        let model = SourceFileViewModel(path: path, serverLanguage: nil, highlighter: SourceHighlighter())
+        let content = (0..<lineCount).map { "{\"n\": \($0)}" }.joined(separator: "\n")
+        await model.load(content: content)
+        return model
+    }
+
+    func testLoadBuildsOneRowPerLineAndKeepsPlainTextOff() async {
+        let model = await loadedModel(lineCount: 10_000)
+        XCTAssertEqual(model.rows.count, 10_000)
+        XCTAssertEqual(model.rowsVersion, 1)
+        XCTAssertFalse(model.isPlainText)
+        XCTAssertTrue(model.tokensByRowID.isEmpty, "Nothing is coloured before the viewport reports itself.")
+    }
+
+    /// Dark mode reports its appearance during the first body pass, while the rows
+    /// are still building off the main actor. That must not discard the rows.
+    func testAppearanceChangeDuringLoadKeepsTheRows() async {
+        let model = SourceFileViewModel(path: "a.json", serverLanguage: nil, highlighter: SourceHighlighter())
+        let load = Task { await model.load(content: "{}\n{}\n{}") }
+        model.setColorScheme(isDark: true)
+        await load.value
+
+        XCTAssertEqual(model.rows.count, 3)
+    }
+
+    func testUnsupportedFileIsPlainTextAndNeverRequestsHighlighting() async {
+        let model = await loadedModel(lineCount: 5, path: "notes.txt")
+        XCTAssertTrue(model.isPlainText)
+        model.visibleRowRangeChanged(0...4)
+        XCTAssertNil(model.highlightTask)
+    }
+
+    func testVisibleRowsAreColouredAndSmallScrollsDoNotReRequest() async throws {
+        let model = await loadedModel(lineCount: 500)
+
+        model.visibleRowRangeChanged(0...30)
+        await model.highlightTask?.value
+
+        XCTAssertNotNil(model.tokensByRowID["source:line:0"])
+        XCTAssertNotNil(model.tokensByRowID["source:line:70"], "Overscan colours rows just past the viewport.")
+        XCTAssertNil(model.tokensByRowID["source:line:71"])
+        XCTAssertNil(model.tokensByRowID["source:line:400"])
+        let version = model.tokensVersion
+
+        model.visibleRowRangeChanged(5...35)
+        XCTAssertNil(model.highlightTask, "Moving fewer than twenty rows keeps the last request.")
+        XCTAssertEqual(model.tokensVersion, version)
+
+        model.visibleRowRangeChanged(300...330)
+        await model.highlightTask?.value
+        XCTAssertNotNil(model.tokensByRowID["source:line:300"])
+        XCTAssertNotNil(model.tokensByRowID["source:line:0"], "Earlier colour survives later requests.")
+        XCTAssertGreaterThan(model.tokensVersion, version)
+    }
+
+    func testAppearanceChangeDropsColourAndRecoloursTheViewport() async {
+        let model = await loadedModel(lineCount: 50)
+        model.visibleRowRangeChanged(0...10)
+        await model.highlightTask?.value
+        let lightRun = model.tokensByRowID["source:line:0"]?.first
+
+        model.setColorScheme(isDark: true)
+        await model.highlightTask?.value
+
+        let darkRun = model.tokensByRowID["source:line:0"]?.first
+        XCTAssertNotNil(darkRun)
+        XCTAssertNotEqual(lightRun?.color, darkRun?.color, "Dark mode uses a different Highlightr theme.")
+    }
+}

--- a/HermesMobileTests/SourceHighlighterTests.swift
+++ b/HermesMobileTests/SourceHighlighterTests.swift
@@ -1,0 +1,48 @@
+import UIKit
+import XCTest
+@testable import HermesMobile
+
+final class SourceHighlighterTests: XCTestCase {
+    func testLanguageResolutionPrefersTheServerThenTheExtension() {
+        XCTAssertEqual(SourceHighlightLanguage.resolve(path: "a/b.swift", serverLanguage: nil), "swift")
+        XCTAssertEqual(SourceHighlightLanguage.resolve(path: "Podfile", serverLanguage: "ruby"), "ruby")
+        XCTAssertEqual(SourceHighlightLanguage.resolve(path: "x.tsx", serverLanguage: "typescriptreact"), "typescript",
+                       "An unknown server language falls back to the extension alias.")
+        XCTAssertEqual(SourceHighlightLanguage.resolve(path: "lib.h", serverLanguage: nil), "c")
+        XCTAssertNil(SourceHighlightLanguage.resolve(path: "notes.txt", serverLanguage: "text"))
+        XCTAssertNil(SourceHighlightLanguage.resolve(path: "LICENSE", serverLanguage: nil))
+    }
+
+    func testRunsByLineSplitsColourRunsAtNewlinesWithLineLocalOffsets() {
+        let text = NSMutableAttributedString(string: "ab\ncde\n\nf")
+        let red = UIColor.red
+        let blue = UIColor.blue
+        // "b\ncd" spans the first newline; "f" is on the last line with no newline after it.
+        text.addAttribute(.foregroundColor, value: red, range: NSRange(location: 1, length: 4))
+        text.addAttribute(.foregroundColor, value: blue, range: NSRange(location: 8, length: 1))
+
+        let runs = SourceHighlighter.runsByLine(in: text, lineCount: 4)
+
+        XCTAssertEqual(runs.count, 4)
+        XCTAssertEqual(runs[0], [SourceHighlightRun(range: NSRange(location: 1, length: 1), color: red)])
+        XCTAssertEqual(runs[1], [SourceHighlightRun(range: NSRange(location: 0, length: 2), color: red)])
+        XCTAssertEqual(runs[2], [])
+        XCTAssertEqual(runs[3], [SourceHighlightRun(range: NSRange(location: 0, length: 1), color: blue)])
+    }
+
+    func testHighlightReturnsColourForJSONAndBlanksOverLongLines() async throws {
+        let long = String(repeating: "x", count: SourceHighlighter.maxLineLength + 1)
+        let lines = ["{\"key\": 1,", long, "\"flag\": true}"]
+
+        let result = await SourceHighlighter().highlight(lines: lines, language: "json", isDark: false)
+        let runs = try XCTUnwrap(result)
+
+        XCTAssertEqual(runs.count, 3)
+        XCTAssertFalse(runs[0].isEmpty, "A JSON key should get at least one colour run.")
+        XCTAssertTrue(runs[1].isEmpty, "Over-long lines are not tokenized.")
+        XCTAssertFalse(runs[2].isEmpty)
+        for run in runs.flatMap({ $0 }) {
+            XCTAssertLessThanOrEqual(NSMaxRange(run.range), (lines[2] as NSString).length + 1)
+        }
+    }
+}


### PR DESCRIPTION
## Linked issue

Maintainer-scoped workspace work; no tracking issue.

## What changed

Opening a code file from the workspace gave you one giant monospaced text block in a two-axis scroll: no line numbers, no syntax colour, no way to land on a line, and a long file stalled the main thread while SwiftUI laid it all out.

Now every non-Markdown text file draws on the same canvas as the Git diff (`ReviewDiffSurface`, `presentation: .source`):

- **Line gutter** with no change bar; every row is a context line numbered from one.
- **Syntax colour** from Highlightr, run on a background actor for the rows on screen plus 40 either side. A row is never tokenized twice; the next window is requested once the viewport has moved 20 rows. Lines over 1000 characters draw plain. Files with no grammar (or where Highlightr gives up) show a quiet "Plain text" caption instead of a loading strip.
- **Wrap Lines** toggle in the toolbar menu, persisted. Wrapping is real character-grid wrapping with variable row heights, not truncation; when on, horizontal pan is off.
- **Tap to select a line, long-press then tap for a range**, with Clear and Copy in a monochrome bottom bar.
- **Initial line**: `FilePreviewView(initialLine:)` scrolls the target 30 % down the viewport and highlights it. No caller yet; covered by tests.
- Copy and Select Text moved from the context menu (the canvas owns long press) to the toolbar menu.

Markdown files keep the chat renderer and their context menu. The Git diff path is unchanged: the new canvas capabilities (zero change bar, wrap, colour runs, scroll-to-row, visible-range reporting) are all defaulted off.

## How it was tested

- Full XCTest suite on the iPhone 17 simulator via XcodeBuildMCP `test_sim`: **2117 passed, 0 failed, 2 skipped** (pre-existing photo-library skips) on the final head.
- New focused tests: `SourceFileRowsTests` (line splitting, CRLF, tabs, trailing newline, row ids), `SourceHighlighterTests` (language resolution, per-line run splitting, real Highlightr run on JSON with the long-line cap), `SourceFileViewModelTests` (10,000-line load, visible-window colouring with overscan, 20-row re-request threshold, appearance change recolours, and the dark-mode-during-load race that first blanked the file), plus a wrap-height case in `ReviewDiffLayoutTests`.
- Manual pass by the maintainer on the simulator against the live server in light and dark: Swift file with colour, LICENSE as plain text, Markdown unchanged, line selection and Copy. Screenshots to follow as a comment.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (no model changes; `FileResponse.language` was already optional)
- [x] No new third-party dependencies (Highlightr is already linked)
- [x] No invented API endpoints or JSON shapes (reuses the existing file endpoint)

---

Built by Claude Fable 5.1 via Claude Code.
