### PR TITLE
feat(chat): reference workspace files from the composer with @path chips

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -388,6 +388,8 @@
 		8618A9261B8047CEA6084798 /* SlashCommandAutocompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */; };
 		8B71DA2AAC521382F54A841C /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5FD09B6B5937573B5F9A4 /* InsightsView.swift */; };
 		8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */; };
+		9F22A768126D503EAFB6D900 /* ComposerFileTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB41BE54A19587EB9037B7B /* ComposerFileTriggerTests.swift */; };
+		063F801939EE5BC0ADD8D7BF /* FilePathSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E518E24247E5D05AA76D419 /* FilePathSearchTests.swift */; };
 		F06907881C5B4BCCB98D2EBA /* ComposerSlashTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */; };
 		A1C0F1000000000000000006 /* ComposerChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000005 /* ComposerChipTests.swift */; };
 		941A67322EB54169A55D7A64 /* SlashCommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB43F55AB4F4262963E6A6E /* SlashCommandCatalog.swift */; };
@@ -402,6 +404,9 @@
 		A1C0F1000000000000000002 /* ComposerChipToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000001 /* ComposerChipToken.swift */; };
 		A1C0F1000000000000000004 /* ComposerChipRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000003 /* ComposerChipRendering.swift */; };
 		A1C0F1000000000000000008 /* ComposerChipTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000007 /* ComposerChipTextView.swift */; };
+		D8FC4AB182545360A544E1FB /* ComposerFileTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB0B6C20A2A5612B0A3809E /* ComposerFileTrigger.swift */; };
+		2E9A26F315A959719F984023 /* FilePathSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE470A9851C57608379F9AF /* FilePathSearch.swift */; };
+		CAB298E458D85C9DAC9599EF /* FilePathAutocompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EE08E38F415FF38272C255 /* FilePathAutocompleteView.swift */; };
 		E067C191AC494934863F613D /* ComposerSlashTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */; };
 		C5A0D8F5502048B6B9258B01 /* InsightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */; };
 		105050000000000000000001 /* ComposerModelPickerSectionExpansionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */; };
@@ -453,6 +458,8 @@
 
 /* Begin PBXFileReference section */
 		0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandTests.swift; sourceTree = "<group>"; };
+		DFB41BE54A19587EB9037B7B /* ComposerFileTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerFileTriggerTests.swift; sourceTree = "<group>"; };
+		8E518E24247E5D05AA76D419 /* FilePathSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePathSearchTests.swift; sourceTree = "<group>"; };
 		92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerSlashTriggerTests.swift; sourceTree = "<group>"; };
 		A1C0F1000000000000000005 /* ComposerChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipTests.swift; sourceTree = "<group>"; };
 		351C0F1600000000000000A1 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
@@ -842,6 +849,9 @@
 		A1C0F1000000000000000001 /* ComposerChipToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipToken.swift; sourceTree = "<group>"; };
 		A1C0F1000000000000000003 /* ComposerChipRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipRendering.swift; sourceTree = "<group>"; };
 		A1C0F1000000000000000007 /* ComposerChipTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipTextView.swift; sourceTree = "<group>"; };
+		BDB0B6C20A2A5612B0A3809E /* ComposerFileTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerFileTrigger.swift; sourceTree = "<group>"; };
+		BCE470A9851C57608379F9AF /* FilePathSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePathSearch.swift; sourceTree = "<group>"; };
+		73EE08E38F415FF38272C255 /* FilePathAutocompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePathAutocompleteView.swift; sourceTree = "<group>"; };
 		417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerSlashTrigger.swift; sourceTree = "<group>"; };
 		C5A0D8F5502048B6B9258B00 /* InsightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModelTests.swift; sourceTree = "<group>"; };
 		FC2A37872AC842629FBDDFA4 /* SlashCommandAutocompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandAutocompleteView.swift; sourceTree = "<group>"; };
@@ -1058,6 +1068,8 @@
 				C0369000000000000000006 /* CronJobEditorConfigurationTests.swift */,
 				1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */,
 				0485E1E1FFB64A24BB729CD4 /* SlashCommandTests.swift */,
+				DFB41BE54A19587EB9037B7B /* ComposerFileTriggerTests.swift */,
+				8E518E24247E5D05AA76D419 /* FilePathSearchTests.swift */,
 				92C4B5F1244F4250AD7DB625 /* ComposerSlashTriggerTests.swift */,
 				A1C0F1000000000000000005 /* ComposerChipTests.swift */,
 				6809B8F1391248A4AA77C453 /* SlashCommandExecutorTests.swift */,
@@ -1248,6 +1260,9 @@
 				A1C0F1000000000000000001 /* ComposerChipToken.swift */,
 				A1C0F1000000000000000003 /* ComposerChipRendering.swift */,
 				A1C0F1000000000000000007 /* ComposerChipTextView.swift */,
+				BDB0B6C20A2A5612B0A3809E /* ComposerFileTrigger.swift */,
+				BCE470A9851C57608379F9AF /* FilePathSearch.swift */,
+				73EE08E38F415FF38272C255 /* FilePathAutocompleteView.swift */,
 				417A680DBE734B64988AC062 /* ComposerSlashTrigger.swift */,
 				C05000000000000000000002 /* ChatComposerAttachmentStripView.swift */,
 				C04900000000000000000002 /* ChatComposerTextInputView.swift */,
@@ -1850,6 +1865,9 @@
 				A1C0F1000000000000000002 /* ComposerChipToken.swift in Sources */,
 				A1C0F1000000000000000004 /* ComposerChipRendering.swift in Sources */,
 				A1C0F1000000000000000008 /* ComposerChipTextView.swift in Sources */,
+				D8FC4AB182545360A544E1FB /* ComposerFileTrigger.swift in Sources */,
+				2E9A26F315A959719F984023 /* FilePathSearch.swift in Sources */,
+				CAB298E458D85C9DAC9599EF /* FilePathAutocompleteView.swift in Sources */,
 				E067C191AC494934863F613D /* ComposerSlashTrigger.swift in Sources */,
 					C05000000000000000000001 /* ChatComposerAttachmentStripView.swift in Sources */,
 					C04900000000000000000001 /* ChatComposerTextInputView.swift in Sources */,
@@ -2094,6 +2112,8 @@
 					C0369000000000000000005 /* CronJobEditorConfigurationTests.swift in Sources */,
 					1050500000000000000000B1 /* OnboardingViewModelIdentityTests.swift in Sources */,
 					8F63EE9A9B344C4FA579D5A8 /* SlashCommandTests.swift in Sources */,
