### PR TITLE
feat(workspace): browse the workspace as a lazily loaded file tree

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -205,6 +205,9 @@
 		1A2B3C4D5E6F7000000000E2 /* ReasoningBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E3 /* ReasoningBlockView.swift */; };
 		1A2B3C4D5E6F7000000000E4 /* FileBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E5 /* FileBrowserView.swift */; };
 		1A2B3C4D5E6F7000000000E6 /* FileBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E7 /* FileBrowserViewModel.swift */; };
+		1F16000000000000000000B3 /* FileBrowserViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16000000000000000000F3 /* FileBrowserViewModelTests.swift */; };
+		1F16000000000000000000B2 /* FileTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16000000000000000000F2 /* FileTreeTests.swift */; };
+		1F16000000000000000000B1 /* FileTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16000000000000000000F1 /* FileTree.swift */; };
 		1A2B3C4D5E6F7000000000E8 /* FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E9 /* FilePreviewView.swift */; };
 		1A2B3C4D5E6F7000000000EA /* FilePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000EB /* FilePreviewViewModel.swift */; };
 		BEEF02600000000000000001 /* FileExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEF02600000000000000002 /* FileExportSupport.swift */; };
@@ -628,6 +631,9 @@
 		1A2B3C4D5E6F7000000000E3 /* ReasoningBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReasoningBlockView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E5 /* FileBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E7 /* FileBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserViewModel.swift; sourceTree = "<group>"; };
+		1F16000000000000000000F3 /* FileBrowserViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserViewModelTests.swift; sourceTree = "<group>"; };
+		1F16000000000000000000F2 /* FileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeTests.swift; sourceTree = "<group>"; };
+		1F16000000000000000000F1 /* FileTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTree.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E9 /* FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000EB /* FilePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewViewModel.swift; sourceTree = "<group>"; };
 		BEEF02600000000000000002 /* FileExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExportSupport.swift; sourceTree = "<group>"; };
@@ -1006,6 +1012,8 @@
 				1D1FF0000000000000000F0C /* ReviewDiffSelectionTests.swift */,
 				1D1FF0000000000000000F21 /* ReviewDiffCanvasViewTests.swift */,
 				1D1FF0000000000000000F34 /* SourceFileRowsTests.swift */,
+				1F16000000000000000000F2 /* FileTreeTests.swift */,
+				1F16000000000000000000F3 /* FileBrowserViewModelTests.swift */,
 				1D1FF0000000000000000F35 /* SourceHighlighterTests.swift */,
 				1D1FF0000000000000000F36 /* SourceFileViewModelTests.swift */,
 				C03120000000000000F008 /* TurnFileChangeAggregatorTests.swift */,
