### PR TITLE
feat(sessions): show Approval, Input, and Working states on session rows

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		C15210000000000000000006 /* OnboardingConnectPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000006 /* OnboardingConnectPage.swift */; };
 		C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000007 /* OnboardingFlowTests.swift */; };
 		C0391000000000000000000F /* SessionListMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000F /* SessionListMutationTests.swift */; };
+		C03910000000000000000019 /* SessionRowAttentionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000019 /* SessionRowAttentionStateTests.swift */; };
 		A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000012 /* SessionNavigationStateTests.swift */; };
 		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
 		C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000010 /* APIEndpointContractTests.swift */; };
@@ -533,6 +534,7 @@
 		C15200000000000000000006 /* OnboardingConnectPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConnectPage.swift; sourceTree = "<group>"; };
 		C15200000000000000000007 /* OnboardingFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowTests.swift; sourceTree = "<group>"; };
 		C0390000000000000000000F /* SessionListMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListMutationTests.swift; sourceTree = "<group>"; };
+		C03900000000000000000019 /* SessionRowAttentionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowAttentionStateTests.swift; sourceTree = "<group>"; };
 		A10900000000000000000012 /* SessionNavigationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationStateTests.swift; sourceTree = "<group>"; };
 		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000010 /* APIEndpointContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointContractTests.swift; sourceTree = "<group>"; };
@@ -1001,6 +1003,7 @@
 					C14600000000000000000001 /* ChatToolbarHeaderTests.swift */,
 					C15200000000000000000007 /* OnboardingFlowTests.swift */,
 				C0390000000000000000000F /* SessionListMutationTests.swift */,
+				C03900000000000000000019 /* SessionRowAttentionStateTests.swift */,
 				A10900000000000000000012 /* SessionNavigationStateTests.swift */,
 				19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */,
 				C03900000000000000000010 /* APIEndpointContractTests.swift */,
@@ -2048,6 +2051,7 @@
 					C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */,
 					C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */,
 				C0391000000000000000000F /* SessionListMutationTests.swift in Sources */,
