### PR TITLE
feat(chat): render Markdown workspace images and zoom them in a full-bleed viewer

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		C14300000000000000000001 /* StreamingMarkdownSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14300000000000000000002 /* StreamingMarkdownSupport.swift */; };
 		C0DE34000000000000000001 /* TranscriptMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000002 /* TranscriptMedia.swift */; };
 		C0DE34000000000000000006 /* TranscriptMediaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000005 /* TranscriptMediaView.swift */; };
+		1F18000000000000000000B2 /* TranscriptMediaImageLightbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18000000000000000000A2 /* TranscriptMediaImageLightbox.swift */; };
+		1F18000000000000000000B1 /* ImageLightboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18000000000000000000A1 /* ImageLightboxView.swift */; };
 		C0DE34000000000000000008 /* TranscriptMediaPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */; };
 		C0DE34000000000000000009 /* TranscriptMediaDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */; };
 		C0DE3400000000000000000D /* TranscriptMediaExportSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */; };
@@ -211,6 +213,8 @@
 		1F16000000000000000000B4 /* FileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16000000000000000000F4 /* FileReference.swift */; };
 		1F16000000000000000000B5 /* FileIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16000000000000000000F5 /* FileIcon.swift */; };
 		1F16000000000000000000B6 /* FileReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16000000000000000000F6 /* FileReferenceTests.swift */; };
+		1F18000000000000000000B4 /* ImageLightboxGesturePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18000000000000000000A4 /* ImageLightboxGesturePolicyTests.swift */; };
+		1F18000000000000000000B3 /* TranscriptMarkdownImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18000000000000000000A3 /* TranscriptMarkdownImageTests.swift */; };
 		1F16000000000000000000B7 /* FileIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F16000000000000000000F7 /* FileIconTests.swift */; };
 		1A2B3C4D5E6F7000000000E8 /* FilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000E9 /* FilePreviewView.swift */; };
 		1A2B3C4D5E6F7000000000EA /* FilePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000EB /* FilePreviewViewModel.swift */; };
@@ -581,6 +585,8 @@
 		C14300000000000000000002 /* StreamingMarkdownSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingMarkdownSupport.swift; sourceTree = "<group>"; };
 		C0DE34000000000000000002 /* TranscriptMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMedia.swift; sourceTree = "<group>"; };
 		C0DE34000000000000000005 /* TranscriptMediaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaView.swift; sourceTree = "<group>"; };
+		1F18000000000000000000A2 /* TranscriptMediaImageLightbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaImageLightbox.swift; sourceTree = "<group>"; };
+		1F18000000000000000000A1 /* ImageLightboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLightboxView.swift; sourceTree = "<group>"; };
 		C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaPreviewViewModel.swift; sourceTree = "<group>"; };
 		C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaDataLoader.swift; sourceTree = "<group>"; };
 		C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMediaExportSupport.swift; sourceTree = "<group>"; };
@@ -641,6 +647,8 @@
 		1F16000000000000000000F4 /* FileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReference.swift; sourceTree = "<group>"; };
 		1F16000000000000000000F5 /* FileIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIcon.swift; sourceTree = "<group>"; };
 		1F16000000000000000000F6 /* FileReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReferenceTests.swift; sourceTree = "<group>"; };
+		1F18000000000000000000A4 /* ImageLightboxGesturePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLightboxGesturePolicyTests.swift; sourceTree = "<group>"; };
+		1F18000000000000000000A3 /* TranscriptMarkdownImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptMarkdownImageTests.swift; sourceTree = "<group>"; };
 		1F16000000000000000000F7 /* FileIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000E9 /* FilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000EB /* FilePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewViewModel.swift; sourceTree = "<group>"; };
@@ -1022,6 +1030,8 @@
 				1D1FF0000000000000000F34 /* SourceFileRowsTests.swift */,
 				1F16000000000000000000F2 /* FileTreeTests.swift */,
 				1F16000000000000000000F6 /* FileReferenceTests.swift */,
+				1F18000000000000000000A4 /* ImageLightboxGesturePolicyTests.swift */,
+				1F18000000000000000000A3 /* TranscriptMarkdownImageTests.swift */,
 				1F16000000000000000000F7 /* FileIconTests.swift */,
 				1F16000000000000000000F3 /* FileBrowserViewModelTests.swift */,
 				1D1FF0000000000000000F35 /* SourceHighlighterTests.swift */,
@@ -1279,6 +1289,8 @@
 				C14300000000000000000002 /* StreamingMarkdownSupport.swift */,
 				C0DE34000000000000000002 /* TranscriptMedia.swift */,
 				C0DE34000000000000000005 /* TranscriptMediaView.swift */,
+				1F18000000000000000000A2 /* TranscriptMediaImageLightbox.swift */,
+				1F18000000000000000000A1 /* ImageLightboxView.swift */,
 				C0DE34000000000000000007 /* TranscriptMediaPreviewViewModel.swift */,
 				C0DE3400000000000000000A /* TranscriptMediaDataLoader.swift */,
 				C0DE3400000000000000000E /* TranscriptMediaExportSupport.swift */,
@@ -1881,6 +1893,8 @@
 				C14300000000000000000001 /* StreamingMarkdownSupport.swift in Sources */,
 				C0DE34000000000000000001 /* TranscriptMedia.swift in Sources */,
 				C0DE34000000000000000006 /* TranscriptMediaView.swift in Sources */,
+				1F18000000000000000000B2 /* TranscriptMediaImageLightbox.swift in Sources */,
+				1F18000000000000000000B1 /* ImageLightboxView.swift in Sources */,
 				C0DE34000000000000000008 /* TranscriptMediaPreviewViewModel.swift in Sources */,
 				C0DE34000000000000000009 /* TranscriptMediaDataLoader.swift in Sources */,
 				C0DE3400000000000000000D /* TranscriptMediaExportSupport.swift in Sources */,
@@ -2052,6 +2066,8 @@
 				1D1FF0000000000000000B34 /* SourceFileRowsTests.swift in Sources */,
 				1F16000000000000000000B2 /* FileTreeTests.swift in Sources */,
 				1F16000000000000000000B6 /* FileReferenceTests.swift in Sources */,
