### PR TITLE
fix(chat): count "Working for" and "Worked for" from the server's turn start

### DIFF
--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -115,10 +115,12 @@ final class ChatStreamCoordinator {
             }
         }
     }
-    /// When the current stream first became known here. Keyed to stream
-    /// identity, so a same-stream reattach keeps the date; a stream discovered
-    /// on session load counts from discovery, since the server does not report
-    /// when it started.
+    /// When the run behind the current stream started. Seeded by the caller from
+    /// the server's `pending_started_at` (session load and `/api/chat/start`),
+    /// then the latest user message's timestamp, and only failing both from the
+    /// local moment this coordinator discovered the stream. Keyed to stream
+    /// identity, so a same-stream reattach keeps counting from the same instant
+    /// instead of restarting "Working for" on every return to the session.
     private(set) var activeRunStartedAt: Date?
     /// The last run's span and how it ended, recorded the moment the run stops
     /// counting (`done` or teardown) so the delegate can key it to a turn.
@@ -206,10 +208,15 @@ final class ChatStreamCoordinator {
         isTransportFinished
     }
 
+    /// `runStartedAt` is the run's real start when the caller knows it — the
+    /// server's `pending_started_at` from `/api/chat/start`, else the local send
+    /// time. Reconnects and replays pass nil: they rejoin the same stream, whose
+    /// start is already recorded.
     func start(
         streamID: String,
         replayAfterSeq: Int? = nil,
-        recoveryState: ActiveStreamRecoveryState = .idle
+        recoveryState: ActiveStreamRecoveryState = .idle,
+        runStartedAt: Date? = nil
     ) {
         hasCompletedCurrentResponse = false
         isTerminalContentFenceActive = false
@@ -218,6 +225,7 @@ final class ChatStreamCoordinator {
         runGeneration &+= 1
         invalidateReconnectTask()
         activeStreamID = streamID
+        seedActiveRunStart(runStartedAt)
         hasInMemorySnapshotForActiveStream = false
         isConnectionSuspended = false
         if replayAfterSeq == nil {
@@ -298,10 +306,15 @@ final class ChatStreamCoordinator {
         return loadedActiveStreamID == activeStreamIDBeforeLoad
     }
 
+    /// `runStartedAt` is when the loaded session says its in-flight turn started
+    /// (`pending_started_at`, else the latest user message's timestamp). Adopting
+    /// a running stream counts from there instead of from this load, so returning
+    /// to a session never restarts its "Working for" counter.
     func reconcileSessionLoad(
         loadedActiveStreamID rawLoadedActiveStreamID: String?,
         preparation: ChatStreamLoadPreparation,
-        usedCacheFallback: Bool
+        usedCacheFallback: Bool,
+        runStartedAt: Date? = nil
     ) {
         hasCompletedCurrentResponse = false
         isTerminalContentFenceActive = false
@@ -323,6 +336,7 @@ final class ChatStreamCoordinator {
             delegate?.streamCoordinatorStreamingAssistantMessageID = nil
             if let streamID = loadedActiveStreamID, !streamID.isEmpty {
                 activeStreamID = streamID
+                seedActiveRunStart(runStartedAt)
                 delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
                 isConnectionSuspended = true
                 let didRestoreSnapshot = restoreSnapshotIfAvailable(streamID: streamID)
@@ -341,6 +355,7 @@ final class ChatStreamCoordinator {
                 : preparation.activeStreamIDBeforeLoad
             if let streamID {
                 activeStreamID = streamID
+                seedActiveRunStart(runStartedAt)
                 delegate?.streamCoordinatorStreamingAssistantMessageID = delegate?.streamCoordinatorLatestAssistantMessageID()
                 let didRestoreSnapshot = restoreSnapshotIfAvailable(streamID: streamID)
                 if preparation.activeStreamIDBeforeLoad != streamID {
@@ -948,6 +963,17 @@ final class ChatStreamCoordinator {
         }
     }
 
+    /// Adopts a server-known start for the run that is now active, replacing the
+    /// local stamp `activeStreamID`'s observer laid down. Every seed a caller can
+    /// supply is stable across re-entry, so applying one on a same-stream
+    /// reattach sharpens the counter rather than restarting it; a nil seed leaves
+    /// the discovery stamp alone. A future-dated seed (clock skew between phone
+    /// and server) is clamped to `now` so the label never counts backwards.
+    private func seedActiveRunStart(_ startedAt: Date?, now: Date = Date()) {
+        guard activeStreamID != nil, let startedAt else { return }
+        activeRunStartedAt = min(startedAt, now)
+    }
+
     /// Records the run's span once. `completeCurrentResponse` already cleared
     /// the run start for a normal completion, so a later teardown event (a
     /// `streamEnd` or `cancelled` after `done`) cannot overwrite that ending.
@@ -1071,13 +1097,17 @@ final class ChatStreamCoordinator {
         delegate?.streamCoordinatorDidResetRecoveryState()
     }
 
+    /// Called right after `seedActiveRunStart`, so the widget's system elapsed
+    /// timer starts from the same instant as the in-app "Working for" label
+    /// rather than from the moment this process attached to the stream (#406).
     private func startLiveActivity(streamID: String) {
         guard let sessionID = delegate?.streamCoordinatorSessionID else { return }
 
         liveActivityManager.start(
             sessionID: sessionID,
             sessionTitle: delegate?.streamCoordinatorDisplayTitle ?? String(localized: "Untitled Session"),
-            streamID: streamID
+            streamID: streamID,
+            startedAt: activeRunStartedAt ?? Date()
         )
     }
 

--- a/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
+++ b/HermesMobile/Features/Chat/ChatStreamCoordinator.swift
@@ -208,6 +208,12 @@ final class ChatStreamCoordinator {
         isTransportFinished
     }
 
+    /// Test seam for the clock-skew clamp: production callers always seed with
+    /// the current instant, which tests cannot advance.
+    func seedActiveRunStartForTesting(_ startedAt: Date?, now: Date) {
+        seedActiveRunStart(startedAt, now: now)
+    }
+
     /// `runStartedAt` is the run's real start when the caller knows it — the
     /// server's `pending_started_at` from `/api/chat/start`, else the local send
     /// time. Reconnects and replays pass nil: they rejoin the same stream, whose
@@ -968,10 +974,14 @@ final class ChatStreamCoordinator {
     /// supply is stable across re-entry, so applying one on a same-stream
     /// reattach sharpens the counter rather than restarting it; a nil seed leaves
     /// the discovery stamp alone. A future-dated seed (clock skew between phone
-    /// and server) is clamped to `now` so the label never counts backwards.
+    /// and server) is clamped to `now` so the label never counts backwards, and
+    /// the earliest start known for this stream wins: a re-seed can only move the
+    /// start earlier, never forward onto a fresh `now`, which would restart
+    /// "Working for" on every reload of a session a skewed server is running.
     private func seedActiveRunStart(_ startedAt: Date?, now: Date = Date()) {
         guard activeStreamID != nil, let startedAt else { return }
-        activeRunStartedAt = min(startedAt, now)
+        let clamped = min(startedAt, now)
+        activeRunStartedAt = min(activeRunStartedAt ?? clamped, clamped)
     }
 
     /// Records the run's span once. `completeCurrentResponse` already cleared

--- a/HermesMobile/Features/Chat/ChatViewModel.swift
+++ b/HermesMobile/Features/Chat/ChatViewModel.swift
@@ -1516,7 +1516,11 @@ final class ChatViewModel {
             streamCoordinator.reconcileSessionLoad(
                 loadedActiveStreamID: loadedActiveStreamID,
                 preparation: streamLoadPreparation,
-                usedCacheFallback: false
+                usedCacheFallback: false,
+                runStartedAt: Self.activeRunStartDate(
+                    pendingStartedAt: session?.pendingStartedAt,
+                    messages: messages
+                )
             )
         } catch {
             lastError = error
@@ -2070,6 +2074,30 @@ final class ChatViewModel {
         }
     }
 
+    /// When the session's in-flight turn started, for seeding the stream
+    /// coordinator's run clock: the server's `pending_started_at` first, then the
+    /// latest user message's timestamp. Both survive leaving and re-entering the
+    /// session, so "Working for" keeps counting from one instant; nil leaves the
+    /// coordinator counting from when it discovered the stream.
+    nonisolated private static func activeRunStartDate(
+        pendingStartedAt: Double?,
+        messages: [ChatMessage]
+    ) -> Date? {
+        if let pendingStartedAt, pendingStartedAt > 0 {
+            return Date(timeIntervalSince1970: pendingStartedAt)
+        }
+
+        guard let latestUserTimestamp = messages
+            .last(where: TranscriptTurnClassifier.isUserTurnBoundary)?
+            .timestamp,
+            latestUserTimestamp > 0
+        else {
+            return nil
+        }
+
+        return Date(timeIntervalSince1970: latestUserTimestamp)
+    }
+
     nonisolated private static func hasAssistantResponseAfterLatestUser(in messages: [ChatMessage]) -> Bool {
         guard !messages.isEmpty else { return false }
 
@@ -2445,6 +2473,7 @@ final class ChatViewModel {
 
         do {
             let explicitModelPick = explicitModelPickForChatStart()
+            let sentAt = Date()
             let response = try await client.startChat(
                 sessionID: sessionID,
                 message: messageForAPI,
@@ -2465,7 +2494,10 @@ final class ChatViewModel {
             }
 
             completeExplicitModelPickForChatStart(explicitModelPick)
-            streamCoordinator.start(streamID: streamID)
+            streamCoordinator.start(
+                streamID: streamID,
+                runStartedAt: response.runStartedAt(sentAt: sentAt)
+            )
             return true
         } catch {
             if let streamID = (error as? APIError)?.activeStreamID {
@@ -3737,6 +3769,7 @@ final class ChatViewModel {
             attachmentCoordinator.removeAllLocalPreviews()
 
             let explicitModelPick = explicitModelPickForChatStart()
+            let sentAt = Date()
             let chatResponse = try await client.startChat(
                 sessionID: sessionID,
                 message: lastUserText,
@@ -3761,7 +3794,10 @@ final class ChatViewModel {
                 )
             )
 
-            streamCoordinator.start(streamID: streamID)
+            streamCoordinator.start(
+                streamID: streamID,
+                runStartedAt: chatResponse.runStartedAt(sentAt: sentAt)
+            )
             return .executed(message: nil)
         } catch {
             lastError = error
@@ -4020,6 +4056,7 @@ final class ChatViewModel {
 
             // Now send the edited text through the normal chat flow
             let explicitModelPick = explicitModelPickForChatStart()
+            let sentAt = Date()
             let chatResponse = try await client.startChat(
                 sessionID: sessionID,
                 message: editedText,
@@ -4048,7 +4085,10 @@ final class ChatViewModel {
 
             streamCoordinator.prepareForNewResponse()
             responseCompletionNeedsTranscriptRefresh = false
-            streamCoordinator.start(streamID: streamID)
+            streamCoordinator.start(
+                streamID: streamID,
+                runStartedAt: chatResponse.runStartedAt(sentAt: sentAt)
+            )
             return true
         } catch {
             lastError = error
@@ -4122,6 +4162,7 @@ final class ChatViewModel {
             }
 
             let explicitModelPick = explicitModelPickForChatStart()
+            let sentAt = Date()
             let chatResponse = try await client.startChat(
                 sessionID: sessionID,
                 message: userText,
@@ -4140,7 +4181,10 @@ final class ChatViewModel {
             completeExplicitModelPickForChatStart(explicitModelPick)
             streamCoordinator.prepareForNewResponse()
             responseCompletionNeedsTranscriptRefresh = false
-            streamCoordinator.start(streamID: streamID)
+            streamCoordinator.start(
+                streamID: streamID,
+                runStartedAt: chatResponse.runStartedAt(sentAt: sentAt)
+            )
             return true
         } catch {
             lastError = error

--- a/HermesMobile/LiveActivities/AgentLiveActivityManager.swift
+++ b/HermesMobile/LiveActivities/AgentLiveActivityManager.swift
@@ -31,7 +31,11 @@ struct OrphanedLiveActivity: Equatable {
 
 @MainActor
 protocol AgentLiveActivityManaging: AnyObject {
-    func start(sessionID: String, sessionTitle: String, streamID: String?)
+    /// `startedAt` is when the *run* began, not when the widget was created: the
+    /// coordinator passes the server-seeded run start so the widget's system
+    /// elapsed timer counts the same span as the in-app "Working for" label
+    /// (#406). Callers without a seeded start pass `Date()`.
+    func start(sessionID: String, sessionTitle: String, streamID: String?, startedAt: Date)
     func update(_ event: AgentLiveActivityEvent)
     func markStale()
     func end(status: AgentRunActivityStatus, activity: String, errorSummary: String?)
@@ -82,7 +86,7 @@ final class AgentLiveActivityManager: AgentLiveActivityManaging {
         self.minimumUpdateInterval = minimumUpdateInterval
     }
 
-    func start(sessionID: String, sessionTitle: String, streamID: String?) {
+    func start(sessionID: String, sessionTitle: String, streamID: String?, startedAt: Date = Date()) {
         let normalizedSessionID = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedSessionID.isEmpty else { return }
         let normalizedStreamID = AgentLiveActivityReusePolicy.normalizedStreamID(streamID)
@@ -114,7 +118,6 @@ final class AgentLiveActivityManager: AgentLiveActivityManaging {
         rawResponseText = ""
         currentSessionID = normalizedSessionID
         currentStreamID = normalizedStreamID
-        let startedAt = Date()
         let state = AgentRunActivityStateReducer.initialState(
             sessionID: normalizedSessionID,
             sessionTitle: sessionTitle,

--- a/HermesMobile/LiveActivities/AgentLiveActivityManager.swift
+++ b/HermesMobile/LiveActivities/AgentLiveActivityManager.swift
@@ -103,7 +103,11 @@ final class AgentLiveActivityManager: AgentLiveActivityManaging {
                     status: state.status,
                     currentActivity: state.currentActivity,
                     responseExcerpt: state.responseExcerpt,
-                    startedAt: state.startedAt,
+                    // Earliest known start wins: the reused activity may have been
+                    // started from a discovery stamp before the coordinator learned
+                    // the server's earlier `pending_started_at`, and the widget timer
+                    // must not run behind the in-app one.
+                    startedAt: min(state.startedAt, startedAt),
                     updatedAt: Date(),
                     isStale: false,
                     isFinal: false,
@@ -142,6 +146,12 @@ final class AgentLiveActivityManager: AgentLiveActivityManaging {
                 lifecycle: lifecycle
             )
         }
+    }
+
+    /// Test seam: the ActivityKit-backed activity is unreachable in unit tests, so
+    /// the reducer state it mirrors is how tests observe `start`/`update` results.
+    func currentStateForTesting() -> AgentRunActivityAttributes.ContentState? {
+        currentState
     }
 
     func update(_ event: AgentLiveActivityEvent) {

--- a/HermesMobile/Models/ServerCatalog.swift
+++ b/HermesMobile/Models/ServerCatalog.swift
@@ -3,7 +3,34 @@ import Foundation
 struct ChatStartResponse: Decodable, Equatable {
     let streamId: String?
     let sessionId: String?
+    /// Unix epoch seconds for when the server started this turn
+    /// (`pending_started_at`), matching the value `/api/sessions/<id>` reports
+    /// while the turn is in flight. Absent on servers that do not send it.
+    let pendingStartedAt: Double?
     let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case streamId
+        case sessionId
+        case pendingStartedAt
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        streamId = container.decodeLossyStringIfPresent(forKey: .streamId)
+        sessionId = container.decodeLossyStringIfPresent(forKey: .sessionId)
+        pendingStartedAt = container.decodeLossyDoubleIfPresent(forKey: .pendingStartedAt)
+        error = container.decodeLossyStringIfPresent(forKey: .error)
+    }
+
+    /// When the turn this response opened really started: the server's
+    /// `pending_started_at` when it reported one, else the local moment the
+    /// client sent. Used to seed the run's "Working for" counter.
+    func runStartedAt(sentAt: Date) -> Date {
+        guard let pendingStartedAt, pendingStartedAt > 0 else { return sentAt }
+        return Date(timeIntervalSince1970: pendingStartedAt)
+    }
 }
 
 struct ChatCancelResponse: Decodable, Equatable {

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -93,6 +93,24 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testFutureDatedSeedDoesNotMoveTheRunStartForwardOnReSeed() throws {
+        let coordinator = makeCoordinator()
+        // A server clock running ahead of the phone reports a start in the future.
+        let t0 = Date()
+        let skewedServerStart = t0.addingTimeInterval(600)
+
+        coordinator.start(streamID: "stream-123")
+        coordinator.seedActiveRunStartForTesting(skewedServerStart, now: t0)
+        XCTAssertEqual(coordinator.activeRunStartedAt, t0)
+
+        // Reloading the same running session re-seeds the same skewed stamp later
+        // on. Clamping alone would pin the start to the new `now` and restart
+        // "Working for"; the earliest known start has to win instead.
+        coordinator.seedActiveRunStartForTesting(skewedServerStart, now: t0.addingTimeInterval(30))
+        XCTAssertEqual(coordinator.activeRunStartedAt, t0)
+    }
+
+    @MainActor
     func testLiveActivityStartsFromTheSeededRunStartRatherThanNow() throws {
         let liveActivityManager = CoordinatorSpyLiveActivityManager()
         // The coordinator holds its delegate weakly, so the spy has to outlive

--- a/HermesMobileTests/ChatStreamCoordinatorTests.swift
+++ b/HermesMobileTests/ChatStreamCoordinatorTests.swift
@@ -62,6 +62,139 @@ final class ChatStreamCoordinatorTests: APIClientTestCase {
     }
 
     @MainActor
+    func testSessionLoadSeedsRunStartFromServerAndReEntryKeepsIt() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient)
+        // The server says this run has been going for 95s (`pending_started_at`).
+        let serverStart = Date().addingTimeInterval(-95)
+
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-123",
+            preparation: coordinator.prepareForSessionLoad(),
+            usedCacheFallback: false,
+            runStartedAt: serverStart
+        )
+
+        XCTAssertEqual(coordinator.activeStreamID, "stream-123")
+        XCTAssertEqual(coordinator.activeRunStartedAt, serverStart)
+
+        // Reattaching to the same run, then leaving and re-entering the session,
+        // both keep counting from the server's start instead of restarting at 0s.
+        coordinator.start(streamID: "stream-123")
+        XCTAssertEqual(coordinator.activeRunStartedAt, serverStart)
+
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-123",
+            preparation: coordinator.prepareForSessionLoad(),
+            usedCacheFallback: false,
+            runStartedAt: serverStart
+        )
+        XCTAssertEqual(coordinator.activeRunStartedAt, serverStart)
+    }
+
+    @MainActor
+    func testLiveActivityStartsFromTheSeededRunStartRatherThanNow() throws {
+        let liveActivityManager = CoordinatorSpyLiveActivityManager()
+        // The coordinator holds its delegate weakly, so the spy has to outlive
+        // `makeCoordinator` for `startLiveActivity` to see a session ID.
+        let delegate = CoordinatorDelegateSpy()
+        let coordinator = makeCoordinator(liveActivityManager: liveActivityManager, delegate: delegate)
+        let serverStart = Date().addingTimeInterval(-95)
+
+        coordinator.start(streamID: "stream-123", runStartedAt: serverStart)
+
+        // The widget's system elapsed timer counts the run, not the moment this
+        // process attached to it, so it agrees with the in-app "Working for".
+        XCTAssertEqual(liveActivityManager.startedAts, [serverStart])
+
+        // Without a seed the widget still starts counting from discovery time.
+        let beforeUnseeded = Date()
+        coordinator.start(streamID: "stream-456")
+        let unseeded = try XCTUnwrap(liveActivityManager.startedAts.last)
+        XCTAssertGreaterThanOrEqual(unseeded, beforeUnseeded)
+        XCTAssertLessThanOrEqual(unseeded, Date())
+    }
+
+    @MainActor
+    func testRunStartFallsBackToDiscoveryAndNeverCountsFromTheFuture() throws {
+        let coordinator = makeCoordinator()
+
+        // No server start for the adopted run: fall back to discovery time.
+        let beforeLoad = Date()
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-123",
+            preparation: coordinator.prepareForSessionLoad(),
+            usedCacheFallback: false
+        )
+        let discovered = try XCTUnwrap(coordinator.activeRunStartedAt)
+        XCTAssertGreaterThanOrEqual(discovered, beforeLoad)
+        XCTAssertLessThanOrEqual(discovered, Date())
+
+        // A nil seed on re-entry leaves that discovery stamp alone.
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-123",
+            preparation: coordinator.prepareForSessionLoad(),
+            usedCacheFallback: false
+        )
+        XCTAssertEqual(coordinator.activeRunStartedAt, discovered)
+
+        // Clock skew can date a server start in the future; clamp it so the
+        // "Working for" label can never show a negative elapsed time.
+        coordinator.start(streamID: "stream-456", runStartedAt: Date().addingTimeInterval(600))
+        let clamped = try XCTUnwrap(coordinator.activeRunStartedAt)
+        XCTAssertLessThanOrEqual(clamped, Date())
+    }
+
+    @MainActor
+    func testRecordedRunEndingSpansFromTheServerSeededStart() throws {
+        let streamClient = CoordinatorSpySSEStreamingClient()
+        let coordinator = makeCoordinator(streamClient: streamClient)
+        let serverStart = Date().addingTimeInterval(-90)
+
+        coordinator.reconcileSessionLoad(
+            loadedActiveStreamID: "stream-123",
+            preparation: coordinator.prepareForSessionLoad(),
+            usedCacheFallback: false,
+            runStartedAt: serverStart
+        )
+        coordinator.start(streamID: "stream-123")
+        streamClient.emit(.streamEnd)
+
+        // "Worked for" lands on the server's span immediately, without waiting
+        // for the post-completion transcript refresh to carry `_turnDuration`.
+        let ending = try XCTUnwrap(coordinator.latestRunEnding)
+        XCTAssertEqual(ending.startedAt, serverStart)
+        XCTAssertEqual(ending.ending, .completed)
+        XCTAssertGreaterThanOrEqual(ending.endedAt.timeIntervalSince(ending.startedAt), 90)
+    }
+
+    @MainActor
+    func testFreshSendSeedsRunStartFromChatStartResponse() throws {
+        let coordinator = makeCoordinator()
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let sentAt = Date()
+
+        let response = try decoder.decode(ChatStartResponse.self, from: Data(#"""
+        {"stream_id": "stream-123", "session_id": "session-abc", "pending_started_at": 1700000000.5}
+        """#.utf8))
+        XCTAssertEqual(response.pendingStartedAt, 1_700_000_000.5)
+
+        coordinator.start(streamID: "stream-123", runStartedAt: response.runStartedAt(sentAt: sentAt))
+        XCTAssertEqual(coordinator.activeRunStartedAt, Date(timeIntervalSince1970: 1_700_000_000.5))
+
+        // A server that omits the field leaves the run counting from the send.
+        let withoutStart = try decoder.decode(
+            ChatStartResponse.self,
+            from: Data(#"{"stream_id": "stream-456"}"#.utf8)
+        )
+        XCTAssertNil(withoutStart.pendingStartedAt)
+
+        coordinator.start(streamID: "stream-456", runStartedAt: withoutStart.runStartedAt(sentAt: sentAt))
+        XCTAssertEqual(coordinator.activeRunStartedAt, sentAt)
+    }
+
+    @MainActor
     func testSessionLoadPreparationBelongsOnlyToCapturedStreamRun() {
         let coordinator = makeCoordinator()
 
@@ -2225,12 +2358,16 @@ private final class CoordinatorSpyLiveActivityManager: AgentLiveActivityManaging
     }
 
     private(set) var starts: [Start] = []
+    /// Run starts handed to the widget, recorded alongside `starts` so the
+    /// existing `Start` equality assertions stay independent of timing (#406).
+    private(set) var startedAts: [Date] = []
     private(set) var updates: [AgentLiveActivityEvent] = []
     private(set) var markStaleCount = 0
     private(set) var ends: [End] = []
 
-    func start(sessionID: String, sessionTitle: String, streamID: String?) {
+    func start(sessionID: String, sessionTitle: String, streamID: String?, startedAt: Date) {
         starts.append(Start(sessionID: sessionID, sessionTitle: sessionTitle, streamID: streamID))
+        startedAts.append(startedAt)
     }
 
     func update(_ event: AgentLiveActivityEvent) {

--- a/HermesMobileTests/ChatViewModelSendTests.swift
+++ b/HermesMobileTests/ChatViewModelSendTests.swift
@@ -7147,6 +7147,43 @@ final class ChatViewModelSendTests: XCTestCase {
         XCTAssertEqual(streamClient.startedURLs.first?.path, "/api/chat/stream")
     }
 
+    /// #406 fallback ordering: an older server omits `pending_started_at`, so the
+    /// run clock falls back to the latest user turn rather than the moment this
+    /// session was opened.
+    @MainActor
+    func testLoadMessagesWithoutPendingStartedAtSeedsRunStartFromLatestUserMessage() async throws {
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path {
+            case "/api/session":
+                return apiTestJSONResponse("""
+                {
+                  "session": {
+                    "session_id": "session-abc",
+                    "title": "Planning",
+                    "active_stream_id": "stream-123",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "Keep working",
+                        "timestamp": 1770000100,
+                        "message_id": "user-1"
+                      }
+                    ]
+                  }
+                }
+                """, for: request)
+            default:
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+        }
+
+        await viewModel.loadMessages()
+
+        XCTAssertEqual(viewModel.activeStreamID, "stream-123")
+        XCTAssertEqual(viewModel.activeRunStartedAt, Date(timeIntervalSince1970: 1_770_000_100))
+    }
+
     @MainActor
     func testLoadMessagesDoesNotFailForWebUICreatedSessionDecodeDrift() async throws {
         let viewModel = try makeViewModel { request in
@@ -9558,7 +9595,7 @@ private final class SpyChatLiveActivityManager: AgentLiveActivityManaging {
 
     private(set) var ends: [End] = []
 
-    func start(sessionID: String, sessionTitle: String, streamID: String?) {}
+    func start(sessionID: String, sessionTitle: String, streamID: String?, startedAt: Date) {}
 
     func update(_ event: AgentLiveActivityEvent) {}
 

--- a/HermesMobileTests/LiveActivityTests.swift
+++ b/HermesMobileTests/LiveActivityTests.swift
@@ -1198,7 +1198,7 @@ private final class SpyAgentLiveActivityManager: AgentLiveActivityManaging {
     private(set) var didMarkStale = false
     private(set) var ends: [End] = []
 
-    func start(sessionID: String, sessionTitle: String, streamID: String?) {
+    func start(sessionID: String, sessionTitle: String, streamID: String?, startedAt: Date) {
         starts.append(Start(sessionID: sessionID, sessionTitle: sessionTitle, streamID: streamID))
     }
 

--- a/HermesMobileTests/LiveActivityTests.swift
+++ b/HermesMobileTests/LiveActivityTests.swift
@@ -1177,6 +1177,41 @@ final class LiveActivityTests: XCTestCase {
         manager.end(status: .complete, activity: "Response complete")
         XCTAssertNil(manager.activeConnectedStreamID)
     }
+
+    // Reusing an activity for the same session and stream keeps the earliest start
+    // it has been told about, so a widget first started from a discovery stamp
+    // adopts the server's earlier turn start once the coordinator learns it.
+    @MainActor
+    func testReusingAnActivityAdoptsTheEarliestKnownStart() throws {
+        let manager = AgentLiveActivityManager()
+        let discoveredAt = Date(timeIntervalSince1970: 1_000)
+        let serverStart = discoveredAt.addingTimeInterval(-95)
+
+        manager.start(
+            sessionID: "session-1",
+            sessionTitle: "Title",
+            streamID: "stream-abc",
+            startedAt: discoveredAt
+        )
+        XCTAssertEqual(manager.currentStateForTesting()?.startedAt, discoveredAt)
+
+        manager.start(
+            sessionID: "session-1",
+            sessionTitle: "Title",
+            streamID: "stream-abc",
+            startedAt: serverStart
+        )
+        XCTAssertEqual(manager.currentStateForTesting()?.startedAt, serverStart)
+
+        // A later stamp for the same run never pushes the widget timer forward.
+        manager.start(
+            sessionID: "session-1",
+            sessionTitle: "Title",
+            streamID: "stream-abc",
+            startedAt: discoveredAt.addingTimeInterval(30)
+        )
+        XCTAssertEqual(manager.currentStateForTesting()?.startedAt, serverStart)
+    }
 }
 
 @MainActor

--- a/HermesMobileTests/TranscriptTurnFoldingTests.swift
+++ b/HermesMobileTests/TranscriptTurnFoldingTests.swift
@@ -135,6 +135,29 @@ final class TranscriptTurnFoldingTests: XCTestCase {
         XCTAssertEqual(folds.folds.first?.label, .worked(elapsed: "1m"))
     }
 
+    func testClientRunSeededFromTheServerStartOutlastsTheUserMessageGap() {
+        // A run adopted on session load and settled while the user watched: the
+        // transcript carries no `_turnDuration` yet, and its last loaded row
+        // predates the reply. The ending the coordinator recorded from the
+        // server's `pending_started_at` still labels the whole run, so "Worked
+        // for" does not shrink to the part of it this client saw.
+        let messages = [
+            user("u1", timestamp: 100),
+            assistantWithTools("a1", timestamp: 105),
+            assistant("a2", text: "Done.", timestamp: 160)
+        ]
+        let outcome = TranscriptTurnRunOutcome(
+            turnKey: firstTurnKey,
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 192),
+            ending: .completed
+        )
+
+        let folds = derive(messages, activityAnchorIDs: ["a1"], outcome: outcome)
+
+        XCTAssertEqual(folds.folds.first?.label, .worked(elapsed: "1m 32s"))
+    }
+
     func testServerTurnDurationWinsOverTheClientMeasuredRun() {
         let messages = [
             user("u1", timestamp: 100),


### PR DESCRIPTION
## Linked issue

Fixes #406

## What changed

Every return to a running session (from the session list, a cold open, or foregrounding) restarted the "Working for" counter at 0s, and the "Worked for" fold showed the time since reattach until the transcript reloaded. The Live Activity timer drifted the same way.

The run start is now seeded from the server's `pending_started_at` instead of the local clock:

- `ChatStreamCoordinator.start` and `reconcileSessionLoad` accept a `runStartedAt` and clamp it to now. A same-stream reattach never resets it.
- `ChatStartResponse` decodes the optional `pending_started_at` from `POST /api/chat/start`, so a fresh send counts from the server's stamp (else the local send time).
- On session load the fallback order is server value, then the latest user message's timestamp, then discovery time.
- `recordRunEndingIfRunning` spans from that seeded start, so the client-measured "Worked for" matches `_turnDuration` before the refresh lands. `_turnDuration` still wins once present.
- `AgentLiveActivityManaging.start` takes `startedAt`, and the coordinator passes the seeded run start.

Verified shapes (pinned upstream `api/routes.py`): `GET /api/sessions/<id>` carries `pending_started_at` as a float epoch or null; the `POST /api/chat/start` response dict is `{stream_id, session_id, pending_started_at, turn_id, title, ...}` with the same float-or-null field.

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP `test_sim`: 2240 passed, 0 failed, 2 skipped.
- New tests: session load seeds from the server start and re-entry keeps it; nil seed keeps discovery time and a future seed clamps; the recorded ending spans from the seeded start; a fresh send seeds from the start response; the view model falls back to the latest user message; the Live Activity spy receives the seeded start; a folding case where a client outcome seeded from the server start outlasts the user-message gap.

Manual simulator plan: start a long prompt, leave to the session list and come back, confirm the counter is continuous; background for a minute and foreground, confirm again; let the turn finish and compare "Worked for" to the web UI's value; check the Live Activity elapsed matches.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (verified against upstream source)

Implemented by Claude Opus (hermes-implementer) orchestrated by Claude Fable 5.1 in Claude Code.