@@ -1323,6 +1331,7 @@
 			children = (
 				1A2B3C4D5E6F7000000000E5 /* FileBrowserView.swift */,
 				1A2B3C4D5E6F7000000000E7 /* FileBrowserViewModel.swift */,
+				1F16000000000000000000F1 /* FileTree.swift */,
 				1A2B3C4D5E6F7000000000E9 /* FilePreviewView.swift */,
 				1A2B3C4D5E6F7000000000EB /* FilePreviewViewModel.swift */,
 				BEEF02600000000000000002 /* FileExportSupport.swift */,
@@ -1850,6 +1859,7 @@
 				C21300000000000000000003 /* StreamingTextFadeRenderer.swift in Sources */,
 				1A2B3C4D5E6F7000000000E4 /* FileBrowserView.swift in Sources */,
 				1A2B3C4D5E6F7000000000E6 /* FileBrowserViewModel.swift in Sources */,
+				1F16000000000000000000B1 /* FileTree.swift in Sources */,
 				1A2B3C4D5E6F7000000000E8 /* FilePreviewView.swift in Sources */,
 				1A2B3C4D5E6F7000000000EA /* FilePreviewViewModel.swift in Sources */,
 				BEEF02600000000000000001 /* FileExportSupport.swift in Sources */,
@@ -2026,6 +2036,8 @@
 				1D1FF0000000000000000B0C /* ReviewDiffSelectionTests.swift in Sources */,
 				1D1FF0000000000000000B21 /* ReviewDiffCanvasViewTests.swift in Sources */,
 				1D1FF0000000000000000B34 /* SourceFileRowsTests.swift in Sources */,
+				1F16000000000000000000B2 /* FileTreeTests.swift in Sources */,
+				1F16000000000000000000B3 /* FileBrowserViewModelTests.swift in Sources */,
 				1D1FF0000000000000000B35 /* SourceHighlighterTests.swift in Sources */,
 				1D1FF0000000000000000B36 /* SourceFileViewModelTests.swift in Sources */,
 				C03120000000000000B008 /* TurnFileChangeAggregatorTests.swift in Sources */,

--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -10,6 +10,8 @@ struct FileBrowserView: View {
     @State private var viewModel: FileBrowserViewModel
     @State private var searchText = ""
     @State private var openedFile: FileTreeNode?
+    /// The warm fetch handed over when `openedFile` was tapped; consumed by that preview only.
+    @State private var openedFilePrefetch: Task<FileResponse, Error>?
 
     init(session: SessionSummary, server: URL, onAPIError: @escaping (Error) -> Void) {
         self.session = session
@@ -32,7 +34,7 @@ struct FileBrowserView: View {
                 session: session,
                 server: server,
                 entry: node.entry,
-                prefetchedFile: viewModel.prefetchedFile(at: node.path),
+                prefetchedFile: openedFilePrefetch,
                 onAPIError: onAPIError
             )
         }
@@ -171,14 +173,14 @@ struct FileBrowserView: View {
             return
         }
 
-        viewModel.keepPrefetch(for: node.path)
+        openedFilePrefetch = viewModel.takePrefetch(for: node.path)
         openedFile = node
         Task { await viewModel.select(path: node.path) }
     }
 
     private func handleLastError() {
-        if let lastError = viewModel.lastError {
-            onAPIError(lastError)
+        if let error = viewModel.takeLastError() {
+            onAPIError(error)
         }
     }
 }

--- a/HermesMobile/Features/Workspace/FileBrowserView.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+/// The workspace file tree: folders open in place, search keeps matches with their parents,
+/// and a file row pushes its preview.
 struct FileBrowserView: View {
     let onAPIError: (Error) -> Void
 
@@ -7,6 +9,7 @@ struct FileBrowserView: View {
     private let server: URL
     @State private var viewModel: FileBrowserViewModel
     @State private var searchText = ""
+    @State private var openedFile: FileTreeNode?
 
     init(session: SessionSummary, server: URL, onAPIError: @escaping (Error) -> Void) {
         self.session = session
@@ -17,73 +20,80 @@ struct FileBrowserView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            pathHeader
             searchBar
 
             content
                 .adaptiveReadableScrollContent(maxWidth: AdaptiveReadableContentWidth.workspace)
         }
-            .navigationTitle("Files")
-            .navigationBarTitleDisplayMode(.inline)
-            .task {
-                await loadInitialRootIfNeeded()
-            }
+        .navigationTitle("Files")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(item: $openedFile) { node in
+            FilePreviewView(
+                session: session,
+                server: server,
+                entry: node.entry,
+                prefetchedFile: viewModel.prefetchedFile(at: node.path),
+                onAPIError: onAPIError
+            )
+        }
+        .task {
+            await viewModel.loadInitialRootIfNeeded()
+            handleLastError()
+        }
     }
 
     @ViewBuilder
     private var content: some View {
-        if viewModel.isLoading && viewModel.entries.isEmpty {
+        let visibleNodes = viewModel.visibleNodes(matching: searchText)
+
+        if viewModel.isLoadingRoot && !viewModel.tree.isRootLoaded {
             ProgressView("Loading files...")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let errorMessage = viewModel.errorMessage, viewModel.entries.isEmpty {
+        } else if let errorMessage = viewModel.errorMessage, !viewModel.tree.isRootLoaded {
             ContentUnavailableView {
                 Label("Could Not Load Files", systemImage: "exclamationmark.triangle")
             } description: {
                 Text(errorMessage)
             } actions: {
                 Button("Try Again") {
-                    Task { await retryLastLoad() }
+                    Task {
+                        await viewModel.retryRoot()
+                        handleLastError()
+                    }
                 }
             }
-        } else if visibleEntries.isEmpty {
+        } else if visibleNodes.isEmpty {
             ContentUnavailableView {
                 Label(searchText.isEmpty ? "No Files" : "No Matches", systemImage: searchText.isEmpty ? "folder" : "magnifyingglass")
             } description: {
-                if searchText.isEmpty {
-                    Text(viewModel.currentPath)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                } else {
+                if !searchText.isEmpty {
                     Text("Try a different file name or path.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
             }
         } else {
-            List(visibleEntries) { entry in
-                if entry.isBrowsableDirectory {
-                    Button {
-                        Task { await load(path: entry.path ?? ".") }
-                    } label: {
-                        FileBrowserRow(entry: entry, showsDisclosure: true)
-                    }
-                    .buttonStyle(.plain)
-                } else if entry.path != nil {
-                    NavigationLink {
-                        FilePreviewView(session: session, server: server, entry: entry, onAPIError: onAPIError)
-                    } label: {
-                        FileBrowserRow(entry: entry, showsDisclosure: false)
-                    }
-                } else {
-                    FileBrowserRow(entry: entry, showsDisclosure: false)
-                }
-            }
-            .refreshable {
-                await reloadCurrentPath()
+            List(visibleNodes) { item in
+                FileTreeRowView(
+                    item: item,
+                    isExpanded: viewModel.isExpanded(item.node.path),
+                    isLoading: viewModel.isLoading(item.node.path),
+                    isSelected: item.node.path == viewModel.selectedPath,
+                    hasLoadFailure: viewModel.loadFailure(for: item.node.path) != nil,
+                    childCount: viewModel.childCount(of: item.node.path),
+                    onPressDown: { viewModel.prefetchFile(at: item.node.path) },
+                    onTap: { open(item.node) }
+                )
+                .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
+                .listRowSeparator(.hidden)
             }
             .listStyle(.plain)
+            .refreshable {
+                await viewModel.refresh()
+                handleLastError()
+            }
             .safeAreaInset(edge: .top, spacing: 0) {
-                if viewModel.isLoading {
+                if viewModel.isLoadingRoot {
                     HStack(spacing: 8) {
                         ProgressView()
                         Text("Loading files...")
@@ -103,7 +113,10 @@ struct FileBrowserView: View {
                         Spacer(minLength: 0)
 
                         Button("Try Again") {
-                            Task { await retryLastLoad() }
+                            Task {
+                                await viewModel.retryRoot()
+                                handleLastError()
+                            }
                         }
                         .font(.footnote.weight(.semibold))
                     }
@@ -113,74 +126,6 @@ struct FileBrowserView: View {
                 }
             }
         }
-    }
-
-    private var pathHeader: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text("Location")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-
-                Text(viewModel.displayPath)
-                    .font(.caption)
-                    .fontDesign(.monospaced)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .foregroundStyle(.primary)
-
-                Spacer(minLength: 8)
-            }
-
-            HStack(spacing: 8) {
-                Button {
-                    Task { await loadRoot() }
-                } label: {
-                    Label("Root", systemImage: "house")
-                }
-                .disabled(viewModel.isAtRoot)
-
-                Button {
-                    guard let parentPath = viewModel.parentPath else { return }
-                    Task { await load(path: parentPath) }
-                } label: {
-                    Label("Up", systemImage: "arrow.up")
-                }
-                .disabled(viewModel.parentPath == nil)
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 6) {
-                        ForEach(Array(viewModel.breadcrumbs.enumerated()), id: \.element.id) { index, breadcrumb in
-                            if index > 0 {
-                                Image(systemName: "chevron.forward")
-                                    .font(.caption2)
-                                    .foregroundStyle(.tertiary)
-                                    .accessibilityHidden(true)
-                            }
-
-                            Button {
-                                Task { await load(path: breadcrumb.path) }
-                            } label: {
-                                Text(breadcrumb.title)
-                                    .font(.caption)
-                                    .lineLimit(1)
-                            }
-                            .disabled(breadcrumb.path == viewModel.currentPath)
-                            .accessibilityLabel("Open \(breadcrumb.title)")
-                        }
-                    }
-                    .frame(height: 30)
-                }
-                .frame(height: 30)
-                .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 10)
-        .background(Color(.systemBackground))
     }
 
     private var searchBar: some View {
@@ -210,45 +155,25 @@ struct FileBrowserView: View {
         .frame(height: 40)
         .background(Color(.tertiarySystemFill).opacity(0.5), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .padding(.horizontal)
-        .padding(.bottom, 10)
+        .padding(.vertical, 10)
         .background(Color(.systemBackground))
         .overlay(alignment: .bottom) {
             Divider()
         }
     }
 
-    private var visibleEntries: [WorkspaceEntry] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return viewModel.entries }
-
-        return viewModel.entries.filter { entry in
-            entry.searchableText.localizedCaseInsensitiveContains(query)
+    private func open(_ node: FileTreeNode) {
+        if node.isDirectory {
+            Task {
+                await viewModel.toggleDirectory(node.path)
+                handleLastError()
+            }
+            return
         }
-    }
 
-    private func loadRoot() async {
-        await viewModel.loadRoot()
-        handleLastError()
-    }
-
-    private func loadInitialRootIfNeeded() async {
-        await viewModel.loadInitialRootIfNeeded()
-        handleLastError()
-    }
-
-    private func reloadCurrentPath() async {
-        await viewModel.reloadCurrentPath()
-        handleLastError()
-    }
-
-    private func retryLastLoad() async {
-        await viewModel.retryLastLoad()
-        handleLastError()
-    }
-
-    private func load(path: String) async {
-        await viewModel.load(path: path)
-        handleLastError()
+        viewModel.keepPrefetch(for: node.path)
+        openedFile = node
+        Task { await viewModel.select(path: node.path) }
     }
 
     private func handleLastError() {
@@ -258,100 +183,126 @@ struct FileBrowserView: View {
     }
 }
 
-private struct FileBrowserRow: View {
-    let entry: WorkspaceEntry
-    let showsDisclosure: Bool
+/// One tree row: 42 pt tall, indented 18 pt per level, chevron for folders, child count once
+/// the folder has been listed. Press-down warms the file preview before the tap lands.
+private struct FileTreeRowView: View {
+    let item: VisibleFileTreeNode
+    let isExpanded: Bool
+    let isLoading: Bool
+    let isSelected: Bool
+    let hasLoadFailure: Bool
+    let childCount: Int?
+    let onPressDown: () -> Void
+    let onTap: () -> Void
+
+    private var node: FileTreeNode { item.node }
 
     var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: iconName)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(iconColor)
-                .frame(width: 26, height: 26)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(iconBackground)
-                )
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(displayName)
-                    .font(.subheadline.weight(.medium))
-                    .lineLimit(1)
-
-                if let detailText {
-                    Text(detailText)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                if node.isDirectory {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.forward")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 12)
+                } else {
+                    Color.clear.frame(width: 12, height: 1)
                 }
-            }
 
-            Spacer(minLength: 8)
+                Image(systemName: iconName)
+                    .font(.system(size: 17))
+                    .foregroundStyle(iconColor)
+                    .frame(width: 22)
 
-            if showsDisclosure {
-                Image(systemName: "chevron.forward")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.tertiary)
-                    .accessibilityHidden(true)
+                Text(node.name)
+                    .font(.subheadline.weight(isSelected ? .semibold : .medium))
+                    .foregroundStyle(isSelected || node.isDirectory ? .primary : .secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer(minLength: 8)
+
+                trailingAccessory
             }
+            .padding(.leading, 8 + CGFloat(item.depth) * 18)
+            .padding(.trailing, 12)
+            .frame(minHeight: 42)
+            .contentShape(Rectangle())
         }
-        .padding(.vertical, 2)
-        .contentShape(Rectangle())
+        .buttonStyle(FileTreeRowButtonStyle(isSelected: isSelected, onPressChanged: { isPressed in
+            if isPressed, !node.isDirectory {
+                onPressDown()
+            }
+        }))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(accessibilityValue)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    private var displayName: String {
-        let name = entry.name?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let name, !name.isEmpty else {
-            return String(localized: "Untitled")
+    @ViewBuilder
+    private var trailingAccessory: some View {
+        if node.isDirectory {
+            if isLoading {
+                ProgressView()
+                    .controlSize(.mini)
+            } else if hasLoadFailure {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            } else if let childCount {
+                Text(childCount, format: .number)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
+            }
         }
-        return name
-    }
-
-    private var detailText: String? {
-        if isDirectory {
-            return entry.path
-        }
-
-        guard let size = entry.size else {
-            return entry.path
-        }
-
-        return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
-    }
-
-    private var accessibilityLabel: String {
-        let kind = isDirectory ? String(localized: "Folder") : String(localized: "File")
-        if let detailText {
-            return String(localized: "\(kind), \(displayName), \(detailText)")
-        }
-        return String(localized: "\(kind), \(displayName)")
-    }
-
-    private var isDirectory: Bool {
-        entry.isBrowsableDirectory
     }
 
     private var iconName: String {
-        isDirectory ? "folder" : "doc.text"
+        if node.isSymlink { return "link" }
+        return node.isDirectory ? (isExpanded ? "folder.fill" : "folder") : "doc.text"
     }
 
     private var iconColor: Color {
-        isDirectory ? .primary : .secondary
+        node.isDirectory ? .accentColor : .secondary
     }
 
-    private var iconBackground: Color {
-        isDirectory ? Color(.tertiarySystemFill) : Color(.secondarySystemFill)
+    private var accessibilityLabel: String {
+        let kind: String
+        if node.isSymlink {
+            kind = String(localized: "Link")
+        } else {
+            kind = node.isDirectory ? String(localized: "Folder") : String(localized: "File")
+        }
+        return String(localized: "\(kind), \(node.name)")
+    }
+
+    private var accessibilityValue: String {
+        guard node.isDirectory else { return "" }
+        if hasLoadFailure { return String(localized: "Could Not Load Files") }
+        return isExpanded ? String(localized: "Expanded") : String(localized: "Collapsed")
     }
 }
 
-private extension WorkspaceEntry {
-    var searchableText: String {
-        [name, path, type]
-            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+/// Highlights the row while pressed and reports press changes so the row can prefetch.
+private struct FileTreeRowButtonStyle: ButtonStyle {
+    let isSelected: Bool
+    let onPressChanged: (Bool) -> Void
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(background(isPressed: configuration.isPressed))
+            )
+            .onChange(of: configuration.isPressed) { _, isPressed in
+                onPressChanged(isPressed)
+            }
+    }
+
+    private func background(isPressed: Bool) -> Color {
+        if isPressed { return Color(.tertiarySystemFill) }
+        return isSelected ? Color(.secondarySystemFill) : .clear
     }
 }

--- a/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
@@ -12,7 +12,8 @@ final class FileBrowserViewModel {
 
     private(set) var tree = FileTree()
     private(set) var expandedPaths: Set<String> = []
-    private(set) var loadingPaths: Set<String> = []
+    /// Directory path → generation of the listing that owns its spinner.
+    private(set) var loadingPaths: [String: Int] = [:]
     /// Directory path → message for listings that failed; tapping the row retries.
     private(set) var failedPaths: [String: String] = [:]
     private(set) var selectedPath: String?
@@ -45,7 +46,7 @@ final class FileBrowserViewModel {
     }
 
     func isLoading(_ path: String) -> Bool {
-        loadingPaths.contains(path)
+        loadingPaths[path] != nil
     }
 
     func loadFailure(for path: String) -> String? {
@@ -162,9 +163,15 @@ final class FileBrowserViewModel {
         guard let sessionID = session.sessionId else { return }
 
         let generation = bumpGeneration(for: path)
-        loadingPaths.insert(path)
+        loadingPaths[path] = generation
         failedPaths[path] = nil
         lastError = nil
+        // Clear the spinner on every exit, but only if a newer listing has not taken it over.
+        defer {
+            if loadingPaths[path] == generation {
+                loadingPaths[path] = nil
+            }
+        }
 
         do {
             let response = try await apiClient.directoryList(sessionID: sessionID, path: path)
@@ -181,8 +188,6 @@ final class FileBrowserViewModel {
                 failedPaths[path] = error.localizedDescription
             }
         }
-
-        loadingPaths.remove(path)
     }
 
     /// Stores a listing and invalidates in-flight requests for every folder the listing

--- a/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
@@ -121,7 +121,7 @@ final class FileBrowserViewModel {
         do {
             let response = try await apiClient.directoryList(sessionID: sessionID, path: FileTree.rootPath)
             guard generation == loadGenerations[FileTree.rootPath] else { return }
-            tree.setChildren(response.entries ?? [], of: FileTree.rootPath)
+            commitListing(response.entries ?? [], of: FileTree.rootPath)
             if !hasRestoredExpansion {
                 hasRestoredExpansion = true
                 expandedPaths = expansionStore.load() ?? FileTree.defaultExpandedPaths(in: tree.rootNodes)
@@ -172,7 +172,7 @@ final class FileBrowserViewModel {
             // A root refresh that finished meanwhile may have dropped this directory; an
             // orphaned listing would be shown as current if the folder ever came back.
             if tree.node(at: path)?.isDirectory == true {
-                tree.setChildren(response.entries ?? [], of: path)
+                commitListing(response.entries ?? [], of: path)
             }
         } catch {
             guard generation == loadGenerations[path] else { return }
@@ -183,6 +183,20 @@ final class FileBrowserViewModel {
         }
 
         loadingPaths.remove(path)
+    }
+
+    /// Stores a listing and invalidates in-flight requests for every folder the listing
+    /// dropped (and any cached listing beneath it), so a folder that is removed and recreated
+    /// cannot resurface a response that was requested before it disappeared.
+    private func commitListing(_ entries: [WorkspaceEntry], of directory: String) {
+        let previousFolders = Set((tree.children(of: directory) ?? []).filter(\.isDirectory).map(\.path))
+        let previousKeys = Set(tree.children.keys)
+        tree.setChildren(entries, of: directory)
+        let currentFolders = Set((tree.children(of: directory) ?? []).filter(\.isDirectory).map(\.path))
+        let stale = previousFolders.subtracting(currentFolders).union(previousKeys.subtracting(tree.children.keys))
+        for path in stale {
+            _ = bumpGeneration(for: path)
+        }
     }
 
     private func bumpGeneration(for path: String) -> Int {

--- a/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
@@ -1,108 +1,218 @@
 import Foundation
 
+/// Owns the workspace file tree for one session: lists directories from the server as the
+/// user opens them, remembers which folders are open per server and workspace, and warms
+/// file previews on press-down so the next screen has its content ready.
+@MainActor
 @Observable
 final class FileBrowserViewModel {
     private let session: SessionSummary
     private let apiClient: APIClient
+    private let expansionStore: FileTreeExpansionStore
 
-    private(set) var entries: [WorkspaceEntry] = []
-    private(set) var currentPath = "."
-    private(set) var isLoading = false
+    private(set) var tree = FileTree()
+    private(set) var expandedPaths: Set<String> = []
+    private(set) var loadingPaths: Set<String> = []
+    /// Directory path → message for listings that failed; tapping the row retries.
+    private(set) var failedPaths: [String: String] = [:]
+    private(set) var selectedPath: String?
+    private(set) var isLoadingRoot = false
     private(set) var errorMessage: String?
     private(set) var lastError: Error?
-    private var hasLoadedInitialPath = false
-    private var lastRequestedPath = "."
-    private var loadRevision = 0
 
-    var isAtRoot: Bool {
-        currentPath == "."
-    }
+    private var hasLoadedInitialRoot = false
+    private var hasRestoredExpansion = false
+    /// Per-directory generation counters so a stale listing never overwrites a newer one.
+    private var loadGenerations: [String: Int] = [:]
+    /// At most one prefetch is kept: a newer press-down replaces the previous one.
+    private var prefetches: [String: Task<FileResponse, Error>] = [:]
 
-    var displayPath: String {
-        isAtRoot ? String(localized: "Root") : currentPath
-    }
-
-    var parentPath: String? {
-        guard !isAtRoot else { return nil }
-
-        let parts = currentPath.split(separator: "/").map(String.init)
-        guard parts.count > 1 else { return "." }
-
-        return parts.dropLast().joined(separator: "/")
-    }
-
-    var breadcrumbs: [FileBreadcrumb] {
-        guard currentPath != "." else {
-            return [FileBreadcrumb(title: String(localized: "Root"), path: ".")]
-        }
-
-        let parts = currentPath.split(separator: "/").map(String.init)
-        var breadcrumbs = [FileBreadcrumb(title: String(localized: "Root"), path: ".")]
-
-        for index in parts.indices {
-            let title = parts[index]
-            let path = parts[...index].joined(separator: "/")
-            breadcrumbs.append(FileBreadcrumb(title: title, path: path))
-        }
-
-        return breadcrumbs
-    }
-
-    init(session: SessionSummary, server: URL, apiClient: APIClient? = nil) {
+    init(session: SessionSummary, server: URL, apiClient: APIClient? = nil, defaults: UserDefaults = .standard) {
         self.session = session
         self.apiClient = apiClient ?? APIClient(baseURL: server)
+        expansionStore = FileTreeExpansionStore(server: server, workspace: session.workspace, defaults: defaults)
     }
 
-    @MainActor
+    // MARK: - Reading
+
+    func visibleNodes(matching searchQuery: String) -> [VisibleFileTreeNode] {
+        tree.visibleNodes(expanded: expandedPaths, searchQuery: searchQuery)
+    }
+
+    func isExpanded(_ path: String) -> Bool {
+        expandedPaths.contains(path)
+    }
+
+    func isLoading(_ path: String) -> Bool {
+        loadingPaths.contains(path)
+    }
+
+    func loadFailure(for path: String) -> String? {
+        failedPaths[path]
+    }
+
+    /// Nil until the directory has been listed.
+    func childCount(of path: String) -> Int? {
+        tree.children(of: path)?.count
+    }
+
+    // MARK: - Loading
+
     func loadInitialRootIfNeeded() async {
-        guard !hasLoadedInitialPath else { return }
-        hasLoadedInitialPath = true
-        await loadRoot()
+        guard !hasLoadedInitialRoot else { return }
+        hasLoadedInitialRoot = true
+        await loadRoot(reloadingOpenDirectories: false)
     }
 
-    @MainActor
-    func loadRoot() async {
-        await load(path: ".")
+    /// Pull-to-refresh: re-lists the root and every open directory, keeping expansion.
+    func refresh() async {
+        await loadRoot(reloadingOpenDirectories: true)
     }
 
-    @MainActor
-    func reloadCurrentPath() async {
-        await load(path: currentPath)
+    func retryRoot() async {
+        await loadRoot(reloadingOpenDirectories: false)
     }
 
-    @MainActor
-    func retryLastLoad() async {
-        await load(path: lastRequestedPath)
+    /// Opens or closes a directory. Opening lists it on first use; tapping a failed listing retries.
+    func toggleDirectory(_ path: String) async {
+        if expandedPaths.contains(path), failedPaths[path] == nil {
+            setExpanded(expandedPaths.subtracting([path]))
+            return
+        }
+
+        setExpanded(expandedPaths.union([path]))
+        if !tree.isLoaded(path) || failedPaths[path] != nil {
+            await loadDirectory(path)
+        }
     }
 
-    @MainActor
-    func load(path: String) async {
+    /// Marks a file as the current one and opens every folder above it, listing any that
+    /// have not been fetched yet, so the row is on screen when the tree is shown again.
+    func select(path: String) async {
+        selectedPath = path
+        let ancestors = FileTree.ancestorPaths(of: path)
+        if !ancestors.allSatisfy(expandedPaths.contains) {
+            setExpanded(expandedPaths.union(ancestors))
+        }
+        for ancestor in ancestors where !tree.isLoaded(ancestor) {
+            await loadDirectory(ancestor)
+        }
+    }
+
+    private func loadRoot(reloadingOpenDirectories: Bool) async {
         guard let sessionID = session.sessionId else {
             errorMessage = String(localized: "Session ID is missing.")
             return
         }
 
-        lastRequestedPath = path
-        loadRevision += 1
-        let revision = loadRevision
-        isLoading = true
+        let generation = bumpGeneration(for: FileTree.rootPath)
+        isLoadingRoot = true
         errorMessage = nil
         lastError = nil
 
         do {
-            let response = try await apiClient.directoryList(sessionID: sessionID, path: path)
-            guard revision == loadRevision else { return }
-            currentPath = response.path ?? path
-            entries = response.entries ?? []
+            let response = try await apiClient.directoryList(sessionID: sessionID, path: FileTree.rootPath)
+            guard generation == loadGenerations[FileTree.rootPath] else { return }
+            tree.setChildren(response.entries ?? [], of: FileTree.rootPath)
+            if !hasRestoredExpansion {
+                hasRestoredExpansion = true
+                expandedPaths = expansionStore.load() ?? FileTree.defaultExpandedPaths(in: tree.rootNodes)
+            }
+            isLoadingRoot = false
+            await loadOpenDescendants(of: FileTree.rootPath, reloadingLoaded: reloadingOpenDirectories)
         } catch {
-            guard revision == loadRevision else { return }
+            guard generation == loadGenerations[FileTree.rootPath] else { return }
             if !Self.isCancellationError(error) {
                 lastError = error
                 errorMessage = error.localizedDescription
             }
+            isLoadingRoot = false
+        }
+    }
+
+    /// Lists every expanded directory under `directory` whose parents are also open, in
+    /// parallel, then recurses into them. Unloaded directories are fetched; loaded ones only
+    /// when `reloadingLoaded` is set.
+    private func loadOpenDescendants(of directory: String, reloadingLoaded: Bool) async {
+        guard let nodes = tree.children(of: directory) else { return }
+        let open = nodes.filter { $0.isDirectory && expandedPaths.contains($0.path) }
+        guard !open.isEmpty else { return }
+
+        await withTaskGroup(of: Void.self) { group in
+            for node in open {
+                group.addTask { @MainActor in
+                    if reloadingLoaded || !self.tree.isLoaded(node.path) {
+                        await self.loadDirectory(node.path)
+                    }
+                    await self.loadOpenDescendants(of: node.path, reloadingLoaded: reloadingLoaded)
+                }
+            }
+        }
+    }
+
+    private func loadDirectory(_ path: String) async {
+        guard let sessionID = session.sessionId else { return }
+
+        let generation = bumpGeneration(for: path)
+        loadingPaths.insert(path)
+        failedPaths[path] = nil
+
+        do {
+            let response = try await apiClient.directoryList(sessionID: sessionID, path: path)
+            guard generation == loadGenerations[path] else { return }
+            tree.setChildren(response.entries ?? [], of: path)
+        } catch {
+            guard generation == loadGenerations[path] else { return }
+            if !Self.isCancellationError(error) {
+                lastError = error
+                failedPaths[path] = error.localizedDescription
+            }
         }
 
-        isLoading = false
+        loadingPaths.remove(path)
+    }
+
+    private func bumpGeneration(for path: String) -> Int {
+        let next = (loadGenerations[path] ?? 0) + 1
+        loadGenerations[path] = next
+        return next
+    }
+
+    private func setExpanded(_ paths: Set<String>) {
+        expandedPaths = paths
+        expansionStore.save(paths)
+    }
+
+    // MARK: - Prefetch
+
+    /// Starts fetching a text file's content while the finger is still down on its row.
+    func prefetchFile(at path: String) {
+        guard prefetches[path] == nil,
+              let sessionID = session.sessionId,
+              FilePreviewViewModel.loadsTextPreview(forPath: path) else { return }
+
+        cancelPrefetches()
+        let apiClient = apiClient
+        prefetches[path] = Task {
+            try await apiClient.file(sessionID: sessionID, path: path)
+        }
+    }
+
+    /// Called when a file opens: keeps that file's prefetch and cancels every other one.
+    func keepPrefetch(for path: String) {
+        for (prefetchedPath, task) in prefetches where prefetchedPath != path {
+            task.cancel()
+            prefetches[prefetchedPath] = nil
+        }
+    }
+
+    func prefetchedFile(at path: String) -> Task<FileResponse, Error>? {
+        prefetches[path]
+    }
+
+    func cancelPrefetches() {
+        prefetches.values.forEach { $0.cancel() }
+        prefetches.removeAll()
     }
 
     private static func isCancellationError(_ error: Error) -> Bool {
@@ -122,9 +232,27 @@ final class FileBrowserViewModel {
     }
 }
 
-struct FileBreadcrumb: Identifiable, Equatable {
-    var id: String { path }
+/// Remembers which folders are open, keyed by server and workspace so one server's layout
+/// never shows up under another. A missing record means "use the default expansion".
+struct FileTreeExpansionStore {
+    private let defaults: UserDefaults
+    private let key: String
 
-    let title: String
-    let path: String
+    init(server: URL, workspace: String?, defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        key = Self.key(server: server, workspace: workspace)
+    }
+
+    static func key(server: URL, workspace: String?) -> String {
+        "fileTree.expanded|\(server.absoluteString)|\(workspace ?? "")"
+    }
+
+    func load() -> Set<String>? {
+        guard let paths = defaults.stringArray(forKey: key) else { return nil }
+        return Set(paths)
+    }
+
+    func save(_ paths: Set<String>) {
+        defaults.set(Array(paths).sorted(), forKey: key)
+    }
 }

--- a/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
+++ b/HermesMobile/Features/Workspace/FileBrowserViewModel.swift
@@ -24,7 +24,8 @@ final class FileBrowserViewModel {
     private var hasRestoredExpansion = false
     /// Per-directory generation counters so a stale listing never overwrites a newer one.
     private var loadGenerations: [String: Int] = [:]
-    /// At most one prefetch is kept: a newer press-down replaces the previous one.
+    /// At most one prefetch is in flight: a newer press-down replaces the previous one, and
+    /// opening a file takes its task out so the next visit fetches fresh content.
     private var prefetches: [String: Task<FileResponse, Error>] = [:]
 
     init(session: SessionSummary, server: URL, apiClient: APIClient? = nil, defaults: UserDefaults = .standard) {
@@ -54,6 +55,13 @@ final class FileBrowserViewModel {
     /// Nil until the directory has been listed.
     func childCount(of path: String) -> Int? {
         tree.children(of: path)?.count
+    }
+
+    /// Hands the most recent failure to the caller once, so a recovered folder or a plain
+    /// collapse never re-reports an error that already surfaced.
+    func takeLastError() -> Error? {
+        defer { lastError = nil }
+        return lastError
     }
 
     // MARK: - Loading
@@ -156,11 +164,16 @@ final class FileBrowserViewModel {
         let generation = bumpGeneration(for: path)
         loadingPaths.insert(path)
         failedPaths[path] = nil
+        lastError = nil
 
         do {
             let response = try await apiClient.directoryList(sessionID: sessionID, path: path)
             guard generation == loadGenerations[path] else { return }
-            tree.setChildren(response.entries ?? [], of: path)
+            // A root refresh that finished meanwhile may have dropped this directory; an
+            // orphaned listing would be shown as current if the folder ever came back.
+            if tree.node(at: path)?.isDirectory == true {
+                tree.setChildren(response.entries ?? [], of: path)
+            }
         } catch {
             guard generation == loadGenerations[path] else { return }
             if !Self.isCancellationError(error) {
@@ -198,12 +211,12 @@ final class FileBrowserViewModel {
         }
     }
 
-    /// Called when a file opens: keeps that file's prefetch and cancels every other one.
-    func keepPrefetch(for path: String) {
-        for (prefetchedPath, task) in prefetches where prefetchedPath != path {
-            task.cancel()
-            prefetches[prefetchedPath] = nil
-        }
+    /// Called when a file opens: hands over that file's prefetch, if any, and cancels every
+    /// other one. The task leaves the table so reopening the file fetches it again.
+    func takePrefetch(for path: String) -> Task<FileResponse, Error>? {
+        let task = prefetches.removeValue(forKey: path)
+        cancelPrefetches()
+        return task
     }
 
     func prefetchedFile(at path: String) -> Task<FileResponse, Error>? {

--- a/HermesMobile/Features/Workspace/FilePreviewView.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewView.swift
@@ -23,17 +23,24 @@ struct FilePreviewView: View {
     @AppStorage(SourceFileSurface.wrapsLinesKey) private var wrapsLines = false
 
     /// `initialLine` is one-based; the source surface scrolls to it and highlights it.
+    /// `prefetchedFile` is a text fetch the file tree already started; the first load reuses it.
     init(
         session: SessionSummary,
         server: URL,
         entry: WorkspaceEntry,
         initialLine: Int? = nil,
+        prefetchedFile: Task<FileResponse, Error>? = nil,
         onAPIError: @escaping (Error) -> Void
     ) {
         self.entry = entry
         self.initialLine = initialLine
         self.onAPIError = onAPIError
-        _viewModel = State(initialValue: FilePreviewViewModel(session: session, server: server, path: entry.path ?? ""))
+        _viewModel = State(initialValue: FilePreviewViewModel(
+            session: session,
+            server: server,
+            path: entry.path ?? "",
+            prefetchedFile: prefetchedFile
+        ))
     }
 
     var body: some View {

--- a/HermesMobile/Features/Workspace/FilePreviewViewModel.swift
+++ b/HermesMobile/Features/Workspace/FilePreviewViewModel.swift
@@ -15,10 +15,26 @@ final class FilePreviewViewModel {
     private(set) var lastError: Error?
     private var exportData: Data?
 
-    init(session: SessionSummary, server: URL, path: String, apiClient: APIClient? = nil) {
+    /// A text fetch the file tree started on press-down; consumed by the first `load()`.
+    private var prefetchedFile: Task<FileResponse, Error>?
+
+    init(
+        session: SessionSummary,
+        server: URL,
+        path: String,
+        apiClient: APIClient? = nil,
+        prefetchedFile: Task<FileResponse, Error>? = nil
+    ) {
         self.session = session
         self.path = path
         self.apiClient = apiClient ?? APIClient(baseURL: server)
+        self.prefetchedFile = prefetchedFile
+    }
+
+    /// True for paths that load through `/api/file` as text rather than as image or raw bytes.
+    static func loadsTextPreview(forPath path: String) -> Bool {
+        let pathExtension = pathExtension(of: path)
+        return !rasterImageExtensions.contains(pathExtension) && !unsupportedBinaryExtensions.contains(pathExtension)
     }
 
     var canExportFile: Bool {
@@ -61,7 +77,14 @@ final class FilePreviewViewModel {
             } else if isKnownUnsupportedBinaryPath {
                 preview = .unavailable(String(localized: "Preview is not available for this file type."))
             } else {
-                let file = try await apiClient.file(sessionID: sessionID, path: path)
+                let prefetched = prefetchedFile
+                prefetchedFile = nil
+                let file: FileResponse
+                if let prefetched, let result = try? await prefetched.value {
+                    file = result
+                } else {
+                    file = try await apiClient.file(sessionID: sessionID, path: path)
+                }
                 exportData = Data((file.content ?? "").utf8)
                 preview = .text(file)
             }
@@ -105,21 +128,29 @@ final class FilePreviewViewModel {
         }
     }
 
-    private var pathExtension: String {
+    private static let rasterImageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "ico", "bmp"]
+
+    private static let unsupportedBinaryExtensions: Set<String> = [
+        "7z", "a", "aiff", "avi", "bin", "bz2", "class", "db", "dmg", "doc",
+        "docx", "dylib", "exe", "flac", "gz", "jar", "m4a", "mov", "mp3",
+        "mp4", "o", "pdf", "pkg", "ppt", "pptx", "pyc", "rar", "sqlite",
+        "svg", "tar", "tgz", "wav", "xls", "xlsx", "xz", "zip"
+    ]
+
+    private static func pathExtension(of path: String) -> String {
         URL(fileURLWithPath: path).pathExtension.lowercased()
     }
 
+    private var pathExtension: String {
+        Self.pathExtension(of: path)
+    }
+
     private var isRasterImagePath: Bool {
-        ["png", "jpg", "jpeg", "gif", "webp", "ico", "bmp"].contains(pathExtension)
+        Self.rasterImageExtensions.contains(pathExtension)
     }
 
     private var isKnownUnsupportedBinaryPath: Bool {
-        [
-            "7z", "a", "aiff", "avi", "bin", "bz2", "class", "db", "dmg", "doc",
-            "docx", "dylib", "exe", "flac", "gz", "jar", "m4a", "mov", "mp3",
-            "mp4", "o", "pdf", "pkg", "ppt", "pptx", "pyc", "rar", "sqlite",
-            "svg", "tar", "tgz", "wav", "xls", "xlsx", "xz", "zip"
-        ].contains(pathExtension)
+        Self.unsupportedBinaryExtensions.contains(pathExtension)
     }
 
     private func payload(with data: Data) -> FileExportPayload {

--- a/HermesMobile/Features/Workspace/FileTree.swift
+++ b/HermesMobile/Features/Workspace/FileTree.swift
@@ -33,7 +33,15 @@ struct FileTreeNode: Identifiable, Hashable {
         name = trimmedName.isEmpty ? String(path.split(separator: "/").last ?? Substring(path)) : trimmedName
         isDirectory = entry.isBrowsableDirectory
         isSymlink = entry.type == "symlink"
-        self.entry = entry
+        // Carry the resolved name and path so the preview never sees a nil path.
+        self.entry = WorkspaceEntry(
+            name: name,
+            path: path,
+            type: entry.type,
+            size: entry.size,
+            modified: entry.modified,
+            isDirectory: entry.isDirectory
+        )
 
         var segments: [String] = []
         var words: [String] = []

--- a/HermesMobile/Features/Workspace/FileTree.swift
+++ b/HermesMobile/Features/Workspace/FileTree.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+/// One entry in the workspace tree. `path` is relative to the workspace root and joined with
+/// "/", which makes it the stable identity for rows, selection, and expansion state.
+struct FileTreeNode: Identifiable, Hashable {
+    var id: String { path }
+
+    let path: String
+    let name: String
+    let isDirectory: Bool
+    let isSymlink: Bool
+    let entry: WorkspaceEntry
+    /// Lowercased path components; search matches these exactly, by prefix, boundary, or substring.
+    let searchSegments: [String]
+    /// camelCase-split words from every component; search also matches these fuzzily.
+    let searchWords: [String]
+
+    /// Returns nil for an entry that carries neither a name nor a path.
+    init?(entry: WorkspaceEntry, parentPath: String) {
+        let trimmedName = entry.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let trimmedPath = entry.path?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        let path: String
+        if !trimmedPath.isEmpty, trimmedPath != FileTree.rootPath {
+            path = trimmedPath
+        } else if !trimmedName.isEmpty {
+            path = parentPath == FileTree.rootPath ? trimmedName : "\(parentPath)/\(trimmedName)"
+        } else {
+            return nil
+        }
+
+        self.path = path
+        name = trimmedName.isEmpty ? String(path.split(separator: "/").last ?? Substring(path)) : trimmedName
+        isDirectory = entry.isBrowsableDirectory
+        isSymlink = entry.type == "symlink"
+        self.entry = entry
+
+        var segments: [String] = []
+        var words: [String] = []
+        for component in path.split(separator: "/") where !component.isEmpty {
+            segments.append(component.lowercased())
+            words.append(contentsOf: FileTreeSearch.splitWords(String(component)))
+        }
+        searchSegments = segments
+        searchWords = words
+    }
+}
+
+/// A node placed in the flattened list, with the depth that drives its indent.
+struct VisibleFileTreeNode: Identifiable, Equatable {
+    var id: String { node.path }
+
+    let node: FileTreeNode
+    let depth: Int
+}
+
+/// The lazily loaded workspace tree. `children` holds the sorted entries of every directory
+/// fetched so far, keyed by directory path (`rootPath` for the workspace root); a missing key
+/// means that directory has not been listed yet.
+struct FileTree: Equatable {
+    static let rootPath = "."
+
+    private(set) var children: [String: [FileTreeNode]] = [:]
+
+    var isRootLoaded: Bool { children[Self.rootPath] != nil }
+    var rootNodes: [FileTreeNode] { children[Self.rootPath] ?? [] }
+
+    func children(of directory: String) -> [FileTreeNode]? {
+        children[directory]
+    }
+
+    func isLoaded(_ directory: String) -> Bool {
+        children[directory] != nil
+    }
+
+    func node(at path: String) -> FileTreeNode? {
+        children[Self.parentPath(of: path)]?.first { $0.path == path }
+    }
+
+    /// Replaces a directory's listing and forgets listings of subdirectories that no longer exist.
+    mutating func setChildren(_ entries: [WorkspaceEntry], of directory: String) {
+        let nodes = Self.sorted(entries.compactMap { FileTreeNode(entry: $0, parentPath: directory) })
+        children[directory] = nodes
+
+        let survivingDirectories = Set(nodes.filter(\.isDirectory).map(\.path))
+        let prefix = directory == Self.rootPath ? "" : directory + "/"
+        for key in children.keys where key != directory && key.hasPrefix(prefix) {
+            let remainder = key.dropFirst(prefix.count)
+            let firstComponent = remainder.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false).first ?? remainder
+            if !survivingDirectories.contains(prefix + firstComponent) {
+                children[key] = nil
+            }
+        }
+    }
+
+    mutating func removeAll() {
+        children.removeAll()
+    }
+
+    /// Directories first, then Finder-style natural order (case-insensitive, numeric-aware).
+    static func sorted(_ nodes: [FileTreeNode]) -> [FileTreeNode] {
+        nodes.sorted { left, right in
+            if left.isDirectory != right.isDirectory {
+                return left.isDirectory
+            }
+            return left.name.localizedStandardCompare(right.name) == .orderedAscending
+        }
+    }
+
+    static func parentPath(of path: String) -> String {
+        guard let slash = path.lastIndex(of: "/") else { return rootPath }
+        return String(path[..<slash])
+    }
+
+    /// Every directory between the root and `path`, top-down, excluding the root and `path` itself.
+    static func ancestorPaths(of path: String) -> [String] {
+        let parts = path.split(separator: "/").filter { !$0.isEmpty }
+        guard parts.count > 1 else { return [] }
+        return (1..<parts.count).map { parts[..<$0].joined(separator: "/") }
+    }
+
+    /// The top-level directories that open on first visit: every one except hidden dot-folders.
+    static func defaultExpandedPaths(in rootNodes: [FileTreeNode]) -> Set<String> {
+        Set(rootNodes.filter { $0.isDirectory && !$0.name.hasPrefix(".") }.map(\.path))
+    }
+
+    /// Flattens the tree for display. Without a query, a directory's children appear only when
+    /// it is expanded. With a query, every loaded directory is traversed and a node stays visible
+    /// when it or any descendant matches, so results keep their ancestors for context.
+    func visibleNodes(expanded: Set<String>, searchQuery: String = "") -> [VisibleFileTreeNode] {
+        let tokens = FileTreeSearch.tokens(from: searchQuery)
+        var output: [VisibleFileTreeNode] = []
+        for node in rootNodes {
+            append(node, depth: 0, expanded: expanded, tokens: tokens, into: &output)
+        }
+        return output
+    }
+
+    @discardableResult
+    private func append(
+        _ node: FileTreeNode,
+        depth: Int,
+        expanded: Set<String>,
+        tokens: [String],
+        into output: inout [VisibleFileTreeNode]
+    ) -> Bool {
+        let isSearching = !tokens.isEmpty
+        let matches = isSearching && FileTreeSearch.matches(node, tokens: tokens)
+        var descendantMatches = false
+        var childOutput: [VisibleFileTreeNode] = []
+
+        if node.isDirectory, expanded.contains(node.path) || isSearching, let children = children[node.path] {
+            for child in children where append(child, depth: depth + 1, expanded: expanded, tokens: tokens, into: &childOutput) {
+                descendantMatches = true
+            }
+        }
+
+        guard !isSearching || matches || descendantMatches else { return false }
+
+        output.append(VisibleFileTreeNode(node: node, depth: depth))
+        output.append(contentsOf: childOutput)
+        return matches || descendantMatches
+    }
+}
+
+/// Tokenized, tiered matching for the tree search. Scores are lower-is-better; a node matches
+/// when every query token matches one of its path segments, or fuzzily one of its words.
+enum FileTreeSearch {
+    static let boundaryMarkers = ["/", "-", "_", "."]
+
+    /// Lowercased query split on whitespace and path punctuation.
+    static func tokens(from query: String) -> [String] {
+        query
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split { $0.isWhitespace || "/\\._-".contains($0) }
+            .map(String.init)
+    }
+
+    /// Splits `ChatStreamCoordinator.swift` into `chat stream coordinator swift`, keeping
+    /// acronym runs like `HTTPServer` as `http server`.
+    static func splitWords(_ value: String) -> [String] {
+        var words: [String] = []
+        var current = ""
+        let characters = Array(value)
+
+        for index in characters.indices {
+            let character = characters[index]
+            guard character.isLetter || character.isNumber else {
+                if !current.isEmpty { words.append(current); current = "" }
+                continue
+            }
+
+            if !current.isEmpty, character.isUppercase {
+                let previous = characters[index - 1]
+                let next = index + 1 < characters.count ? characters[index + 1] : nil
+                let lowerToUpper = previous.isLowercase || previous.isNumber
+                let acronymEnd = previous.isUppercase && (next?.isLowercase ?? false)
+                if lowerToUpper || acronymEnd {
+                    words.append(current)
+                    current = ""
+                }
+            }
+            current.append(character)
+        }
+
+        if !current.isEmpty { words.append(current) }
+        return words.map { $0.lowercased() }
+    }
+
+    /// Tiers: exact 0, prefix 2, boundary 4, substring 6, then fuzzy subsequence at 100 when
+    /// enabled. Each tier adds position and length penalties. Expects lowercased inputs.
+    static func score(value: String, query: String, fuzzy: Bool) -> Int? {
+        guard !value.isEmpty, !query.isEmpty else { return nil }
+        if value == query { return 0 }
+
+        let lengthPenalty = min(64, max(0, value.count - query.count))
+        if value.hasPrefix(query) { return 2 + lengthPenalty }
+
+        let characters = Array(value)
+        let boundaryIndex = boundaryMarkers
+            .compactMap { marker -> Int? in
+                guard let range = value.range(of: marker + query) else { return nil }
+                return value.distance(from: value.startIndex, to: range.lowerBound) + marker.count
+            }
+            .min()
+        if let boundaryIndex { return 4 + boundaryIndex * 2 + lengthPenalty }
+
+        if let range = value.range(of: query) {
+            return 6 + value.distance(from: value.startIndex, to: range.lowerBound) * 2 + lengthPenalty
+        }
+
+        guard fuzzy, let subsequence = subsequenceScore(Array(query), in: characters) else { return nil }
+        return 100 + subsequence
+    }
+
+    static func matches(_ node: FileTreeNode, tokens: [String]) -> Bool {
+        tokens.allSatisfy { token in
+            node.searchSegments.contains { score(value: $0, query: token, fuzzy: false) != nil }
+                || node.searchWords.contains { score(value: $0, query: token, fuzzy: true) != nil }
+        }
+    }
+
+    private static func subsequenceScore(_ query: [Character], in value: [Character]) -> Int? {
+        var queryIndex = 0
+        var firstMatch = -1
+        var previousMatch = -1
+        var gapPenalty = 0
+
+        for (index, character) in value.enumerated() where character == query[queryIndex] {
+            if firstMatch == -1 { firstMatch = index }
+            if previousMatch != -1 { gapPenalty += index - previousMatch - 1 }
+            previousMatch = index
+            queryIndex += 1
+
+            if queryIndex == query.count {
+                let spanPenalty = index - firstMatch + 1 - query.count
+                let lengthPenalty = min(64, value.count - query.count)
+                return firstMatch * 2 + gapPenalty * 3 + spanPenalty + lengthPenalty
+            }
+        }
+
+        return nil
+    }
+}

--- a/HermesMobile/Models/Workspace.swift
+++ b/HermesMobile/Models/Workspace.swift
@@ -85,7 +85,7 @@ struct DirectoryListResponse: Decodable, Equatable {
     let error: String?
 }
 
-struct WorkspaceEntry: Decodable, Equatable, Identifiable {
+struct WorkspaceEntry: Decodable, Hashable, Identifiable {
     var id: String { path ?? name ?? UUID().uuidString }
     var isBrowsableDirectory: Bool {
         isDirectory == true || type == "dir"
@@ -97,6 +97,15 @@ struct WorkspaceEntry: Decodable, Equatable, Identifiable {
     let size: Int?
     let modified: Double?
     let isDirectory: Bool?
+
+    init(name: String?, path: String?, type: String? = nil, size: Int? = nil, modified: Double? = nil, isDirectory: Bool? = nil) {
+        self.name = name
+        self.path = path
+        self.type = type
+        self.size = size
+        self.modified = modified
+        self.isDirectory = isDirectory
+    }
 
     enum CodingKeys: String, CodingKey {
         case name

--- a/HermesMobileTests/APIClientWorkspaceFileTests.swift
+++ b/HermesMobileTests/APIClientWorkspaceFileTests.swift
@@ -443,106 +443,6 @@ final class APIClientWorkspaceFileTests: APIClientTestCase {
         XCTAssertEqual(response.path, "Sources/App")
     }
 
-    @MainActor
-    func testFileBrowserLatestDirectoryRequestWins() async throws {
-        let firstRequestStarted = expectation(description: "First directory request started")
-        let client = makeClient { request in
-            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
-            let path = components?.queryItems?.first(where: { $0.name == "path" })?.value
-
-            if path == "cat" {
-                firstRequestStarted.fulfill()
-                Thread.sleep(forTimeInterval: 0.3)
-            }
-
-            return apiTestJSONResponse("""
-            {
-              "entries": [],
-              "path": "\(path ?? ".")"
-            }
-            """, for: request)
-        }
-        let viewModel = try FileBrowserViewModel(
-            session: makeFilePreviewSession(),
-            server: XCTUnwrap(URL(string: "https://example.test")),
-            apiClient: client
-        )
-
-        let firstLoad = Task { await viewModel.load(path: "cat") }
-        await fulfillment(of: [firstRequestStarted], timeout: 1)
-        let latestLoad = Task { await viewModel.load(path: "leetcode-editor") }
-
-        await latestLoad.value
-        await firstLoad.value
-
-        XCTAssertEqual(viewModel.currentPath, "leetcode-editor")
-    }
-
-    @MainActor
-    func testFileBrowserRetriesFailedDirectoryWithoutDiscardingCurrentEntries() async throws {
-        var catAttempts = 0
-        let client = makeClient { request in
-            let components = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
-            let path = components?.queryItems?.first(where: { $0.name == "path" })?.value
-
-            if path == "cat" {
-                catAttempts += 1
-                if catAttempts == 1 {
-                    let response = HTTPURLResponse(
-                        url: try XCTUnwrap(request.url),
-                        statusCode: 503,
-                        httpVersion: nil,
-                        headerFields: ["Content-Type": "application/json"]
-                    )
-                    return (try XCTUnwrap(response), Data(#"{"error":"temporarily unavailable"}"#.utf8))
-                }
-            }
-
-            return apiTestJSONResponse("""
-            {
-              "entries": [{"name": "cat", "path": "cat", "type": "dir"}],
-              "path": "\(path ?? ".")"
-            }
-            """, for: request)
-        }
-        let viewModel = try FileBrowserViewModel(
-            session: makeFilePreviewSession(),
-            server: XCTUnwrap(URL(string: "https://example.test")),
-            apiClient: client
-        )
-
-        await viewModel.loadRoot()
-        await viewModel.load(path: "cat")
-
-        XCTAssertEqual(viewModel.currentPath, ".")
-        XCTAssertEqual(viewModel.entries.first?.name, "cat")
-        XCTAssertNotNil(viewModel.errorMessage)
-
-        await viewModel.retryLastLoad()
-
-        XCTAssertEqual(viewModel.currentPath, "cat")
-        XCTAssertNil(viewModel.errorMessage)
-        XCTAssertEqual(catAttempts, 2)
-    }
-
-    @MainActor
-    func testFileBrowserCancellationDoesNotSurfaceError() async throws {
-        let client = makeClient { _ in
-            throw URLError(.cancelled)
-        }
-        let viewModel = try FileBrowserViewModel(
-            session: makeFilePreviewSession(),
-            server: XCTUnwrap(URL(string: "https://example.test")),
-            apiClient: client
-        )
-
-        await viewModel.loadRoot()
-
-        XCTAssertFalse(viewModel.isLoading)
-        XCTAssertNil(viewModel.errorMessage)
-        XCTAssertNil(viewModel.lastError)
-    }
-
     func testFileReadBuildsExpectedQueryAndDecodesTextResponse() async throws {
         let client = makeClient { request in
             XCTAssertEqual(request.url?.path, "/api/file")
@@ -712,5 +612,60 @@ final class APIClientWorkspaceFileTests: APIClientTestCase {
         XCTAssertEqual(payload.contentType, UTType.zip)
         XCTAssertFalse(payload.isImage)
         XCTAssertEqual(requestedPaths, ["/api/file/raw"])
+    }
+
+    // MARK: - Prefetch
+
+    @MainActor
+    func testFilePreviewUsesPrefetchedContentWithoutRefetching() async throws {
+        let client = makeClient { request in
+            XCTFail("Prefetched content must not be fetched again: \(request.url?.path ?? "")")
+            return apiTestJSONResponse("{}", for: request, status: 500)
+        }
+        let prefetched = Task<FileResponse, Error> {
+            try JSONDecoder().decode(FileResponse.self, from: Data(#"{"path": "Sources/Notes.txt", "content": "warm"}"#.utf8))
+        }
+        let viewModel = try FilePreviewViewModel(
+            session: makeFilePreviewSession(),
+            server: XCTUnwrap(URL(string: "https://example.test")),
+            path: "Sources/Notes.txt",
+            apiClient: client,
+            prefetchedFile: prefetched
+        )
+
+        await viewModel.load()
+
+        guard case let .text(file) = viewModel.preview else {
+            return XCTFail("Expected a text preview, got \(String(describing: viewModel.preview))")
+        }
+        XCTAssertEqual(file.content, "warm")
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testFilePreviewFallsBackToNetworkWhenPrefetchWasCancelled() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/file")
+            return apiTestJSONResponse(#"{"path": "Sources/Notes.txt", "content": "fresh"}"#, for: request)
+        }
+        let prefetched = Task<FileResponse, Error> {
+            try Task.checkCancellation()
+            return try JSONDecoder().decode(FileResponse.self, from: Data(#"{"content": "stale"}"#.utf8))
+        }
+        prefetched.cancel()
+        let viewModel = try FilePreviewViewModel(
+            session: makeFilePreviewSession(),
+            server: XCTUnwrap(URL(string: "https://example.test")),
+            path: "Sources/Notes.txt",
+            apiClient: client,
+            prefetchedFile: prefetched
+        )
+
+        await viewModel.load()
+
+        guard case let .text(file) = viewModel.preview else {
+            return XCTFail("Expected a text preview, got \(String(describing: viewModel.preview))")
+        }
+        XCTAssertEqual(file.content, "fresh")
     }
 }

--- a/HermesMobileTests/FileBrowserViewModelTests.swift
+++ b/HermesMobileTests/FileBrowserViewModelTests.swift
@@ -212,6 +212,7 @@ final class FileBrowserViewModelTests: APIClientTestCase {
         await slowOpen.value
 
         XCTAssertFalse(viewModel.tree.isLoaded("src"), "The folder vanished from the root while its listing was in flight")
+        XCTAssertFalse(viewModel.isLoading("src"), "A dropped listing must not leave its spinner behind")
 
         await viewModel.retryRoot()
 
@@ -256,6 +257,7 @@ final class FileBrowserViewModelTests: APIClientTestCase {
         await slowOpen.value
 
         XCTAssertFalse(viewModel.tree.isLoaded("src"), "The listing from before the folder was recreated is stale and must not be stored")
+        XCTAssertFalse(viewModel.isLoading("src"), "The recreated folder must not show a spinner with no listing in flight")
     }
 
     @MainActor

--- a/HermesMobileTests/FileBrowserViewModelTests.swift
+++ b/HermesMobileTests/FileBrowserViewModelTests.swift
@@ -1,0 +1,294 @@
+import XCTest
+@testable import HermesMobile
+
+/// Lazy loading, expansion memory, selection reveal, and preview prefetch for the file tree.
+final class FileBrowserViewModelTests: APIClientTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "FileBrowserViewModelTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    /// Records every `/api/list` path the model asked for, in call order, and names the
+    /// paths whose listing should currently fail.
+    private final class RequestLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var paths: [String] = []
+        private var failing: Set<String>
+
+        init(failing: Set<String> = []) {
+            self.failing = failing
+        }
+
+        func record(_ path: String) {
+            lock.lock(); defer { lock.unlock() }
+            paths.append(path)
+        }
+
+        func shouldFail(_ path: String) -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            return failing.contains(path)
+        }
+
+        func setFailing(_ paths: Set<String>) {
+            lock.lock(); defer { lock.unlock() }
+            failing = paths
+        }
+
+        var listedPaths: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return paths
+        }
+    }
+
+    private func session(id: String = "s1", workspace: String = "/tmp/ws") throws -> SessionSummary {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(
+            SessionSummary.self,
+            from: Data(#"{"session_id": "\#(id)", "title": "T", "workspace": "\#(workspace)"}"#.utf8)
+        )
+    }
+
+    private func entryJSON(_ name: String, path: String, isDirectory: Bool) -> String {
+        #"{"name": "\#(name)", "path": "\#(path)", "type": "\#(isDirectory ? "dir" : "file")", "is_dir": \#(isDirectory)}"#
+    }
+
+    /// `.git/{HEAD}`, `src/{Chat/{ChatView.swift}}`, `README.md`.
+    private func listingJSON(for path: String) -> String? {
+        switch path {
+        case ".":
+            return #"{"path": ".", "entries": [\#(entryJSON(".git", path: ".git", isDirectory: true)), \#(entryJSON("src", path: "src", isDirectory: true)), \#(entryJSON("README.md", path: "README.md", isDirectory: false))]}"#
+        case ".git":
+            return #"{"path": ".git", "entries": [\#(entryJSON("HEAD", path: ".git/HEAD", isDirectory: false))]}"#
+        case "src":
+            return #"{"path": "src", "entries": [\#(entryJSON("Chat", path: "src/Chat", isDirectory: true))]}"#
+        case "src/Chat":
+            return #"{"path": "src/Chat", "entries": [\#(entryJSON("ChatView.swift", path: "src/Chat/ChatView.swift", isDirectory: false))]}"#
+        default:
+            return nil
+        }
+    }
+
+    private func listedPath(in request: URLRequest) -> String {
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        return components?.queryItems?.first { $0.name == "path" }?.value ?? "."
+    }
+
+    private func makeListingClient(log: RequestLog) -> APIClient {
+        makeClient { [self] request in
+            XCTAssertEqual(request.url?.path, "/api/list")
+            let path = listedPath(in: request)
+            log.record(path)
+            if log.shouldFail(path) {
+                return apiTestJSONResponse(#"{"error": "boom"}"#, for: request, status: 500)
+            }
+            guard let json = listingJSON(for: path) else {
+                return apiTestJSONResponse(#"{"error": "not found"}"#, for: request, status: 404)
+            }
+            return apiTestJSONResponse(json, for: request)
+        }
+    }
+
+    @MainActor
+    private func makeViewModel(
+        client: APIClient,
+        server: String = "https://example.test",
+        workspace: String = "/tmp/ws"
+    ) throws -> FileBrowserViewModel {
+        FileBrowserViewModel(
+            session: try session(workspace: workspace),
+            server: try XCTUnwrap(URL(string: server)),
+            apiClient: client,
+            defaults: defaults
+        )
+    }
+
+    // MARK: - Loading
+
+    @MainActor
+    func testFirstLoadOpensVisibleTopLevelFoldersAndSkipsHiddenOnes() async throws {
+        let log = RequestLog()
+        let viewModel = try makeViewModel(client: makeListingClient(log: log))
+
+        await viewModel.loadInitialRootIfNeeded()
+
+        XCTAssertEqual(log.listedPaths, [".", "src"])
+        XCTAssertEqual(viewModel.expandedPaths, ["src"])
+        XCTAssertEqual(viewModel.visibleNodes(matching: "").map(\.node.path), [".git", "src", "src/Chat", "README.md"])
+        XCTAssertEqual(viewModel.childCount(of: "src"), 1)
+        XCTAssertNil(viewModel.childCount(of: ".git"))
+        XCTAssertFalse(viewModel.isLoadingRoot)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testOpeningAFolderListsItOnceAndClosingKeepsItsChildren() async throws {
+        let log = RequestLog()
+        let viewModel = try makeViewModel(client: makeListingClient(log: log))
+        await viewModel.loadInitialRootIfNeeded()
+
+        await viewModel.toggleDirectory(".git")
+        XCTAssertTrue(viewModel.isExpanded(".git"))
+        XCTAssertTrue(viewModel.visibleNodes(matching: "").map(\.node.path).contains(".git/HEAD"))
+
+        await viewModel.toggleDirectory(".git")
+        XCTAssertFalse(viewModel.isExpanded(".git"))
+        XCTAssertFalse(viewModel.visibleNodes(matching: "").map(\.node.path).contains(".git/HEAD"))
+
+        await viewModel.toggleDirectory(".git")
+        XCTAssertEqual(log.listedPaths.filter { $0 == ".git" }.count, 1)
+    }
+
+    @MainActor
+    func testFailedFolderListingIsRecordedAndTappingRetries() async throws {
+        let log = RequestLog(failing: ["src"])
+        let viewModel = try makeViewModel(client: makeListingClient(log: log))
+
+        await viewModel.loadInitialRootIfNeeded()
+
+        XCTAssertNotNil(viewModel.loadFailure(for: "src"))
+        XCTAssertTrue(viewModel.isExpanded("src"))
+        XCTAssertNil(viewModel.errorMessage, "A folder failure must not read as a root failure")
+
+        log.setFailing([])
+        await viewModel.toggleDirectory("src")
+
+        XCTAssertNil(viewModel.loadFailure(for: "src"))
+        XCTAssertTrue(viewModel.isExpanded("src"))
+        XCTAssertEqual(viewModel.childCount(of: "src"), 1)
+    }
+
+    @MainActor
+    func testRefreshRelistsRootAndOpenFoldersOnly() async throws {
+        let log = RequestLog()
+        let viewModel = try makeViewModel(client: makeListingClient(log: log))
+        await viewModel.loadInitialRootIfNeeded()
+        await viewModel.toggleDirectory("src/Chat")
+        await viewModel.toggleDirectory("src")
+
+        let before = log.listedPaths.count
+        await viewModel.refresh()
+
+        XCTAssertEqual(Array(log.listedPaths.dropFirst(before)), ["."], "Collapsed folders are not re-listed")
+        XCTAssertEqual(viewModel.expandedPaths, ["src/Chat"])
+    }
+
+    // MARK: - Selection
+
+    @MainActor
+    func testSelectingAFileOpensAndListsEveryAncestor() async throws {
+        let log = RequestLog()
+        FileTreeExpansionStore(server: try XCTUnwrap(URL(string: "https://example.test")), workspace: "/tmp/ws", defaults: defaults).save([])
+        let viewModel = try makeViewModel(client: makeListingClient(log: log))
+        await viewModel.loadInitialRootIfNeeded()
+        XCTAssertEqual(log.listedPaths, ["."])
+
+        await viewModel.select(path: "src/Chat/ChatView.swift")
+
+        XCTAssertEqual(viewModel.selectedPath, "src/Chat/ChatView.swift")
+        XCTAssertEqual(log.listedPaths, [".", "src", "src/Chat"])
+        XCTAssertEqual(viewModel.expandedPaths, ["src", "src/Chat"])
+        XCTAssertEqual(viewModel.visibleNodes(matching: "").map(\.node.path), [".git", "src", "src/Chat", "src/Chat/ChatView.swift", "README.md"])
+    }
+
+    // MARK: - Persistence
+
+    @MainActor
+    func testExpansionIsRememberedPerServerAndWorkspace() async throws {
+        let log = RequestLog()
+        let first = try makeViewModel(client: makeListingClient(log: log))
+        await first.loadInitialRootIfNeeded()
+        await first.toggleDirectory("src")
+        await first.toggleDirectory(".git")
+        XCTAssertEqual(first.expandedPaths, [".git"])
+
+        let sameServer = try makeViewModel(client: makeListingClient(log: log))
+        await sameServer.loadInitialRootIfNeeded()
+        XCTAssertEqual(sameServer.expandedPaths, [".git"])
+
+        let otherServer = try makeViewModel(client: makeListingClient(log: log), server: "https://other.test")
+        await otherServer.loadInitialRootIfNeeded()
+        XCTAssertEqual(otherServer.expandedPaths, ["src"], "Another server starts from the default expansion")
+
+        let otherWorkspace = try makeViewModel(client: makeListingClient(log: log), workspace: "/tmp/other")
+        await otherWorkspace.loadInitialRootIfNeeded()
+        XCTAssertEqual(otherWorkspace.expandedPaths, ["src"], "Another workspace on the same server starts from the default expansion")
+    }
+
+    // MARK: - Prefetch
+
+    @MainActor
+    func testPressDownPrefetchesTextFilesAndOpeningKeepsOnlyThatFile() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/api/file")
+            return apiTestJSONResponse(#"{"path": "README.md", "content": "hi"}"#, for: request)
+        }
+        let viewModel = try makeViewModel(client: client)
+
+        viewModel.prefetchFile(at: "logo.png")
+        XCTAssertNil(viewModel.prefetchedFile(at: "logo.png"), "Images are not fetched as text")
+
+        viewModel.prefetchFile(at: "notes.txt")
+        let stale = try XCTUnwrap(viewModel.prefetchedFile(at: "notes.txt"))
+        viewModel.prefetchFile(at: "README.md")
+        XCTAssertTrue(stale.isCancelled, "A newer press-down replaces the older prefetch")
+        XCTAssertNil(viewModel.prefetchedFile(at: "notes.txt"))
+
+        viewModel.keepPrefetch(for: "README.md")
+        let kept = try XCTUnwrap(viewModel.prefetchedFile(at: "README.md"))
+        let file = try await kept.value
+        XCTAssertEqual(file.content, "hi")
+    }
+
+    // MARK: - Races and cancellation
+
+    @MainActor
+    func testStaleRootListingNeverOverwritesANewerOne() async throws {
+        let slowRequestStarted = expectation(description: "slow root request started")
+        let calls = RequestLog()
+        let client = makeClient { request in
+            calls.record(".")
+            if calls.listedPaths.count == 1 {
+                slowRequestStarted.fulfill()
+                Thread.sleep(forTimeInterval: 0.3)
+                return apiTestJSONResponse(#"{"path": ".", "entries": [{"name": "old.txt", "path": "old.txt", "type": "file"}]}"#, for: request)
+            }
+            return apiTestJSONResponse(#"{"path": ".", "entries": [{"name": "new.txt", "path": "new.txt", "type": "file"}]}"#, for: request)
+        }
+        let viewModel = try makeViewModel(client: client)
+
+        let slowLoad = Task { await viewModel.loadInitialRootIfNeeded() }
+        await fulfillment(of: [slowRequestStarted], timeout: 1)
+        let latestLoad = Task { await viewModel.refresh() }
+
+        await latestLoad.value
+        await slowLoad.value
+
+        XCTAssertEqual(viewModel.tree.rootNodes.map(\.name), ["new.txt"])
+        XCTAssertFalse(viewModel.isLoadingRoot)
+    }
+
+    @MainActor
+    func testCancelledRootRequestDoesNotSurfaceAnError() async throws {
+        let client = makeClient { _ in
+            throw URLError(.cancelled)
+        }
+        let viewModel = try makeViewModel(client: client)
+
+        await viewModel.loadInitialRootIfNeeded()
+
+        XCTAssertFalse(viewModel.isLoadingRoot)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNil(viewModel.lastError)
+    }
+}

--- a/HermesMobileTests/FileBrowserViewModelTests.swift
+++ b/HermesMobileTests/FileBrowserViewModelTests.swift
@@ -220,6 +220,45 @@ final class FileBrowserViewModelTests: APIClientTestCase {
     }
 
     @MainActor
+    func testFolderRemovedAndRecreatedDuringAnInFlightListingDropsTheOldResponse() async throws {
+        let slowListingStarted = expectation(description: "slow src listing started")
+        let log = RequestLog()
+        let client = makeClient { [self] request in
+            let path = listedPath(in: request)
+            log.record(path)
+            switch path {
+            case ".":
+                let rootCalls = log.listedPaths.filter { $0 == "." }.count
+                let entries = rootCalls == 2 ? "" : entryJSON("src", path: "src", isDirectory: true)
+                return apiTestJSONResponse(#"{"path": ".", "entries": [\#(entries)]}"#, for: request)
+            case "src":
+                if log.listedPaths.filter({ $0 == "src" }).count == 1 {
+                    slowListingStarted.fulfill()
+                    Thread.sleep(forTimeInterval: 0.3)
+                }
+                return apiTestJSONResponse(#"{"path": "src", "entries": [\#(entryJSON("a.txt", path: "src/a.txt", isDirectory: false))]}"#, for: request)
+            default:
+                return apiTestJSONResponse(#"{"error": "not found"}"#, for: request, status: 404)
+            }
+        }
+        FileTreeExpansionStore(server: try XCTUnwrap(URL(string: "https://example.test")), workspace: "/tmp/ws", defaults: defaults).save([])
+        let viewModel = try makeViewModel(client: client)
+        await viewModel.loadInitialRootIfNeeded()
+
+        let slowOpen = Task { await viewModel.toggleDirectory("src") }
+        await fulfillment(of: [slowListingStarted], timeout: 1)
+        await viewModel.toggleDirectory("src")
+        XCTAssertFalse(viewModel.isExpanded("src"), "Collapsed while the listing is still in flight")
+        await viewModel.refresh()
+        XCTAssertNil(viewModel.tree.node(at: "src"), "Second root listing dropped the folder")
+        await viewModel.retryRoot()
+        XCTAssertNotNil(viewModel.tree.node(at: "src"), "Third root listing brought it back, collapsed, so nothing re-listed it")
+        await slowOpen.value
+
+        XCTAssertFalse(viewModel.tree.isLoaded("src"), "The listing from before the folder was recreated is stale and must not be stored")
+    }
+
+    @MainActor
     func testRefreshRelistsRootAndOpenFoldersOnly() async throws {
         let log = RequestLog()
         let viewModel = try makeViewModel(client: makeListingClient(log: log))

--- a/HermesMobileTests/FileBrowserViewModelTests.swift
+++ b/HermesMobileTests/FileBrowserViewModelTests.swift
@@ -166,6 +166,57 @@ final class FileBrowserViewModelTests: APIClientTestCase {
         XCTAssertNil(viewModel.loadFailure(for: "src"))
         XCTAssertTrue(viewModel.isExpanded("src"))
         XCTAssertEqual(viewModel.childCount(of: "src"), 1)
+        XCTAssertNil(viewModel.takeLastError(), "A recovered folder must not re-report the old failure")
+    }
+
+    @MainActor
+    func testLastErrorIsHandedOverOnce() async throws {
+        let log = RequestLog(failing: ["src"])
+        let viewModel = try makeViewModel(client: makeListingClient(log: log))
+
+        await viewModel.loadInitialRootIfNeeded()
+
+        XCTAssertNotNil(viewModel.takeLastError())
+        XCTAssertNil(viewModel.takeLastError())
+    }
+
+    @MainActor
+    func testFolderRemovedDuringAnInFlightListingIsNotKeptAsLoaded() async throws {
+        let slowListingStarted = expectation(description: "slow src listing started")
+        let log = RequestLog()
+        let client = makeClient { [self] request in
+            let path = listedPath(in: request)
+            log.record(path)
+            switch path {
+            case ".":
+                let rootCalls = log.listedPaths.filter { $0 == "." }.count
+                let entries = rootCalls == 2 ? "" : entryJSON("src", path: "src", isDirectory: true)
+                return apiTestJSONResponse(#"{"path": ".", "entries": [\#(entries)]}"#, for: request)
+            case "src":
+                if log.listedPaths.filter({ $0 == "src" }).count == 1 {
+                    slowListingStarted.fulfill()
+                    Thread.sleep(forTimeInterval: 0.3)
+                }
+                return apiTestJSONResponse(#"{"path": "src", "entries": [\#(entryJSON("a.txt", path: "src/a.txt", isDirectory: false))]}"#, for: request)
+            default:
+                return apiTestJSONResponse(#"{"error": "not found"}"#, for: request, status: 404)
+            }
+        }
+        FileTreeExpansionStore(server: try XCTUnwrap(URL(string: "https://example.test")), workspace: "/tmp/ws", defaults: defaults).save([])
+        let viewModel = try makeViewModel(client: client)
+        await viewModel.loadInitialRootIfNeeded()
+
+        let slowOpen = Task { await viewModel.toggleDirectory("src") }
+        await fulfillment(of: [slowListingStarted], timeout: 1)
+        await viewModel.refresh()
+        await slowOpen.value
+
+        XCTAssertFalse(viewModel.tree.isLoaded("src"), "The folder vanished from the root while its listing was in flight")
+
+        await viewModel.retryRoot()
+
+        XCTAssertEqual(viewModel.childCount(of: "src"), 1, "A folder that comes back is listed again, not served from the orphaned listing")
+        XCTAssertEqual(log.listedPaths.filter { $0 == "src" }.count, 2)
     }
 
     @MainActor
@@ -244,10 +295,15 @@ final class FileBrowserViewModelTests: APIClientTestCase {
         XCTAssertTrue(stale.isCancelled, "A newer press-down replaces the older prefetch")
         XCTAssertNil(viewModel.prefetchedFile(at: "notes.txt"))
 
-        viewModel.keepPrefetch(for: "README.md")
-        let kept = try XCTUnwrap(viewModel.prefetchedFile(at: "README.md"))
-        let file = try await kept.value
+        let handedOver = try XCTUnwrap(viewModel.takePrefetch(for: "README.md"))
+        let file = try await handedOver.value
         XCTAssertEqual(file.content, "hi")
+        XCTAssertNil(viewModel.prefetchedFile(at: "README.md"), "A handed-over prefetch leaves the table")
+
+        viewModel.prefetchFile(at: "README.md")
+        let fresh = try XCTUnwrap(viewModel.prefetchedFile(at: "README.md"))
+        XCTAssertNotEqual(fresh, handedOver, "Reopening the same file starts a new fetch instead of reusing the old response")
+        _ = try await fresh.value
     }
 
     // MARK: - Races and cancellation

--- a/HermesMobileTests/FileTreeTests.swift
+++ b/HermesMobileTests/FileTreeTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import HermesMobile
+
+/// Pure tree behaviour for the workspace file browser: ordering, lazy structure, search.
+final class FileTreeTests: XCTestCase {
+
+    private func dir(_ name: String, path: String? = nil) -> WorkspaceEntry {
+        WorkspaceEntry(name: name, path: path ?? name, type: "dir", isDirectory: true)
+    }
+
+    private func file(_ name: String, path: String? = nil) -> WorkspaceEntry {
+        WorkspaceEntry(name: name, path: path ?? name, type: "file", size: 1, isDirectory: false)
+    }
+
+    /// src/{Chat/{ChatView.swift}, Util/{Math.swift}}, README.md — every directory listed.
+    private func sampleTree() -> FileTree {
+        var tree = FileTree()
+        tree.setChildren([file("README.md"), dir("src")], of: FileTree.rootPath)
+        tree.setChildren([dir("Util", path: "src/Util"), dir("Chat", path: "src/Chat")], of: "src")
+        tree.setChildren([file("ChatView.swift", path: "src/Chat/ChatView.swift")], of: "src/Chat")
+        tree.setChildren([file("Math.swift", path: "src/Util/Math.swift")], of: "src/Util")
+        return tree
+    }
+
+    private func paths(_ nodes: [VisibleFileTreeNode]) -> [String] {
+        nodes.map(\.node.path)
+    }
+
+    // MARK: - Structure
+
+    func testSortsDirectoriesFirstThenNaturalOrder() {
+        var tree = FileTree()
+        tree.setChildren([file("file10.txt"), file("file2.txt"), dir("Zeta"), file("Beta.txt"), dir("alpha")], of: FileTree.rootPath)
+
+        XCTAssertEqual(tree.rootNodes.map(\.name), ["alpha", "Zeta", "Beta.txt", "file2.txt", "file10.txt"])
+    }
+
+    func testNodePathFallsBackToParentAndNameAndSkipsBlankEntries() {
+        var tree = FileTree()
+        tree.setChildren([
+            WorkspaceEntry(name: "notes.txt", path: nil),
+            WorkspaceEntry(name: nil, path: nil)
+        ], of: "docs")
+
+        XCTAssertEqual(tree.children(of: "docs")?.map(\.path), ["docs/notes.txt"])
+        XCTAssertEqual(tree.node(at: "docs/notes.txt")?.name, "notes.txt")
+    }
+
+    func testSymlinkKeepsDirectoryFlagFromServer() {
+        var tree = FileTree()
+        tree.setChildren([
+            WorkspaceEntry(name: "AGENTS.md", path: "AGENTS.md", type: "symlink", isDirectory: false),
+            WorkspaceEntry(name: "shared", path: "shared", type: "symlink", isDirectory: true)
+        ], of: FileTree.rootPath)
+
+        let nodes = tree.rootNodes
+        XCTAssertEqual(nodes.map(\.path), ["shared", "AGENTS.md"])
+        XCTAssertTrue(nodes[0].isDirectory)
+        XCTAssertTrue(nodes[0].isSymlink)
+        XCTAssertFalse(nodes[1].isDirectory)
+        XCTAssertTrue(nodes[1].isSymlink)
+    }
+
+    func testReloadingADirectoryForgetsListingsOfRemovedSubdirectories() {
+        var tree = sampleTree()
+
+        tree.setChildren([dir("Chat", path: "src/Chat")], of: "src")
+
+        XCTAssertTrue(tree.isLoaded("src/Chat"))
+        XCTAssertFalse(tree.isLoaded("src/Util"))
+    }
+
+    func testAncestorAndParentPaths() {
+        XCTAssertEqual(FileTree.ancestorPaths(of: "a/b/c.txt"), ["a", "a/b"])
+        XCTAssertEqual(FileTree.ancestorPaths(of: "top.txt"), [])
+        XCTAssertEqual(FileTree.parentPath(of: "a/b/c.txt"), "a/b")
+        XCTAssertEqual(FileTree.parentPath(of: "top.txt"), FileTree.rootPath)
+    }
+
+    func testDefaultExpansionOpensTopLevelFoldersExceptHiddenOnes() {
+        var tree = FileTree()
+        tree.setChildren([dir(".git"), dir("src"), dir("docs"), file("README.md")], of: FileTree.rootPath)
+
+        XCTAssertEqual(FileTree.defaultExpandedPaths(in: tree.rootNodes), ["src", "docs"])
+    }
+
+    // MARK: - Flattening
+
+    func testFlattenShowsChildrenOnlyOfExpandedDirectories() {
+        let tree = sampleTree()
+
+        XCTAssertEqual(paths(tree.visibleNodes(expanded: [])), ["src", "README.md"])
+        XCTAssertEqual(paths(tree.visibleNodes(expanded: ["src"])), ["src", "src/Chat", "src/Util", "README.md"])
+
+        let deep = tree.visibleNodes(expanded: ["src", "src/Util"])
+        XCTAssertEqual(paths(deep), ["src", "src/Chat", "src/Util", "src/Util/Math.swift", "README.md"])
+        XCTAssertEqual(deep.map(\.depth), [0, 1, 1, 2, 0])
+    }
+
+    func testFlattenSkipsChildrenOfUnloadedDirectories() {
+        var tree = FileTree()
+        tree.setChildren([dir("src")], of: FileTree.rootPath)
+
+        XCTAssertEqual(paths(tree.visibleNodes(expanded: ["src"])), ["src"])
+    }
+
+    // MARK: - Search
+
+    func testSearchKeepsAncestorsOfMatchesAndTraversesCollapsedFolders() {
+        let tree = sampleTree()
+
+        let visible = tree.visibleNodes(expanded: [], searchQuery: "chatview")
+
+        XCTAssertEqual(paths(visible), ["src", "src/Chat", "src/Chat/ChatView.swift"])
+    }
+
+    func testSearchRequiresEveryToken() {
+        let tree = sampleTree()
+
+        XCTAssertEqual(paths(tree.visibleNodes(expanded: [], searchQuery: "src chat")), ["src", "src/Chat", "src/Chat/ChatView.swift"])
+        XCTAssertEqual(paths(tree.visibleNodes(expanded: [], searchQuery: "chat math")), [])
+    }
+
+    func testSearchMatchesCamelCaseWordsFuzzily() {
+        let tree = sampleTree()
+
+        XCTAssertEqual(paths(tree.visibleNodes(expanded: [], searchQuery: "vew")), ["src", "src/Chat", "src/Chat/ChatView.swift"])
+    }
+
+    func testSearchShowsMatchingUnloadedDirectory() {
+        var tree = FileTree()
+        tree.setChildren([dir("Features"), dir("Networking")], of: FileTree.rootPath)
+
+        XCTAssertEqual(paths(tree.visibleNodes(expanded: [], searchQuery: "feat")), ["Features"])
+    }
+
+    func testSplitWordsHandlesCamelCaseAcronymsAndPunctuation() {
+        XCTAssertEqual(FileTreeSearch.splitWords("ChatStreamCoordinator.swift"), ["chat", "stream", "coordinator", "swift"])
+        XCTAssertEqual(FileTreeSearch.splitWords("HTTPServer"), ["http", "server"])
+        XCTAssertEqual(FileTreeSearch.splitWords("file_v2-final"), ["file", "v2", "final"])
+    }
+
+    func testTokensSplitOnWhitespaceAndPathPunctuation() {
+        XCTAssertEqual(FileTreeSearch.tokens(from: "  Src/Chat_view.swift  "), ["src", "chat", "view", "swift"])
+        XCTAssertEqual(FileTreeSearch.tokens(from: "   "), [])
+    }
+
+    func testScoreTiersRankExactBeforePrefixBoundaryAndSubstring() throws {
+        let exact = try XCTUnwrap(FileTreeSearch.score(value: "chat", query: "chat", fuzzy: false))
+        let prefix = try XCTUnwrap(FileTreeSearch.score(value: "chatview", query: "chat", fuzzy: false))
+        let boundary = try XCTUnwrap(FileTreeSearch.score(value: "my-chat", query: "chat", fuzzy: false))
+        let substring = try XCTUnwrap(FileTreeSearch.score(value: "myxchat", query: "chat", fuzzy: false))
+
+        XCTAssertEqual(exact, 0)
+        XCTAssertLessThan(exact, prefix)
+        XCTAssertLessThan(prefix, boundary)
+        XCTAssertLessThan(boundary, substring)
+    }
+
+    func testScoreFallsBackToSubsequenceOnlyWhenFuzzy() throws {
+        XCTAssertNil(FileTreeSearch.score(value: "coordinator", query: "cdt", fuzzy: false))
+        let fuzzy = try XCTUnwrap(FileTreeSearch.score(value: "coordinator", query: "cdt", fuzzy: true))
+        XCTAssertGreaterThanOrEqual(fuzzy, 100)
+        XCTAssertNil(FileTreeSearch.score(value: "coordinator", query: "xyz", fuzzy: true))
+    }
+}

--- a/HermesMobileTests/FileTreeTests.swift
+++ b/HermesMobileTests/FileTreeTests.swift
@@ -44,6 +44,7 @@ final class FileTreeTests: XCTestCase {
 
         XCTAssertEqual(tree.children(of: "docs")?.map(\.path), ["docs/notes.txt"])
         XCTAssertEqual(tree.node(at: "docs/notes.txt")?.name, "notes.txt")
+        XCTAssertEqual(tree.node(at: "docs/notes.txt")?.entry.path, "docs/notes.txt", "The preview reads the entry's path")
     }
 
     func testSymlinkKeepsDirectoryFlagFromServer() {


### PR DESCRIPTION
## Linked issue

Maintainer-scoped workspace work; no tracking issue.

## What changed

The Files screen showed one folder at a time with Root, Up, and breadcrumbs, and search only filtered that folder. Finding a file three levels down meant three round trips and three screens of context lost.

Now the workspace is one nested tree:

- **Folders first, natural order** (`file2` before `file10`), with a child count once a folder has been listed.
- **Top-level folders open on first visit**, hidden dot-folders stay closed. Every folder is listed from `/api/list` only when it is first opened; nothing recursive, no whole-workspace fetch. Open folders are fetched in parallel.
- **Tap a folder to open or close it.** A failed listing shows a warning mark and tapping retries. Pull to refresh re-lists the root and every open folder and keeps them open.
- **Search over loaded nodes** with t3code's tiered scoring (exact, prefix, boundary, substring, then fuzzy on camelCase-split words). Every token must match; a folder stays visible when any descendant matches, so results keep their path context. Collapsed folders are searched too.
- **Press-down prefetch.** Holding a file row starts its `/api/file` fetch before the tap lands; opening the file hands that fetch to the preview and cancels any other prefetch. Images and known binaries are not prefetched.
- **Expansion state persists per server and workspace** (`fileTree.expanded|<server>|<workspace>` in UserDefaults), so one server's layout never shows up under another.
- Opening a file marks it selected and opens every folder above it, listing any that were not fetched yet.

Rows are 42 pt, indented 18 pt per level, with folder, file, and symlink symbols. The richer per-type icon map is a separate piece of work. Every user-facing string reuses an existing catalog key, so no String Catalog change.

`WorkspaceEntry` gained a memberwise init and `Hashable` (needed for `navigationDestination(item:)`); decoding is unchanged and still tolerant.

## How it was tested

- Full XCTest suite on the iPhone 17 simulator via XcodeBuildMCP `test_sim`: **2144 passed, 0 failed, 2 skipped** (pre-existing photo-library skips) on the final head.
- New focused tests: `FileTreeTests` (sort, symlink flags, subtree pruning on reload, ancestor paths, default expansion, flatten with and without search, camelCase splitting, tokenizing, score tiers, fuzzy fallback) and `FileBrowserViewModelTests` (default expansion skips hidden folders, list-once on open, failed folder retry, refresh re-lists only open folders, select opens and lists ancestors, per-server and per-workspace persistence, prefetch replacement and hand-off, stale root listing dropped, cancellation stays quiet). Two prefetch cases in `APIClientWorkspaceFileTests` cover the preview using a warm fetch and falling back when it was cancelled.
- Live server check: `/api/list` is one folder per call with no recursion (about 0.7 s per hop over the tunnel), which is why loading is lazy.
- Manual pass by the maintainer on the simulator against the live server: default expansion, open and close, search, press-and-hold preview, pull to refresh, relaunch persistence. After screenshot to follow as a comment.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

---

Built by Claude Fable 5.1 through Claude Code.