+				9F22A768126D503EAFB6D900 /* ComposerFileTriggerTests.swift in Sources */,
+				063F801939EE5BC0ADD8D7BF /* FilePathSearchTests.swift in Sources */,
 				F06907881C5B4BCCB98D2EBA /* ComposerSlashTriggerTests.swift in Sources */,
 				A1C0F1000000000000000006 /* ComposerChipTests.swift in Sources */,
 				0D82B28493C6401D98DA9C0E /* SlashCommandExecutorTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -24,11 +24,16 @@ struct ComposerTextInputView: View {
     /// The skills whose references the editor draws as chips. Empty until the
     /// server's skill list has loaded, which leaves the draft as plain text.
     let chipSkills: [SkillSlashSuggestion]
+    /// The workspace files picked in this chat, whose `@path` references the
+    /// editor draws as chips.
+    let chipFilePaths: Set<String>
     let onKeyboardSend: () -> Void
     let onPasteFileProviders: ([NSItemProvider]) -> Void
     let onPasteFileURLs: ([URL]) -> Void
     let onPasteImageProviders: ([NSItemProvider]) -> Void
     let onPasteImages: ([UIImage]) -> Void
+    /// A tap that landed on a chip's glyph.
+    let onTapChip: (ComposerChipToken) -> Void
 
     private let placeholder = String(localized: "Ask anything... /commands")
     private let collapsedLineHeight: CGFloat = 22
@@ -43,7 +48,9 @@ struct ComposerTextInputView: View {
                 isDisabled: isDisabled,
                 isKeyboardSendEnabled: isKeyboardSendEnabled,
                 chipSkills: chipSkills,
+                chipFilePaths: chipFilePaths,
                 renderedChips: $renderedChips,
+                onTapChip: onTapChip,
                 onKeyboardSend: onKeyboardSend,
                 onHeightChange: updateMeasuredHeight,
                 onPasteFileProviders: onPasteFileProviders,
@@ -159,7 +166,9 @@ private struct ComposerTextView: UIViewRepresentable {
     let isDisabled: Bool
     let isKeyboardSendEnabled: Bool
     let chipSkills: [SkillSlashSuggestion]
+    let chipFilePaths: Set<String>
     @Binding var renderedChips: [ComposerChipToken]
+    let onTapChip: (ComposerChipToken) -> Void
     let onKeyboardSend: () -> Void
     let onHeightChange: (CGFloat) -> Void
     let onPasteFileProviders: ([NSItemProvider]) -> Void
@@ -205,6 +214,7 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.onPasteFileURLs = onPasteFileURLs
         textView.onPasteImageProviders = onPasteImageProviders
         textView.onPasteImages = onPasteImages
+        textView.onTapChip = onTapChip
         context.coordinator.reportHeight(for: textView)
         return textView
     }
@@ -228,7 +238,9 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.onPasteFileURLs = onPasteFileURLs
         textView.onPasteImageProviders = onPasteImageProviders
         textView.onPasteImages = onPasteImages
+        textView.onTapChip = onTapChip
         textView.chipSkills = chipSkills
+        textView.chipFilePaths = chipFilePaths
         context.coordinator.onDropFileProviders = onPasteFileProviders
         context.coordinator.onDropImageProviders = onPasteImageProviders
         context.coordinator.applyBoundText(text, generation: selection.publishGeneration, to: textView)

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -116,6 +116,17 @@ struct MessageComposerView: View {
     /// the "New Chat with Voice" App Intent (#338). Defaults to false for normal composers.
     let autoStartsVoiceInput: Bool
     let apiClient: APIClient?
+    /// This chat's server-side session, which the `@` panel lists workspace
+    /// files for. Nil before the session exists, which keeps the panel closed.
+    let sessionID: String?
+    /// The workspace files already picked in this chat. The editor draws their
+    /// `@path` references as chips; the view model owns the set so the sent
+    /// transcript can draw the same ones.
+    let chipFilePaths: Set<String>
+    /// The `@` panel's rows and its directory listings. Owned by the view model
+    /// so a folder listed to confirm a restored draft's references is not listed
+    /// again the first time the panel opens.
+    let filePathSearch: ComposerFilePathSearch
     let uploadAttachmentErrorMessage: String?
     let onSend: () -> Void
     let onSendVoiceNote: (Data, String) -> Void
@@ -139,6 +150,10 @@ struct MessageComposerView: View {
     let onRemoveAttachment: (UUID) -> Void
     let onPreviewAttachment: (PendingAttachment) -> Void
     let onDismissUploadAttachmentError: () -> Void
+    /// A workspace file the user just picked, for the chip catalog.
+    let onSelectFileReference: (String) -> Void
+    /// A file chip the user tapped, by workspace-relative path.
+    let onOpenFileReference: (String) -> Void
     let onSelectGitBranch: (GitCheckoutTarget) -> Void
     let onCreateGitBranch: (GitCheckoutTarget) -> Void
     let onRefreshGitBranches: () -> Void
@@ -186,7 +201,33 @@ struct MessageComposerView: View {
         ComposerSlashTrigger.detect(in: draftMessage, selection: composerSelection.range)
     }
 
+    /// The `@…` the caret is sitting in, or `nil` when there is none.
+    ///
+    /// Needs a session to list, since every path the panel offers comes from
+    /// that session's workspace.
+    private var fileTrigger: ComposerFileTrigger? {
+        guard !isReadOnly, apiClient != nil, fileReferenceSessionID != nil else { return nil }
+        return ComposerFileTrigger.detect(in: draftMessage, selection: composerSelection.range)
+    }
+
+    private var showsFileAutocomplete: Bool {
+        fileTrigger != nil
+    }
+
+    private var fileReferenceSessionID: String? {
+        guard let sessionID = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionID.isEmpty
+        else {
+            return nil
+        }
+        return sessionID
+    }
+
     /// What the panel filters on, or `nil` when it should be closed.
+    ///
+    /// The `@` panel wins when both triggers match: a `/` inside a path never
+    /// triggers at all (it follows a non-space), but an `@` inside a command's
+    /// free-form argument is still a file reference.
     ///
     /// A command the user has typed past no longer produces a trigger at all —
     /// `ComposerSlashTrigger` ends at the space after a command that takes no
@@ -194,7 +235,7 @@ struct MessageComposerView: View {
     /// panel: a settled `/skills` invocation, a settled goal action, and a
     /// mid-sentence word no loaded skill matches.
     private var slashQuery: String? {
-        guard let query = slashTrigger?.text else { return nil }
+        guard fileTrigger == nil, let query = slashTrigger?.text else { return nil }
 
         let parsed = ParsedSlashQuery(query: query)
         if parsed.commandName.lowercased() == "skills",
@@ -244,6 +285,28 @@ struct MessageComposerView: View {
         let completed = trigger.applying(replacement, to: draftMessage)
         draftMessage = completed.draft
         composerSelection = composerSelection.moved(to: completed.selection)
+    }
+
+    /// Swaps the `@…` at the caret for the picked entry.
+    ///
+    /// A file finishes the reference: `@path` plus a space, recorded so the
+    /// editor draws it as a chip. A folder is a step on the way, so it inserts
+    /// with a trailing `/` and no space and the panel stays open listing what is
+    /// inside it. Only files are recorded, which is what keeps a folder
+    /// reference from becoming a chip that opens nothing.
+    private func applyFileCompletion(_ match: ComposerFilePathSearch.Match) {
+        guard let trigger = fileTrigger else { return }
+
+        let completed = trigger.applying(
+            match.isDirectory ? "@\(match.path)/" : "@\(match.path) ",
+            to: draftMessage
+        )
+        draftMessage = completed.draft
+        composerSelection = composerSelection.moved(to: completed.selection)
+
+        if !match.isDirectory {
+            onSelectFileReference(match.path)
+        }
     }
 
     private var parsedSlashQuery: ParsedSlashQuery {
@@ -298,7 +361,17 @@ struct MessageComposerView: View {
                 }
 
                 Group {
-                    if let slashQuery {
+                    if let fileTrigger, let sessionID = fileReferenceSessionID, let apiClient {
+                        FilePathAutocompleteView(
+                            query: fileTrigger.query,
+                            sessionID: sessionID,
+                            apiClient: apiClient,
+                            search: filePathSearch,
+                            onSelect: applyFileCompletion
+                        )
+                        .padding(.horizontal)
+                        .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
+                    } else if let slashQuery {
                         SlashCommandAutocompleteView(
                             query: slashQuery,
                             selectedModelID: selectedModelID,
@@ -334,6 +407,7 @@ struct MessageComposerView: View {
                     }
                 }
                 .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: showsSlashAutocomplete)
+                .animation(ChatMotion.quickState(reduceMotion: reduceMotion), value: showsFileAutocomplete)
 
                 composerSurface
                     .padding(.horizontal)
@@ -604,11 +678,17 @@ struct MessageComposerView: View {
                     isKeyboardSendEnabled: !showsStopButton && !isActionButtonDisabled,
                     verticalPadding: 12,
                     chipSkills: skillSuggestions,
+                    chipFilePaths: chipFilePaths,
                     onKeyboardSend: actionButtonTapped,
                     onPasteFileProviders: onPasteFileProviders,
                     onPasteFileURLs: onPasteFileURLs,
                     onPasteImageProviders: onPasteImageProviders,
-                    onPasteImages: onPasteImages
+                    onPasteImages: onPasteImages,
+                    onTapChip: { token in
+                        // A skill chip is inert; a file chip opens the file.
+                        guard let path = token.filePath else { return }
+                        onOpenFileReference(path)
+                    }
                 )
 
                 if !isExpanded {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1470,17 +1470,22 @@ struct ChatView: View {
         }
     }
 
-    /// Changes whenever there is new text that could name a workspace file: the
-    /// transcript grew or was swapped for the server's copy, or the draft gained
-    /// or lost a finished `@…`. Everything here is O(1) or bounded by the
-    /// draft, because it runs on every transcript update, including each token
-    /// of a live stream. The scan of the transcript itself is the view model's,
-    /// and it skips candidates the server has already answered for.
+    /// Changes whenever there is new text that could name a workspace file, or
+    /// whenever the answers already given have been thrown away: the transcript
+    /// grew, was swapped for the server's copy (which can rewrite a message in
+    /// the middle without changing the count or the last id), the workspace
+    /// moved, or the draft gained or lost a finished `@…`.
+    ///
+    /// Everything here is O(1) or bounded by the draft, because it runs on every
+    /// transcript update, including each token of a live stream. The scan of the
+    /// transcript itself is the view model's, and it skips candidates the server
+    /// has already answered for.
     private var fileChipReferenceScanToken: String {
         let draftCandidates = ComposerChipTokenizer.fileReferenceCandidates(in: draftMessage)
         return [
             String(viewModel.messages.count),
-            viewModel.messages.last?.messageId ?? "",
+            String(viewModel.transcriptRevision),
+            String(viewModel.fileChipScopeRevision),
             draftCandidates.joined(separator: " ")
         ].joined(separator: "|")
     }

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -454,6 +454,9 @@ struct ChatView: View {
             isSendingVoiceNote: viewModel.isSendingVoiceNote,
             autoStartsVoiceInput: autoStartsVoiceInput,
             apiClient: viewModel.client,
+            sessionID: session.sessionId,
+            chipFilePaths: viewModel.fileChipPaths,
+            filePathSearch: viewModel.filePathSearch,
             uploadAttachmentErrorMessage: viewModel.uploadAttachmentErrorMessage,
             onSend: {
                 Task { await sendDraftMessage() }
@@ -539,6 +542,12 @@ struct ChatView: View {
             },
             onDismissUploadAttachmentError: {
                 viewModel.setUploadAttachmentError(nil)
+            },
+            onSelectFileReference: { path in
+                viewModel.recordFileChipReference(path)
+            },
+            onOpenFileReference: { path in
+                openedFileReference = FileReference(path: path, line: nil, column: nil)
             },
             onSelectGitBranch: { target in
                 Task { await performGitCheckout(target) }
@@ -1450,12 +1459,30 @@ struct ChatView: View {
         .onChange(of: viewModel.latestRunOutcome) {
             handleLatestRunOutcomeChange(viewModel.latestRunOutcome)
         }
-        .environment(\.skillChipCatalog, viewModel.skillChipCatalog)
+        .environment(\.composerChipCatalog, viewModel.composerChipCatalog)
         .environment(\.openURL, OpenURLAction(handler: handleTranscriptLink))
         .environment(\.chatWorkspaceRoot, session.workspace)
         .task(id: transcriptSkillReferenceCount) {
             await loadSkillSuggestionsForTranscriptChipsIfNeeded()
         }
+        .task(id: fileChipReferenceScanToken) {
+            await viewModel.loadFileChipReferences(draft: draftMessage)
+        }
+    }
+
+    /// Changes whenever there is new text that could name a workspace file: the
+    /// transcript grew or was swapped for the server's copy, or the draft gained
+    /// or lost a finished `@…`. Everything here is O(1) or bounded by the
+    /// draft, because it runs on every transcript update, including each token
+    /// of a live stream. The scan of the transcript itself is the view model's,
+    /// and it skips candidates the server has already answered for.
+    private var fileChipReferenceScanToken: String {
+        let draftCandidates = ComposerChipTokenizer.fileReferenceCandidates(in: draftMessage)
+        return [
+            String(viewModel.messages.count),
+            viewModel.messages.last?.messageId ?? "",
+            draftCandidates.joined(separator: " ")
+        ].joined(separator: "|")
     }
 
     /// How many sent messages look like they name a skill.

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -377,8 +377,19 @@ final class ChatViewModel {
     /// Candidates the server has already answered for, so a `@word` that is not
     /// a file is not re-checked on every transcript update.
     @ObservationIgnored private var checkedFileChipCandidates: Set<String> = []
-    /// Most distinct folders one confirmation pass will list. A message can name
-    /// files all over a workspace; the panel is a convenience, not a crawler.
+    /// Bumped whenever the confirmed paths are thrown away because the
+    /// workspace moved. The chat re-runs its confirmation pass on the change, so
+    /// a file that exists in the new workspace too comes back as a chip.
+    private(set) var fileChipScopeRevision = 0
+    /// Bumped whenever the transcript is replaced rather than extended: a
+    /// cache-first paint, the server's reconcile, a page of older messages. A
+    /// reconcile can rewrite a message in the middle of the list without
+    /// changing the count or the last id, so nothing cheaper than "the
+    /// transcript was swapped" can be trusted to notice a reference arriving.
+    private(set) var transcriptRevision = 0
+    /// Most folders one batch of a confirmation pass lists. The pass works
+    /// through every folder its candidates name, a batch at a time, so a long
+    /// transcript is answered in full without one burst of requests.
     private static let fileChipDirectoryLimit = 20
     private(set) var profileOptions: [ProfileSummary] = []
     private(set) var isSingleProfileMode = false
@@ -422,7 +433,15 @@ final class ChatViewModel {
     private(set) var hasActivatedGoalCommand = false
 
     private let sessionID: String?
-    private var currentWorkspace: String?
+    /// The workspace this chat's session is pointed at. `/workspace` and the
+    /// composer's picker move it without the session id changing, and every
+    /// `@path` the chat has confirmed was confirmed against the old root.
+    private var currentWorkspace: String? {
+        didSet {
+            guard currentWorkspace != oldValue else { return }
+            resetFileChipReferences()
+        }
+    }
     private var currentModel: String?
     private var currentModelProvider: String?
     private var currentProfile: String?
@@ -1510,6 +1529,7 @@ final class ChatViewModel {
                     if !cachedMessages.isEmpty {
                         clearCompressionAnchorMetadata()
                         messages = cachedMessages
+                        transcriptRevision &+= 1
                         latestServerLoadHadAssistantResponseAfterLatestUser = Self.hasAssistantResponseAfterLatestUser(
                             in: messages
                         )
@@ -1616,6 +1636,7 @@ final class ChatViewModel {
         guard !cachedMessages.isEmpty else { return [] }
 
         messages = cachedMessages
+        transcriptRevision &+= 1
         messagesOffset = 0
         hasOlderMessages = false
         isViewingCachedData = false
@@ -1635,6 +1656,7 @@ final class ChatViewModel {
         // in-flight local content while its send/stream is still running.
         guard messages == placeholder else { return }
         messages = previousMessages
+        transcriptRevision &+= 1
         messagesOffset = previousMessagesOffset
         hasOlderMessages = previousMessagesOffset > 0
     }
@@ -1680,6 +1702,7 @@ final class ChatViewModel {
             let didAddMessages = mergedMessages.count > messages.count
             applyCompressionAnchorMetadata(from: session)
             messages = mergedMessages
+            transcriptRevision &+= 1
             latestServerLoadHadAssistantResponseAfterLatestUser = Self.hasAssistantResponseAfterLatestUser(
                 in: messages
             )
@@ -1813,6 +1836,7 @@ final class ChatViewModel {
             reloadedMessagesOffset: reloadedMessagesOffset
         ) {
             messages = expandedMessages
+            transcriptRevision &+= 1
             messagesOffset = previousMessagesOffset
             hasOlderMessages = previousMessagesOffset > 0
             return
@@ -1825,12 +1849,14 @@ final class ChatViewModel {
             reloadedMessagesOffset: reloadedMessagesOffset
         ) {
             messages = trimmedMessages
+            transcriptRevision &+= 1
             messagesOffset = previousMessagesOffset
             hasOlderMessages = previousMessagesOffset > 0 || session?.messagesTruncated == true
             return
         }
 
         messages = reloadedMessages
+        transcriptRevision &+= 1
         updateOlderMessagePagination(from: session, loadedMessageCount: messages.count)
     }
 
@@ -2592,6 +2618,7 @@ final class ChatViewModel {
         resetPendingStreamingContentBuffers()
         clearCompressionAnchorMetadata()
         messages = []
+        transcriptRevision &+= 1
         messagesOffset = 0
         hasOlderMessages = false
         setCompletedToolCallGroups([])
@@ -3203,13 +3230,34 @@ final class ChatViewModel {
         let candidates = fileChipReferenceCandidates(draft: draft)
         guard !candidates.isEmpty else { return }
 
+        let workspace = currentWorkspace
         let load = Task { [weak self] in
             guard let self else { return }
-            await self.confirmFileChipReferences(candidates, sessionID: sessionID)
+            await self.confirmFileChipReferences(candidates, sessionID: sessionID, workspace: workspace)
             self.fileChipReferenceLoad = nil
         }
         fileChipReferenceLoad = load
         await load.value
+    }
+
+    /// Forgets every confirmed `@path` because the workspace moved.
+    ///
+    /// A path is only a file inside the workspace it was found in, so switching
+    /// one has to take the chips with it — including the ones accepted from the
+    /// panel, which were never checked against anything else. The revision bump
+    /// is what asks the chat for a fresh pass, so a file that exists under the
+    /// new root as well comes straight back.
+    private func resetFileChipReferences() {
+        filePathSearch.reset()
+        checkedFileChipCandidates.removeAll()
+        fileChipReferenceLoad = nil
+
+        fileChipScopeRevision &+= 1
+        guard !fileChipPaths.isEmpty else { return }
+
+        fileChipPaths.removeAll()
+        composerChipCatalog = skillChipCatalog.withFilePaths(fileChipPaths)
+        transcriptRelayoutScrollToken += 1
     }
 
     /// Every `@…` the chat still has no answer for, draft first: what the user
@@ -3243,7 +3291,11 @@ final class ChatViewModel {
     /// than answered "no", so the next pass retries them; a folder that answered
     /// marks its candidates settled, which is what keeps a `@word` that is not a
     /// file from costing a request on every transcript update.
-    private func confirmFileChipReferences(_ candidates: [String], sessionID: String) async {
+    private func confirmFileChipReferences(
+        _ candidates: [String],
+        sessionID: String,
+        workspace: String?
+    ) async {
         var wantedByDirectory: [String: Set<String>] = [:]
         var directories: [String] = []
         for candidate in candidates {
@@ -3252,28 +3304,55 @@ final class ChatViewModel {
             wantedByDirectory[directory, default: []].insert(candidate)
         }
 
-        var confirmed: Set<String> = []
-        var settled: Set<String> = []
+        var start = directories.startIndex
+        while start < directories.endIndex {
+            let end = directories.index(
+                start,
+                offsetBy: Self.fileChipDirectoryLimit,
+                limitedBy: directories.endIndex
+            ) ?? directories.endIndex
+            let batch = directories[start..<end]
+            start = end
 
-        for directory in directories.prefix(Self.fileChipDirectoryLimit) {
-            guard let wanted = wantedByDirectory[directory] else { continue }
-            guard let entries = try? await filePathSearch.entries(
-                in: directory,
-                sessionID: sessionID,
-                apiClient: client
-            ) else {
-                continue
+            var confirmed: Set<String> = []
+            var settled: Set<String> = []
+
+            for directory in batch {
+                guard let wanted = wantedByDirectory[directory] else { continue }
+                guard let entries = try? await filePathSearch.entries(
+                    in: directory,
+                    sessionID: sessionID,
+                    apiClient: client
+                ) else {
+                    // A listing that failed is not an answer. Leaving the
+                    // candidates open is what lets the next pass retry them.
+                    continue
+                }
+
+                confirmed.formUnion(wanted.intersection(Set(entries.map(\.path))))
+                settled.formUnion(wanted)
             }
 
-            confirmed.formUnion(wanted.intersection(Set(entries.map(\.path))))
-            settled.formUnion(wanted)
+            // Checked between batches as well as at the end: the chat can be
+            // left, or its workspace switched, part-way through a long pass, and
+            // a listing taken against the old root must never widen the new
+            // one's catalog.
+            guard !Task.isCancelled,
+                  sessionID == self.sessionID,
+                  workspace == currentWorkspace
+            else {
+                return
+            }
+
+            apply(confirmed: confirmed, settled: settled)
         }
+    }
 
-        // The view model is built per session, but a listing that outlived its
-        // chat must never widen another one's catalog.
-        guard sessionID == self.sessionID else { return }
-
+    /// Folds one batch's answers into the catalog, drawing whatever it confirmed
+    /// straight away rather than making the reader wait for the last folder.
+    private func apply(confirmed: Set<String>, settled: Set<String>) {
         checkedFileChipCandidates.formUnion(settled)
+
         let recovered = confirmed.subtracting(fileChipPaths)
         guard !recovered.isEmpty else { return }
 
@@ -3403,6 +3482,7 @@ final class ChatViewModel {
 
             applyCompressionAnchorMetadata(from: session)
             messages = session.messages ?? []
+            transcriptRevision &+= 1
             updateOlderMessagePagination(from: session, loadedMessageCount: messages.count)
             isViewingCachedData = false
             let snapshot = ContextWindowSnapshot(

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -361,6 +361,25 @@ final class ChatViewModel {
     /// list so the transcript's `body` never rebuilds it. Always assigned
     /// through `applySkillSlashSuggestions(_:)`.
     private(set) var skillChipCatalog: ComposerChipCatalog = .empty
+    /// Workspace files picked from the composer's `@` panel in this chat.
+    /// Held here rather than in the composer so the transcript draws the same
+    /// references the composer does, and so switching chats never carries one
+    /// session's paths into another.
+    private(set) var fileChipPaths: Set<String> = []
+    /// The catalog both the composer and the transcript draw from: this chat's
+    /// skills plus the files it has referenced.
+    private(set) var composerChipCatalog: ComposerChipCatalog = .empty
+    /// The workspace directory listings behind both the composer's `@` panel and
+    /// the confirmation of `@path` references in a restored draft or transcript,
+    /// so a folder either surface has already listed is never listed twice.
+    @ObservationIgnored let filePathSearch = ComposerFilePathSearch()
+    @ObservationIgnored private var fileChipReferenceLoad: Task<Void, Never>?
+    /// Candidates the server has already answered for, so a `@word` that is not
+    /// a file is not re-checked on every transcript update.
+    @ObservationIgnored private var checkedFileChipCandidates: Set<String> = []
+    /// Most distinct folders one confirmation pass will list. A message can name
+    /// files all over a workspace; the panel is a convenience, not a crawler.
+    private static let fileChipDirectoryLimit = 20
     private(set) var profileOptions: [ProfileSummary] = []
     private(set) var isSingleProfileMode = false
     private(set) var selectedProfileName: String?
@@ -3129,6 +3148,7 @@ final class ChatViewModel {
         let previousCatalog = skillChipCatalog
         skillSlashSuggestions = suggestions
         skillChipCatalog = ComposerChipCatalog(skills: suggestions)
+        composerChipCatalog = skillChipCatalog.withFilePaths(fileChipPaths)
 
         // A catalog that draws differently redraws the transcript: sent `/slug`
         // text becomes a chip, or an existing chip changes size or goes away.
@@ -3137,6 +3157,129 @@ final class ChatViewModel {
         if skillChipCatalog != previousCatalog {
             transcriptRelayoutScrollToken += 1
         }
+    }
+
+    /// Remembers a workspace file the user picked in the composer, so its
+    /// `@path` draws as a chip there and in the sent message.
+    ///
+    /// Recorded straight away rather than waiting on the server: the panel only
+    /// ever offers paths a listing just returned, so the chip appears with the
+    /// insertion instead of a beat later.
+    func recordFileChipReference(_ path: String) {
+        let path = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else { return }
+
+        checkedFileChipCandidates.insert(path)
+        guard !fileChipPaths.contains(path) else { return }
+
+        fileChipPaths.insert(path)
+        composerChipCatalog = skillChipCatalog.withFilePaths(fileChipPaths)
+        // A wider catalog can turn sent `@path` text into a chip, which changes
+        // the height of a bubble already on screen.
+        transcriptRelayoutScrollToken += 1
+    }
+
+    /// Confirms the `@path` candidates in `draft` and in the transcript's user
+    /// messages against the session's workspace.
+    ///
+    /// What the composer picked lives in this view model, and this view model
+    /// dies when the chat is left — so on the way back in, and on any other
+    /// device, the only thing that knows a `@word` is a file is the server. Each
+    /// candidate's parent folder is listed once, through the same cache the `@`
+    /// panel fills, and every candidate the listing contains becomes a chip in
+    /// both the composer and the transcript.
+    ///
+    /// The work lives on a task this view model owns, like the skill loader: a
+    /// caller cancelled by an unrelated view update cannot take the listings
+    /// down with it, and a caller arriving mid-pass waits for that pass rather
+    /// than starting a second one over the same folders.
+    func loadFileChipReferences(draft: String) async {
+        guard let sessionID, !sessionID.isEmpty else { return }
+
+        while let existing = fileChipReferenceLoad {
+            await existing.value
+        }
+
+        let candidates = fileChipReferenceCandidates(draft: draft)
+        guard !candidates.isEmpty else { return }
+
+        let load = Task { [weak self] in
+            guard let self else { return }
+            await self.confirmFileChipReferences(candidates, sessionID: sessionID)
+            self.fileChipReferenceLoad = nil
+        }
+        fileChipReferenceLoad = load
+        await load.value
+    }
+
+    /// Every `@…` the chat still has no answer for, draft first: what the user
+    /// is looking at while typing is worth confirming before the backlog.
+    private func fileChipReferenceCandidates(draft: String) -> [String] {
+        var candidates: [String] = []
+        var seen: Set<String> = []
+
+        // The draft's own trailing reference counts as finished here: a chip
+        // whose trailing space was backspaced is still a reference, and by the
+        // time a pass runs the user has moved on to whatever changed the token.
+        for text in [draft] + messages.filter({ $0.role == "user" }).map({ $0.content ?? "" }) {
+            for candidate in ComposerChipTokenizer.fileReferenceCandidates(in: text, isComplete: true) {
+                guard !checkedFileChipCandidates.contains(candidate),
+                      !fileChipPaths.contains(candidate),
+                      seen.insert(candidate).inserted
+                else {
+                    continue
+                }
+                candidates.append(candidate)
+            }
+        }
+
+        return candidates
+    }
+
+    /// Lists each candidate's parent folder once and keeps the candidates that
+    /// folder actually holds.
+    ///
+    /// A folder whose listing failed leaves its candidates unanswered rather
+    /// than answered "no", so the next pass retries them; a folder that answered
+    /// marks its candidates settled, which is what keeps a `@word` that is not a
+    /// file from costing a request on every transcript update.
+    private func confirmFileChipReferences(_ candidates: [String], sessionID: String) async {
+        var wantedByDirectory: [String: Set<String>] = [:]
+        var directories: [String] = []
+        for candidate in candidates {
+            let directory = FileTree.parentPath(of: candidate)
+            if wantedByDirectory[directory] == nil { directories.append(directory) }
+            wantedByDirectory[directory, default: []].insert(candidate)
+        }
+
+        var confirmed: Set<String> = []
+        var settled: Set<String> = []
+
+        for directory in directories.prefix(Self.fileChipDirectoryLimit) {
+            guard let wanted = wantedByDirectory[directory] else { continue }
+            guard let entries = try? await filePathSearch.entries(
+                in: directory,
+                sessionID: sessionID,
+                apiClient: client
+            ) else {
+                continue
+            }
+
+            confirmed.formUnion(wanted.intersection(Set(entries.map(\.path))))
+            settled.formUnion(wanted)
+        }
+
+        // The view model is built per session, but a listing that outlived its
+        // chat must never widen another one's catalog.
+        guard sessionID == self.sessionID else { return }
+
+        checkedFileChipCandidates.formUnion(settled)
+        let recovered = confirmed.subtracting(fileChipPaths)
+        guard !recovered.isEmpty else { return }
+
+        fileChipPaths.formUnion(recovered)
+        composerChipCatalog = skillChipCatalog.withFilePaths(fileChipPaths)
+        transcriptRelayoutScrollToken += 1
     }
 
     private func branchSessionFromSlashCommand(_ args: String) async -> SlashCommandExecutionResult {

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -374,6 +374,9 @@ final class ChatViewModel {
     /// so a folder either surface has already listed is never listed twice.
     @ObservationIgnored let filePathSearch = ComposerFilePathSearch()
     @ObservationIgnored private var fileChipReferenceLoad: Task<Void, Never>?
+    /// Identifies the pass a handle belongs to, so a pass that was cancelled and
+    /// finishes late cannot clear the handle of the one that replaced it.
+    @ObservationIgnored private var fileChipReferenceLoadGeneration = 0
     /// Candidates the server has already answered for, so a `@word` that is not
     /// a file is not re-checked on every transcript update.
     @ObservationIgnored private var checkedFileChipCandidates: Set<String> = []
@@ -3231,9 +3234,12 @@ final class ChatViewModel {
         guard !candidates.isEmpty else { return }
 
         let workspace = currentWorkspace
+        fileChipReferenceLoadGeneration &+= 1
+        let loadGeneration = fileChipReferenceLoadGeneration
         let load = Task { [weak self] in
             guard let self else { return }
             await self.confirmFileChipReferences(candidates, sessionID: sessionID, workspace: workspace)
+            guard loadGeneration == self.fileChipReferenceLoadGeneration else { return }
             self.fileChipReferenceLoad = nil
         }
         fileChipReferenceLoad = load
@@ -3250,7 +3256,12 @@ final class ChatViewModel {
     private func resetFileChipReferences() {
         filePathSearch.reset()
         checkedFileChipCandidates.removeAll()
+        // Cancelling, not just forgetting: a pass left running would keep
+        // listing the old root's folders, and every folder it had already
+        // listed would settle candidates against a workspace that is gone.
+        fileChipReferenceLoad?.cancel()
         fileChipReferenceLoad = nil
+        fileChipReferenceLoadGeneration &+= 1
 
         fileChipScopeRevision &+= 1
         guard !fileChipPaths.isEmpty else { return }
@@ -3318,6 +3329,10 @@ final class ChatViewModel {
             var settled: Set<String> = []
 
             for directory in batch {
+                // Between folders, not just between batches: a workspace switch
+                // part-way through a pass must stop it before the next request,
+                // and nothing it has learned since may be applied.
+                guard !Task.isCancelled else { return }
                 guard let wanted = wantedByDirectory[directory] else { continue }
                 guard let entries = try? await filePathSearch.entries(
                     in: directory,

--- a/HermesMobile/Features/Chat/ComposerChipRendering.swift
+++ b/HermesMobile/Features/Chat/ComposerChipRendering.swift
@@ -7,14 +7,19 @@ import UIKit
 /// Everything that leaves the editor - what is sent, copied, cut, or saved as a
 /// draft - reads `source` back out, so the chip never changes the message.
 final class ComposerChipAttachment: NSTextAttachment {
-    let source: String
+    /// The reference this glyph stands for. Carried whole so a tap on the chip
+    /// can report what was tapped without the caller re-deriving it from a
+    /// caret offset.
+    let token: ComposerChipToken
 
-    init(source: String, label: String, image: UIImage, baselineOffset: CGFloat) {
-        self.source = source
+    var source: String { token.source }
+
+    init(token: ComposerChipToken, image: UIImage, baselineOffset: CGFloat) {
+        self.token = token
         super.init(data: nil, ofType: nil)
-        image.accessibilityLabel = label
+        image.accessibilityLabel = token.label
         self.image = image
-        accessibilityLabel = label
+        accessibilityLabel = token.label
         bounds = CGRect(origin: CGPoint(x: 0, y: baselineOffset), size: image.size)
     }
 
@@ -55,10 +60,6 @@ struct ComposerChipMetrics: Equatable {
 /// Draws the chip. The image is baked against a trait collection, so the editor
 /// re-renders it when the appearance or the content size category changes.
 enum ComposerChipRenderer {
-    /// Matches the Skills screen's own glyph so a chip reads as the same thing
-    /// the rest of the app calls a skill.
-    private static let iconName = "hammer"
-
     /// Baked chips, keyed by everything that changes one. The editor redraws
     /// only when its chips or its style move, but the collapsed composer draws
     /// from `body`, which runs again on every parent update — including each
@@ -68,12 +69,14 @@ enum ComposerChipRenderer {
 
     static func image(
         label: String,
+        icon: ComposerChipIcon,
         metrics: ComposerChipMetrics,
         traits: UITraitCollection,
         isRightToLeft: Bool
     ) -> UIImage {
         let key = [
             label,
+            icon.cacheKey,
             String(describing: metrics.labelFont.pointSize),
             String(describing: metrics.height),
             String(traits.userInterfaceStyle.rawValue),
@@ -85,13 +88,42 @@ enum ComposerChipRenderer {
             return cached
         }
 
-        let image = draw(label: label, metrics: metrics, traits: traits, isRightToLeft: isRightToLeft)
+        let image = draw(
+            label: label,
+            icon: icon,
+            metrics: metrics,
+            traits: traits,
+            isRightToLeft: isRightToLeft
+        )
         cache.setObject(image, forKey: key)
         return image
     }
 
+    /// The chip's glyph: an SF Symbol takes the chip's muted tint, a file-type
+    /// asset keeps its own colours.
+    private static func iconImage(
+        _ icon: ComposerChipIcon,
+        metrics: ComposerChipMetrics,
+        traits: UITraitCollection
+    ) -> UIImage? {
+        switch icon {
+        case let .symbol(name):
+            let tint = UIColor.secondaryLabel.resolvedColor(with: traits)
+            return UIImage(
+                systemName: name,
+                withConfiguration: UIImage.SymbolConfiguration(
+                    pointSize: metrics.iconSize - 2,
+                    weight: .medium
+                )
+            )?.withTintColor(tint, renderingMode: .alwaysOriginal)
+        case let .asset(name):
+            return UIImage(named: name)
+        }
+    }
+
     private static func draw(
         label: String,
+        icon iconStyle: ComposerChipIcon,
         metrics: ComposerChipMetrics,
         traits: UITraitCollection,
         isRightToLeft: Bool
@@ -99,15 +131,8 @@ enum ComposerChipRenderer {
         let background = UIColor.secondarySystemFill.resolvedColor(with: traits)
         let border = UIColor.separator.resolvedColor(with: traits)
         let textColor = UIColor.label.resolvedColor(with: traits)
-        let tint = UIColor.secondaryLabel.resolvedColor(with: traits)
 
-        let icon = UIImage(
-            systemName: iconName,
-            withConfiguration: UIImage.SymbolConfiguration(
-                pointSize: metrics.iconSize - 2,
-                weight: .medium
-            )
-        )?.withTintColor(tint, renderingMode: .alwaysOriginal)
+        let icon = iconImage(iconStyle, metrics: metrics, traits: traits)
 
         let attributes: [NSAttributedString.Key: Any] = [
             .font: metrics.labelFont,
@@ -235,6 +260,7 @@ enum ComposerChipTextLine {
 
             let chip = ComposerChipRenderer.image(
                 label: token.label,
+                icon: token.icon,
                 metrics: style.metrics,
                 traits: style.traits,
                 isRightToLeft: style.isRightToLeft
@@ -258,6 +284,12 @@ enum ComposerChipTextLine {
 /// to be translated. The rendered document is the authority: reading the
 /// mapping off the attachments themselves means a caret can never be computed
 /// from a stale idea of where the chips are.
+///
+/// An attachment this file did not make contributes nothing at all — not even
+/// the U+FFFC placeholder standing in for it on screen. The draft is what gets
+/// sent, saved, and copied, so anything the editor cannot describe as text has
+/// no business reaching it: a stray glyph would travel to the server, come back
+/// in the transcript, and be rendered by whatever reads it next.
 extension NSAttributedString {
     /// The draft text this document stands for.
     var composerSourceText: String {
@@ -273,7 +305,7 @@ extension NSAttributedString {
         enumerateAttribute(.attachment, in: range) { value, attributeRange, _ in
             if let chip = value as? ComposerChipAttachment {
                 source.append(chip.source)
-            } else {
+            } else if value == nil {
                 source.append(display.substring(with: attributeRange))
             }
         }
@@ -290,7 +322,7 @@ extension NSAttributedString {
         enumerateAttribute(.attachment, in: NSRange(location: 0, length: bounded)) { value, range, _ in
             if let chip = value as? ComposerChipAttachment {
                 source += (chip.source as NSString).length
-            } else {
+            } else if value == nil {
                 source += range.length
             }
         }
@@ -317,7 +349,7 @@ extension NSAttributedString {
                     return
                 }
                 source += chipLength
-            } else {
+            } else if value == nil {
                 if sourceOffset < source + range.length {
                     display = range.location + (sourceOffset - source)
                     stop.pointee = true

--- a/HermesMobile/Features/Chat/ComposerChipTextView.swift
+++ b/HermesMobile/Features/Chat/ComposerChipTextView.swift
@@ -10,12 +10,24 @@ final class ComposerChipTextView: UITextView {
     var onPasteFileURLs: ([URL]) -> Void = { _ in }
     var onPasteImageProviders: ([NSItemProvider]) -> Void = { _ in }
     var onPasteImages: ([UIImage]) -> Void = { _ in }
+    /// Reports a tap that landed on a chip's glyph. Every chip reports; what a
+    /// tap means belongs to the composer.
+    var onTapChip: (ComposerChipToken) -> Void = { _ in }
 
     /// The skills whose references are drawn as chips.
     var chipSkills: [SkillSlashSuggestion] = [] {
         didSet {
             guard chipSkills != oldValue else { return }
-            chipCatalog = ComposerChipCatalog(skills: chipSkills)
+            rebuildChipCatalog()
+        }
+    }
+
+    /// The workspace files this composer has inserted, whose `@path` references
+    /// are drawn as chips.
+    var chipFilePaths: Set<String> = [] {
+        didSet {
+            guard chipFilePaths != oldValue else { return }
+            rebuildChipCatalog()
         }
     }
 
@@ -39,6 +51,13 @@ final class ComposerChipTextView: UITextView {
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
+
+        // Rides alongside the text view's own tap rather than replacing it, so
+        // the caret still lands where the finger did and only a tap that
+        // actually covers a chip's glyph reports one.
+        let chipTap = UITapGestureRecognizer(target: self, action: #selector(handleChipTap))
+        chipTap.cancelsTouchesInView = false
+        addGestureRecognizer(chipTap)
 
         registerForTraitChanges(
             [UITraitUserInterfaceStyle.self, UITraitAccessibilityContrast.self, UITraitPreferredContentSizeCategory.self]
@@ -81,6 +100,46 @@ final class ComposerChipTextView: UITextView {
     }
 
     // MARK: - Chips
+
+    private func rebuildChipCatalog() {
+        chipCatalog = ComposerChipCatalog(skills: chipSkills, filePaths: chipFilePaths)
+    }
+
+    @objc private func handleChipTap(_ recognizer: UITapGestureRecognizer) {
+        guard recognizer.state == .ended,
+              let token = chipToken(at: recognizer.location(in: self))
+        else {
+            return
+        }
+        onTapChip(token)
+    }
+
+    /// The chip whose glyph covers `point`, or `nil`.
+    ///
+    /// `closestPosition` answers with a caret boundary, so the characters on
+    /// both sides of it are candidates; the glyph's own rectangle is what
+    /// decides, which is what keeps a tap in the space beside a chip from
+    /// counting as a tap on it.
+    private func chipToken(at point: CGPoint) -> ComposerChipToken? {
+        guard let position = closestPosition(to: point) else { return nil }
+        let caret = offset(from: beginningOfDocument, to: position)
+
+        for index in [caret - 1, caret] where index >= 0 && index < textStorage.length {
+            guard let attachment = textStorage.attribute(
+                .attachment,
+                at: index,
+                effectiveRange: nil
+            ) as? ComposerChipAttachment,
+                let range = textRange(from: NSRange(location: index, length: 1)),
+                firstRect(for: range).contains(point)
+            else {
+                continue
+            }
+            return attachment.token
+        }
+
+        return nil
+    }
 
     /// Redraws the document when the chips the draft calls for, or the way they
     /// have to be drawn, no longer match what is on screen. Ordinary typing
@@ -201,14 +260,14 @@ final class ComposerChipTextView: UITextView {
     ) -> NSAttributedString {
         let image = ComposerChipRenderer.image(
             label: token.label,
+            icon: token.icon,
             metrics: metrics,
             traits: traitCollection,
             isRightToLeft: isRightToLeft
         )
         let font = (attributes[.font] as? UIFont) ?? .preferredFont(forTextStyle: .body)
         let attachment = ComposerChipAttachment(
-            source: token.source,
-            label: token.label,
+            token: token,
             image: image,
             baselineOffset: floor((font.capHeight - image.size.height) / 2)
         )

--- a/HermesMobile/Features/Chat/ComposerChipToken.swift
+++ b/HermesMobile/Features/Chat/ComposerChipToken.swift
@@ -1,7 +1,35 @@
 import Foundation
 import SwiftUI
 
-/// A skill reference in the draft that the composer draws as one atomic chip.
+/// What a chip stands for. The kind picks the glyph and decides whether tapping
+/// the chip does anything: a file opens on the source viewer, a skill is inert.
+enum ComposerChipKind: Equatable {
+    case skill
+    case file
+}
+
+/// The picture inside a chip.
+///
+/// A skill draws an SF Symbol in the chip's own muted tint. A file draws the
+/// full-colour glyph the file tree already uses for its type, so one file reads
+/// the same in the composer, the workspace, and the transcript.
+enum ComposerChipIcon: Equatable {
+    case symbol(String)
+    case asset(String)
+
+    /// Stable text for the renderer's image cache key.
+    var cacheKey: String {
+        switch self {
+        case let .symbol(name):
+            return "symbol:\(name)"
+        case let .asset(name):
+            return "asset:\(name)"
+        }
+    }
+}
+
+/// A skill or workspace-file reference in the draft that the composer draws as
+/// one atomic chip.
 ///
 /// `range` and `source` are always in draft coordinates. The chip is a picture
 /// of `source`, never a replacement for it, so what the server receives and what
@@ -9,29 +37,56 @@ import SwiftUI
 struct ComposerChipToken: Equatable {
     /// UTF-16 range of the reference inside the draft.
     let range: NSRange
-    /// The exact draft substring the chip stands for, `/` included.
+    /// The exact draft substring the chip stands for, `/` or `@` included.
     let source: String
-    /// What the chip reads on screen.
+    /// What the chip reads on screen: a skill's name, or a file's last path
+    /// component.
     let label: String
+    let kind: ComposerChipKind
+
+    /// Matches the Skills screen's own glyph so a skill chip reads as the same
+    /// thing the rest of the app calls a skill.
+    private static let skillSymbol = "hammer"
+
+    /// Derived rather than stored so a chip's picture can never drift from what
+    /// the chip stands for.
+    var icon: ComposerChipIcon {
+        switch kind {
+        case .skill:
+            return .symbol(Self.skillSymbol)
+        case .file:
+            return .asset(FileIcon.resolve(label).assetName)
+        }
+    }
+
+    /// The workspace-relative path a file chip names, or `nil` for a skill.
+    var filePath: String? {
+        guard kind == .file else { return nil }
+        return String(source.dropFirst())
+    }
 }
 
-/// The skills a draft can reference, in the shape the tokenizer needs.
+/// The references a draft can draw as chips, in the shape the tokenizer needs.
 ///
-/// Built from the composer's skill suggestions once and compared by value, so
-/// the editor only redraws when the server's skill list has actually changed.
+/// Built from the composer's skill suggestions and the workspace files the user
+/// has picked, and compared by value, so the editor only redraws when one of
+/// those two lists has actually changed.
 struct ComposerChipCatalog: Equatable {
     /// Lowercased slug to chip label.
     private let labelsBySlug: [String: String]
+    /// Workspace-relative paths, exactly as the server spells them.
+    private let filePaths: Set<String>
 
-    static let empty = ComposerChipCatalog(labelsBySlug: [:])
+    static let empty = ComposerChipCatalog(labelsBySlug: [:], filePaths: [])
 
-    private init(labelsBySlug: [String: String]) {
+    private init(labelsBySlug: [String: String], filePaths: Set<String>) {
         self.labelsBySlug = labelsBySlug
+        self.filePaths = filePaths
     }
 
     /// A slug that is also a built-in command is left out: `/model` is the
     /// command, whatever a server happens to call its skills.
-    init(skills: [SkillSlashSuggestion]) {
+    init(skills: [SkillSlashSuggestion], filePaths: Set<String> = []) {
         var labels: [String: String] = [:]
         for skill in skills {
             let slug = skill.slashName.lowercased()
@@ -39,29 +94,44 @@ struct ComposerChipCatalog: Equatable {
             labels[slug] = skill.name
         }
         labelsBySlug = labels
+        self.filePaths = filePaths
     }
 
-    var isEmpty: Bool { labelsBySlug.isEmpty }
+    var isEmpty: Bool { labelsBySlug.isEmpty && filePaths.isEmpty }
 
     func label(forSlug slug: String) -> String? {
         labelsBySlug[slug.lowercased()]
     }
+
+    /// Paths are compared exactly: the server's filesystem decides case, and a
+    /// path the app has never been handed is not a reference.
+    func containsFile(path: String) -> Bool {
+        filePaths.contains(path)
+    }
+
+    /// The same skills with `paths` as the files a chip may be drawn for.
+    func withFilePaths(_ paths: Set<String>) -> ComposerChipCatalog {
+        ComposerChipCatalog(labelsBySlug: labelsBySlug, filePaths: paths)
+    }
 }
 
-/// Finds the skill references in a draft. Pure: the same draft and catalog
-/// always produce the same chips, which is what lets a pasted or restored draft
-/// come back with its chips intact without storing anything beside the text.
+/// Finds the references in a draft. Pure: the same draft and catalog always
+/// produce the same chips, which is what lets a pasted or restored draft come
+/// back with its chips intact without storing anything beside the text.
 enum ComposerChipTokenizer {
     private static let slash: UInt16 = 0x2F
+    private static let at: UInt16 = 0x40
 
-    /// Every skill reference in `draft` worth drawing as a chip.
+    /// Every reference in `draft` worth drawing as a chip.
     ///
-    /// A reference is a `/` that starts the draft or follows whitespace, a slug
-    /// the server knows, and whitespace after it. The trailing whitespace is
-    /// what says the user is done typing the name, so a half-typed `/ask-ma`
-    /// stays ordinary editable text. `previous` keeps a chip at the very end of
-    /// the draft drawn after its trailing space is deleted, so backspacing the
-    /// space a completion added does not flicker the chip back into text.
+    /// A reference is a `/` or `@` that starts the draft or follows whitespace,
+    /// a name the catalog knows, and whitespace after it. A skill's name runs to
+    /// the end of its slug; a file's path runs to the next whitespace, because a
+    /// path is one unbroken word. The trailing whitespace is what says the user
+    /// is done typing, so a half-typed `/ask-ma` or `@src/Cha` stays ordinary
+    /// editable text. `previous` keeps a chip at the very end of the draft drawn
+    /// after its trailing space is deleted, so backspacing the space a
+    /// completion added does not flicker the chip back into text.
     ///
     /// `isComplete` says the text is finished rather than being typed, which is
     /// what a sent message is: a reference that ends the message is a whole
@@ -80,7 +150,8 @@ enum ComposerChipTokenizer {
         var index = 0
 
         while index < text.length {
-            guard text.character(at: index) == slash,
+            let marker = text.character(at: index)
+            guard marker == slash || marker == at,
                   index == 0 || isWhitespaceOrNewline(text.character(at: index - 1))
             else {
                 index += 1
@@ -88,7 +159,7 @@ enum ComposerChipTokenizer {
             }
 
             var end = index + 1
-            while end < text.length, isSlugUnit(text.character(at: end)) {
+            while end < text.length, isBodyUnit(text.character(at: end), after: marker) {
                 end += 1
             }
 
@@ -101,14 +172,25 @@ enum ComposerChipTokenizer {
             let source = text.substring(with: range)
             index = end
 
-            guard let label = catalog.label(forSlug: String(source.dropFirst())) else { continue }
+            let body = String(source.dropFirst())
+            let kind: ComposerChipKind
+            let label: String
+            if marker == slash {
+                guard let skillLabel = catalog.label(forSlug: body) else { continue }
+                kind = .skill
+                label = skillLabel
+            } else {
+                guard catalog.containsFile(path: body) else { continue }
+                kind = .file
+                label = String(body.split(separator: "/").last ?? Substring(body))
+            }
 
             let isClosed = end < text.length && isWhitespaceOrNewline(text.character(at: end))
             let isPreservedTail = end == text.length
                 && (isComplete || previous.contains { $0.range == range && $0.source == source })
             guard isClosed || isPreservedTail else { continue }
 
-            tokens.append(ComposerChipToken(range: range, source: source, label: label))
+            tokens.append(ComposerChipToken(range: range, source: source, label: label, kind: kind))
         }
 
         return tokens
@@ -141,17 +223,61 @@ enum ComposerChipTokenizer {
         return spoken as String
     }
 
+    /// Every `@…` run in `text` that could name a workspace file, in the order
+    /// they appear and without repeats.
+    ///
+    /// Deliberately the same scan the tokenizer uses — an `@` that starts the
+    /// text or follows whitespace, running to the next whitespace — and
+    /// deliberately without a "looks like a filename" heuristic. Whether a
+    /// candidate is a file is the server's answer to give, and guessing here
+    /// would mean a real reference silently failing to draw.
+    ///
+    /// `isComplete` carries the tokenizer's meaning: without it a reference that
+    /// ends the text is still being typed, so `@sr` on the way to `@src/x.swift`
+    /// is not offered as something to look up.
+    static func fileReferenceCandidates(in text: String, isComplete: Bool = false) -> [String] {
+        let text = text as NSString
+        var candidates: [String] = []
+        var seen: Set<String> = []
+        var index = 0
+
+        while index < text.length {
+            guard text.character(at: index) == at,
+                  index == 0 || isWhitespaceOrNewline(text.character(at: index - 1))
+            else {
+                index += 1
+                continue
+            }
+
+            var end = index + 1
+            while end < text.length, isBodyUnit(text.character(at: end), after: at) {
+                end += 1
+            }
+
+            let path = text.substring(with: NSRange(location: index + 1, length: end - index - 1))
+            let isClosed = end < text.length || isComplete
+            index = end
+
+            guard isClosed, !path.isEmpty, seen.insert(path).inserted else { continue }
+            candidates.append(path)
+        }
+
+        return candidates
+    }
+
     /// Whether `draft` holds anything that could become a chip once the skill
-    /// list arrives. The composer uses it to warm that list for a restored
-    /// draft instead of fetching skills every time a chat opens.
+    /// list or the session's picked files arrive. The composer uses it to warm
+    /// that list for a restored draft instead of fetching skills every time a
+    /// chat opens.
     static func mayContainReference(_ draft: String) -> Bool {
         let text = draft as NSString
         var index = 0
 
         while index < text.length - 1 {
-            if text.character(at: index) == slash,
+            let marker = text.character(at: index)
+            if marker == slash || marker == at,
                index == 0 || isWhitespaceOrNewline(text.character(at: index - 1)),
-               isSlugUnit(text.character(at: index + 1)) {
+               isBodyUnit(text.character(at: index + 1), after: marker) {
                 return true
             }
             index += 1
@@ -160,12 +286,18 @@ enum ComposerChipTokenizer {
         return false
     }
 
-    /// The characters a skill slug is made of. `SlashSkillFormatter.slug`
-    /// only ever emits lowercase letters, digits, and hyphens; the rest are
+    /// Whether `unit` continues a reference opened by `marker`.
+    ///
+    /// A file path is any run of non-whitespace, since `/`, `.`, and `-` are all
+    /// ordinary path characters. A skill slug is narrower: `SlashSkillFormatter`
+    /// only ever emits lowercase letters, digits, and hyphens, and the rest are
     /// accepted so a hand-typed `/Ask_Matt` is scanned as one word and rejected
     /// by the catalog rather than cut in half.
-    private static func isSlugUnit(_ unit: UInt16) -> Bool {
+    private static func isBodyUnit(_ unit: UInt16, after marker: UInt16) -> Bool {
         guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        guard marker == slash else {
+            return !CharacterSet.whitespacesAndNewlines.contains(scalar)
+        }
         return CharacterSet.alphanumerics.contains(scalar)
             || scalar == "-"
             || scalar == "_"
@@ -177,20 +309,20 @@ enum ComposerChipTokenizer {
     }
 }
 
-private struct SkillChipCatalogKey: EnvironmentKey {
+private struct ComposerChipCatalogKey: EnvironmentKey {
     static let defaultValue = ComposerChipCatalog.empty
 }
 
 extension EnvironmentValues {
-    /// The skills a transcript may draw as chips.
+    /// The skills and workspace files a transcript may draw as chips.
     ///
     /// Sent messages carry no marker for a reference, so the bubble has to look
-    /// the slug up the same way the composer does. It travels in the
+    /// the slug or path up the same way the composer does. It travels in the
     /// environment because it belongs to the chat, not to any one bubble, and
     /// the rows in between are `Equatable` blocks that should not have to
     /// forward it.
-    var skillChipCatalog: ComposerChipCatalog {
-        get { self[SkillChipCatalogKey.self] }
-        set { self[SkillChipCatalogKey.self] = newValue }
+    var composerChipCatalog: ComposerChipCatalog {
+        get { self[ComposerChipCatalogKey.self] }
+        set { self[ComposerChipCatalogKey.self] = newValue }
     }
 }

--- a/HermesMobile/Features/Chat/ComposerFileTrigger.swift
+++ b/HermesMobile/Features/Chat/ComposerFileTrigger.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The `@…` run the caret is sitting in, if there is one.
+///
+/// Typing `@` opens the workspace file panel the way `/` opens the command
+/// panel. The trigger is found at the caret and reports the range it occupies,
+/// so accepting a row replaces only that much and the rest of the draft
+/// survives.
+struct ComposerFileTrigger: Equatable {
+    /// UTF-16 range of the trigger inside the draft: the `@` up to the caret.
+    let range: NSRange
+    /// The trigger's text, `@` included.
+    let text: String
+
+    /// The workspace path typed so far, without the `@`. This is what the panel
+    /// lists and filters on.
+    var query: String { String(text.dropFirst()) }
+
+    private static let at: UInt16 = 0x40
+
+    /// The trigger `selection` sits in, or `nil` when there is none.
+    ///
+    /// A trigger is an `@` that starts the draft or follows whitespace, running
+    /// forward to the caret and never across whitespace or a line break. Those
+    /// two rules together are what keep an email address out: the `@` in
+    /// `foo@bar` follows a letter, and the scan stops at the space in front of
+    /// `foo` rather than looking further back. A selection with a length is
+    /// never a trigger: the user is selecting text, not naming a file.
+    static func detect(in draft: String, selection: NSRange) -> ComposerFileTrigger? {
+        guard selection.length == 0 else { return nil }
+
+        let draft = draft as NSString
+        let caret = selection.location
+        guard caret >= 0, caret <= draft.length else { return nil }
+
+        var index = caret - 1
+        while index >= 0 {
+            let unit = draft.character(at: index)
+            if isWhitespaceOrNewline(unit) { return nil }
+
+            if unit == Self.at, index == 0 || isWhitespaceOrNewline(draft.character(at: index - 1)) {
+                let range = NSRange(location: index, length: caret - index)
+                return ComposerFileTrigger(range: range, text: draft.substring(with: range))
+            }
+
+            index -= 1
+        }
+
+        return nil
+    }
+
+    /// What the draft and caret become when the user accepts `replacement`.
+    ///
+    /// Only the trigger's own range changes. When the completion wants a
+    /// trailing space and the draft already has one waiting there, the space is
+    /// dropped and the caret steps over the existing one instead, so accepting a
+    /// file mid-sentence leaves neither a double space nor a caret stranded in
+    /// front of one. Deliberately the same arithmetic as
+    /// `ComposerSlashTrigger.applying(_:to:)`, which owns the `/` panel.
+    func applying(_ replacement: String, to draft: String) -> (draft: String, selection: NSRange) {
+        let draft = draft as NSString
+        let location = min(max(0, range.location), draft.length)
+        let range = NSRange(location: location, length: min(max(0, range.length), draft.length - location))
+
+        var inserted = replacement
+        var caretOffset = 0
+        if inserted.hasSuffix(" "),
+           range.upperBound < draft.length,
+           Self.isSpace(draft.character(at: range.upperBound)) {
+            inserted.removeLast()
+            caretOffset = 1
+        }
+
+        let caret = range.location + (inserted as NSString).length + caretOffset
+        return (
+            draft.replacingCharacters(in: range, with: inserted),
+            NSRange(location: caret, length: 0)
+        )
+    }
+
+    private static func isWhitespaceOrNewline(_ unit: UInt16) -> Bool {
+        guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+
+    private static func isSpace(_ unit: UInt16) -> Bool {
+        guard let scalar = Unicode.Scalar(UInt32(unit)) else { return false }
+        return CharacterSet.whitespaces.contains(scalar)
+    }
+}

--- a/HermesMobile/Features/Chat/FilePathAutocompleteView.swift
+++ b/HermesMobile/Features/Chat/FilePathAutocompleteView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// The `@` panel: the workspace files and folders that match the path being
+/// typed, on the same glass as the `/` panel so the two read as one surface.
+struct FilePathAutocompleteView: View {
+    // Row height tracks Dynamic Type so the panel is never taller or shorter
+    // than the rows it actually draws.
+    @ScaledMetric(relativeTo: .subheadline) private var rowHeight: CGFloat = 48
+    @ScaledMetric(relativeTo: .subheadline) private var emptyPanelHeight: CGFloat = 64
+    private let maxPanelHeight: CGFloat = 280
+
+    /// The path typed after the `@`, without it.
+    let query: String
+    let sessionID: String
+    let apiClient: APIClient
+    /// Owned by the composer, so its directory listings outlive one open panel.
+    let search: ComposerFilePathSearch
+    let onSelect: (ComposerFilePathSearch.Match) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if search.matches.isEmpty {
+                emptyText
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 20)
+                    .frame(maxWidth: .infinity)
+            } else {
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(search.matches.enumerated()), id: \.element.id) { index, match in
+                            row(match)
+
+                            if index < search.matches.count - 1 {
+                                Divider()
+                                    .padding(.horizontal, 16)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .adaptiveGlass(
+            .regular,
+            fallbackMaterial: .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .shadow(color: Color.black.opacity(0.15), radius: 12, y: 4)
+        .frame(height: panelHeight)
+        .task(id: query) {
+            await search.search(query, sessionID: sessionID, apiClient: apiClient)
+        }
+    }
+
+    /// A listing that failed reads as "nothing matched": the panel is a
+    /// shortcut past typing the path, never the only way to name a file.
+    @ViewBuilder
+    private var emptyText: some View {
+        if search.isLoading {
+            Text("Searching files…")
+        } else {
+            Text("No matching files or folders.")
+        }
+    }
+
+    private var panelHeight: CGFloat {
+        guard !search.matches.isEmpty else { return emptyPanelHeight }
+        return min(maxPanelHeight, CGFloat(search.matches.count) * rowHeight)
+    }
+
+    /// One row: the entry's own glyph, its name, and the folder it sits in.
+    /// A folder ends in a chevron, because picking one goes deeper rather than
+    /// finishing the reference.
+    private func row(_ match: ComposerFilePathSearch.Match) -> some View {
+        Button {
+            onSelect(match)
+        } label: {
+            HStack(spacing: 12) {
+                icon(for: match)
+                    .frame(width: 20)
+
+                Text(match.name)
+                    .font(Font.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .layoutPriority(2)
+
+                if !match.parentPath.isEmpty {
+                    Text(match.parentPath)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                        .layoutPriority(1)
+                }
+
+                Spacer(minLength: 8)
+
+                if match.isDirectory {
+                    Image(systemName: "chevron.forward")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel(for: match))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    /// The same glyphs the file tree draws: a quiet grey folder, or the file's
+    /// own type icon.
+    @ViewBuilder
+    private func icon(for match: ComposerFilePathSearch.Match) -> some View {
+        if match.isDirectory {
+            Image(systemName: "folder")
+                .font(.system(size: 16))
+                .foregroundStyle(Color(uiColor: .systemGray))
+        } else {
+            FileIcon.resolve(match.name).image
+                .resizable()
+                .scaledToFit()
+                .frame(width: 16, height: 16)
+        }
+    }
+
+    private func accessibilityLabel(for match: ComposerFilePathSearch.Match) -> String {
+        let kind = match.isDirectory ? String(localized: "Folder") : String(localized: "File")
+        return String(localized: "\(kind), \(match.name)")
+    }
+}

--- a/HermesMobile/Features/Chat/FilePathSearch.swift
+++ b/HermesMobile/Features/Chat/FilePathSearch.swift
@@ -42,8 +42,13 @@ final class ComposerFilePathSearch {
     private var listings: [String: [FileTreeNode]] = [:]
     private var loadedSessionID: String?
     /// Bumped per query so a listing that lands after a newer query never
-    /// overwrites it.
+    /// overwrites the rows on screen.
     private var generation = 0
+    /// Bumped whenever the cache stops meaning what it meant: another session,
+    /// or a workspace switch. A listing still in flight belongs to the scope it
+    /// was asked in, so it must neither be cached under the new one nor counted
+    /// as an answer about it.
+    private var cacheGeneration = 0
 
     /// Most rows one panel offers. Past this the panel is a scroll rather than
     /// a choice, and the ranking already put the best rows on top.
@@ -87,13 +92,21 @@ final class ComposerFilePathSearch {
     /// re-opening the panel over a directory a restored draft already had
     /// checked costs nothing. Never recurses, and a folder that climbs out of
     /// the workspace is answered empty without asking the server.
+    ///
+    /// Throws `CancellationError` when the session or workspace moved while the
+    /// listing was in flight. That is deliberately the same shape as a failed
+    /// request: the folder is *unanswered*, so its candidates stay open for the
+    /// next pass rather than being settled against a root they never described.
     func entries(in directory: String, sessionID: String, apiClient: APIClient) async throws -> [FileTreeNode] {
         dropCacheIfSessionChanged(sessionID)
 
         guard !Self.climbsOutOfWorkspace(directory) else { return [] }
         if let cached = listings[directory] { return cached }
 
+        let cacheGeneration = self.cacheGeneration
         let response = try await apiClient.directoryList(sessionID: sessionID, path: directory)
+        guard cacheGeneration == self.cacheGeneration else { throw CancellationError() }
+
         let nodes = Self.nodes(from: response.entries ?? [], in: directory)
         listings[directory] = nodes
         return nodes
@@ -106,9 +119,11 @@ final class ComposerFilePathSearch {
     /// a folder listed against the old root says nothing about the new one. The
     /// view model calls this the moment the workspace moves.
     func reset() {
-        // A listing already in flight belongs to the old workspace; bumping the
-        // generation is what stops it landing in the new one's rows.
+        // A listing already in flight belongs to the old workspace; bumping both
+        // generations is what stops it reaching the new one's rows and the new
+        // one's cache.
         generation &+= 1
+        cacheGeneration &+= 1
         listings.removeAll()
         loadedSessionID = nil
         matches = []
@@ -118,6 +133,7 @@ final class ComposerFilePathSearch {
     /// A path only means anything inside the session it came from.
     private func dropCacheIfSessionChanged(_ sessionID: String) {
         guard sessionID != loadedSessionID else { return }
+        cacheGeneration &+= 1
         listings.removeAll()
         loadedSessionID = sessionID
     }

--- a/HermesMobile/Features/Chat/FilePathSearch.swift
+++ b/HermesMobile/Features/Chat/FilePathSearch.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// The workspace files and folders the composer's `@` panel offers for one query.
+///
+/// The query is a path being typed, so exactly one folder has to be listed: the
+/// one the query names. `src/Ch` lists `src` and ranks its entries against `Ch`;
+/// `Ch` ranks the workspace root's own entries. Nothing recurses, so a large
+/// workspace costs the same as a small one.
+///
+/// Listings are cached for the composer's lifetime, so walking back up a path
+/// the user is retyping costs no requests at all. The cache is dropped when the
+/// session changes, because a path is only meaningful inside the workspace it
+/// came from.
+@MainActor
+@Observable
+final class ComposerFilePathSearch {
+    /// One row: the path that gets inserted, plus what the row draws.
+    struct Match: Identifiable, Equatable {
+        var id: String { path }
+        /// Workspace-relative, exactly as the server spelled it.
+        let path: String
+        let name: String
+        /// The folder the entry sits in, empty at the workspace root.
+        let parentPath: String
+        let isDirectory: Bool
+
+        init(node: FileTreeNode) {
+            path = node.path
+            name = node.name
+            let parent = FileTree.parentPath(of: node.path)
+            parentPath = parent == FileTree.rootPath ? "" : parent
+            isDirectory = node.isDirectory
+        }
+    }
+
+    private(set) var matches: [Match] = []
+    private(set) var isLoading = false
+
+    /// Directory path → its entries. A composer is short-lived next to a
+    /// workspace, and the worst a stale row can do is send the viewer after a
+    /// file the server no longer has, which the viewer already reports.
+    private var listings: [String: [FileTreeNode]] = [:]
+    private var loadedSessionID: String?
+    /// Bumped per query so a listing that lands after a newer query never
+    /// overwrites it.
+    private var generation = 0
+
+    /// Most rows one panel offers. Past this the panel is a scroll rather than
+    /// a choice, and the ranking already put the best rows on top.
+    private static let matchLimit = 20
+
+    /// Lists the folder `query` names and ranks it against the query's last
+    /// segment. A failed listing reads as "nothing matched": the panel is a
+    /// shortcut, and an error box over the keyboard would be in the way of the
+    /// user simply typing the path.
+    func search(_ query: String, sessionID: String, apiClient: APIClient) async {
+        dropCacheIfSessionChanged(sessionID)
+
+        generation &+= 1
+        let generation = self.generation
+        let request = Request(query: query)
+
+        if listings[request.directory] == nil {
+            isLoading = true
+            matches = []
+        }
+
+        do {
+            let nodes = try await entries(
+                in: request.directory,
+                sessionID: sessionID,
+                apiClient: apiClient
+            )
+            guard generation == self.generation else { return }
+            isLoading = false
+            matches = Self.ranked(nodes, against: request.segment)
+        } catch {
+            guard generation == self.generation else { return }
+            isLoading = false
+            matches = []
+        }
+    }
+
+    /// The entries of one workspace folder, listed at most once.
+    ///
+    /// The panel and the view model's `@path` confirmation share this cache, so
+    /// re-opening the panel over a directory a restored draft already had
+    /// checked costs nothing. Never recurses, and a folder that climbs out of
+    /// the workspace is answered empty without asking the server.
+    func entries(in directory: String, sessionID: String, apiClient: APIClient) async throws -> [FileTreeNode] {
+        dropCacheIfSessionChanged(sessionID)
+
+        guard !Self.climbsOutOfWorkspace(directory) else { return [] }
+        if let cached = listings[directory] { return cached }
+
+        let response = try await apiClient.directoryList(sessionID: sessionID, path: directory)
+        let nodes = Self.nodes(from: response.entries ?? [], in: directory)
+        listings[directory] = nodes
+        return nodes
+    }
+
+    /// A path only means anything inside the workspace it came from.
+    private func dropCacheIfSessionChanged(_ sessionID: String) {
+        guard sessionID != loadedSessionID else { return }
+        listings.removeAll()
+        loadedSessionID = sessionID
+    }
+
+    /// The folder a query names and the segment it is filtering that folder by.
+    private struct Request {
+        let directory: String
+        let segment: String
+
+        init(query: String) {
+            guard let slash = query.lastIndex(of: "/") else {
+                directory = FileTree.rootPath
+                segment = query
+                return
+            }
+            let prefix = String(query[query.startIndex..<slash])
+            directory = prefix.isEmpty ? FileTree.rootPath : prefix
+            segment = String(query[query.index(after: slash)...])
+        }
+    }
+
+    /// Drops anything the workspace does not contain: an entry the server marked
+    /// as a symlink pointing outside it, and any path with a `..` component,
+    /// which no listing of a workspace folder should ever produce.
+    private static func nodes(from entries: [WorkspaceEntry], in directory: String) -> [FileTreeNode] {
+        entries
+            .filter { $0.targetOutsideWorkspace != true }
+            .compactMap { FileTreeNode(entry: $0, parentPath: directory) }
+            .filter { !climbsOutOfWorkspace($0.path) }
+    }
+
+    private static func climbsOutOfWorkspace(_ path: String) -> Bool {
+        path.split(separator: "/", omittingEmptySubsequences: false).contains("..")
+    }
+
+    /// An empty segment is the whole folder in tree order. A typed segment is
+    /// ranked by `FileTreeSearch`, which is the same scorer the workspace search
+    /// field uses, so the same typing finds the same file in both places.
+    private static func ranked(_ nodes: [FileTreeNode], against segment: String) -> [Match] {
+        guard !segment.isEmpty else {
+            return FileTree.sorted(nodes).prefix(matchLimit).map { Match(node: $0) }
+        }
+
+        let query = segment.lowercased()
+        let scored = nodes.compactMap { node -> (node: FileTreeNode, score: Int)? in
+            guard let score = FileTreeSearch.score(
+                value: node.name.lowercased(),
+                query: query,
+                fuzzy: true
+            ) else {
+                return nil
+            }
+            return (node, score)
+        }
+
+        return scored
+            .sorted { left, right in
+                if left.score != right.score { return left.score < right.score }
+                if left.node.isDirectory != right.node.isDirectory { return left.node.isDirectory }
+                return left.node.name.localizedStandardCompare(right.node.name) == .orderedAscending
+            }
+            .prefix(matchLimit)
+            .map { Match(node: $0.node) }
+    }
+}

--- a/HermesMobile/Features/Chat/FilePathSearch.swift
+++ b/HermesMobile/Features/Chat/FilePathSearch.swift
@@ -99,7 +99,23 @@ final class ComposerFilePathSearch {
         return nodes
     }
 
-    /// A path only means anything inside the workspace it came from.
+    /// Forgets every listing.
+    ///
+    /// The session's workspace can be switched underneath a chat (`/workspace`,
+    /// or the composer's workspace picker) without the session id changing, and
+    /// a folder listed against the old root says nothing about the new one. The
+    /// view model calls this the moment the workspace moves.
+    func reset() {
+        // A listing already in flight belongs to the old workspace; bumping the
+        // generation is what stops it landing in the new one's rows.
+        generation &+= 1
+        listings.removeAll()
+        loadedSessionID = nil
+        matches = []
+        isLoading = false
+    }
+
+    /// A path only means anything inside the session it came from.
     private func dropCacheIfSessionChanged(_ sessionID: String) {
         guard sessionID != loadedSessionID else { return }
         listings.removeAll()
@@ -123,14 +139,20 @@ final class ComposerFilePathSearch {
         }
     }
 
-    /// Drops anything the workspace does not contain: an entry the server marked
-    /// as a symlink pointing outside it, and any path with a `..` component,
-    /// which no listing of a workspace folder should ever produce.
+    /// Drops anything a reference cannot name: an entry the server marked as a
+    /// symlink pointing outside the workspace, any path with a `..` component,
+    /// and any path containing whitespace.
+    ///
+    /// The whitespace rule is the reference syntax's, not the filesystem's. The
+    /// only form verified against upstream is `@` plus the plain path followed
+    /// by a space, which means the space inside `My File.swift` ends the
+    /// reference: the path would insert and then never read back as one. Better
+    /// not to offer it than to offer something that quietly does not work.
     private static func nodes(from entries: [WorkspaceEntry], in directory: String) -> [FileTreeNode] {
         entries
             .filter { $0.targetOutsideWorkspace != true }
             .compactMap { FileTreeNode(entry: $0, parentPath: directory) }
-            .filter { !climbsOutOfWorkspace($0.path) }
+            .filter { !climbsOutOfWorkspace($0.path) && !$0.path.contains(where: \.isWhitespace) }
     }
 
     private static func climbsOutOfWorkspace(_ path: String) -> Bool {

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -7,7 +7,7 @@ struct MessageBubbleView: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The skills this chat can draw as chips, published by `ChatView`.
-    @Environment(\.skillChipCatalog) private var skillChipCatalog
+    @Environment(\.composerChipCatalog) private var composerChipCatalog
     @Environment(\.chatWorkspaceRoot) private var chatWorkspaceRoot
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
@@ -256,8 +256,8 @@ struct MessageBubbleView: View {
     /// A slug the server no longer knows resolves to nothing and stays plain
     /// text, which is the same rule the composer follows.
     private func userBubbleChips(in text: String) -> [ComposerChipToken] {
-        guard !skillChipCatalog.isEmpty else { return [] }
-        return ComposerChipTokenizer.tokens(in: text, catalog: skillChipCatalog, isComplete: true)
+        guard !composerChipCatalog.isEmpty else { return [] }
+        return ComposerChipTokenizer.tokens(in: text, catalog: composerChipCatalog, isComplete: true)
     }
 
     private var chipStyle: ComposerChipTextStyle {

--- a/HermesMobile/Models/Workspace.swift
+++ b/HermesMobile/Models/Workspace.swift
@@ -97,14 +97,27 @@ struct WorkspaceEntry: Decodable, Hashable, Identifiable {
     let size: Int?
     let modified: Double?
     let isDirectory: Bool?
+    /// `target_outside_workspace` for a symlink: the server resolved it and the
+    /// target is not under the workspace root. Absent for everything else, and
+    /// on servers that predate the flag, so callers treat `nil` as "no claim".
+    let targetOutsideWorkspace: Bool?
 
-    init(name: String?, path: String?, type: String? = nil, size: Int? = nil, modified: Double? = nil, isDirectory: Bool? = nil) {
+    init(
+        name: String?,
+        path: String?,
+        type: String? = nil,
+        size: Int? = nil,
+        modified: Double? = nil,
+        isDirectory: Bool? = nil,
+        targetOutsideWorkspace: Bool? = nil
+    ) {
         self.name = name
         self.path = path
         self.type = type
         self.size = size
         self.modified = modified
         self.isDirectory = isDirectory
+        self.targetOutsideWorkspace = targetOutsideWorkspace
     }
 
     enum CodingKeys: String, CodingKey {
@@ -115,6 +128,7 @@ struct WorkspaceEntry: Decodable, Hashable, Identifiable {
         case modified
         case isDirectory
         case isDir
+        case targetOutsideWorkspace
     }
 
     init(from decoder: Decoder) throws {
@@ -126,6 +140,7 @@ struct WorkspaceEntry: Decodable, Hashable, Identifiable {
         modified = try container.decodeIfPresent(Double.self, forKey: .modified)
         isDirectory = try container.decodeIfPresent(Bool.self, forKey: .isDirectory)
             ?? container.decodeIfPresent(Bool.self, forKey: .isDir)
+        targetOutsideWorkspace = try container.decodeIfPresent(Bool.self, forKey: .targetOutsideWorkspace)
     }
 }
 

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -129890,6 +129890,218 @@
           }
         }
       }
+    },
+    "Searching files…" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "جارٍ البحث في الملفات…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dateien werden durchsucht…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Buscando archivos…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recherche de fichiers…"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "מחפש קבצים…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ricerca file…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ファイルを検索中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "파일 검색 중…"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bestanden zoeken…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wyszukiwanie plików…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Buscando arquivos…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Поиск файлов…"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dosyalar aranıyor…"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "فائلیں تلاش کی جا رہی ہیں…"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在搜尋檔案…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在搜索文件…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在搜尋檔案…"
+          }
+        }
+      }
+    },
+    "No matching files or folders." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "لا توجد ملفات أو مجلدات مطابقة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine passenden Dateien oder Ordner."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No hay archivos ni carpetas que coincidan."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aucun fichier ou dossier correspondant."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "אין קבצים או תיקיות תואמים."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nessun file o cartella corrispondente."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一致するファイルまたはフォルダがありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "일치하는 파일 또는 폴더가 없습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Geen overeenkomende bestanden of mappen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Brak pasujących plików ani folderów."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum arquivo ou pasta correspondente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Нет подходящих файлов или папок."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eşleşen dosya veya klasör yok."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کوئی مماثل فائل یا فولڈر نہیں۔"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "沒有相符的檔案或資料夾。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "没有匹配的文件或文件夹。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "沒有相符的檔案或資料夾。"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -8939,6 +8939,191 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 0)
     }
 
+    // MARK: - Workspace file references (`@path`)
+
+    /// `.` holds `a/`; `a/` holds `b.md` and `c.md`.
+    private func fileListingJSON(for path: String) -> String? {
+        switch path {
+        case ".":
+            return #"{"path": ".", "entries": [{"name": "a", "path": "a", "type": "dir", "is_dir": true}]}"#
+        case "a":
+            return #"{"path": "a", "entries": [{"name": "b.md", "path": "a/b.md", "type": "file"}, {"name": "c.md", "path": "a/c.md", "type": "file"}]}"#
+        default:
+            return nil
+        }
+    }
+
+    private func listedPath(in request: URLRequest) -> String {
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        return components?.queryItems?.first { $0.name == "path" }?.value ?? "."
+    }
+
+    /// What the composer picked dies with the view model, so a chat re-entered
+    /// from the session list has to ask the server whether a `@word` in the
+    /// restored draft is really a file before it can draw the chip again.
+    @MainActor
+    func testARestoredDraftReferenceIsConfirmedAgainstTheWorkspace() async throws {
+        let listed = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            XCTAssertEqual(request.url?.path, "/api/list")
+            let path = listedPath(in: request)
+            listed.append(path)
+            return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+        }
+
+        XCTAssertFalse(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+
+        await viewModel.loadFileChipReferences(draft: "read @a/b.md please")
+
+        XCTAssertEqual(listed.values, ["a"])
+        XCTAssertTrue(viewModel.fileChipPaths.contains("a/b.md"))
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 1)
+    }
+
+    /// A `@word` the folder does not hold stays plain text, and the answer
+    /// sticks: it must not cost a listing on every later transcript update.
+    @MainActor
+    func testACandidateItsFolderDoesNotHoldIsNeverDrawnAsAChip() async throws {
+        let listed = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            let path = listedPath(in: request)
+            listed.append(path)
+            return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+        }
+
+        await viewModel.loadFileChipReferences(draft: "see @a/missing.md now")
+        await viewModel.loadFileChipReferences(draft: "see @a/missing.md now")
+
+        XCTAssertEqual(listed.values, ["a"])
+        XCTAssertFalse(viewModel.composerChipCatalog.containsFile(path: "a/missing.md"))
+        XCTAssertEqual(viewModel.transcriptRelayoutScrollToken, 0)
+    }
+
+    @MainActor
+    func testTwoReferencesInOneFolderCostOneListing() async throws {
+        let listed = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            let path = listedPath(in: request)
+            listed.append(path)
+            return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+        }
+
+        await viewModel.loadFileChipReferences(draft: "@a/b.md and @a/c.md together")
+
+        XCTAssertEqual(listed.values, ["a"])
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/c.md"))
+    }
+
+    /// The confirmation lives on a task the view model owns, so a caller
+    /// cancelled by an unrelated view update cannot take the listing down with
+    /// it — and the next caller finds the answer rather than asking again.
+    @MainActor
+    func testACancelledCallerDoesNotCancelTheConfirmation() async throws {
+        let listed = LockedStrings()
+        let listingStarted = expectation(description: "listing started")
+        let releaseListing = DispatchSemaphore(value: 0)
+
+        let viewModel = try makeViewModel { [self] request in
+            let path = listedPath(in: request)
+            listed.append(path)
+            listingStarted.fulfill()
+            releaseListing.wait()
+            return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+        }
+
+        let cancelled = Task { await viewModel.loadFileChipReferences(draft: "@a/b.md here") }
+        await fulfillment(of: [listingStarted], timeout: 5)
+        cancelled.cancel()
+        releaseListing.signal()
+
+        await viewModel.loadFileChipReferences(draft: "@a/b.md here")
+
+        XCTAssertEqual(listed.values, ["a"])
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+    }
+
+    /// A listing that failed is not an answer, so the candidate stays open and
+    /// the next pass asks again.
+    @MainActor
+    func testAFailedListingIsRetriedByTheNextCaller() async throws {
+        let attempts = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            let path = listedPath(in: request)
+            attempts.append(path)
+            if attempts.values.count == 1 {
+                return apiTestJSONResponse(#"{"error": "boom"}"#, for: request, status: 500)
+            }
+            return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+        }
+
+        await viewModel.loadFileChipReferences(draft: "@a/b.md here")
+        XCTAssertFalse(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+
+        await viewModel.loadFileChipReferences(draft: "@a/b.md here")
+
+        XCTAssertEqual(attempts.values, ["a", "a"])
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+    }
+
+    /// The sent bubble draws from the same catalog, so a reference that only
+    /// exists in the loaded transcript has to be confirmed too.
+    @MainActor
+    func testASentMessageReferenceIsConfirmedAfterTheTranscriptLoads() async throws {
+        let viewModel = try makeViewModel { [self] request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "look at @a/b.md",
+                        "timestamp": 1770000100,
+                        "message_id": "user-1"
+                      }
+                    ]
+                  }
+                }
+                """, for: request)
+            case "/api/list":
+                let path = listedPath(in: request)
+                return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        await viewModel.loadFileChipReferences(draft: "")
+
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+    }
+
+    /// A path the panel just offered is a chip immediately: the listing that
+    /// produced the row is the same answer a confirmation pass would get.
+    @MainActor
+    func testAPickedPathIsNeverRecheckedAgainstTheServer() async throws {
+        let listed = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            let path = listedPath(in: request)
+            listed.append(path)
+            return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+        }
+
+        viewModel.recordFileChipReference("a/b.md")
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+
+        await viewModel.loadFileChipReferences(draft: "@a/b.md here")
+
+        XCTAssertTrue(listed.values.isEmpty)
+    }
+
     private static func ttsUnavailableResponse(for request: URLRequest) -> (HTTPURLResponse, Data) {
         let response = HTTPURLResponse(
             url: request.url!,
@@ -9156,6 +9341,27 @@ final class ChatViewModelSendTests: XCTestCase {
             file: file,
             line: line
         )
+    }
+}
+
+/// Every `/api/list` path a handler was asked for, in call order. Handlers run
+/// off the test's thread, so the record needs its own lock.
+private final class LockedStrings: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String] = []
+
+    func append(_ value: String) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        stored.append(value)
+    }
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return stored
     }
 }
 

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -9124,6 +9124,120 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(listed.values.isEmpty)
     }
 
+    /// A path is only a file inside the workspace it was found in, so switching
+    /// the session's workspace has to take every confirmed chip with it —
+    /// including one accepted straight from the panel — and ask again.
+    @MainActor
+    func testAWorkspaceChangeDropsConfirmedFileChipsAndAsksAgain() async throws {
+        let listed = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            guard request.url?.path == "/api/list" else {
+                return apiTestJSONResponse(#"""
+                {"session": {"session_id": "session-abc", "workspace": "/tmp/other", "model": "gpt-5.4"}}
+                """#, for: request)
+            }
+            let path = listedPath(in: request)
+            listed.append(path)
+            return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+        }
+
+        await viewModel.loadFileChipReferences(draft: "@a/b.md here")
+        viewModel.recordFileChipReference("a/c.md")
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/c.md"))
+        let scopeBefore = viewModel.fileChipScopeRevision
+
+        await viewModel.selectWorkspacePath("/tmp/other")
+
+        XCTAssertTrue(viewModel.fileChipPaths.isEmpty)
+        XCTAssertFalse(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+        XCTAssertFalse(viewModel.composerChipCatalog.containsFile(path: "a/c.md"))
+        XCTAssertGreaterThan(viewModel.fileChipScopeRevision, scopeBefore)
+
+        await viewModel.loadFileChipReferences(draft: "@a/b.md here")
+
+        // The folder is listed again rather than answered from a cache filled
+        // against the old root.
+        XCTAssertEqual(listed.values, ["a", "a"])
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+    }
+
+    /// Every folder the candidates name is answered, a batch at a time, rather
+    /// than the first batch and silence for the rest.
+    @MainActor
+    func testEveryFolderIsAnsweredBeyondOneBatch() async throws {
+        let folders = (0..<25).map { "d\($0)" }
+        let listed = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            let path = listedPath(in: request)
+            listed.append(path)
+            return apiTestJSONResponse(
+                #"{"path": "\#(path)", "entries": [{"name": "f.md", "path": "\#(path)/f.md", "type": "file"}]}"#,
+                for: request
+            )
+        }
+
+        let draft = folders.map { "@\($0)/f.md" }.joined(separator: " ") + " done"
+        await viewModel.loadFileChipReferences(draft: draft)
+
+        XCTAssertEqual(listed.values, folders)
+        for folder in folders {
+            XCTAssertTrue(
+                viewModel.composerChipCatalog.containsFile(path: "\(folder)/f.md"),
+                "\(folder)/f.md was never confirmed"
+            )
+        }
+    }
+
+    /// A cache-first transcript swapped for the server's copy can rewrite a
+    /// message in the middle of the list without changing the count or the last
+    /// id, so the swap itself has to be the signal.
+    @MainActor
+    func testReplacingAMiddleUserMessageIsRescanned() async throws {
+        let loads = LockedStrings()
+        let viewModel = try makeViewModel { [self] request in
+            switch request.url?.path {
+            case "/api/session":
+                loads.append("session")
+                let firstUserContent = loads.values.count == 1 ? "hello" : "look at @a/b.md"
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "messages": [
+                      {"role": "user", "content": "\(firstUserContent)", "timestamp": 1770000100, "message_id": "user-1"},
+                      {"role": "assistant", "content": "sure", "timestamp": 1770000101, "message_id": "assistant-1"},
+                      {"role": "user", "content": "thanks", "timestamp": 1770000102, "message_id": "user-2"}
+                    ]
+                  }
+                }
+                """, for: request)
+            case "/api/list":
+                let path = listedPath(in: request)
+                return apiTestJSONResponse(try XCTUnwrap(fileListingJSON(for: path)), for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+        await viewModel.loadFileChipReferences(draft: "")
+        let revisionBefore = viewModel.transcriptRevision
+        XCTAssertFalse(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+
+        await viewModel.loadMessages()
+
+        XCTAssertEqual(viewModel.messages.count, 3)
+        XCTAssertEqual(viewModel.messages.last?.messageId, "user-2")
+        XCTAssertGreaterThan(viewModel.transcriptRevision, revisionBefore)
+
+        await viewModel.loadFileChipReferences(draft: "")
+
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+    }
+
     private static func ttsUnavailableResponse(for request: URLRequest) -> (HTTPURLResponse, Data) {
         let response = HTTPURLResponse(
             url: request.url!,

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -9162,6 +9162,55 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
     }
 
+    /// A pass still listing the old workspace's folders when the workspace moves
+    /// is cancelled outright: it stops before the next folder, settles nothing,
+    /// and the candidates are asked again under the new root.
+    @MainActor
+    func testAWorkspaceChangeCancelsTheConfirmationPassInFlight() async throws {
+        let listed = LockedStrings()
+        let listingStarted = expectation(description: "first listing started")
+        let releaseListing = DispatchSemaphore(value: 0)
+
+        let viewModel = try makeViewModel { [self] request in
+            guard request.url?.path == "/api/list" else {
+                return apiTestJSONResponse(#"""
+                {"session": {"session_id": "session-abc", "workspace": "/tmp/other", "model": "gpt-5.4"}}
+                """#, for: request)
+            }
+
+            let path = listedPath(in: request)
+            listed.append(path)
+            if listed.values.count == 1 {
+                listingStarted.fulfill()
+                releaseListing.wait()
+            }
+            return apiTestJSONResponse(
+                #"{"path": "\#(path)", "entries": [{"name": "b.md", "path": "\#(path)/b.md", "type": "file"}]}"#,
+                for: request
+            )
+        }
+
+        let draft = "@a/b.md and @e/b.md here"
+        let stale = Task { await viewModel.loadFileChipReferences(draft: draft) }
+        await fulfillment(of: [listingStarted], timeout: 5)
+
+        // Moves `currentWorkspace` synchronously, before its own request goes out.
+        await viewModel.selectWorkspacePath("/tmp/other")
+        releaseListing.signal()
+        await stale.value
+
+        // Stopped between folders: `e` was never asked for, and `a`'s listing
+        // arrived after the reset so it settled nothing.
+        XCTAssertEqual(listed.values, ["a"])
+        XCTAssertTrue(viewModel.fileChipPaths.isEmpty)
+
+        await viewModel.loadFileChipReferences(draft: draft)
+
+        XCTAssertEqual(listed.values, ["a", "a", "e"])
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "a/b.md"))
+        XCTAssertTrue(viewModel.composerChipCatalog.containsFile(path: "e/b.md"))
+    }
+
     /// Every folder the candidates name is answered, a batch at a time, rather
     /// than the first batch and silence for the rest.
     @MainActor

--- a/HermesMobileTests/ComposerChipTests.swift
+++ b/HermesMobileTests/ComposerChipTests.swift
@@ -74,7 +74,8 @@ final class ComposerChipTokenizerTests: XCTestCase {
             ComposerChipToken(
                 range: NSRange(location: 0, length: 9),
                 source: "/ask-matt",
-                label: "ask-matt"
+                label: "ask-matt",
+                kind: .skill
             )
         ]
 
@@ -90,12 +91,103 @@ final class ComposerChipTokenizerTests: XCTestCase {
         XCTAssertTrue(ComposerChipTokenizer.tokens(in: "/ask-matt hi", catalog: .empty).isEmpty)
     }
 
+    func testFileReferenceCandidatesSkipTheOneStillBeingTyped() {
+        XCTAssertEqual(
+            ComposerChipTokenizer.fileReferenceCandidates(in: "read @a/b.md and @c.md now"),
+            ["a/b.md", "c.md"]
+        )
+        XCTAssertEqual(ComposerChipTokenizer.fileReferenceCandidates(in: "read @a/b"), [])
+        XCTAssertEqual(
+            ComposerChipTokenizer.fileReferenceCandidates(in: "read @a/b", isComplete: true),
+            ["a/b"]
+        )
+    }
+
+    func testFileReferenceCandidatesIgnoreAnEmailAddressAndRepeats() {
+        XCTAssertEqual(ComposerChipTokenizer.fileReferenceCandidates(in: "me@example.com now"), [])
+        XCTAssertEqual(
+            ComposerChipTokenizer.fileReferenceCandidates(in: "@a.md and @a.md again"),
+            ["a.md"]
+        )
+    }
+
     func testMayContainReferenceSpotsACandidateWithoutTheCatalog() {
         XCTAssertTrue(ComposerChipTokenizer.mayContainReference("/ask-matt hello"))
         XCTAssertTrue(ComposerChipTokenizer.mayContainReference("please run /x"))
+        XCTAssertTrue(ComposerChipTokenizer.mayContainReference("open @src/main.swift"))
         XCTAssertFalse(ComposerChipTokenizer.mayContainReference("no references here"))
         XCTAssertFalse(ComposerChipTokenizer.mayContainReference("docs/ask-matt"))
+        XCTAssertFalse(ComposerChipTokenizer.mayContainReference("mail me at me@example.com"))
         XCTAssertFalse(ComposerChipTokenizer.mayContainReference(""))
+    }
+}
+
+extension ComposerChipTokenizerTests {
+    // MARK: - Workspace file references
+
+    private var fileCatalog: ComposerChipCatalog {
+        ComposerChipCatalog(
+            skills: [SkillSlashSuggestion(name: "ask-matt", category: nil, description: nil)],
+            filePaths: ["src/Chat/ChatView.swift", "README.md"]
+        )
+    }
+
+    func testFileReferenceInTheCatalogBecomesAChipLabelledByItsFilename() {
+        let tokens = ComposerChipTokenizer.tokens(in: "read @src/Chat/ChatView.swift now", catalog: fileCatalog)
+
+        XCTAssertEqual(tokens.map(\.source), ["@src/Chat/ChatView.swift"])
+        XCTAssertEqual(tokens.first?.label, "ChatView.swift")
+        XCTAssertEqual(tokens.first?.kind, .file)
+        XCTAssertEqual(tokens.first?.filePath, "src/Chat/ChatView.swift")
+        XCTAssertEqual(tokens.first?.range, NSRange(location: 5, length: 24))
+    }
+
+    func testFilePathOutsideTheCatalogStaysPlainText() {
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "@src/Other.swift now", catalog: fileCatalog).isEmpty)
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "@README.md here", catalog: .empty).isEmpty)
+    }
+
+    func testHalfTypedFilePathStaysPlainText() {
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "@src/Chat/ChatVie", catalog: fileCatalog).isEmpty)
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "@README.md", catalog: fileCatalog).isEmpty)
+    }
+
+    func testAnEmailAddressIsNeverAFileChip() {
+        let catalog = ComposerChipCatalog(skills: [], filePaths: ["example.com"])
+
+        XCTAssertTrue(ComposerChipTokenizer.tokens(in: "mail me@example.com now", catalog: catalog).isEmpty)
+    }
+
+    func testSkillAndFileReferencesCoexistInOneDraft() {
+        let draft = "/ask-matt about @README.md please"
+        let tokens = ComposerChipTokenizer.tokens(in: draft, catalog: fileCatalog)
+
+        XCTAssertEqual(tokens.map(\.source), ["/ask-matt", "@README.md"])
+        XCTAssertEqual(tokens.map(\.kind), [.skill, .file])
+        XCTAssertEqual(
+            ComposerChipTokenizer.spokenText(in: draft, tokens: tokens),
+            "ask-matt about README.md please"
+        )
+    }
+
+    func testSentMessageEndingInAFileReferenceDrawsAChip() {
+        let tokens = ComposerChipTokenizer.tokens(
+            in: "look at @README.md",
+            catalog: fileCatalog,
+            isComplete: true
+        )
+
+        XCTAssertEqual(tokens.map(\.source), ["@README.md"])
+    }
+
+    func testAFileChipDrawsItsOwnFileTypeGlyph() {
+        let tokens = ComposerChipTokenizer.tokens(in: "@src/Chat/ChatView.swift ", catalog: fileCatalog)
+
+        XCTAssertEqual(tokens.first?.icon, .asset(FileIcon.swift.assetName))
+        XCTAssertEqual(
+            ComposerChipTokenizer.tokens(in: "/ask-matt ", catalog: fileCatalog).first?.icon,
+            .symbol("hammer")
+        )
     }
 }
 
@@ -172,8 +264,12 @@ final class ComposerChipDocumentTests: XCTestCase {
         result.append(
             NSAttributedString(
                 attachment: ComposerChipAttachment(
-                    source: "/ask-matt",
-                    label: "ask-matt",
+                    token: ComposerChipToken(
+                        range: NSRange(location: 4, length: 9),
+                        source: "/ask-matt",
+                        label: "ask-matt",
+                        kind: .skill
+                    ),
                     image: UIImage(),
                     baselineOffset: 0
                 )
@@ -181,6 +277,36 @@ final class ComposerChipDocumentTests: XCTestCase {
         )
         result.append(NSAttributedString(string: " now"))
         return result
+    }
+
+    /// The draft is what gets sent, saved, and copied, so an attachment this
+    /// composer did not make contributes nothing at all — not the U+FFFC glyph
+    /// standing in for it, and so nothing that a later reader could take for
+    /// markup. Anything else travels to the server as a character the user
+    /// never typed.
+    func testAForeignAttachmentContributesNothingToTheDraft() {
+        let document = NSMutableAttributedString(string: "read ")
+        document.append(NSAttributedString(attachment: NSTextAttachment(image: UIImage())))
+        document.append(NSAttributedString(string: " @a/b.md "))
+
+        let source = document.composerSourceText
+
+        XCTAssertEqual(source, "read  @a/b.md ")
+        XCTAssertFalse(source.contains("\u{FFFC}"))
+        XCTAssertFalse(source.contains("]("))
+        XCTAssertFalse(source.contains("%3C"))
+    }
+
+    /// The caret mapping has to agree with the text: a glyph worth no draft
+    /// characters must not be counted as one either.
+    func testAForeignAttachmentIsWorthNoDraftOffsets() {
+        let document = NSMutableAttributedString(string: "ab")
+        document.append(NSAttributedString(attachment: NSTextAttachment(image: UIImage())))
+        document.append(NSAttributedString(string: "cd"))
+
+        XCTAssertEqual(document.composerSourceText, "abcd")
+        XCTAssertEqual(document.composerSourceOffset(forDisplayOffset: 5), 4)
+        XCTAssertEqual(document.composerSourceOffset(forDisplayOffset: 3), 2)
     }
 
     func testSerializesChipsBackToTheirSource() {

--- a/HermesMobileTests/ComposerChipTests.swift
+++ b/HermesMobileTests/ComposerChipTests.swift
@@ -111,6 +111,25 @@ final class ComposerChipTokenizerTests: XCTestCase {
         )
     }
 
+    /// A candidate ends at whitespace by construction, so a path holding a space
+    /// can never be produced as one — which is why the panel does not offer such
+    /// a path in the first place.
+    func testAPathWithASpaceIsNeverOneCandidate() {
+        let candidates = ComposerChipTokenizer.fileReferenceCandidates(
+            in: "open @src/My File.swift now",
+            isComplete: true
+        )
+
+        XCTAssertEqual(candidates, ["src/My"])
+        XCTAssertFalse(candidates.contains { $0.contains(where: \.isWhitespace) })
+        XCTAssertTrue(
+            ComposerChipTokenizer.tokens(
+                in: "open @src/My File.swift now",
+                catalog: ComposerChipCatalog(skills: [], filePaths: ["src/My File.swift"])
+            ).isEmpty
+        )
+    }
+
     func testMayContainReferenceSpotsACandidateWithoutTheCatalog() {
         XCTAssertTrue(ComposerChipTokenizer.mayContainReference("/ask-matt hello"))
         XCTAssertTrue(ComposerChipTokenizer.mayContainReference("please run /x"))

--- a/HermesMobileTests/ComposerFileTriggerTests.swift
+++ b/HermesMobileTests/ComposerFileTriggerTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import HermesMobile
+
+final class ComposerFileTriggerTests: XCTestCase {
+    // MARK: - Detection
+
+    func testDetectsTriggerAtStartOfDraft() {
+        let trigger = ComposerFileTrigger.detect(in: "@src", selection: caret(4))
+
+        XCTAssertEqual(trigger?.text, "@src")
+        XCTAssertEqual(trigger?.query, "src")
+        XCTAssertEqual(trigger?.range, NSRange(location: 0, length: 4))
+    }
+
+    func testDetectsABareAtWithNothingTypedYet() {
+        let trigger = ComposerFileTrigger.detect(in: "@", selection: caret(1))
+
+        XCTAssertEqual(trigger?.text, "@")
+        XCTAssertEqual(trigger?.query, "")
+    }
+
+    func testDetectsTriggerMidSentence() {
+        let trigger = ComposerFileTrigger.detect(in: "please read @src/Chat", selection: caret(21))
+
+        XCTAssertEqual(trigger?.text, "@src/Chat")
+        XCTAssertEqual(trigger?.query, "src/Chat")
+        XCTAssertEqual(trigger?.range, NSRange(location: 12, length: 9))
+    }
+
+    func testDetectsTriggerAfterANewline() {
+        let trigger = ComposerFileTrigger.detect(in: "hello\n@README", selection: caret(13))
+
+        XCTAssertEqual(trigger?.text, "@README")
+    }
+
+    func testAnEmailAddressIsNotATrigger() {
+        XCTAssertNil(ComposerFileTrigger.detect(in: "mail me@example.com", selection: caret(19)))
+        XCTAssertNil(ComposerFileTrigger.detect(in: "me@example.com", selection: caret(14)))
+    }
+
+    func testTheTriggerEndsAtWhitespace() {
+        // The caret has moved past the reference, so there is nothing to complete.
+        XCTAssertNil(ComposerFileTrigger.detect(in: "@src/main.swift now", selection: caret(19)))
+        XCTAssertNil(ComposerFileTrigger.detect(in: "@src/main.swift ", selection: caret(16)))
+    }
+
+    func testTheTriggerStopsAtTheCaretRatherThanTheEndOfTheWord() {
+        let trigger = ComposerFileTrigger.detect(in: "@src/main.swift", selection: caret(4))
+
+        XCTAssertEqual(trigger?.text, "@src")
+        XCTAssertEqual(trigger?.range, NSRange(location: 0, length: 4))
+    }
+
+    func testASelectionIsNeverATrigger() {
+        XCTAssertNil(
+            ComposerFileTrigger.detect(in: "@src", selection: NSRange(location: 1, length: 3))
+        )
+    }
+
+    func testADraftWithoutAnAtHasNoTrigger() {
+        XCTAssertNil(ComposerFileTrigger.detect(in: "no references here", selection: caret(18)))
+        XCTAssertNil(ComposerFileTrigger.detect(in: "", selection: caret(0)))
+    }
+
+    // MARK: - Accepting a row
+
+    func testApplyingReplacesOnlyTheTriggerAndLeavesTheCaretAfterIt() throws {
+        let draft = "please read @src and stop"
+        let trigger = try XCTUnwrap(ComposerFileTrigger.detect(in: draft, selection: caret(16)))
+        let completed = trigger.applying("@src/main.swift ", to: draft)
+
+        XCTAssertEqual(completed.draft, "please read @src/main.swift and stop")
+        XCTAssertEqual(completed.selection, caret(28))
+    }
+
+    func testApplyingCollapsesADoubleSpaceAndStepsOverTheExistingOne() throws {
+        let draft = "read @src now"
+        let trigger = try XCTUnwrap(ComposerFileTrigger.detect(in: draft, selection: caret(9)))
+        let completed = trigger.applying("@README.md ", to: draft)
+
+        XCTAssertEqual(completed.draft, "read @README.md now")
+        XCTAssertEqual(completed.selection, caret(16))
+    }
+
+    func testApplyingAnEmptyReplacementRemovesTheTrigger() throws {
+        let draft = "read @src now"
+        let trigger = try XCTUnwrap(ComposerFileTrigger.detect(in: draft, selection: caret(9)))
+        let completed = trigger.applying("", to: draft)
+
+        XCTAssertEqual(completed.draft, "read  now")
+        XCTAssertEqual(completed.selection, caret(5))
+    }
+
+    func testApplyingAFolderKeepsTheCaretInsideTheReference() throws {
+        let draft = "@sr"
+        let trigger = try XCTUnwrap(ComposerFileTrigger.detect(in: draft, selection: caret(3)))
+        let completed = trigger.applying("@src/", to: draft)
+
+        XCTAssertEqual(completed.draft, "@src/")
+        XCTAssertEqual(completed.selection, caret(5))
+    }
+
+    private func caret(_ location: Int) -> NSRange {
+        NSRange(location: location, length: 0)
+    }
+}

--- a/HermesMobileTests/FilePathSearchTests.swift
+++ b/HermesMobileTests/FilePathSearchTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import HermesMobile
+
+/// What the composer's `@` panel lists: one folder per query, ranked against the
+/// query's last segment, with nothing from outside the workspace.
+final class FilePathSearchTests: APIClientTestCase {
+
+    /// Records every `/api/list` path asked for, in call order.
+    private final class RequestLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var paths: [String] = []
+
+        func record(_ path: String) {
+            lock.lock(); defer { lock.unlock() }
+            paths.append(path)
+        }
+
+        var listedPaths: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return paths
+        }
+    }
+
+    private func entryJSON(_ name: String, path: String, type: String, extra: String = "") -> String {
+        #"{"name": "\#(name)", "path": "\#(path)", "type": "\#(type)", "is_dir": \#(type == "dir")\#(extra)}"#
+    }
+
+    /// Root holds `src/`, `README.md`, a `..` entry, and a symlink the server
+    /// resolved to somewhere outside the workspace. `src/` holds `Chat/`,
+    /// `chores.md`, and `Main.swift`.
+    private func listingJSON(for path: String) -> String? {
+        switch path {
+        case ".":
+            return #"{"path": ".", "entries": [\#(entryJSON("..", path: "..", type: "dir")), \#(entryJSON("escape", path: "escape", type: "symlink", extra: #", "target_outside_workspace": true"#)), \#(entryJSON("src", path: "src", type: "dir")), \#(entryJSON("README.md", path: "README.md", type: "file"))]}"#
+        case "src":
+            return #"{"path": "src", "entries": [\#(entryJSON("Chat", path: "src/Chat", type: "dir")), \#(entryJSON("chores.md", path: "src/chores.md", type: "file")), \#(entryJSON("Main.swift", path: "src/Main.swift", type: "file"))]}"#
+        default:
+            return nil
+        }
+    }
+
+    private func listedPath(in request: URLRequest) -> String {
+        let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+        return components?.queryItems?.first { $0.name == "path" }?.value ?? "."
+    }
+
+    private func makeListingClient(log: RequestLog, failingPaths: Set<String> = []) -> APIClient {
+        makeClient { [self] request in
+            XCTAssertEqual(request.url?.path, "/api/list")
+            let path = listedPath(in: request)
+            log.record(path)
+            if failingPaths.contains(path) {
+                return apiTestJSONResponse(#"{"error": "boom"}"#, for: request, status: 500)
+            }
+            guard let json = listingJSON(for: path) else {
+                return apiTestJSONResponse(#"{"error": "not found"}"#, for: request, status: 404)
+            }
+            return apiTestJSONResponse(json, for: request)
+        }
+    }
+
+    // MARK: - Listing
+
+    @MainActor
+    func testAnEmptyQueryListsTheWorkspaceRootFoldersFirst() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+
+        await search.search("", sessionID: "s1", apiClient: makeListingClient(log: log))
+
+        XCTAssertEqual(log.listedPaths, ["."])
+        XCTAssertEqual(search.matches.map(\.path), ["src", "README.md"])
+        XCTAssertEqual(search.matches.first?.isDirectory, true)
+        XCTAssertFalse(search.isLoading)
+    }
+
+    @MainActor
+    func testAPathQueryListsOnlyTheFolderItNamesAndRanksItsEntries() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+
+        await search.search("src/Ch", sessionID: "s1", apiClient: makeListingClient(log: log))
+
+        XCTAssertEqual(log.listedPaths, ["src"])
+        XCTAssertEqual(search.matches.map(\.path), ["src/Chat", "src/chores.md"])
+        XCTAssertEqual(search.matches.first?.parentPath, "src")
+    }
+
+    @MainActor
+    func testARepeatedFolderIsListedOnlyOnce() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+        let client = makeListingClient(log: log)
+
+        await search.search("", sessionID: "s1", apiClient: client)
+        await search.search("RE", sessionID: "s1", apiClient: client)
+
+        XCTAssertEqual(log.listedPaths, ["."])
+        XCTAssertEqual(search.matches.map(\.path), ["README.md"])
+    }
+
+    // MARK: - Containment
+
+    @MainActor
+    func testNothingOutsideTheWorkspaceIsEverOffered() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+
+        await search.search("", sessionID: "s1", apiClient: makeListingClient(log: log))
+
+        XCTAssertFalse(search.matches.contains { $0.name == ".." })
+        XCTAssertFalse(search.matches.contains { $0.name == "escape" })
+    }
+
+    @MainActor
+    func testAQueryThatClimbsOutOfTheWorkspaceIsNeverRequested() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+
+        await search.search("../etc/pa", sessionID: "s1", apiClient: makeListingClient(log: log))
+
+        XCTAssertTrue(log.listedPaths.isEmpty)
+        XCTAssertTrue(search.matches.isEmpty)
+    }
+
+    // MARK: - Failure
+
+    @MainActor
+    func testAFailedListingReadsAsNoMatches() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+
+        await search.search(
+            "",
+            sessionID: "s1",
+            apiClient: makeListingClient(log: log, failingPaths: ["."])
+        )
+
+        XCTAssertTrue(search.matches.isEmpty)
+        XCTAssertFalse(search.isLoading)
+    }
+
+    // MARK: - Ordering
+
+    @MainActor
+    func testAStaleListingNeverOverwritesANewerQuery() async {
+        let log = RequestLog()
+        let rootStarted = expectation(description: "root listing started")
+        let releaseRoot = DispatchSemaphore(value: 0)
+
+        let client = makeClient { [self] request in
+            let path = listedPath(in: request)
+            log.record(path)
+            if path == "." {
+                rootStarted.fulfill()
+                // Held on the mock's own loading queue, so the `src` request
+                // this test fires next still gets served.
+                releaseRoot.wait()
+            }
+            return apiTestJSONResponse(listingJSON(for: path) ?? "{}", for: request)
+        }
+
+        let search = ComposerFilePathSearch()
+        let stale = Task { await search.search("", sessionID: "s1", apiClient: client) }
+        await fulfillment(of: [rootStarted], timeout: 2)
+
+        await search.search("src/Ch", sessionID: "s1", apiClient: client)
+        XCTAssertEqual(search.matches.map(\.path), ["src/Chat", "src/chores.md"])
+
+        releaseRoot.signal()
+        await stale.value
+
+        XCTAssertEqual(search.matches.map(\.path), ["src/Chat", "src/chores.md"])
+    }
+
+    // MARK: - Session isolation
+
+    @MainActor
+    func testSwitchingSessionDropsTheCachedListings() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+        let client = makeListingClient(log: log)
+
+        await search.search("", sessionID: "s1", apiClient: client)
+        await search.search("", sessionID: "s2", apiClient: client)
+
+        XCTAssertEqual(log.listedPaths, [".", "."])
+    }
+}

--- a/HermesMobileTests/FilePathSearchTests.swift
+++ b/HermesMobileTests/FilePathSearchTests.swift
@@ -33,7 +33,7 @@ final class FilePathSearchTests: APIClientTestCase {
         case ".":
             return #"{"path": ".", "entries": [\#(entryJSON("..", path: "..", type: "dir")), \#(entryJSON("escape", path: "escape", type: "symlink", extra: #", "target_outside_workspace": true"#)), \#(entryJSON("src", path: "src", type: "dir")), \#(entryJSON("README.md", path: "README.md", type: "file"))]}"#
         case "src":
-            return #"{"path": "src", "entries": [\#(entryJSON("Chat", path: "src/Chat", type: "dir")), \#(entryJSON("chores.md", path: "src/chores.md", type: "file")), \#(entryJSON("Main.swift", path: "src/Main.swift", type: "file"))]}"#
+            return #"{"path": "src", "entries": [\#(entryJSON("Chat", path: "src/Chat", type: "dir")), \#(entryJSON("chores.md", path: "src/chores.md", type: "file")), \#(entryJSON("Main.swift", path: "src/Main.swift", type: "file")), \#(entryJSON("My File.swift", path: "src/My File.swift", type: "file"))]}"#
         default:
             return nil
         }
@@ -112,6 +112,20 @@ final class FilePathSearchTests: APIClientTestCase {
         XCTAssertFalse(search.matches.contains { $0.name == "escape" })
     }
 
+    /// A reference ends at whitespace, so `@src/My File.swift` would insert and
+    /// then never read back as one. The panel does not offer what it cannot
+    /// finish.
+    @MainActor
+    func testAnEntryWhoseNameHoldsASpaceIsNeverOffered() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+
+        await search.search("src/", sessionID: "s1", apiClient: makeListingClient(log: log))
+
+        XCTAssertEqual(search.matches.map(\.path), ["src/Chat", "src/chores.md", "src/Main.swift"])
+        XCTAssertFalse(search.matches.contains { $0.name == "My File.swift" })
+    }
+
     @MainActor
     func testAQueryThatClimbsOutOfTheWorkspaceIsNeverRequested() async {
         let log = RequestLog()
@@ -174,6 +188,26 @@ final class FilePathSearchTests: APIClientTestCase {
     }
 
     // MARK: - Session isolation
+
+    /// The workspace can move under a session without its id changing, so the
+    /// view model resets the cache by hand; a folder listed against the old root
+    /// says nothing about the new one.
+    @MainActor
+    func testResettingDropsTheCachedListings() async {
+        let log = RequestLog()
+        let search = ComposerFilePathSearch()
+        let client = makeListingClient(log: log)
+
+        await search.search("", sessionID: "s1", apiClient: client)
+        XCTAssertFalse(search.matches.isEmpty)
+
+        search.reset()
+        XCTAssertTrue(search.matches.isEmpty)
+
+        await search.search("", sessionID: "s1", apiClient: client)
+
+        XCTAssertEqual(log.listedPaths, [".", "."])
+    }
 
     @MainActor
     func testSwitchingSessionDropsTheCachedListings() async {

--- a/HermesMobileTests/FilePathSearchTests.swift
+++ b/HermesMobileTests/FilePathSearchTests.swift
@@ -187,6 +187,70 @@ final class FilePathSearchTests: APIClientTestCase {
         XCTAssertEqual(search.matches.map(\.path), ["src/Chat", "src/chores.md"])
     }
 
+    /// A listing already on the wire when the workspace moves belongs to the old
+    /// root: it must not fill the new root's cache, so the next caller asks
+    /// again rather than being answered from it.
+    @MainActor
+    func testAListingThatResolvesAfterAResetIsNeverCached() async throws {
+        let log = RequestLog()
+        let listingStarted = expectation(description: "root listing started")
+        let releaseListing = DispatchSemaphore(value: 0)
+
+        let client = makeClient { [self] request in
+            let path = listedPath(in: request)
+            log.record(path)
+            if log.listedPaths.count == 1 {
+                listingStarted.fulfill()
+                // Held on the mock's own loading queue so the reset lands first.
+                releaseListing.wait()
+            }
+            return apiTestJSONResponse(listingJSON(for: path) ?? "{}", for: request)
+        }
+
+        let search = ComposerFilePathSearch()
+        let inFlight = Task { await search.search("", sessionID: "s1", apiClient: client) }
+        await fulfillment(of: [listingStarted], timeout: 5)
+
+        search.reset()
+        releaseListing.signal()
+        await inFlight.value
+
+        XCTAssertTrue(search.matches.isEmpty)
+
+        await search.search("", sessionID: "s1", apiClient: client)
+
+        XCTAssertEqual(log.listedPaths, [".", "."])
+        XCTAssertEqual(search.matches.map(\.path), ["src", "README.md"])
+    }
+
+    /// The confirmation pass reads this as "unanswered", the same as a failed
+    /// request, so the candidates it was about stay open for the next pass.
+    @MainActor
+    func testEntriesThrowsRatherThanAnsweringForAScopeThatMoved() async throws {
+        let listingStarted = expectation(description: "listing started")
+        let releaseListing = DispatchSemaphore(value: 0)
+
+        let client = makeClient { [self] request in
+            listingStarted.fulfill()
+            releaseListing.wait()
+            return apiTestJSONResponse(listingJSON(for: listedPath(in: request)) ?? "{}", for: request)
+        }
+
+        let search = ComposerFilePathSearch()
+        let entries = Task { try await search.entries(in: ".", sessionID: "s1", apiClient: client) }
+        await fulfillment(of: [listingStarted], timeout: 5)
+
+        search.reset()
+        releaseListing.signal()
+
+        do {
+            _ = try await entries.value
+            XCTFail("A listing taken against a scope that has moved must not answer")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
     // MARK: - Session isolation
 
     /// The workspace can move under a session without its id changing, so the


### PR DESCRIPTION
## Linked issue

Composer follow-up to #386 (skill chips) and #402 (file links and icons); no separate issue.

## What changed

You could not point the agent at a workspace file from the phone: you typed the path from memory or copied it out of the file browser.

Typing `@` in the composer now opens a panel listing the folder you are typing into, folders first, each with its file-type icon. It lists only that one folder through the existing `/api/list` endpoint, scored with the file tree's scorer, capped at 20 rows, and never fetches the workspace recursively. Symlinks that leave the workspace and any `..` path are never offered.

Picking a file inserts `@<workspace-relative path> ` and the composer draws it as a chip with the file's icon. Picking a folder inserts `@folder/` and drills in. Tapping a composer chip opens the file in the source viewer. What is sent, copied, and saved as a draft is always the plain `@path`; chips are pictures of a substring, the same mechanism as skill chips.

**Chips survive leaving the chat.** The accepted paths are not stored; the server is the authority. On opening a chat, the view model scans the restored draft and the sent messages for `@path` candidates, lists each parent folder once, and chips the ones the folder actually contains. The request is owned by the view model like the skill loader, so a cancelled caller cannot kill it and a failure retries on the next open. Those listings also warm the `@` panel.

**Server contract.** Verified against upstream's web UI and a live server: the web UI inserts `@` plus the tree entry's workspace-relative path followed by a space, `/api/list` entries carry those paths (`.firecrawl/fin-reddit.json`), and the server passes the text through untouched for the agent. `WorkspaceEntry` gains an optional `targetOutsideWorkspace`. No endpoint changed.

**Notes.** Sent-bubble file chips draw with the right icon but are display-only: the bubble is one SwiftUI `Text` with inline images and has no per-chip hit target. The `skillChipCatalog` environment key became `composerChipCatalog` since it now carries both kinds.

## How it was tested

Full XCTest suite on the iPhone 17 simulator: **2224 passed, 0 failed, 2 skipped** (the pre-existing photo-library skips).

New coverage: `ComposerFileTriggerTests` (trigger at draft start and mid-sentence, not for `foo@bar`, ends at whitespace, no trigger with a selection, caret placement and double-space collapse), `FilePathSearchTests` on the `URLProtocol` mock (root and sub-folder listings, scoring by the last segment, `..` and out-of-workspace symlink exclusion, stale response dropped, failure → empty), `ComposerChipTests` additions (`@path` chips only for known paths, label is the last component, mixed skill and file tokens, candidate scan, foreign attachments contribute nothing to the draft), and `ChatViewModelSendTests` additions for the reference loader (one listing per folder, missing candidate not added, cancelled caller does not cancel the load, failed listing retries).

Owner-tested on the simulator against a live server: panel open and drill-in, chip on pick, chip tap opens the viewer, send producing plain `@path`, atomic backspace, no panel for an email, slash panel unaffected, and chips restored after leaving and re-entering the chat.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (verified against upstream's web UI and a running server)

---

Planned and reviewed by Claude Fable 5.1, implemented by Claude Opus 5, in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)