### PR TITLE
fix(chat): allow sending attachments without composer text

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		C04700000000000000000001 /* ChatPendingActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04700000000000000000002 /* ChatPendingActionCoordinator.swift */; };
 		C04800000000000000000001 /* ChatAttachmentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04800000000000000000002 /* ChatAttachmentCoordinator.swift */; };
 		C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */; };
+		C0GATE000000000000000001 /* ChatComposerSendGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0GATE000000000000000002 /* ChatComposerSendGateTests.swift */; };
 		1A2B3C4D5E6F7000000000AD /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BD /* Workspace.swift */; };
 		1A2B3C4D5E6F7000000000AE /* ServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BE /* ServerCatalog.swift */; };
 		1A2B3C4D5E6F7000000000AF /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7000000000BF /* ChatView.swift */; };
@@ -398,6 +399,7 @@
 		B53F3F24A5C24D9E8E54A810 /* SlashCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1CE5F12B9E4D4D9E5A01C1 /* SlashCommandExecutor.swift */; };
 		C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CAM000000000000000B002 /* CameraPickerView.swift */; };
 		C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000002 /* ChatComposerView.swift */; };
+		C0DEC0DE0000000000000003 /* ChatComposerSendGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE0000000000000004 /* ChatComposerSendGate.swift */; };
 		D01ECB8354BE43609DB90E77 /* ComposerTextEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */; };
 		A1C0F1000000000000000002 /* ComposerChipToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000001 /* ComposerChipToken.swift */; };
 		A1C0F1000000000000000004 /* ComposerChipRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F1000000000000000003 /* ComposerChipRendering.swift */; };
@@ -550,6 +552,7 @@
 		C04700000000000000000002 /* ChatPendingActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPendingActionCoordinator.swift; sourceTree = "<group>"; };
 		C04800000000000000000002 /* ChatAttachmentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentCoordinator.swift; sourceTree = "<group>"; };
 		C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentCoordinatorTests.swift; sourceTree = "<group>"; };
+		C0GATE000000000000000002 /* ChatComposerSendGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSendGateTests.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BD /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BE /* ServerCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerCatalog.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7000000000BF /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
@@ -838,6 +841,7 @@
 		A04500000000000000000018 /* LiveActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityTests.swift; sourceTree = "<group>"; };
 		C0CAM000000000000000B002 /* CameraPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPickerView.swift; sourceTree = "<group>"; };
 		C0DEC0DE0000000000000002 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
+		C0DEC0DE0000000000000004 /* ChatComposerSendGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerSendGate.swift; sourceTree = "<group>"; };
 		93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTextEditing.swift; sourceTree = "<group>"; };
 		A1C0F1000000000000000001 /* ComposerChipToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipToken.swift; sourceTree = "<group>"; };
 		A1C0F1000000000000000003 /* ComposerChipRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerChipRendering.swift; sourceTree = "<group>"; };
@@ -981,6 +985,7 @@
 					C04100000000000000000004 /* ChatComposerConfigLoaderTests.swift */,
 					C04600000000000000000004 /* ChatStreamCoordinatorTests.swift */,
 					C04800000000000000000004 /* ChatAttachmentCoordinatorTests.swift */,
+					C0GATE000000000000000002 /* ChatComposerSendGateTests.swift */,
 					C0390000000000000000000E /* ChatViewModelSendTests.swift */,
 					C0DED00000000000000DE000 /* ChatViewModelMergeDedupTests.swift */,
 					C14600000000000000000001 /* ChatToolbarHeaderTests.swift */,
@@ -1244,6 +1249,7 @@
 				C05100000000000000000014 /* ChatTranscriptSupportingViews.swift */,
 				C0CAM000000000000000B002 /* CameraPickerView.swift */,
 				C0DEC0DE0000000000000002 /* ChatComposerView.swift */,
+				C0DEC0DE0000000000000004 /* ChatComposerSendGate.swift */,
 				93ED01E261E647E79540A6AD /* ComposerTextEditing.swift */,
 				A1C0F1000000000000000001 /* ComposerChipToken.swift */,
 				A1C0F1000000000000000003 /* ComposerChipRendering.swift */,