+				1F18000000000000000000B4 /* ImageLightboxGesturePolicyTests.swift in Sources */,
+				1F18000000000000000000B3 /* TranscriptMarkdownImageTests.swift in Sources */,
 				1F16000000000000000000B7 /* FileIconTests.swift in Sources */,
 				1F16000000000000000000B3 /* FileBrowserViewModelTests.swift in Sources */,
 				1D1FF0000000000000000B35 /* SourceHighlighterTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatAttachmentPreviewView.swift
+++ b/HermesMobile/Features/Chat/ChatAttachmentPreviewView.swift
@@ -275,6 +275,77 @@ struct ChatAttachmentPreviewView: View {
     }
 }
 
+/// An attachment that is already known to be an image opens in the full-bleed lightbox.
+/// Text, audio, and anything without a preview keeps `ChatAttachmentPreviewView`, which
+/// only learns what it has once the server answers.
+struct ChatAttachmentImageLightbox: View {
+    let onAPIError: (Error) -> Void
+
+    private let item: ChatAttachmentPreviewItem
+    @State private var viewModel: ChatAttachmentPreviewViewModel
+
+    init(
+        session: SessionSummary,
+        server: URL,
+        item: ChatAttachmentPreviewItem,
+        onAPIError: @escaping (Error) -> Void
+    ) {
+        self.item = item
+        self.onAPIError = onAPIError
+        _viewModel = State(
+            initialValue: ChatAttachmentPreviewViewModel(session: session, server: server, item: item)
+        )
+    }
+
+    var body: some View {
+        ImageLightboxView(
+            content: content,
+            title: item.displayName,
+            path: item.displayPath,
+            imageAccessibilityLabel: item.displayName,
+            onRetry: { Task { await loadAttachment(force: true) } }
+        )
+        .task {
+            await loadAttachment()
+        }
+    }
+
+    private var content: ImageLightboxContent {
+        switch viewModel.preview {
+        case let .image(file):
+            if let image = UIImage(data: file.data) {
+                return .image(
+                    image,
+                    detail: ByteCountFormatter.string(
+                        fromByteCount: Int64(file.originalByteCount),
+                        countStyle: .file
+                    )
+                )
+            }
+            return .failure(String(localized: "Could not preview this image."))
+
+        case let .unavailable(message):
+            return .failure(message)
+
+        case .text, .audio:
+            return .failure(String(localized: "Preview is not available for this attachment."))
+
+        case .none:
+            if !viewModel.isLoading, let message = viewModel.errorMessage {
+                return .failure(message)
+            }
+            return .loading(String(localized: "Loading attachment..."))
+        }
+    }
+
+    private func loadAttachment(force: Bool = false) async {
+        await viewModel.load(force: force)
+        if let lastError = viewModel.lastError {
+            onAPIError(lastError)
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class ChatAttachmentPreviewViewModel {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -316,6 +316,8 @@ struct ChatView: View {
     @State private var selectableResponseText: SelectableTextPresentation?
     @State private var attachmentPreviewItem: ChatAttachmentPreviewItem?
     @State private var transcriptMediaPreviewItem: TranscriptMediaPreviewItem?
+    @State private var transcriptMediaImageItem: TranscriptMediaPreviewItem?
+    @State private var attachmentImageItem: ChatAttachmentPreviewItem?
     /// A workspace file a chat link named; presented on the source viewer at its line.
     @State private var openedFileReference: FileReference?
     @State private var pendingProfileSelection: ProfileSummary?
@@ -533,9 +535,7 @@ struct ChatView: View {
                 }
             },
             onPreviewAttachment: { attachment in
-                presentPreviewRestoringComposerFocusIfNeeded {
-                    attachmentPreviewItem = ChatAttachmentPreviewItem(pending: attachment)
-                }
+                presentAttachmentPreview(ChatAttachmentPreviewItem(pending: attachment))
             },
             onDismissUploadAttachmentError: {
                 viewModel.setUploadAttachmentError(nil)
@@ -578,6 +578,39 @@ struct ChatView: View {
             return String(localized: "Read-only")
         }
         return nil
+    }
+
+    /// An image is known to be an image before it is fetched, so it opens in the
+    /// full-bleed lightbox. Everything else keeps the preview sheet, which still has to
+    /// decide between audio, video, and an unsupported file once the bytes arrive.
+    private func presentTranscriptMediaPreview(_ reference: TranscriptMediaReference) {
+        presentPreviewRestoringComposerFocusIfNeeded {
+            let item = TranscriptMediaPreviewItem(reference: reference)
+            if reference.isRasterImageCandidate, !reference.isExtensionlessRemoteMediaCandidate {
+                transcriptMediaImageItem = item
+            } else {
+                transcriptMediaPreviewItem = item
+            }
+        }
+    }
+
+    private func presentAttachmentPreview(_ item: ChatAttachmentPreviewItem) {
+        presentPreviewRestoringComposerFocusIfNeeded {
+            if item.inferredIsImage {
+                attachmentImageItem = item
+            } else {
+                attachmentPreviewItem = item
+            }
+        }
+    }
+
+    private func transcriptMediaImageLightbox(for item: TranscriptMediaPreviewItem) -> some View {
+        TranscriptMediaImageLightbox(
+            server: server,
+            sessionID: transcriptMediaSessionID,
+            item: item,
+            onAPIError: onAPIError
+        )
     }
 
     private func transcriptMediaPreviewView(for item: TranscriptMediaPreviewItem) -> some View {
@@ -811,6 +844,30 @@ struct ChatView: View {
                 }
             }
             .sheet(item: $transcriptMediaPreviewItem, content: transcriptMediaPreviewView)
+            .fullScreenCover(item: $attachmentImageItem) { item in
+                ChatAttachmentImageLightbox(
+                    session: session,
+                    server: server,
+                    item: item,
+                    onAPIError: onAPIError
+                )
+            }
+            .onChange(of: attachmentImageItem == nil) { _, isDismissed in
+                if isDismissed {
+                    restoreComposerFocusAfterPreviewIfNeeded()
+                }
+            }
+            .fullScreenCover(item: $transcriptMediaImageItem, content: transcriptMediaImageLightbox)
+            .onChange(of: transcriptMediaImageItem == nil) { _, isDismissed in
+                if isDismissed {
+                    restoreComposerFocusAfterPreviewIfNeeded()
+                }
+            }
+            .onChange(of: transcriptMediaPreviewItem == nil) { _, isDismissed in
+                if isDismissed {
+                    restoreComposerFocusAfterPreviewIfNeeded()
+                }
+            }
             .sheet(item: $openedFileReference, content: fileReferenceSheet)
             .sheet(item: $activeGitSheet, content: gitSheet)
             .sheet(item: $turnDiffPresentation, content: turnDiffSheet)
@@ -1355,12 +1412,12 @@ struct ChatView: View {
                 scrollToLatestContent(proxy, animated: animated)
             },
             onPreviewAttachment: { attachment, localData in
-                presentPreviewRestoringComposerFocusIfNeeded {
-                    attachmentPreviewItem = ChatAttachmentPreviewItem(message: attachment, localData: localData)
-                }
+                presentAttachmentPreview(
+                    ChatAttachmentPreviewItem(message: attachment, localData: localData)
+                )
             },
             onPreviewTranscriptMedia: { reference in
-                transcriptMediaPreviewItem = TranscriptMediaPreviewItem(reference: reference)
+                presentTranscriptMediaPreview(reference)
             },
             onToggleListening: { context in
                 viewModel.toggleListening(to: context)
@@ -1395,6 +1452,7 @@ struct ChatView: View {
         }
         .environment(\.skillChipCatalog, viewModel.skillChipCatalog)
         .environment(\.openURL, OpenURLAction(handler: handleTranscriptLink))
+        .environment(\.chatWorkspaceRoot, session.workspace)
         .task(id: transcriptSkillReferenceCount) {
             await loadSkillSuggestionsForTranscriptChipsIfNeeded()
         }

--- a/HermesMobile/Features/Chat/ImageLightboxView.swift
+++ b/HermesMobile/Features/Chat/ImageLightboxView.swift
@@ -1,0 +1,565 @@
+import SwiftUI
+import UIKit
+
+/// Where a lightbox is in its caller's load. The caller owns the fetch, so the transcript
+/// and attachment surfaces keep their own loading, retry, and error rules.
+enum ImageLightboxContent {
+    case loading(String)
+    /// `detail` is the one-line fact under the path, usually the file size.
+    case image(UIImage, detail: String?)
+    case failure(String)
+}
+
+/// The gesture thresholds of the lightbox, kept apart from UIKit so they can be reasoned
+/// about and tested without a running scroll view.
+enum ImageLightboxGesturePolicy {
+    /// The drag distance that both closes the viewer and drives the shrink underneath it.
+    static let dismissDistance: CGFloat = 220
+    static let dismissDistanceThreshold: CGFloat = 110
+    static let dismissVelocityThreshold: CGFloat = 900
+
+    /// A flick down closes on either distance or speed, so a short fast flick works as
+    /// well as a slow long drag. Upward and sideways drags never close.
+    static func shouldDismiss(translation: CGFloat, velocity: CGFloat) -> Bool {
+        guard translation > 0 else { return false }
+        return translation > dismissDistanceThreshold || velocity > dismissVelocityThreshold
+    }
+
+    /// The dismiss drag only exists at fit scale. Once the image is zoomed the same
+    /// downward drag has to pan it instead, so the two gestures never compete.
+    static func canBeginDismiss(
+        zoomScale: CGFloat,
+        minimumZoomScale: CGFloat,
+        velocity: CGPoint
+    ) -> Bool {
+        guard zoomScale <= minimumZoomScale + 0.01 else { return false }
+        return velocity.y > 0 && velocity.y > abs(velocity.x)
+    }
+
+    /// How far the image can be zoomed: enough to reach its own pixels, but always at
+    /// least 3x so a small image is still inspectable, and never so far that a huge
+    /// screenshot turns into a maze.
+    static func maximumZoomScale(imagePixelWidth: CGFloat, fittedWidth: CGFloat) -> CGFloat {
+        guard fittedWidth > 0, imagePixelWidth > 0 else { return 3 }
+        return min(8, max(3, imagePixelWidth / fittedWidth))
+    }
+
+    /// Where a double tap lands when the image is at fit scale.
+    static func doubleTapZoomScale(maximumZoomScale: CGFloat) -> CGFloat {
+        min(maximumZoomScale, 2.5)
+    }
+}
+
+/// A full-bleed image viewer: pinch, double tap, and pan to inspect, flick down at fit
+/// scale to close. One tap takes the chrome away so nothing covers the picture. VoiceOver
+/// keeps the chrome up, because a hidden Done button is not a way out.
+///
+/// The caller supplies the loaded image and any toolbar actions; use
+/// `ImageLightboxActionButton` for those so an empty action list draws nothing.
+struct ImageLightboxView<Actions: View>: View {
+    let content: ImageLightboxContent
+    let title: String
+    let path: String?
+    let imageAccessibilityLabel: String
+    let onRetry: () -> Void
+    let actions: Actions
+
+    @State private var showsChrome = true
+    @State private var isZoomed = false
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
+
+    init(
+        content: ImageLightboxContent,
+        title: String,
+        path: String?,
+        imageAccessibilityLabel: String,
+        onRetry: @escaping () -> Void,
+        @ViewBuilder actions: () -> Actions
+    ) {
+        self.content = content
+        self.title = title
+        self.path = path
+        self.imageAccessibilityLabel = imageAccessibilityLabel
+        self.onRetry = onRetry
+        self.actions = actions()
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            contentLayer
+
+            chromeLayer
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    /// The chrome hides only once there is an image to look at: while loading or after a
+    /// failure the way out has to stay on screen.
+    private var isChromeVisible: Bool {
+        guard case .image = content, !voiceOverEnabled else { return true }
+        return showsChrome && !isZoomed
+    }
+
+    @ViewBuilder
+    private var contentLayer: some View {
+        switch content {
+        case let .loading(message):
+            VStack(spacing: 12) {
+                ProgressView()
+                    .tint(.white)
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+
+        case let .image(image, _):
+            ZoomableImageView(
+                image: image,
+                reduceMotion: reduceMotion,
+                onSingleTap: { showsChrome.toggle() },
+                onZoomChange: { isZoomed = $0 },
+                onDismiss: { dismiss() }
+            )
+            .ignoresSafeArea()
+            .accessibilityElement()
+            .accessibilityLabel(imageAccessibilityLabel)
+            .accessibilityAddTraits(.isImage)
+
+        case let .failure(message):
+            VStack(spacing: 14) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 30))
+                    .foregroundStyle(.white.opacity(0.6))
+                Text(message)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.white.opacity(0.85))
+                Button("Try Again", action: onRetry)
+                    .buttonStyle(.bordered)
+                    .tint(.white)
+            }
+            .padding(32)
+        }
+    }
+
+    private var chromeLayer: some View {
+        VStack(spacing: 0) {
+            topBar
+
+            Spacer(minLength: 0)
+
+            if let path, !path.isEmpty {
+                caption(path: path)
+            }
+        }
+        .opacity(isChromeVisible ? 1 : 0)
+        .allowsHitTesting(isChromeVisible)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: isChromeVisible)
+    }
+
+    private var topBar: some View {
+        ZStack {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(.white)
+                .padding(.horizontal, 88)
+
+            HStack(spacing: 10) {
+                ImageLightboxActionButton(
+                    systemImage: "xmark",
+                    accessibilityLabel: String(localized: "Done"),
+                    action: { dismiss() }
+                )
+
+                Spacer(minLength: 0)
+
+                actions
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private func caption(path: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(path)
+                .font(.caption2)
+                .fontDesign(.monospaced)
+                .foregroundStyle(.white.opacity(0.75))
+                .lineLimit(2)
+                .truncationMode(.head)
+
+            if case let .image(_, detail) = content, let detail {
+                Text(detail)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 18)
+        .padding(.top, 28)
+        .padding(.bottom, 14)
+        .background(
+            LinearGradient(
+                colors: [.black.opacity(0), .black.opacity(0.7)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+}
+
+extension ImageLightboxView where Actions == EmptyView {
+    init(
+        content: ImageLightboxContent,
+        title: String,
+        path: String?,
+        imageAccessibilityLabel: String,
+        onRetry: @escaping () -> Void
+    ) {
+        self.init(
+            content: content,
+            title: title,
+            path: path,
+            imageAccessibilityLabel: imageAccessibilityLabel,
+            onRetry: onRetry,
+            actions: { EmptyView() }
+        )
+    }
+}
+
+/// A round glass button for the lightbox's floating chrome. Each action carries its own
+/// background, so a surface with no actions adds nothing to the bar.
+struct ImageLightboxActionButton: View {
+    let systemImage: String
+    let accessibilityLabel: String
+    let isDisabled: Bool
+    let action: () -> Void
+
+    init(
+        systemImage: String,
+        accessibilityLabel: String,
+        isDisabled: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.systemImage = systemImage
+        self.accessibilityLabel = accessibilityLabel
+        self.isDisabled = isDisabled
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 34, height: 34)
+                .background(.ultraThinMaterial, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.4 : 1)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+/// A `UIScrollView` around one image. UIKit already arbitrates pinch, pan, and double tap
+/// correctly; the only addition is a drag that closes the viewer, and it is allowed to
+/// start only at fit scale so it can never steal a pan from a zoomed image.
+struct ZoomableImageView: UIViewRepresentable {
+    let image: UIImage
+    let reduceMotion: Bool
+    let onSingleTap: () -> Void
+    let onZoomChange: (Bool) -> Void
+    let onDismiss: () -> Void
+
+    func makeUIView(context: Context) -> ZoomableScrollView {
+        let coordinator = context.coordinator
+
+        let scrollView = ZoomableScrollView()
+        scrollView.delegate = coordinator
+        scrollView.backgroundColor = .clear
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.alwaysBounceVertical = false
+        scrollView.alwaysBounceHorizontal = false
+        scrollView.bouncesZoom = true
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.minimumZoomScale = 1
+        scrollView.maximumZoomScale = 1
+
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        imageView.isUserInteractionEnabled = true
+        scrollView.addSubview(imageView)
+
+        coordinator.scrollView = scrollView
+        coordinator.imageView = imageView
+        scrollView.onLayoutSizeChange = { [weak coordinator] size in
+            coordinator?.layoutImage(in: size)
+        }
+
+        let doubleTap = UITapGestureRecognizer(
+            target: coordinator,
+            action: #selector(Coordinator.handleDoubleTap(_:))
+        )
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+
+        let singleTap = UITapGestureRecognizer(
+            target: coordinator,
+            action: #selector(Coordinator.handleSingleTap)
+        )
+        singleTap.require(toFail: doubleTap)
+        scrollView.addGestureRecognizer(singleTap)
+
+        let dismissPan = UIPanGestureRecognizer(
+            target: coordinator,
+            action: #selector(Coordinator.handleDismissPan(_:))
+        )
+        dismissPan.delegate = coordinator
+        scrollView.addGestureRecognizer(dismissPan)
+        coordinator.dismissPan = dismissPan
+
+        return scrollView
+    }
+
+    func updateUIView(_ scrollView: ZoomableScrollView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.reduceMotion = reduceMotion
+        coordinator.onSingleTap = onSingleTap
+        coordinator.onZoomChange = onZoomChange
+        coordinator.onDismiss = onDismiss
+
+        if coordinator.imageView?.image !== image {
+            coordinator.imageView?.image = image
+            coordinator.layoutImage(in: scrollView.bounds.size)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, UIScrollViewDelegate, UIGestureRecognizerDelegate {
+        weak var scrollView: ZoomableScrollView?
+        weak var imageView: UIImageView?
+        weak var dismissPan: UIPanGestureRecognizer?
+
+        var reduceMotion = false
+        var onSingleTap: () -> Void = {}
+        var onZoomChange: (Bool) -> Void = { _ in }
+        var onDismiss: () -> Void = {}
+
+        private var isDismissing = false
+
+        /// Fits the image to the viewport and resets the zoom. Called on every size
+        /// change, so a rotation re-fits instead of leaving the image half off screen.
+        func layoutImage(in size: CGSize) {
+            guard let scrollView,
+                  let imageView,
+                  let image = imageView.image,
+                  size.width > 0, size.height > 0,
+                  image.size.width > 0, image.size.height > 0
+            else { return }
+
+            let scale = min(size.width / image.size.width, size.height / image.size.height)
+            let fitted = CGSize(
+                width: image.size.width * scale,
+                height: image.size.height * scale
+            )
+
+            scrollView.zoomScale = 1
+            imageView.transform = .identity
+            imageView.alpha = 1
+            imageView.frame = CGRect(origin: .zero, size: fitted)
+            scrollView.contentSize = fitted
+            scrollView.maximumZoomScale = ImageLightboxGesturePolicy.maximumZoomScale(
+                imagePixelWidth: image.size.width * image.scale,
+                fittedWidth: fitted.width
+            )
+            centerContent()
+            onZoomChange(false)
+        }
+
+        // MARK: - UIScrollViewDelegate
+
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            imageView
+        }
+
+        func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            centerContent()
+        }
+
+        func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+            onZoomChange(scale > scrollView.minimumZoomScale + 0.01)
+        }
+
+        // MARK: - Gestures
+
+        @objc func handleSingleTap() {
+            onSingleTap()
+        }
+
+        @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scrollView, let imageView else { return }
+            let animated = !reduceMotion
+
+            if scrollView.zoomScale > scrollView.minimumZoomScale + 0.01 {
+                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: animated)
+                onZoomChange(false)
+                return
+            }
+
+            let target = ImageLightboxGesturePolicy.doubleTapZoomScale(
+                maximumZoomScale: scrollView.maximumZoomScale
+            )
+            scrollView.zoom(
+                to: zoomRect(for: target, around: gesture.location(in: imageView)),
+                animated: animated
+            )
+            onZoomChange(true)
+        }
+
+        @objc func handleDismissPan(_ gesture: UIPanGestureRecognizer) {
+            guard let scrollView, let imageView else { return }
+            let translation = gesture.translation(in: scrollView)
+            let velocity = gesture.velocity(in: scrollView)
+
+            switch gesture.state {
+            case .changed:
+                let progress = min(1, max(0, translation.y / ImageLightboxGesturePolicy.dismissDistance))
+                let shrink = 1 - progress * 0.15
+                imageView.transform = CGAffineTransform(
+                    translationX: translation.x,
+                    y: max(0, translation.y)
+                ).scaledBy(x: shrink, y: shrink)
+
+            case .ended where ImageLightboxGesturePolicy.shouldDismiss(
+                translation: translation.y,
+                velocity: velocity.y
+            ):
+                dismiss(from: translation)
+
+            case .ended, .cancelled, .failed:
+                restoreImagePosition()
+
+            default:
+                break
+            }
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard gestureRecognizer === dismissPan,
+                  let pan = gestureRecognizer as? UIPanGestureRecognizer,
+                  let scrollView
+            else { return true }
+
+            return ImageLightboxGesturePolicy.canBeginDismiss(
+                zoomScale: scrollView.zoomScale,
+                minimumZoomScale: scrollView.minimumZoomScale,
+                velocity: pan.velocity(in: scrollView)
+            )
+        }
+
+        /// At fit scale the scroll view's own pan has nothing to scroll, so letting both
+        /// recognizers run avoids a `require(toFail:)` delay on every touch.
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+
+        // MARK: - Helpers
+
+        private func centerContent() {
+            guard let scrollView else { return }
+            let horizontal = max(0, (scrollView.bounds.width - scrollView.contentSize.width) / 2)
+            let vertical = max(0, (scrollView.bounds.height - scrollView.contentSize.height) / 2)
+            scrollView.contentInset = UIEdgeInsets(
+                top: vertical,
+                left: horizontal,
+                bottom: vertical,
+                right: horizontal
+            )
+        }
+
+        private func zoomRect(for scale: CGFloat, around point: CGPoint) -> CGRect {
+            guard let scrollView, scale > 0 else { return .zero }
+            let size = CGSize(
+                width: scrollView.bounds.width / scale,
+                height: scrollView.bounds.height / scale
+            )
+            return CGRect(
+                x: point.x - size.width / 2,
+                y: point.y - size.height / 2,
+                width: size.width,
+                height: size.height
+            )
+        }
+
+        /// Reduce Motion drops the throw-away animation entirely: the viewer just closes.
+        private func dismiss(from translation: CGPoint) {
+            guard !isDismissing else { return }
+            isDismissing = true
+
+            guard !reduceMotion, let imageView, let scrollView else {
+                onDismiss()
+                return
+            }
+
+            let offScreen = max(scrollView.bounds.height, 480)
+            UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseIn]) {
+                imageView.transform = CGAffineTransform(translationX: translation.x, y: offScreen)
+                    .scaledBy(x: 0.7, y: 0.7)
+                imageView.alpha = 0
+            } completion: { [weak self] _ in
+                self?.onDismiss()
+            }
+        }
+
+        private func restoreImagePosition() {
+            guard let imageView else { return }
+
+            guard !reduceMotion else {
+                imageView.transform = .identity
+                imageView.alpha = 1
+                return
+            }
+
+            UIView.animate(
+                withDuration: 0.25,
+                delay: 0,
+                usingSpringWithDamping: 0.85,
+                initialSpringVelocity: 0
+            ) {
+                imageView.transform = .identity
+                imageView.alpha = 1
+            }
+        }
+    }
+}
+
+/// A scroll view that reports viewport size changes, which is the one thing a
+/// `UIViewRepresentable` cannot see on its own.
+final class ZoomableScrollView: UIScrollView {
+    var onLayoutSizeChange: ((CGSize) -> Void)?
+
+    private var lastLaidOutSize: CGSize = .zero
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard bounds.width > 0, bounds.height > 0, bounds.size != lastLaidOutSize else { return }
+        lastLaidOutSize = bounds.size
+        onLayoutSizeChange?(bounds.size)
+    }
+}

--- a/HermesMobile/Features/Chat/ImageLightboxView.swift
+++ b/HermesMobile/Features/Chat/ImageLightboxView.swift
@@ -323,6 +323,8 @@ struct ZoomableImageView: UIViewRepresentable {
             target: coordinator,
             action: #selector(Coordinator.handleDismissPan(_:))
         )
+        // One finger only: a two-finger pinch that drifts downward must stay a zoom.
+        dismissPan.maximumNumberOfTouches = 1
         dismissPan.delegate = coordinator
         scrollView.addGestureRecognizer(dismissPan)
         coordinator.dismissPan = dismissPan
@@ -469,13 +471,16 @@ struct ZoomableImageView: UIViewRepresentable {
             )
         }
 
-        /// At fit scale the scroll view's own pan has nothing to scroll, so letting both
-        /// recognizers run avoids a `require(toFail:)` delay on every touch.
+        /// At fit scale the scroll view's own pan has nothing to scroll, so letting the two
+        /// pans run together avoids a `require(toFail:)` delay on every touch. Nothing else
+        /// pairs with the dismiss drag: sharing with the pinch would let a zoom and a
+        /// dismiss animate the same image view at once.
         func gestureRecognizer(
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
         ) -> Bool {
-            true
+            guard gestureRecognizer === dismissPan else { return true }
+            return other === scrollView?.panGestureRecognizer
         }
 
         // MARK: - Helpers
@@ -528,6 +533,12 @@ struct ZoomableImageView: UIViewRepresentable {
 
         private func restoreImagePosition() {
             guard let imageView else { return }
+
+            // Once zoomed, the transform belongs to the scroll view; resetting it here
+            // would snap the image back to fit while `zoomScale` still says otherwise.
+            if let scrollView, scrollView.zoomScale > scrollView.minimumZoomScale + 0.01 {
+                return
+            }
 
             guard !reduceMotion else {
                 imageView.transform = .identity

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -8,6 +8,7 @@ struct MessageBubbleView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The skills this chat can draw as chips, published by `ChatView`.
     @Environment(\.skillChipCatalog) private var skillChipCatalog
+    @Environment(\.chatWorkspaceRoot) private var chatWorkspaceRoot
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
 
@@ -92,7 +93,10 @@ struct MessageBubbleView: View {
     }
 
     private var assistantMessageRow: some View {
-        let segments = TranscriptMediaParser.segments(in: messageText)
+        let segments = TranscriptMediaParser.segments(
+            in: messageText,
+            workspaceRoot: chatWorkspaceRoot
+        )
 
         return VStack(alignment: .leading, spacing: 6) {
             if showsAssistantTurnHeaderForThisMessage {

--- a/HermesMobile/Features/Chat/TranscriptMedia.swift
+++ b/HermesMobile/Features/Chat/TranscriptMedia.swift
@@ -245,31 +245,66 @@ enum TranscriptMediaParser {
         let end: String.Index
     }
 
-    /// Reads a Markdown image starting at `![`. Only the flat form is recognized: the
-    /// first `]` ends the alt text and the first `)` ends the destination, so a nested
-    /// or reference-style image stays ordinary Markdown rather than being mis-split.
+    /// Reads a Markdown image starting at `![`. Brackets and parentheses nest and can be
+    /// backslash-escaped, so `![Build (1)](/tmp/build(1)/shot.png)` reads as one image
+    /// rather than being cut at the first `)`. A reference-style image, which has no
+    /// destination at all, stays ordinary Markdown.
     private static func markdownImage(in line: String, from start: String.Index) -> MarkdownImage? {
-        guard let altStart = line.index(
-            start,
-            offsetBy: markdownImageMarker.count,
-            limitedBy: line.endIndex
-        ) else { return nil }
+        guard let altOpen = line.index(start, offsetBy: 1, limitedBy: line.endIndex),
+              altOpen < line.endIndex,
+              let altEnd = balancedEnd(in: line, after: altOpen, open: "[", close: "]")
+        else { return nil }
 
-        guard let altEnd = line[altStart...].firstIndex(of: "]") else { return nil }
         let openParenthesis = line.index(after: altEnd)
         guard openParenthesis < line.endIndex, line[openParenthesis] == "(" else { return nil }
+        guard let closeParenthesis = balancedEnd(
+            in: line,
+            after: openParenthesis,
+            open: "(",
+            close: ")"
+        ) else { return nil }
 
-        let destinationStart = line.index(after: openParenthesis)
-        guard let closeParenthesis = line[destinationStart...].firstIndex(of: ")") else { return nil }
-
-        let body = String(line[destinationStart..<closeParenthesis])
+        let body = String(line[line.index(after: openParenthesis)..<closeParenthesis])
         guard let destination = destination(inLinkBody: body) else { return nil }
 
         return MarkdownImage(
-            alt: String(line[altStart..<altEnd]).trimmingCharacters(in: .whitespacesAndNewlines),
+            alt: String(line[line.index(after: altOpen)..<altEnd])
+                .trimmingCharacters(in: .whitespacesAndNewlines),
             destination: destination,
             end: line.index(after: closeParenthesis)
         )
+    }
+
+    /// The index of the delimiter closing the run opened at `openIndex`, counting nesting
+    /// and skipping backslash-escaped characters the way CommonMark does. Nil when the
+    /// run never closes on this line.
+    private static func balancedEnd(
+        in line: String,
+        after openIndex: String.Index,
+        open: Character,
+        close: Character
+    ) -> String.Index? {
+        var depth = 1
+        var index = line.index(after: openIndex)
+
+        while index < line.endIndex {
+            switch line[index] {
+            case "\\":
+                index = line.index(after: index)
+            case open:
+                depth += 1
+            case close:
+                depth -= 1
+                if depth == 0 { return index }
+            default:
+                break
+            }
+
+            guard index < line.endIndex else { break }
+            index = line.index(after: index)
+        }
+
+        return nil
     }
 
     /// The destination out of a link body, dropping any `"title"`. An angle-bracketed
@@ -280,11 +315,32 @@ enum TranscriptMediaParser {
 
         if trimmed.hasPrefix("<") {
             guard let close = trimmed.firstIndex(of: ">") else { return nil }
-            return String(trimmed[trimmed.index(after: trimmed.startIndex)..<close])
+            return unescaped(String(trimmed[trimmed.index(after: trimmed.startIndex)..<close]))
         }
 
-        guard let space = trimmed.firstIndex(where: \.isWhitespace) else { return trimmed }
-        return String(trimmed[..<space])
+        guard let space = trimmed.firstIndex(where: \.isWhitespace) else { return unescaped(trimmed) }
+        return unescaped(String(trimmed[..<space]))
+    }
+
+    /// Drops the backslashes CommonMark uses to escape punctuation, so a path written as
+    /// `/tmp/a\)b.png` reaches the server as `/tmp/a)b.png`.
+    private static func unescaped(_ destination: String) -> String {
+        guard destination.contains("\\") else { return destination }
+
+        var result = ""
+        var isEscaped = false
+        for character in destination {
+            if isEscaped {
+                result.append(character)
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else {
+                result.append(character)
+            }
+        }
+        if isEscaped { result.append("\\") }
+        return result
     }
 
     /// A Markdown image becomes transcript media when its destination names a raster

--- a/HermesMobile/Features/Chat/TranscriptMedia.swift
+++ b/HermesMobile/Features/Chat/TranscriptMedia.swift
@@ -15,8 +15,28 @@ enum TranscriptMediaKind: Equatable {
 struct TranscriptMediaReference: Equatable, Identifiable {
     let rawReference: String
 
+    /// The alt text of the `![alt](path)` this came from. `MEDIA:` tokens and bare
+    /// `file://` URLs have none, so they fall back to the file name.
+    let altText: String?
+
+    init(rawReference: String, altText: String? = nil) {
+        self.rawReference = rawReference
+        self.altText = altText
+    }
+
     var id: String {
         rawReference
+    }
+
+    /// What VoiceOver should call this image: the author's alt text when there is one,
+    /// otherwise the file name.
+    var accessibilityName: String {
+        guard let altText = altText?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !altText.isEmpty
+        else {
+            return displayName
+        }
+        return altText
     }
 
     var source: TranscriptMediaSource {
@@ -113,7 +133,13 @@ enum TranscriptMediaSegment: Equatable {
 }
 
 enum TranscriptMediaParser {
-    static func segments(in markdown: String) -> [TranscriptMediaSegment] {
+    /// Splits an assistant message into text and media. `workspaceRoot` only resolves the
+    /// relative forms of `![alt](path)`; an absolute path or a `file:` URL needs no root,
+    /// and the server's `/api/media` allow-list decides what is actually served.
+    static func segments(
+        in markdown: String,
+        workspaceRoot: String? = nil
+    ) -> [TranscriptMediaSegment] {
         guard !markdown.isEmpty else { return [] }
 
         var segments: [TranscriptMediaSegment] = []
@@ -136,7 +162,7 @@ enum TranscriptMediaParser {
                 isInFence = true
                 fenceCharacter = marker
             } else {
-                appendMediaSegments(in: line, to: &segments)
+                appendMediaSegments(in: line, to: &segments, workspaceRoot: workspaceRoot)
             }
 
             index = lineRange.upperBound
@@ -145,12 +171,28 @@ enum TranscriptMediaParser {
         return segments
     }
 
-    private static func appendMediaSegments(in line: String, to segments: inout [TranscriptMediaSegment]) {
+    private static func appendMediaSegments(
+        in line: String,
+        to segments: inout [TranscriptMediaSegment],
+        workspaceRoot: String?
+    ) {
         var cursor = line.startIndex
         var textStart = cursor
         let inlineCodeRanges = inlineCodeRanges(in: line)
 
         while cursor < line.endIndex {
+            if line[cursor...].hasPrefix(markdownImageMarker),
+               !inlineCodeRanges.contains(where: { $0.contains(cursor) }),
+               let image = markdownImage(in: line, from: cursor),
+               let reference = markdownImageReference(for: image, workspaceRoot: workspaceRoot) {
+                appendText(String(line[textStart..<cursor]), to: &segments)
+                segments.append(.media(reference))
+
+                cursor = image.end
+                textStart = cursor
+                continue
+            }
+
             if line[cursor...].hasPrefix("MEDIA:"),
                let referenceRange = referenceRange(
                    in: line,
@@ -194,6 +236,75 @@ enum TranscriptMediaParser {
         }
 
         appendText(String(line[textStart..<line.endIndex]), to: &segments)
+    }
+
+    /// One `![alt](destination "title")` occurrence, already split apart.
+    private struct MarkdownImage {
+        let alt: String
+        let destination: String
+        let end: String.Index
+    }
+
+    /// Reads a Markdown image starting at `![`. Only the flat form is recognized: the
+    /// first `]` ends the alt text and the first `)` ends the destination, so a nested
+    /// or reference-style image stays ordinary Markdown rather than being mis-split.
+    private static func markdownImage(in line: String, from start: String.Index) -> MarkdownImage? {
+        guard let altStart = line.index(
+            start,
+            offsetBy: markdownImageMarker.count,
+            limitedBy: line.endIndex
+        ) else { return nil }
+
+        guard let altEnd = line[altStart...].firstIndex(of: "]") else { return nil }
+        let openParenthesis = line.index(after: altEnd)
+        guard openParenthesis < line.endIndex, line[openParenthesis] == "(" else { return nil }
+
+        let destinationStart = line.index(after: openParenthesis)
+        guard let closeParenthesis = line[destinationStart...].firstIndex(of: ")") else { return nil }
+
+        let body = String(line[destinationStart..<closeParenthesis])
+        guard let destination = destination(inLinkBody: body) else { return nil }
+
+        return MarkdownImage(
+            alt: String(line[altStart..<altEnd]).trimmingCharacters(in: .whitespacesAndNewlines),
+            destination: destination,
+            end: line.index(after: closeParenthesis)
+        )
+    }
+
+    /// The destination out of a link body, dropping any `"title"`. An angle-bracketed
+    /// destination keeps its spaces; a bare one ends at the first space.
+    private static func destination(inLinkBody body: String) -> String? {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed.hasPrefix("<") {
+            guard let close = trimmed.firstIndex(of: ">") else { return nil }
+            return String(trimmed[trimmed.index(after: trimmed.startIndex)..<close])
+        }
+
+        guard let space = trimmed.firstIndex(where: \.isWhitespace) else { return trimmed }
+        return String(trimmed[..<space])
+    }
+
+    /// A Markdown image becomes transcript media when its destination names a raster
+    /// image on the server's filesystem, which `/api/media` then decides whether to
+    /// serve. Remote URLs and bare relative paths keep whatever the Markdown renderer
+    /// already does with them.
+    private static func markdownImageReference(
+        for image: MarkdownImage,
+        workspaceRoot: String?
+    ) -> TranscriptMediaReference? {
+        guard let path = FileReference.absoluteMediaPath(
+            image.destination,
+            workspaceRoot: workspaceRoot
+        ) else { return nil }
+
+        let reference = TranscriptMediaReference(
+            rawReference: path,
+            altText: image.alt.isEmpty ? nil : image.alt
+        )
+        return reference.isRasterImageCandidate ? reference : nil
     }
 
     private static func appendText(_ text: String, to segments: inout [TranscriptMediaSegment]) {
@@ -355,6 +466,7 @@ enum TranscriptMediaParser {
     private static let trailingPunctuation: Set<Character> = [".", ",", ";", ":", "!", "?"]
     private static let fileURLTerminators: Set<Character> = ["<", ">", "\"", "'"]
     private static let fileURLMarker = "file://"
+    private static let markdownImageMarker = "!["
 
     private enum ReferenceSyntax {
         case mediaToken

--- a/HermesMobile/Features/Chat/TranscriptMedia.swift
+++ b/HermesMobile/Features/Chat/TranscriptMedia.swift
@@ -323,7 +323,9 @@ enum TranscriptMediaParser {
     }
 
     /// Drops the backslashes CommonMark uses to escape punctuation, so a path written as
-    /// `/tmp/a\)b.png` reaches the server as `/tmp/a)b.png`.
+    /// `/tmp/a\)b.png` reaches the server as `/tmp/a)b.png`. A backslash before anything
+    /// else is a literal one, and POSIX allows it in a filename, so `/tmp/a\b.png` keeps
+    /// its backslash and still names the file the agent meant.
     private static func unescaped(_ destination: String) -> String {
         guard destination.contains("\\") else { return destination }
 
@@ -331,6 +333,9 @@ enum TranscriptMediaParser {
         var isEscaped = false
         for character in destination {
             if isEscaped {
+                if !escapablePunctuation.contains(character) {
+                    result.append("\\")
+                }
                 result.append(character)
                 isEscaped = false
             } else if character == "\\" {
@@ -342,6 +347,9 @@ enum TranscriptMediaParser {
         if isEscaped { result.append("\\") }
         return result
     }
+
+    /// The ASCII punctuation CommonMark lets a backslash escape.
+    private static let escapablePunctuation = Set(##"!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##)
 
     /// A Markdown image becomes transcript media when its destination names a raster
     /// image on the server's filesystem, which `/api/media` then decides whether to

--- a/HermesMobile/Features/Chat/TranscriptMediaImageLightbox.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaImageLightbox.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+/// The transcript's viewer for an image. Audio, video, and unsupported media keep
+/// `TranscriptMediaPreviewView`, which can only tell them apart after the bytes arrive;
+/// an image is known to be an image before anything is fetched, so it can open straight
+/// into the full-bleed lightbox.
+struct TranscriptMediaImageLightbox: View {
+    let onAPIError: (Error) -> Void
+
+    private let item: TranscriptMediaPreviewItem
+    @State private var viewModel: TranscriptMediaPreviewViewModel
+    @State private var exportDocument = ExportedFileDocument(data: Data())
+    @State private var exportContentType = UTType.data
+    @State private var exportFilename = String(localized: "Hermes Media")
+    @State private var isFileExporterPresented = false
+    @State private var isExportingMedia = false
+    @State private var isSavingToPhotos = false
+    @State private var saveConfirmationMessage: String?
+    @State private var errorMessage: String?
+
+    init(
+        server: URL,
+        sessionID: String?,
+        item: TranscriptMediaPreviewItem,
+        onAPIError: @escaping (Error) -> Void
+    ) {
+        self.item = item
+        self.onAPIError = onAPIError
+        _viewModel = State(
+            initialValue: TranscriptMediaPreviewViewModel(
+                server: server,
+                sessionID: sessionID,
+                reference: item.reference
+            )
+        )
+    }
+
+    var body: some View {
+        ImageLightboxView(
+            content: content,
+            title: item.reference.displayName,
+            path: item.reference.rawReference,
+            imageAccessibilityLabel: item.reference.accessibilityName,
+            onRetry: { Task { await loadMedia(force: true) } }
+        ) {
+            if viewModel.canSaveMediaToPhotos {
+                ImageLightboxActionButton(
+                    systemImage: "photo",
+                    accessibilityLabel: String(localized: "Save media to Photos"),
+                    isDisabled: exportActionsAreDisabled,
+                    action: { Task { await saveMediaToPhotos() } }
+                )
+            }
+
+            if viewModel.canExportMedia {
+                ImageLightboxActionButton(
+                    systemImage: "square.and.arrow.up",
+                    accessibilityLabel: String(localized: "Export media"),
+                    isDisabled: exportActionsAreDisabled,
+                    action: { Task { await exportMedia() } }
+                )
+            }
+        }
+        .task {
+            await loadMedia()
+        }
+        .fileExporter(
+            isPresented: $isFileExporterPresented,
+            document: exportDocument,
+            contentType: exportContentType,
+            defaultFilename: exportFilename
+        ) { result in
+            if case let .failure(error) = result {
+                errorMessage = error.localizedDescription
+            }
+        }
+        .alert(
+            "Saved",
+            isPresented: Binding(
+                get: { saveConfirmationMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        saveConfirmationMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK") {
+                saveConfirmationMessage = nil
+            }
+        } message: {
+            Text(saveConfirmationMessage ?? "")
+        }
+        .alert(
+            "Media Action Failed",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        errorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK") {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .onDisappear {
+            viewModel.cleanupTemporaryFiles()
+        }
+    }
+
+    private var content: ImageLightboxContent {
+        if let data = viewModel.previewData, let image = UIImage(data: data) {
+            return .image(image, detail: detailText)
+        }
+
+        if !viewModel.isLoading, let message = viewModel.errorMessage {
+            return .failure(message)
+        }
+
+        return .loading(String(localized: "Loading media..."))
+    }
+
+    private var detailText: String? {
+        guard let originalByteCount = viewModel.originalByteCount else { return nil }
+        return ByteCountFormatter.string(fromByteCount: Int64(originalByteCount), countStyle: .file)
+    }
+
+    private var exportActionsAreDisabled: Bool {
+        viewModel.isLoading || isSavingToPhotos || isExportingMedia
+    }
+
+    private func loadMedia(force: Bool = false) async {
+        await viewModel.load(force: force)
+        if let lastError = viewModel.lastError {
+            onAPIError(lastError)
+        }
+    }
+
+    private func exportMedia() async {
+        isExportingMedia = true
+        defer { isExportingMedia = false }
+
+        do {
+            let payload = try await viewModel.exportPayload()
+            exportDocument = ExportedFileDocument(data: payload.data)
+            exportContentType = payload.contentType
+            exportFilename = payload.filename
+            isFileExporterPresented = true
+        } catch {
+            errorMessage = error.localizedDescription
+            onAPIError(error)
+        }
+    }
+
+    private func saveMediaToPhotos() async {
+        isSavingToPhotos = true
+        defer { isSavingToPhotos = false }
+
+        do {
+            let payload = try await viewModel.exportPayload()
+            guard payload.isImage, UIImage(data: payload.data) != nil else {
+                throw PhotoLibrarySaveError.notImage
+            }
+            try await PhotoLibrarySaver.saveImageData(payload.data)
+            saveConfirmationMessage = String(localized: "Media saved to Photos.")
+        } catch {
+            errorMessage = error.localizedDescription
+            onAPIError(error)
+        }
+    }
+}

--- a/HermesMobile/Features/Chat/TranscriptMediaImageLightbox.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaImageLightbox.swift
@@ -116,7 +116,10 @@ struct TranscriptMediaImageLightbox: View {
     }
 
     private var content: ImageLightboxContent {
-        if let data = viewModel.previewData, let image = UIImage(data: data) {
+        if let data = viewModel.previewData {
+            guard let image = UIImage(data: data) else {
+                return .failure(String(localized: "Could not decode this image."))
+            }
             return .image(image, detail: detailText)
         }
 

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -12,9 +12,10 @@ struct TranscriptMediaPreviewItem: Identifiable, Equatable {
     }
 }
 
-/// The active session's workspace root, read by the transcript when it parses
-/// `![alt](path)` images: an image only becomes media when its path is contained by
-/// this root, so a message can never point the media loader outside the workspace.
+/// The active session's workspace root, read by the transcript to resolve the relative
+/// forms of `![alt](path)` (`./`, `../`, `~/`). It is a base, not a boundary: absolute
+/// paths and `file:` URLs need no root, and `/api/media` owns the allow-list that decides
+/// what the server will actually serve.
 extension EnvironmentValues {
     var chatWorkspaceRoot: String? {
         get { self[ChatWorkspaceRootKey.self] }

--- a/HermesMobile/Features/Chat/TranscriptMediaView.swift
+++ b/HermesMobile/Features/Chat/TranscriptMediaView.swift
@@ -12,6 +12,20 @@ struct TranscriptMediaPreviewItem: Identifiable, Equatable {
     }
 }
 
+/// The active session's workspace root, read by the transcript when it parses
+/// `![alt](path)` images: an image only becomes media when its path is contained by
+/// this root, so a message can never point the media loader outside the workspace.
+extension EnvironmentValues {
+    var chatWorkspaceRoot: String? {
+        get { self[ChatWorkspaceRootKey.self] }
+        set { self[ChatWorkspaceRootKey.self] = newValue }
+    }
+}
+
+private struct ChatWorkspaceRootKey: EnvironmentKey {
+    static let defaultValue: String? = nil
+}
+
 struct TranscriptMediaContentView: View {
     let segments: [TranscriptMediaSegment]
     let cacheNamespace: String
@@ -158,7 +172,7 @@ private struct TranscriptMediaThumbnailView: View {
             return String(localized: "Open media video \(reference.displayName)")
         }
 
-        return String(localized: "Open media image \(reference.displayName)")
+        return String(localized: "Open media image \(reference.accessibilityName)")
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Workspace/FileReference.swift
+++ b/HermesMobile/Features/Workspace/FileReference.swift
@@ -25,6 +25,31 @@ struct FileReference: Hashable, Identifiable {
         return "\(name):\(line):\(column)"
     }
 
+    /// The absolute path a Markdown destination names, accepting the same syntax as
+    /// `parse` but without its workspace containment. Media is deliberately not workspace
+    /// scoped: the server keeps chat images in its own attachment store
+    /// (`~/.hermes/webui/attachments/`), well outside any workspace, and `/api/media`
+    /// owns the allow-list that decides what it will serve. A containment check here
+    /// would only hide images the server is happy to hand over.
+    ///
+    /// `./` and `../` need a workspace root to resolve against; an absolute path or a
+    /// `file:` URL does not. Bare relative paths stay unrecognized, as they do for links.
+    static func absoluteMediaPath(_ destination: String, workspaceRoot: String?) -> String? {
+        var normalized = destination.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.hasPrefix("<"), normalized.hasSuffix(">"), normalized.count >= 2 {
+            normalized = String(normalized.dropFirst().dropLast())
+        }
+        guard let target = fileTarget(of: normalized) else { return nil }
+
+        let rootComponents = pathComponents(ofAbsolutePath: workspaceRoot ?? "") ?? []
+        guard target.path.hasPrefix("/") || !rootComponents.isEmpty else { return nil }
+        guard let components = absolutePath(for: target.path, rootComponents: rootComponents),
+              !components.isEmpty
+        else { return nil }
+
+        return "/" + components.joined(separator: "/")
+    }
+
     /// Parses a Markdown link destination against the session's workspace root. Nil when
     /// the destination is not a file link, the workspace root is unknown, or the path
     /// resolves outside the workspace (including `..` traversal).

--- a/HermesMobileTests/ImageLightboxGesturePolicyTests.swift
+++ b/HermesMobileTests/ImageLightboxGesturePolicyTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import HermesMobile
+
+/// The lightbox's two gesture rules: the dismiss drag exists only at fit scale, and it
+/// closes on either distance or speed.
+final class ImageLightboxGesturePolicyTests: XCTestCase {
+    func testDismissDragOnlyStartsAtFitScale() {
+        let downward = CGPoint(x: 0, y: 600)
+
+        XCTAssertTrue(
+            ImageLightboxGesturePolicy.canBeginDismiss(
+                zoomScale: 1,
+                minimumZoomScale: 1,
+                velocity: downward
+            )
+        )
+        XCTAssertFalse(
+            ImageLightboxGesturePolicy.canBeginDismiss(
+                zoomScale: 2.5,
+                minimumZoomScale: 1,
+                velocity: downward
+            )
+        )
+    }
+
+    func testDismissDragIgnoresUpwardAndSidewaysDrags() {
+        let cases: [CGPoint] = [
+            CGPoint(x: 0, y: -600),
+            CGPoint(x: 900, y: 200),
+            CGPoint(x: -900, y: 200)
+        ]
+
+        for velocity in cases {
+            XCTAssertFalse(
+                ImageLightboxGesturePolicy.canBeginDismiss(
+                    zoomScale: 1,
+                    minimumZoomScale: 1,
+                    velocity: velocity
+                ),
+                "\(velocity)"
+            )
+        }
+    }
+
+    func testClosesOnDistanceOrSpeed() {
+        // A slow, long drag.
+        XCTAssertTrue(ImageLightboxGesturePolicy.shouldDismiss(translation: 160, velocity: 40))
+        // A short, fast flick.
+        XCTAssertTrue(ImageLightboxGesturePolicy.shouldDismiss(translation: 30, velocity: 1_400))
+        // A small nudge either way stays open.
+        XCTAssertFalse(ImageLightboxGesturePolicy.shouldDismiss(translation: 30, velocity: 40))
+        XCTAssertFalse(ImageLightboxGesturePolicy.shouldDismiss(translation: -400, velocity: -1_400))
+    }
+
+    func testZoomCeilingReachesThePixelsWithoutRunningAway() {
+        // A screenshot far wider than the phone can zoom to its own pixels.
+        XCTAssertEqual(
+            ImageLightboxGesturePolicy.maximumZoomScale(imagePixelWidth: 2_400, fittedWidth: 400),
+            6
+        )
+        // A small image still gets a useful ceiling.
+        XCTAssertEqual(
+            ImageLightboxGesturePolicy.maximumZoomScale(imagePixelWidth: 200, fittedWidth: 400),
+            3
+        )
+        // An enormous one is capped so it cannot become a maze.
+        XCTAssertEqual(
+            ImageLightboxGesturePolicy.maximumZoomScale(imagePixelWidth: 12_000, fittedWidth: 400),
+            8
+        )
+        // A viewport that has not been laid out yet still returns something usable.
+        XCTAssertEqual(
+            ImageLightboxGesturePolicy.maximumZoomScale(imagePixelWidth: 2_400, fittedWidth: 0),
+            3
+        )
+    }
+
+    func testDoubleTapNeverExceedsTheCeiling() {
+        XCTAssertEqual(ImageLightboxGesturePolicy.doubleTapZoomScale(maximumZoomScale: 6), 2.5)
+        XCTAssertEqual(ImageLightboxGesturePolicy.doubleTapZoomScale(maximumZoomScale: 2), 2)
+    }
+}

--- a/HermesMobileTests/TranscriptMarkdownImageTests.swift
+++ b/HermesMobileTests/TranscriptMarkdownImageTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import HermesMobile
+
+/// Standard `![alt](path)` images in an assistant message become transcript media when
+/// they name a raster image on the server's filesystem. Containment is the server's job:
+/// `/api/media` owns the allow-list, and chat images live in its attachment store rather
+/// than in any workspace.
+final class TranscriptMarkdownImageTests: XCTestCase {
+    private let workspace = "/Users/hermes/projects/app"
+
+    func testResolvesAnAbsoluteWorkspaceImage() throws {
+        let segments = TranscriptMediaParser.segments(
+            in: "Here it is: ![Login screen](/Users/hermes/projects/app/shots/login.png) done",
+            workspaceRoot: workspace
+        )
+
+        let media = try XCTUnwrap(mediaReferences(in: segments).first)
+        XCTAssertEqual(media.rawReference, "/Users/hermes/projects/app/shots/login.png")
+        XCTAssertEqual(media.altText, "Login screen")
+        XCTAssertEqual(media.accessibilityName, "Login screen")
+        XCTAssertEqual(segments.first, .text("Here it is: "))
+        XCTAssertEqual(segments.last, .text(" done"))
+    }
+
+    func testResolvesRelativeAndHomeRelativeImages() throws {
+        for destination in ["./shots/login.png", "../app/shots/login.png", "~/projects/app/shots/login.png"] {
+            let segments = TranscriptMediaParser.segments(
+                in: "![](\(destination))",
+                workspaceRoot: workspace
+            )
+
+            let media = try XCTUnwrap(mediaReferences(in: segments).first, destination)
+            XCTAssertEqual(media.rawReference, "/Users/hermes/projects/app/shots/login.png", destination)
+        }
+    }
+
+    func testFallsBackToFileNameWithoutAltText() throws {
+        let segments = TranscriptMediaParser.segments(
+            in: "![](/Users/hermes/projects/app/shots/login.png)",
+            workspaceRoot: workspace
+        )
+
+        let media = try XCTUnwrap(mediaReferences(in: segments).first)
+        XCTAssertNil(media.altText)
+        XCTAssertEqual(media.accessibilityName, "login.png")
+    }
+
+    func testIgnoresTitleAndAngleBrackets() throws {
+        let titled = TranscriptMediaParser.segments(
+            in: "![Shot](/Users/hermes/projects/app/a.png \"After the fix\")",
+            workspaceRoot: workspace
+        )
+        XCTAssertEqual(try XCTUnwrap(mediaReferences(in: titled).first).rawReference, "/Users/hermes/projects/app/a.png")
+
+        let bracketed = TranscriptMediaParser.segments(
+            in: "![Shot](</Users/hermes/projects/app/my shot.png>)",
+            workspaceRoot: workspace
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(mediaReferences(in: bracketed).first).rawReference,
+            "/Users/hermes/projects/app/my shot.png"
+        )
+    }
+
+    /// The server keeps chat images in its own attachment store, outside every workspace,
+    /// so an image outside the workspace is the normal case rather than an attack. The
+    /// phone normalizes the path and `/api/media` decides what it will serve.
+    func testResolvesImagesOutsideTheWorkspace() throws {
+        let attachment = TranscriptMediaParser.segments(
+            in: "![Image](file:///Users/hermes/.hermes/webui/attachments/abc/image_1788.jpg)",
+            workspaceRoot: workspace
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(mediaReferences(in: attachment).first).rawReference,
+            "/Users/hermes/.hermes/webui/attachments/abc/image_1788.jpg"
+        )
+
+        let screenshot = TranscriptMediaParser.segments(
+            in: "![](/tmp/shot.png)",
+            workspaceRoot: workspace
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(mediaReferences(in: screenshot).first).rawReference,
+            "/tmp/shot.png"
+        )
+    }
+
+    func testTraversalIsNormalizedRatherThanCarriedThrough() throws {
+        let segments = TranscriptMediaParser.segments(
+            in: "![x](./../other/../shots/login.png)",
+            workspaceRoot: workspace
+        )
+
+        XCTAssertEqual(
+            try XCTUnwrap(mediaReferences(in: segments).first).rawReference,
+            "/Users/hermes/projects/shots/login.png"
+        )
+    }
+
+    func testAbsoluteImagesResolveWithoutAWorkspaceRoot() throws {
+        let segments = TranscriptMediaParser.segments(in: "![x](/tmp/shot.png)")
+
+        XCTAssertEqual(try XCTUnwrap(mediaReferences(in: segments).first).rawReference, "/tmp/shot.png")
+    }
+
+    func testRelativeImagesNeedAWorkspaceRoot() {
+        let markdown = "![x](./shots/login.png)"
+
+        XCTAssertEqual(TranscriptMediaParser.segments(in: markdown), [.text(markdown)])
+    }
+
+    func testLeavesRemoteAndBareRelativeImagesToTheMarkdownRenderer() {
+        let untouched = [
+            "![badge](https://img.example.test/badge.svg)",
+            "![x](shots/login.png)",
+            "![notes](/Users/hermes/projects/app/notes.txt)"
+        ]
+
+        for markdown in untouched {
+            let segments = TranscriptMediaParser.segments(in: markdown, workspaceRoot: workspace)
+            XCTAssertEqual(segments, [.text(markdown)], markdown)
+        }
+    }
+
+    func testSkipsImagesInCode() {
+        let fenced = """
+        ```md
+        ![x](/Users/hermes/projects/app/shots/login.png)
+        ```
+        """
+        XCTAssertTrue(mediaReferences(in: TranscriptMediaParser.segments(in: fenced, workspaceRoot: workspace)).isEmpty)
+
+        let inline = "Write `![x](/Users/hermes/projects/app/shots/login.png)` in the doc"
+        XCTAssertTrue(mediaReferences(in: TranscriptMediaParser.segments(in: inline, workspaceRoot: workspace)).isEmpty)
+    }
+
+    func testMediaPathToleratesATrailingSlashOnTheRoot() {
+        XCTAssertEqual(
+            FileReference.absoluteMediaPath("./shots/login.png", workspaceRoot: "/Users/hermes/projects/app/"),
+            "/Users/hermes/projects/app/shots/login.png"
+        )
+    }
+
+    private func mediaReferences(in segments: [TranscriptMediaSegment]) -> [TranscriptMediaReference] {
+        segments.compactMap { segment in
+            if case let .media(reference) = segment { return reference }
+            return nil
+        }
+    }
+}

--- a/HermesMobileTests/TranscriptMarkdownImageTests.swift
+++ b/HermesMobileTests/TranscriptMarkdownImageTests.swift
@@ -122,6 +122,39 @@ final class TranscriptMarkdownImageTests: XCTestCase {
         }
     }
 
+    /// CommonMark allows nested and escaped delimiters, and macOS hands out duplicate
+    /// names like `build (1)`, so cutting at the first `)` would blank exactly the images
+    /// this is meant to show.
+    func testHandlesNestedAndEscapedDelimiters() throws {
+        let nested = TranscriptMediaParser.segments(
+            in: "![Build (1)](/tmp/build(1)/shot.png) after",
+            workspaceRoot: workspace
+        )
+        let nestedMedia = try XCTUnwrap(mediaReferences(in: nested).first)
+        XCTAssertEqual(nestedMedia.rawReference, "/tmp/build(1)/shot.png")
+        XCTAssertEqual(nestedMedia.altText, "Build (1)")
+        XCTAssertEqual(nested.last, .text(" after"))
+
+        let escaped = TranscriptMediaParser.segments(
+            in: #"![x](/tmp/a\)b.png)"#,
+            workspaceRoot: workspace
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(mediaReferences(in: escaped).first).rawReference,
+            "/tmp/a)b.png"
+        )
+    }
+
+    func testUnclosedDelimitersStayOrdinaryMarkdown() {
+        for markdown in ["![x(/tmp/shot.png)", "![x](/tmp/shot.png"] {
+            XCTAssertEqual(
+                TranscriptMediaParser.segments(in: markdown, workspaceRoot: workspace),
+                [.text(markdown)],
+                markdown
+            )
+        }
+    }
+
     func testSkipsImagesInCode() {
         let fenced = """
         ```md

--- a/HermesMobileTests/TranscriptMarkdownImageTests.swift
+++ b/HermesMobileTests/TranscriptMarkdownImageTests.swift
@@ -143,6 +143,16 @@ final class TranscriptMarkdownImageTests: XCTestCase {
             try XCTUnwrap(mediaReferences(in: escaped).first).rawReference,
             "/tmp/a)b.png"
         )
+
+        // A backslash before a letter is a literal one, and POSIX allows it in a filename.
+        let literal = TranscriptMediaParser.segments(
+            in: #"![x](/tmp/a\b.png)"#,
+            workspaceRoot: workspace
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(mediaReferences(in: literal).first).rawReference,
+            #"/tmp/a\b.png"#
+        )
     }
 
     func testUnclosedDelimitersStayOrdinaryMarkdown() {


### PR DESCRIPTION
## Linked issue

No issue; maintainer-approved work.

## What changed

An assistant message written as `![alt](path)` showed nothing at all. The destination went to the Markdown renderer's network image loader, which has no URL to fetch and draws an empty box, so a screenshot the agent had just written was simply invisible. Markdown images now take the same route `MEDIA:` tokens already take: the authenticated media loader, the transcript thumbnail, and the preview surface, with the alt text as the accessibility label.

Containment for media stays with the server. `/api/media` owns the allow-list, and chat images live in the server's own attachment store (`~/.hermes/webui/attachments/`) rather than in any session workspace, so a client-side workspace check only hides images the server is happy to serve. Absolute paths and `file:` URLs pass straight through, `./`, `../`, and `~/` resolve against the workspace, and bare relative paths and `https://` stay with the Markdown renderer, exactly as they do for file links. Nothing new is reachable: `MEDIA:/any/path.png` has always been sent as written.

Opening an image used to land in a scrolling sheet with the picture fit to about a third of the screen, so reading a screenshot meant pinching every time, and pinching did nothing. Images now open full-bleed:

- Pinch, double tap to zoom to the point you tapped, and pan while zoomed, on a small `UIScrollView` surface rather than stacked SwiftUI gestures.
- Flick down to close, but only at fit scale, so the close gesture can never steal a pan from a zoomed image.
- One tap hides the floating chrome so nothing covers the picture. VoiceOver keeps it up, because a hidden Done button is not a way out.
- Reduce Motion drops the close animation.
- Path, file size, Save to Photos, and Export all survive, in a floating bar and caption.

Audio, video, text, and unavailable previews keep the sheets they had. Closing the viewer now restores composer focus when the keyboard was up beforehand, which the transcript media sheet never did.

Structure:

- `TranscriptMediaParser` recognises `![alt](destination "title")`, including angle-bracketed destinations, and skips fenced and inline code.
- `FileReference.absoluteMediaPath` accepts the same syntax as `parse` without its workspace containment, which is right for links and wrong for media.
- `ImageLightboxView` is the shared shell; `ImageLightboxGesturePolicy` holds the thresholds as plain values so they are testable without a scroll view.

## How it was tested

- Full XCTest suite via XcodeBuildMCP `test_sim` on iPhone 17: **2183 passed, 0 failed, 2 skipped** (the pre-existing photo-library integration skips).
- New `TranscriptMarkdownImageTests` cover absolute, `file:`, `./`, `../`, `~/`, titles, angle brackets, alt text and its fallback, fenced and inline code, and the remote and bare-relative cases that stay with the Markdown renderer. `ImageLightboxGesturePolicyTests` cover the fit-scale-only rule, direction, the distance and velocity thresholds, and the zoom ceiling.
- Verified against the maintainer's live server rather than assumed: the failing message was `![Image](file:///Users/hermes/.hermes/webui/attachments/<session>/image_…jpg)`, whose session workspace is `/Users/hermes/projects/workspace`. `GET /api/media?session_id=…&path=…` returned `200 image/jpeg`, 292 KB, which is what showed the client-side containment check was wrong.
- Manual on the simulator against that server: the previously blank message renders a thumbnail, opens full-bleed, zooms, pans, hides its chrome on tap, and closes on a downward flick.

Before and after screenshots of that message are with the maintainer; `gh` cannot attach images, so they need to be dropped into this body from the web UI.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (`/api/media` already takes an absolute path; verified with a live request and against upstream `_handle_media`)

Written by Claude Opus 5 (1M context) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)