+				C03910000000000000000019 /* SessionRowAttentionStateTests.swift in Sources */,
 				A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */,
 				19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */,
 				C03910000000000000000010 /* APIEndpointContractTests.swift in Sources */,

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -532,6 +532,7 @@ struct SessionInteractiveRow: View {
                 showsMessageCount: showsMessageCount,
                 showsWorkspace: showsWorkspace,
                 isViewingCachedData: viewModel.isViewingCachedData,
+                attentionState: viewModel.attentionState(for: session),
                 searchExcerpt: viewModel.searchExcerpt(for: session, searchText: searchText)
             )
         }

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -467,7 +467,9 @@ final class SessionListViewModel {
 
     /// One approval probe and one clarification probe per streaming row, on the
     /// tick the caller already runs. Sessions without an active stream are never
-    /// probed, and there is no separate polling loop or timer.
+    /// probed, and there is no separate polling loop or timer. A row's two
+    /// probes go out together, so N streaming rows cost about N round trips per
+    /// tick instead of 2N.
     private func refreshAttentionStates() async -> ActiveSessionStateRefreshResult {
         let streamingSessions = sessions.filter { SessionRowView.isActiveStreaming($0) }
         guard !streamingSessions.isEmpty else {
@@ -480,24 +482,37 @@ final class SessionListViewModel {
         for session in streamingSessions {
             guard let sessionID = Self.nonEmpty(session.sessionId) else { continue }
 
+            async let pendingApproval = client.approvalPending(sessionID: sessionID)
+            async let pendingClarification = client.clarifyPending(sessionID: sessionID)
+
+            // A failed probe is not evidence that nothing is pending, so it
+            // keeps what the last successful tick knew rather than letting the
+            // row fall back to "Working". The rule is deliberately simple: a
+            // previous `.approval` masks any clarification, so it carries no
+            // clarify knowledge, and a clarify probe that fails behind it
+            // resolves to nothing pending.
+            let previous = attentionStatesBySessionID[sessionID]
             var hasPendingApproval = false
             var hasPendingClarification = false
+            var probeErrors: [Error] = []
 
             do {
-                let response = try await client.approvalPending(sessionID: sessionID)
+                let response = try await pendingApproval
                 hasPendingApproval = Self.hasPending(response.pending)
             } catch {
-                guard !isCancellationError(error) else { return .unchanged }
-                if case APIError.unauthorized = error {
-                    lastError = error
-                    return .failed
-                }
+                probeErrors.append(error)
+                hasPendingApproval = previous == .approval
             }
 
             do {
-                let response = try await client.clarifyPending(sessionID: sessionID)
+                let response = try await pendingClarification
                 hasPendingClarification = Self.hasPending(response.pending)
             } catch {
+                probeErrors.append(error)
+                hasPendingClarification = previous == .input
+            }
+
+            for error in probeErrors {
                 guard !isCancellationError(error) else { return .unchanged }
                 if case APIError.unauthorized = error {
                     lastError = error

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -79,6 +79,12 @@ final class SessionListViewModel {
     /// server omits the field — the Archived entry stays hidden then.
     private(set) var archivedCount: Int?
 
+    /// Attention state per streaming session, refreshed on the same tick that
+    /// already checks stream liveness. Only sessions with an active stream ever
+    /// have an entry, and the map is reassigned only when a value actually
+    /// changes so rows do not invalidate once a second.
+    private(set) var attentionStatesBySessionID: [String: SessionRowAttentionState] = [:]
+
     private(set) var remoteContentSearchSessionIDs: [String] = []
     /// `match_preview` per content-matched session from the last search, so a
     /// row can show why it matched. Empty against servers that omit the field.
@@ -252,6 +258,9 @@ final class SessionListViewModel {
                         sessions = cachedSessions
                         isViewingCachedData = true
                         errorMessage = nil
+                        // Cached rows carry no live server state, so nothing can
+                        // still be waiting on the user here.
+                        clearAttentionStates()
                     } else {
                         isViewingCachedData = false
                         errorMessage = error.localizedDescription
@@ -447,7 +456,94 @@ final class SessionListViewModel {
             }
         }
 
+        return await refreshAttentionStates()
+    }
+
+    /// The attention state a row should show, or nil while nothing is pending.
+    func attentionState(for session: SessionSummary) -> SessionRowAttentionState? {
+        guard let sessionID = Self.nonEmpty(session.sessionId) else { return nil }
+        return attentionStatesBySessionID[sessionID]
+    }
+
+    /// One approval probe and one clarification probe per streaming row, on the
+    /// tick the caller already runs. Sessions without an active stream are never
+    /// probed, and there is no separate polling loop or timer.
+    private func refreshAttentionStates() async -> ActiveSessionStateRefreshResult {
+        let streamingSessions = sessions.filter { SessionRowView.isActiveStreaming($0) }
+        guard !streamingSessions.isEmpty else {
+            clearAttentionStates()
+            return .unchanged
+        }
+
+        var refreshed: [String: SessionRowAttentionState] = [:]
+
+        for session in streamingSessions {
+            guard let sessionID = Self.nonEmpty(session.sessionId) else { continue }
+
+            var hasPendingApproval = false
+            var hasPendingClarification = false
+
+            do {
+                let response = try await client.approvalPending(sessionID: sessionID)
+                hasPendingApproval = Self.hasPending(response.pending)
+            } catch {
+                guard !isCancellationError(error) else { return .unchanged }
+                if case APIError.unauthorized = error {
+                    lastError = error
+                    return .failed
+                }
+            }
+
+            do {
+                let response = try await client.clarifyPending(sessionID: sessionID)
+                hasPendingClarification = Self.hasPending(response.pending)
+            } catch {
+                guard !isCancellationError(error) else { return .unchanged }
+                if case APIError.unauthorized = error {
+                    lastError = error
+                    return .failed
+                }
+            }
+
+            refreshed[sessionID] = SessionRowAttentionState.resolve(
+                session: session,
+                hasPendingApproval: hasPendingApproval,
+                hasPendingClarification: hasPendingClarification
+            )
+        }
+
+        guard refreshed != attentionStatesBySessionID else { return .unchanged }
+        attentionStatesBySessionID = refreshed
         return .unchanged
+    }
+
+    private static func hasPending(_ pending: PendingApproval?) -> Bool {
+        guard let pending else { return false }
+        return !pending.isEmpty
+    }
+
+    private static func hasPending(_ pending: PendingClarification?) -> Bool {
+        guard let pending else { return false }
+        return !pending.isEmpty
+    }
+
+    private func clearAttentionStates() {
+        guard !attentionStatesBySessionID.isEmpty else { return }
+        attentionStatesBySessionID = [:]
+    }
+
+    /// Attention state only means something for a row the server still reports
+    /// as streaming, so a reload that ends a stream drops that row's entry.
+    private func pruneAttentionStates() {
+        guard !attentionStatesBySessionID.isEmpty else { return }
+
+        let streamingSessionIDs = Set(sessions.compactMap { session -> String? in
+            guard SessionRowView.isActiveStreaming(session) else { return nil }
+            return Self.nonEmpty(session.sessionId)
+        })
+        let pruned = attentionStatesBySessionID.filter { streamingSessionIDs.contains($0.key) }
+        guard pruned != attentionStatesBySessionID else { return }
+        attentionStatesBySessionID = pruned
     }
 
     func loadSessionForDeepLink(id rawSessionID: String, modelContext: ModelContext? = nil) async -> SessionSummary? {
@@ -1148,6 +1244,7 @@ final class SessionListViewModel {
         guard let animation else {
             sessions = newSessions
             archivedCount = newArchivedCount
+            pruneAttentionStates()
             return
         }
 
@@ -1155,6 +1252,7 @@ final class SessionListViewModel {
             sessions = newSessions
             archivedCount = newArchivedCount
         }
+        pruneAttentionStates()
     }
 
     /// Content-match rows narrowed to sessions the list can actually show, in

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -61,11 +61,23 @@ struct SessionRowView: View {
 
     /// The state the row actually shows: what the polling screen resolved, or —
     /// for screens that do not poll — whatever the session alone can say.
+    ///
+    /// The fallback is off while the row is showing cached data: a cached
+    /// summary keeps whatever `isStreaming`/`activeStreamId` it was captured
+    /// with, so an offline row would otherwise claim the agent is still
+    /// working. Cached rows fall back to their relative time instead.
     static func effectiveAttentionState(
         for session: SessionSummary,
-        attentionState: SessionRowAttentionState?
+        attentionState: SessionRowAttentionState?,
+        isViewingCachedData: Bool
     ) -> SessionRowAttentionState? {
-        attentionState ?? SessionRowAttentionState.resolve(
+        if let attentionState {
+            return attentionState
+        }
+
+        guard !isViewingCachedData else { return nil }
+
+        return SessionRowAttentionState.resolve(
             session: session,
             hasPendingApproval: false,
             hasPendingClarification: false
@@ -79,7 +91,11 @@ struct SessionRowView: View {
     ) -> [String] {
         var labels: [String] = []
 
-        if let state = effectiveAttentionState(for: session, attentionState: attentionState) {
+        if let state = effectiveAttentionState(
+            for: session,
+            attentionState: attentionState,
+            isViewingCachedData: isViewingCachedData
+        ) {
             labels.append(state.accessibilityLabel)
         }
 
@@ -185,7 +201,11 @@ struct SessionRowView: View {
     }
 
     private var effectiveAttentionState: SessionRowAttentionState? {
-        Self.effectiveAttentionState(for: session, attentionState: attentionState)
+        Self.effectiveAttentionState(
+            for: session,
+            attentionState: attentionState,
+            isViewingCachedData: isViewingCachedData
+        )
     }
 
     private func attentionStateText(_ state: SessionRowAttentionState) -> some View {

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -9,6 +9,10 @@ struct SessionRowView: View {
     var showsMessageCount = true
     var showsWorkspace = true
     var isViewingCachedData = false
+    /// The resolved attention state for this row, supplied by the screen that
+    /// polls the server (`SessionListViewModel`). Screens that do not poll pass
+    /// nothing and the row falls back to what the session itself reports.
+    var attentionState: SessionRowAttentionState?
     /// Set only while a remote content search is showing this row, so the row
     /// can say why it matched.
     var searchExcerpt: SessionSearchExcerpt?
@@ -55,14 +59,28 @@ struct SessionRowView: View {
         return parts.isEmpty ? nil : parts.joined(separator: " • ")
     }
 
+    /// The state the row actually shows: what the polling screen resolved, or —
+    /// for screens that do not poll — whatever the session alone can say.
+    static func effectiveAttentionState(
+        for session: SessionSummary,
+        attentionState: SessionRowAttentionState?
+    ) -> SessionRowAttentionState? {
+        attentionState ?? SessionRowAttentionState.resolve(
+            session: session,
+            hasPendingApproval: false,
+            hasPendingClarification: false
+        )
+    }
+
     static func accessibilityStateLabels(
         for session: SessionSummary,
-        isViewingCachedData: Bool
+        isViewingCachedData: Bool,
+        attentionState: SessionRowAttentionState? = nil
     ) -> [String] {
         var labels: [String] = []
 
-        if isActiveStreaming(session) {
-            labels.append(String(localized: "Streaming"))
+        if let state = effectiveAttentionState(for: session, attentionState: attentionState) {
+            labels.append(state.accessibilityLabel)
         }
 
         if session.pinned == true {
@@ -135,21 +153,49 @@ struct SessionRowView: View {
             VStack(alignment: .leading, spacing: 3) {
                 titleAndPin
 
-                if let relativeDate {
-                    relativeDateText(relativeDate)
-                }
+                trailingStatusSlot
             }
         } else {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 titleAndPin
 
-                if let relativeDate {
+                if showsTrailingStatus {
                     Spacer(minLength: 8)
-
-                    relativeDateText(relativeDate)
                 }
+
+                trailingStatusSlot
             }
         }
+    }
+
+    /// One line, one meaning: the attention state when the session wants
+    /// something, otherwise the relative time. Never both, so the row keeps its
+    /// height in every state.
+    @ViewBuilder
+    private var trailingStatusSlot: some View {
+        if let effectiveAttentionState {
+            attentionStateText(effectiveAttentionState)
+        } else if let relativeDate {
+            relativeDateText(relativeDate)
+        }
+    }
+
+    private var showsTrailingStatus: Bool {
+        effectiveAttentionState != nil || relativeDate != nil
+    }
+
+    private var effectiveAttentionState: SessionRowAttentionState? {
+        Self.effectiveAttentionState(for: session, attentionState: attentionState)
+    }
+
+    private func attentionStateText(_ state: SessionRowAttentionState) -> some View {
+        Text(state.title)
+            .font(AppFont.caption(weight: .semibold))
+            .monospacedDigit()
+            .foregroundStyle(state.tint)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityHidden(true)
     }
 
     private var titleAndPin: some View {
@@ -249,11 +295,9 @@ struct SessionRowView: View {
     }
 
     private var visibleStateBadges: [SessionRowStateBadgeKind] {
+        // Streaming has no badge: the trailing "Working" label and the pulsing
+        // dot already say it, and a third marker only added noise.
         var badges: [SessionRowStateBadgeKind] = []
-
-        if Self.isActiveStreaming(session) {
-            badges.append(.streaming)
-        }
 
         if isViewingCachedData {
             badges.append(.cached)
@@ -316,7 +360,11 @@ struct SessionRowView: View {
             parts.append(String(localized: "Matched: \(searchExcerpt.text)"))
         }
 
-        parts.append(contentsOf: Self.accessibilityStateLabels(for: session, isViewingCachedData: isViewingCachedData))
+        parts.append(contentsOf: Self.accessibilityStateLabels(
+            for: session,
+            isViewingCachedData: isViewingCachedData,
+            attentionState: attentionState
+        ))
 
         if let metadataLabel {
             parts.append(metadataLabel)
@@ -330,8 +378,68 @@ struct SessionRowView: View {
     }
 }
 
+/// What one session row is asking of the user, shown where the relative time
+/// otherwise sits. `nil` means ready: nothing is waiting and the row shows its
+/// time as usual.
+enum SessionRowAttentionState: String, Equatable {
+    case approval
+    case input
+    case working
+
+    /// Precedence: approval → input → working → ready. Pure by design — the
+    /// caller decides which sessions are worth asking the server about, so a
+    /// pending flag on a non-streaming session still resolves here.
+    static func resolve(
+        session: SessionSummary,
+        hasPendingApproval: Bool,
+        hasPendingClarification: Bool
+    ) -> SessionRowAttentionState? {
+        if hasPendingApproval {
+            return .approval
+        }
+
+        if hasPendingClarification {
+            return .input
+        }
+
+        return SessionRowView.isActiveStreaming(session) ? .working : nil
+    }
+
+    var title: String {
+        switch self {
+        case .approval:
+            return String(localized: "Approval")
+        case .input:
+            return String(localized: "Input")
+        case .working:
+            return String(localized: "Working")
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .approval:
+            return String(localized: "Waiting for approval")
+        case .input:
+            return String(localized: "Needs input")
+        case .working:
+            return String(localized: "Working")
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .approval:
+            return Color("AttentionApproval")
+        case .input:
+            return Color("AttentionInput")
+        case .working:
+            return Color("AttentionWorking")
+        }
+    }
+}
+
 private enum SessionRowStateBadgeKind: String, Identifiable {
-    case streaming
     case cached
     case readOnly
 
@@ -339,8 +447,6 @@ private enum SessionRowStateBadgeKind: String, Identifiable {
 
     var title: String {
         switch self {
-        case .streaming:
-            return String(localized: "Live")
         case .cached:
             return String(localized: "Cached")
         case .readOnly:
@@ -350,8 +456,6 @@ private enum SessionRowStateBadgeKind: String, Identifiable {
 
     var tint: Color {
         switch self {
-        case .streaming:
-            return .green
         case .cached:
             return .orange
         case .readOnly:

--- a/HermesMobile/Resources/Assets.xcassets/AttentionApproval.colorset/Contents.json
+++ b/HermesMobile/Resources/Assets.xcassets/AttentionApproval.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x09",
+          "green" : "0x53",
+          "red" : "0xB4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4D",
+          "green" : "0xD3",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HermesMobile/Resources/Assets.xcassets/AttentionInput.colorset/Contents.json
+++ b/HermesMobile/Resources/Assets.xcassets/AttentionInput.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0x46",
+          "red" : "0x4F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFC",
+          "green" : "0xB4",
+          "red" : "0xA5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HermesMobile/Resources/Assets.xcassets/AttentionWorking.colorset/Contents.json
+++ b/HermesMobile/Resources/Assets.xcassets/AttentionWorking.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC7",
+          "green" : "0x84",
+          "red" : "0x02"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xBD",
+          "red" : "0x38"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HermesMobile/Resources/Localizable.xcstrings
+++ b/HermesMobile/Resources/Localizable.xcstrings
@@ -130102,6 +130102,324 @@
           }
         }
       }
+    },
+    "Approval" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "موافقة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Genehmigung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aprobación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Approbation"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "אישור"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Approvazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "承認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "승인"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Goedkeuring"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zatwierdzenie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aprovação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Подтверждение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Onay"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "منظوری"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "批准"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "批准"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "核准"
+          }
+        }
+      }
+    },
+    "Needs input" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يحتاج إلى مدخلات"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eingabe erforderlich"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Necesita información"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Saisie requise"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "נדרש קלט"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Richiede input"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "入力が必要"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "입력 필요"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Invoer vereist"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wymaga danych wejściowych"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Precisa de entrada"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Требуется ввод"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Girdi gerekiyor"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "اِن پٹ درکار ہے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要輸入"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要输入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要輸入"
+          }
+        }
+      }
+    },
+    "Working" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "يعمل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arbeitet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabajando"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "En cours"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "עובד"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Al lavoro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "作業中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "작업 중"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bezig"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pracuje"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trabalhando"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Работает"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Çalışıyor"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "کام جاری ہے"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "工作中"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "工作中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "工作中"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/HermesMobileTests/SessionIdentityTests.swift
+++ b/HermesMobileTests/SessionIdentityTests.swift
@@ -83,7 +83,7 @@ final class SessionIdentityTests: XCTestCase {
         XCTAssertNil(SessionRowView.metadataLabel(for: session, showsMessageCount: false, showsWorkspace: false))
     }
 
-    func testSessionRowAccessibilityStateLabelsIncludeStreamingPinnedAndCachedState() {
+    func testSessionRowAccessibilityStateLabelsIncludeAttentionPinnedAndCachedState() {
         let session = SessionSummary(
             sessionId: "stateful",
             pinned: true,
@@ -93,7 +93,7 @@ final class SessionIdentityTests: XCTestCase {
 
         XCTAssertEqual(
             SessionRowView.accessibilityStateLabels(for: session, isViewingCachedData: true),
-            ["Streaming", "Pinned", "Cached"]
+            ["Working", "Pinned", "Cached"]
         )
         XCTAssertEqual(
             SessionRowView.accessibilityStateLabels(for: SessionSummary(sessionId: "plain"), isViewingCachedData: false),

--- a/HermesMobileTests/SessionIdentityTests.swift
+++ b/HermesMobileTests/SessionIdentityTests.swift
@@ -91,9 +91,15 @@ final class SessionIdentityTests: XCTestCase {
             isStreaming: false
         )
 
+        // Cached rows say nothing about attention: the stream fields in a
+        // cached summary are as old as the cache.
         XCTAssertEqual(
             SessionRowView.accessibilityStateLabels(for: session, isViewingCachedData: true),
-            ["Working", "Pinned", "Cached"]
+            ["Pinned", "Cached"]
+        )
+        XCTAssertEqual(
+            SessionRowView.accessibilityStateLabels(for: session, isViewingCachedData: false),
+            ["Working", "Pinned"]
         )
         XCTAssertEqual(
             SessionRowView.accessibilityStateLabels(for: SessionSummary(sessionId: "plain"), isViewingCachedData: false),

--- a/HermesMobileTests/SessionListMutationTests.swift
+++ b/HermesMobileTests/SessionListMutationTests.swift
@@ -729,6 +729,10 @@ final class SessionListMutationTests: XCTestCase {
                     #"{"active":true,"stream_id":"stream-123"}"#,
                     for: request
                 )
+            case "/api/approval/pending", "/api/clarify/pending":
+                // The same tick also probes the streaming row's attention state
+                // (see SessionRowAttentionStateTests); nothing is pending here.
+                return apiTestJSONResponse(#"{"pending": null}"#, for: request)
             default:
                 XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
                 throw URLError(.badURL)

--- a/HermesMobileTests/SessionRowAttentionStateTests.swift
+++ b/HermesMobileTests/SessionRowAttentionStateTests.swift
@@ -103,14 +103,41 @@ final class SessionRowAttentionStateTests: XCTestCase {
         let streaming = SessionSummary(sessionId: "s", activeStreamId: "stream-1")
 
         XCTAssertEqual(
-            SessionRowView.effectiveAttentionState(for: streaming, attentionState: nil),
+            SessionRowView.effectiveAttentionState(
+                for: streaming,
+                attentionState: nil,
+                isViewingCachedData: false
+            ),
             .working
         )
         XCTAssertNil(
             SessionRowView.effectiveAttentionState(
                 for: SessionSummary(sessionId: "s"),
-                attentionState: nil
+                attentionState: nil,
+                isViewingCachedData: false
             )
+        )
+    }
+
+    /// A cached summary keeps the stream fields it was captured with, so an
+    /// offline row must not say the agent is working.
+    func testCachedRowDoesNotFallBackToWorking() {
+        let streaming = SessionSummary(sessionId: "s", activeStreamId: "stream-1")
+
+        XCTAssertNil(
+            SessionRowView.effectiveAttentionState(
+                for: streaming,
+                attentionState: nil,
+                isViewingCachedData: true
+            )
+        )
+        XCTAssertEqual(
+            SessionRowView.accessibilityStateLabels(for: streaming, isViewingCachedData: true),
+            ["Cached"]
+        )
+        XCTAssertEqual(
+            SessionRowView.accessibilityStateLabels(for: streaming, isViewingCachedData: false),
+            ["Working"]
         )
     }
 
@@ -221,6 +248,43 @@ final class SessionRowAttentionStateTests: XCTestCase {
         XCTAssertTrue(viewModel.attentionStatesBySessionID.isEmpty)
     }
 
+    /// A probe that fails is not an answer. A tick that cannot reach the server
+    /// keeps the row's known Approval instead of demoting it to Working.
+    @MainActor
+    func testFailedApprovalProbeKeepsTheKnownApprovalState() async throws {
+        let approvalProbes = LockedCounter()
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path ?? "" {
+            case "/api/sessions":
+                return apiTestJSONResponse("""
+                {"sessions": [{"session_id": "waiting", "title": "Waiting", "active_stream_id": "stream-waiting"}]}
+                """, for: request)
+            case "/api/chat/stream/status":
+                return apiTestJSONResponse(#"{"active": true}"#, for: request)
+            case "/api/approval/pending":
+                guard approvalProbes.increment() == 1 else {
+                    return apiTestJSONResponse(#"{"error": "boom"}"#, for: request, status: 500)
+                }
+
+                return apiTestJSONResponse("""
+                {"pending": {"approval_id": "ap-1"}, "pending_count": 1}
+                """, for: request)
+            case "/api/clarify/pending":
+                return apiTestJSONResponse(#"{"pending": null}"#, for: request)
+            default:
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+
+        await viewModel.load()
+        await viewModel.refreshActiveSessionStatesIfNeeded(streamIDs: ["stream-waiting"])
+        XCTAssertEqual(viewModel.attentionStatesBySessionID, ["waiting": .approval])
+
+        await viewModel.refreshActiveSessionStatesIfNeeded(streamIDs: ["stream-waiting"])
+
+        XCTAssertEqual(viewModel.attentionStatesBySessionID, ["waiting": .approval])
+    }
+
     // MARK: - Helpers
 
     @MainActor
@@ -259,6 +323,22 @@ private final class RequestCounts: @unchecked Sendable {
         defer { lock.unlock() }
 
         return counts["\(path)|\(sessionID)"] ?? 0
+    }
+}
+
+/// Counts calls from the mock's loading queue, so a handler can answer the
+/// first probe differently from the ones after it.
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    /// Returns the new count, so `== 1` means "this was the first call".
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+
+        value += 1
+        return value
     }
 }
 

--- a/HermesMobileTests/SessionRowAttentionStateTests.swift
+++ b/HermesMobileTests/SessionRowAttentionStateTests.swift
@@ -1,0 +1,281 @@
+import XCTest
+@testable import HermesMobile
+
+/// The session row's attention state: the pure precedence rule, and the bound
+/// on how often the list asks the server about it.
+final class SessionRowAttentionStateTests: XCTestCase {
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    // MARK: - Resolver
+
+    func testApprovalBeatsInputAndWorking() {
+        let streaming = SessionSummary(sessionId: "s", activeStreamId: "stream-1")
+
+        XCTAssertEqual(
+            SessionRowAttentionState.resolve(
+                session: streaming,
+                hasPendingApproval: true,
+                hasPendingClarification: true
+            ),
+            .approval
+        )
+    }
+
+    func testInputBeatsWorking() {
+        let streaming = SessionSummary(sessionId: "s", isStreaming: true)
+
+        XCTAssertEqual(
+            SessionRowAttentionState.resolve(
+                session: streaming,
+                hasPendingApproval: false,
+                hasPendingClarification: true
+            ),
+            .input
+        )
+    }
+
+    func testActiveStreamWithNothingPendingResolvesToWorking() {
+        let streaming = SessionSummary(sessionId: "s", isStreaming: true)
+
+        XCTAssertEqual(
+            SessionRowAttentionState.resolve(
+                session: streaming,
+                hasPendingApproval: false,
+                hasPendingClarification: false
+            ),
+            .working
+        )
+    }
+
+    func testIdleSessionWithNothingPendingResolvesToReady() {
+        XCTAssertNil(
+            SessionRowAttentionState.resolve(
+                session: SessionSummary(sessionId: "s"),
+                hasPendingApproval: false,
+                hasPendingClarification: false
+            )
+        )
+    }
+
+    /// The resolver is pure: the "only ask about streaming rows" bound lives in
+    /// the view model, not here.
+    func testPendingApprovalOnIdleSessionStillResolvesToApproval() {
+        XCTAssertEqual(
+            SessionRowAttentionState.resolve(
+                session: SessionSummary(sessionId: "s"),
+                hasPendingApproval: true,
+                hasPendingClarification: false
+            ),
+            .approval
+        )
+    }
+
+    // MARK: - Row presentation
+
+    /// VoiceOver reads the state once, in place of the old "Streaming" label.
+    func testAccessibilityStateLabelsReadTheAttentionState() {
+        let session = SessionSummary(sessionId: "s", pinned: true, activeStreamId: "stream-1")
+
+        XCTAssertEqual(
+            SessionRowView.accessibilityStateLabels(
+                for: session,
+                isViewingCachedData: false,
+                attentionState: .approval
+            ),
+            ["Waiting for approval", "Pinned"]
+        )
+        XCTAssertEqual(
+            SessionRowView.accessibilityStateLabels(
+                for: session,
+                isViewingCachedData: false,
+                attentionState: .input
+            ),
+            ["Needs input", "Pinned"]
+        )
+    }
+
+    /// A screen that does not poll (Archived) passes no state, and a streaming
+    /// row still reads and shows Working.
+    func testRowWithoutSuppliedStateFallsBackToTheSessionsOwnStream() {
+        let streaming = SessionSummary(sessionId: "s", activeStreamId: "stream-1")
+
+        XCTAssertEqual(
+            SessionRowView.effectiveAttentionState(for: streaming, attentionState: nil),
+            .working
+        )
+        XCTAssertNil(
+            SessionRowView.effectiveAttentionState(
+                for: SessionSummary(sessionId: "s"),
+                attentionState: nil
+            )
+        )
+    }
+
+    // MARK: - View model bound
+
+    @MainActor
+    func testRefreshChecksPendingStateOncePerStreamingSessionAndSkipsIdleRows() async throws {
+        let counts = RequestCounts()
+        let viewModel = try makeViewModel { request in
+            let path = request.url?.path ?? ""
+            let sessionID = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?
+                .first(where: { $0.name == "session_id" })?
+                .value
+
+            counts.record(path: path, sessionID: sessionID)
+
+            switch path {
+            case "/api/sessions":
+                return apiTestJSONResponse("""
+                {
+                  "sessions": [
+                    {"session_id": "waiting", "title": "Waiting", "active_stream_id": "stream-waiting"},
+                    {"session_id": "busy", "title": "Busy", "active_stream_id": "stream-busy"},
+                    {"session_id": "idle", "title": "Idle"}
+                  ]
+                }
+                """, for: request)
+            case "/api/chat/stream/status":
+                return apiTestJSONResponse(#"{"active": true}"#, for: request)
+            case "/api/approval/pending":
+                guard sessionID == "waiting" else {
+                    return apiTestJSONResponse(#"{"pending": null}"#, for: request)
+                }
+
+                return apiTestJSONResponse("""
+                {"pending": {"approval_id": "ap-1", "command": "rm -rf build"}, "pending_count": 1}
+                """, for: request)
+            case "/api/clarify/pending":
+                return apiTestJSONResponse(#"{"pending": null}"#, for: request)
+            default:
+                XCTFail("Unexpected request to \(path)")
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+
+        let loaded = await viewModel.load()
+        XCTAssertTrue(loaded)
+
+        let result = await viewModel.refreshActiveSessionStatesIfNeeded(
+            streamIDs: ["stream-waiting", "stream-busy"]
+        )
+
+        XCTAssertEqual(result, .unchanged)
+        XCTAssertEqual(
+            viewModel.attentionStatesBySessionID,
+            ["waiting": .approval, "busy": .working]
+        )
+        XCTAssertEqual(viewModel.attentionState(for: SessionSummary(sessionId: "waiting")), .approval)
+        XCTAssertEqual(viewModel.attentionState(for: SessionSummary(sessionId: "busy")), .working)
+        XCTAssertNil(viewModel.attentionState(for: SessionSummary(sessionId: "idle")))
+
+        // Exactly one probe of each kind per streaming session, and none at all
+        // for the session without an active stream.
+        XCTAssertEqual(counts.count(path: "/api/approval/pending", sessionID: "waiting"), 1)
+        XCTAssertEqual(counts.count(path: "/api/approval/pending", sessionID: "busy"), 1)
+        XCTAssertEqual(counts.count(path: "/api/approval/pending", sessionID: "idle"), 0)
+        XCTAssertEqual(counts.count(path: "/api/clarify/pending", sessionID: "waiting"), 1)
+        XCTAssertEqual(counts.count(path: "/api/clarify/pending", sessionID: "busy"), 1)
+        XCTAssertEqual(counts.count(path: "/api/clarify/pending", sessionID: "idle"), 0)
+    }
+
+    /// A reload that drops a session's stream must drop its attention entry, or
+    /// a finished row would keep claiming it wants something.
+    @MainActor
+    func testReloadClearsAttentionStateForSessionsThatStoppedStreaming() async throws {
+        let sessionsResponses = LockedQueue([
+            """
+            {"sessions": [{"session_id": "waiting", "title": "Waiting", "active_stream_id": "stream-waiting"}]}
+            """,
+            """
+            {"sessions": [{"session_id": "waiting", "title": "Waiting"}]}
+            """
+        ])
+        let viewModel = try makeViewModel { request in
+            switch request.url?.path ?? "" {
+            case "/api/sessions":
+                return apiTestJSONResponse(sessionsResponses.next(), for: request)
+            case "/api/approval/pending":
+                return apiTestJSONResponse("""
+                {"pending": {"approval_id": "ap-1"}, "pending_count": 1}
+                """, for: request)
+            case "/api/clarify/pending":
+                return apiTestJSONResponse(#"{"pending": null}"#, for: request)
+            case "/api/chat/stream/status":
+                return apiTestJSONResponse(#"{"active": true}"#, for: request)
+            default:
+                return apiTestJSONResponse("{}", for: request)
+            }
+        }
+
+        await viewModel.load()
+        await viewModel.refreshActiveSessionStatesIfNeeded(streamIDs: ["stream-waiting"])
+        XCTAssertEqual(viewModel.attentionStatesBySessionID, ["waiting": .approval])
+
+        await viewModel.load()
+
+        XCTAssertTrue(viewModel.attentionStatesBySessionID.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeViewModel(
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) throws -> SessionListViewModel {
+        MockURLProtocol.requestHandler = handler
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let server = try XCTUnwrap(URL(string: "https://example.test"))
+
+        return SessionListViewModel(
+            server: server,
+            client: APIClient(baseURL: server, session: session)
+        )
+    }
+}
+
+/// Request tallies written from the mock's loading queue and read from the test,
+/// so counting needs no sleeps.
+private final class RequestCounts: @unchecked Sendable {
+    private let lock = NSLock()
+    private var counts: [String: Int] = [:]
+
+    func record(path: String, sessionID: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        counts["\(path)|\(sessionID ?? "")", default: 0] += 1
+    }
+
+    func count(path: String, sessionID: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return counts["\(path)|\(sessionID)"] ?? 0
+    }
+}
+
+/// Scripted responses handed out in order, repeating the last one.
+private final class LockedQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String]
+
+    init(_ values: [String]) {
+        self.values = values
+    }
+
+    func next() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard values.count > 1 else { return values[0] }
+        return values.removeFirst()
+    }
+}


### PR DESCRIPTION
## Linked issue

None; maintainer-approved work without an issue.

## What changed

A streaming session row only said "Live", so the list never showed that the agent was stuck waiting on the user. The trailing slot of each row now shows one state label in place of the relative time: amber **Approval**, indigo **Input**, or sky **Working**. Ready rows keep the time. The label and the time never show together, so row height is unchanged.

- Precedence is approval → input → working → ready, in a pure `SessionRowAttentionState.resolve`.
- The list's existing one-second liveness tick now also asks each streaming session for pending approval and clarification (`/api/approval/pending`, `/api/clarify/pending`, both already used by the chat screen). Idle rows are never probed; there is no new polling loop or per-row timer. The state map is only reassigned when a value changes.
- The redundant "Live" badge is gone; the pulsing dot stays and still respects Reduce Motion.
- Colors are three semantic asset-catalog tokens with light and dark variants. VoiceOver reads "Working", "Waiting for approval", or "Needs input" once.
- A Failed state is deliberately not included: session rows carry no error field.

## How it was tested

- Focused XCTest via XcodeBuildMCP `test_sim` (iPhone 17): `SessionRowAttentionStateTests` (resolver precedence, VoiceOver labels, request bound with two streaming rows and one idle row), `SessionIdentityTests`, `SessionListMutationTests`, `LocalizationCatalogTests`. 103 passed, 0 failed.
- Manual simulator pass by the maintainer against the live server: Working → Approval → Working → Input → time; idle and cached rows show no label; VoiceOver, dark mode, largest Dynamic Type.

## Checklist

- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

Implemented by Claude Fable 5.1 (orchestration) and Claude Opus (implementation) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiRThRAsnd8jVii7v71Yc3