@@ -1846,6 +1852,7 @@
 					C05100000000000000000004 /* ChatTranscriptSupportingViews.swift in Sources */,
 					C0CAM000000000000000B001 /* CameraPickerView.swift in Sources */,
 				C0DEC0DE0000000000000001 /* ChatComposerView.swift in Sources */,
+				C0DEC0DE0000000000000003 /* ChatComposerSendGate.swift in Sources */,
 				D01ECB8354BE43609DB90E77 /* ComposerTextEditing.swift in Sources */,
 				A1C0F1000000000000000002 /* ComposerChipToken.swift in Sources */,
 				A1C0F1000000000000000004 /* ComposerChipRendering.swift in Sources */,
@@ -2017,6 +2024,7 @@
 					C04100000000000000000003 /* ChatComposerConfigLoaderTests.swift in Sources */,
 					C04600000000000000000003 /* ChatStreamCoordinatorTests.swift in Sources */,
 					C04800000000000000000003 /* ChatAttachmentCoordinatorTests.swift in Sources */,
+					C0GATE000000000000000001 /* ChatComposerSendGateTests.swift in Sources */,
 					C0391000000000000000000E /* ChatViewModelSendTests.swift in Sources */,
 					C0DED00000000000000DE001 /* ChatViewModelMergeDedupTests.swift in Sources */,
 					C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatComposerSendGate.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSendGate.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Decides whether the composer's Send/Stop action button is disabled.
+/// Send is allowed when the user typed something OR staged at least one
+/// attachment (attachment-only sends synthesize their message text in
+/// `PendingAttachment.chatMessageText`); the busy flags always disable.
+enum ChatComposerSendGate {
+    static func isDisabled(
+        hasText: Bool,
+        hasStagedAttachments: Bool,
+        isSending: Bool,
+        isCompressingSession: Bool,
+        isUploadingAttachment: Bool,
+        isUpdatingConfiguration: Bool
+    ) -> Bool {
+        guard !isSending, !isCompressingSession, !isUploadingAttachment, !isUpdatingConfiguration else {
+            return true
+        }
+
+        return !hasText && !hasStagedAttachments
+    }
+}

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -1103,11 +1103,14 @@ struct MessageComposerView: View {
             return isCancellingStream
         }
 
-        return trimmedDraftMessage.isEmpty
-            || isSending
-            || isCompressingSession
-            || isUploadingAttachment
-            || isUpdatingConfiguration
+        return ChatComposerSendGate.isDisabled(
+            hasText: !trimmedDraftMessage.isEmpty,
+            hasStagedAttachments: !pendingAttachments.isEmpty,
+            isSending: isSending,
+            isCompressingSession: isCompressingSession,
+            isUploadingAttachment: isUploadingAttachment,
+            isUpdatingConfiguration: isUpdatingConfiguration
+        )
     }
 
     private func actionButtonTapped() {

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -1919,7 +1919,11 @@ struct ChatView: View {
         _ submittedDraft: String,
         submittedDraftRevision: Int
     ) async -> Bool {
-        guard !submittedDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        // Attachment-only sends (empty text) flow through; the view model
+        // synthesize the message text. `draftStore.setDraft("")` below is the
+        // correct end state for them: the draft is empty after sending.
+        let hasStagedAttachments = !viewModel.pendingAttachments.isEmpty
+        guard !submittedDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || hasStagedAttachments else {
             return false
         }
 

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -2234,7 +2234,9 @@ final class ChatViewModel {
         }
 
         let message = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !message.isEmpty else { return false }
+        // Attachment-only sends (empty text, staged attachments) synthesize
+        // their message text in `PendingAttachment.chatMessageText` below.
+        guard !message.isEmpty || !attachmentCoordinator.pendingAttachments.isEmpty else { return false }
 
         guard let sessionID else {
             sendErrorMessage = String(localized: "The server did not provide a session ID.")
@@ -2243,12 +2245,16 @@ final class ChatViewModel {
 
         let localMessageID = "local-\(UUID().uuidString)"
         let attachmentPreparation = attachmentCoordinator.prepareForSend(localMessageID: localMessageID)
+        let messageForAPI = attachmentPreparation.chatMessageText(draft: message)
+        // Attachment-only sends show the synthesized text in the bubble, matching
+        // what a reload from the server displays; text sends keep the bare draft.
+        let displayText = message.isEmpty ? messageForAPI : message
 
         let didStart = await performChatSend(
             sessionID: sessionID,
             localMessageID: localMessageID,
-            displayContent: message,
-            messageForAPI: attachmentPreparation.chatMessageText(draft: message),
+            displayContent: displayText,
+            messageForAPI: messageForAPI,
             messageAttachments: attachmentPreparation.messageAttachments,
             apiPayloads: attachmentPreparation.apiPayloads,
             attachmentsToRestoreOnFailure: attachmentPreparation.attachments,

--- a/HermesMobile/Models/UploadResponse.swift
+++ b/HermesMobile/Models/UploadResponse.swift
@@ -170,6 +170,13 @@ extension PendingAttachment {
             return draft
         }
 
+        // Attachment-only sends synthesize the message the web UI sends
+        // (`static/messages.js`), since the server requires non-empty text.
+        let base = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if base.isEmpty {
+            return "I've uploaded \(references.count) file(s): \(references.joined(separator: ", "))"
+        }
+
         return "\(draft)\n\n[Attached files: \(references.joined(separator: ", "))]"
     }
 }

--- a/HermesMobileTests/ChatComposerSendGateTests.swift
+++ b/HermesMobileTests/ChatComposerSendGateTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import HermesMobile
+
+/// Send-button gate for the composer: text-only, attachment-only, both, or
+/// neither (#403). Busy flags always disable; attachment-only sends synthesize
+/// their message text in `PendingAttachment.chatMessageText`.
+final class ChatComposerSendGateTests: XCTestCase {
+    func testAttachmentOnlySendIsEnabled() {
+        XCTAssertFalse(ChatComposerSendGate.isDisabled(
+            hasText: false,
+            hasStagedAttachments: true,
+            isSending: false,
+            isCompressingSession: false,
+            isUploadingAttachment: false,
+            isUpdatingConfiguration: false
+        ))
+    }
+
+    func testTextOnlySendIsEnabled() {
+        XCTAssertFalse(ChatComposerSendGate.isDisabled(
+            hasText: true,
+            hasStagedAttachments: false,
+            isSending: false,
+            isCompressingSession: false,
+            isUploadingAttachment: false,
+            isUpdatingConfiguration: false
+        ))
+    }
+
+    func testTextAndAttachmentsSendIsEnabled() {
+        XCTAssertFalse(ChatComposerSendGate.isDisabled(
+            hasText: true,
+            hasStagedAttachments: true,
+            isSending: false,
+            isCompressingSession: false,
+            isUploadingAttachment: false,
+            isUpdatingConfiguration: false
+        ))
+    }
+
+    func testEmptyDraftWithNoAttachmentsIsDisabled() {
+        XCTAssertTrue(ChatComposerSendGate.isDisabled(
+            hasText: false,
+            hasStagedAttachments: false,
+            isSending: false,
+            isCompressingSession: false,
+            isUploadingAttachment: false,
+            isUpdatingConfiguration: false
+        ))
+    }
+
+    func testAttachmentWhileUploadingIsDisabled() {
+        XCTAssertTrue(ChatComposerSendGate.isDisabled(
+            hasText: false,
+            hasStagedAttachments: true,
+            isSending: false,
+            isCompressingSession: false,
+            isUploadingAttachment: true,
+            isUpdatingConfiguration: false
+        ))
+    }
+
+    func testBusyFlagsDisableEvenWithContent() {
+        XCTAssertTrue(ChatComposerSendGate.isDisabled(
+            hasText: true,
+            hasStagedAttachments: true,
+            isSending: true,
+            isCompressingSession: false,
+            isUploadingAttachment: false,
+            isUpdatingConfiguration: false
+        ))
+        XCTAssertTrue(ChatComposerSendGate.isDisabled(
+            hasText: true,
+            hasStagedAttachments: true,
+            isSending: false,
+            isCompressingSession: true,
+            isUploadingAttachment: false,
+            isUpdatingConfiguration: false
+        ))
+        XCTAssertTrue(ChatComposerSendGate.isDisabled(
+            hasText: true,
+            hasStagedAttachments: true,
+            isSending: false,
+            isCompressingSession: false,
+            isUploadingAttachment: true,
+            isUpdatingConfiguration: false
+        ))
+        XCTAssertTrue(ChatComposerSendGate.isDisabled(
+            hasText: true,
+            hasStagedAttachments: true,
+            isSending: false,
+            isCompressingSession: false,
+            isUploadingAttachment: false,
+            isUpdatingConfiguration: true
+        ))
+    }
+}

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -1068,6 +1068,116 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(text, "Summarize this\n\n[Attached files: /tmp/workspace/report.pdf]")
     }
 
+    func testChatMessageTextSynthesizesUploadedFormForEmptyDraft() {
+        // Attachment-only send (#403): with no typed draft the message text is
+        // synthesized exactly like the web UI (`static/messages.js`), since the
+        // server requires non-empty text.
+        let image = PendingAttachment(
+            name: "photo.jpg",
+            path: "/tmp/workspace/photo.jpg",
+            mime: "image/jpeg",
+            size: 45_678,
+            isImage: true,
+            thumbnailData: nil
+        )
+        let file = PendingAttachment(
+            name: "report.pdf",
+            path: "/tmp/workspace/report.pdf",
+            mime: "application/pdf",
+            size: 1234,
+            isImage: false,
+            thumbnailData: nil
+        )
+
+        XCTAssertEqual(
+            PendingAttachment.chatMessageText(draft: "", attachments: [image, file]),
+            "I've uploaded 2 file(s): /tmp/workspace/photo.jpg, /tmp/workspace/report.pdf"
+        )
+        XCTAssertEqual(
+            PendingAttachment.chatMessageText(draft: "   ", attachments: [file]),
+            "I've uploaded 1 file(s): /tmp/workspace/report.pdf",
+            "Whitespace-only draft counts as attachment-only"
+        )
+        XCTAssertEqual(
+            PendingAttachment.chatMessageText(draft: "", attachments: []),
+            "",
+            "No attachments: the empty draft passes through unchanged"
+        )
+    }
+
+    @MainActor
+    func testSendMessageWithEmptyDraftAndStagedAttachmentSendsSynthesizedMessage() async throws {
+        let streamClient = SpySSEStreamingClient()
+        var startMessage: String?
+        var startAttachments: [[String: Any]]?
+
+        let viewModel = try makeViewModel(streamClient: streamClient) { request in
+            switch request.url?.path {
+            case "/api/upload":
+                return apiTestJSONResponse("""
+                {
+                  "filename": "photo.jpg",
+                  "path": "/tmp/workspace/photo.jpg",
+                  "size": 45678,
+                  "mime": "image/jpeg",
+                  "is_image": true
+                }
+                """, for: request)
+            case "/api/chat/start":
+                let body = try apiTestJSONBody(from: request)
+                startMessage = body["message"] as? String
+                startAttachments = body["attachments"] as? [[String: Any]]
+                return apiTestJSONResponse("""
+                {
+                  "session_id": "session-abc",
+                  "stream_id": "stream-403"
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        // Stage one attachment through the real coordinator (mocked upload).
+        let staged = await viewModel.uploadAttachment(
+            data: Data("fake-jpeg".utf8),
+            filename: "photo.jpg"
+        )
+        try XCTUnwrap(staged)
+        XCTAssertEqual(viewModel.pendingAttachments.count, 1)
+
+        // Empty draft + staged attachment: previously rejected, now sends.
+        let didStart = await viewModel.sendMessage("")
+
+        XCTAssertTrue(didStart)
+        XCTAssertEqual(startMessage, "I've uploaded 1 file(s): /tmp/workspace/photo.jpg")
+        XCTAssertEqual(viewModel.activeStreamID, "stream-403")
+
+        // Optimistic bubble shows the synthesized text plus the attachment.
+        let optimistic = try XCTUnwrap(viewModel.messages.first)
+        XCTAssertEqual(optimistic.role, "user")
+        XCTAssertEqual(optimistic.content, "I've uploaded 1 file(s): /tmp/workspace/photo.jpg")
+        XCTAssertEqual(optimistic.attachments?.count, 1)
+        XCTAssertEqual(optimistic.attachments?.first?.path, "/tmp/workspace/photo.jpg")
+        XCTAssertEqual(try XCTUnwrap(startAttachments)?.count, 1)
+
+        // The composer strip is empty after a successful send.
+        XCTAssertTrue(viewModel.pendingAttachments.isEmpty)
+    }
+
+    @MainActor
+    func testSendMessageWithEmptyDraftAndNoAttachmentsStillReturnsFalse() async {
+        let viewModel = try? makeViewModel { _ in
+            XCTFail("No request should be made for an empty draft with no attachments")
+            throw URLError(.badURL)
+        }
+
+        let didStart = await viewModel?.sendMessage("") ?? false
+
+        XCTAssertFalse(didStart)
+    }
+
     @MainActor
     func testSubmitGoalAttachesToServerStartedKickoffStream() async throws {
         let streamClient = SpySSEStreamingClient()


### PR DESCRIPTION
## Problem

The composer disables Send when the draft is empty, even with staged attachments — you cannot send a photo without typing something first. Both `ChatView.sendStandardMessage` and `ChatViewModel.sendMessage` returned early on empty trimmed text, so every entry point (tap, Return / ⌘-Return, share-extension hand-off) was blocked.

Fixes #403.

## How it works

Send is enabled when trimmed text is non-empty **or** at least one attachment is staged and not mid-upload. With attachments and empty text, the message sent to the server is `I've uploaded N file(s): <paths>` — the same wording and shape the web UI synthesizes in `static/messages.js` (`sendMessage`). With text present, the existing `[Attached files: <paths>]` suffix form is unchanged.

The optimistic bubble shows the same synthesized text, so the local bubble matches what a reload from the server displays. The transcript's `[Attached files: …]` marker-stripping only removes suffixes, so the synthesized text passes through untouched.

## Changes

- `PendingAttachment.chatMessageText` — empty (or whitespace-only) draft with references now returns the `I've uploaded N file(s): …` form; text drafts keep the suffix form; no attachments passes the draft through.
- `ChatViewModel.sendMessage` — early-return now requires empty text **and** no staged attachments.
- `ChatComposerView` — button-disabled logic extracted to `ChatComposerSendGate`, which allows attachment-only sends; busy flags (sending, compressing, uploading, updating configuration) still disable.
- `ChatView.sendStandardMessage` — guard allows empty text when the composer holds staged attachments. Draft handling is unchanged: for an attachment-only send the stored draft is already empty, which is the correct post-send state.

Untouched by design: Stop button (mid-stream with empty text still shows Stop — `showsStopButton` already requires empty text), slash-command path (empty text never reaches the parser), queued/steer paths (mid-stream sends with empty text are Stop, not Send), voice notes (own flow, bare transcript), failure rollback (attachments still restore into the composer).

## Tests

- `ChatComposerSendGateTests` — enabled states: text only, attachment only, both; disabled: neither, any busy flag.
- `ChatViewModelSendTests` — empty draft + staged attachment starts a send and posts the synthesized message with the attachment payload; empty draft + no attachments still returns false with no request; `chatMessageText` empty/whitespace/text/no-attachment matrix; existing suffix-form and voice-note-bare-transcript guards unchanged and passing.

## Validation

- Full XCTest suite on branch head `f588df8`: **2,193 passed, 0 failed** (iPhone 17 simulator, `CODE_SIGNING_ALLOWED=NO`).
- `git diff --check` clean.

## Owner checks (simulator, branch build)

1. Attach a photo with no text → Send enabled → send → bubble shows `I've uploaded 1 file(s): …` + photo preview; agent replies about the photo.
2. Attach a non-image file with no text → send → same synthesized form.
3. Attach + text → send → existing `[Attached files: …]` suffix form in the transcript.
4. With a stream running and empty text, the composer button still shows Stop even with attachments staged.
5. Kill the network, send attachment-only → attachments restore into the composer.

Ends with: model GLM (glm-5.3-flash) via Hermes Agent, harness `/hermes-issue-pr-workflow`.
