### PR TITLE
fix(chat): unify corner radius of surfaces stacked above the composer

### DIFF
--- a/HermesMobile/Features/Chat/ChatActiveRunStatusView.swift
+++ b/HermesMobile/Features/Chat/ChatActiveRunStatusView.swift
@@ -20,7 +20,7 @@ struct ChatActiveRunStatusView: View {
         .padding(.vertical, 7)
         .chatTimelineAccessorySurface(
             fallbackMaterial: .regularMaterial,
-            cornerRadius: 16
+            in: Capsule(style: .continuous)
         )
         .fixedSize(horizontal: false, vertical: true)
         .accessibilityElement(children: .ignore)

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -2,6 +2,12 @@ import SwiftUI
 import UIKit
 import PhotosUI
 
+/// Shape metrics for the composer stack: the expanded composer card and every
+/// full-width surface stacked above it share this radius so they read as one set.
+enum ChatComposerMetrics {
+    static let cardCornerRadius: CGFloat = 26
+}
+
 private struct ComposerStatusView: View {
     let text: String
     let isError: Bool
@@ -66,7 +72,6 @@ struct MessageComposerView: View {
     /// t3code sizing: every circle in the composer is 44 pt, which is also the
     /// minimum hit target, so no invisible hit padding is needed.
     private let circleSize: CGFloat = 44
-    private let cardCornerRadius: CGFloat = 26
     private let pillInset: CGFloat = 5
 
     @Binding var draftMessage: String
@@ -649,7 +654,10 @@ struct MessageComposerView: View {
     }
 
     private var composerSurfaceShape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: isExpanded ? cardCornerRadius : (circleSize + pillInset * 2) / 2, style: .continuous)
+        RoundedRectangle(
+            cornerRadius: isExpanded ? ChatComposerMetrics.cardCornerRadius : (circleSize + pillInset * 2) / 2,
+            style: .continuous
+        )
     }
 
     /// The glass surface: one text view in both states so focus and the draft

--- a/HermesMobile/Features/Chat/ChatTimelineAccessorySurface.swift
+++ b/HermesMobile/Features/Chat/ChatTimelineAccessorySurface.swift
@@ -1,26 +1,26 @@
 import SwiftUI
 
-private struct ChatTimelineAccessorySurfaceModifier: ViewModifier {
+private struct ChatTimelineAccessorySurfaceModifier<SurfaceShape: Shape>: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
 
     let fallbackMaterial: Material
-    let cornerRadius: CGFloat
+    let shape: SurfaceShape
 
     func body(content: Content) -> some View {
         content
             .background(
                 Color(.secondarySystemBackground).opacity(colorScheme == .dark ? 0.28 : 0.48),
-                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                in: shape
             )
             .adaptiveGlass(
                 .regular,
                 isInteractive: false,
                 fallbackMaterial: fallbackMaterial,
-                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                in: shape
             )
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .clipShape(shape)
             .overlay {
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                shape
                     .stroke(Color(.separator).opacity(colorScheme == .dark ? 0.42 : 0.28), lineWidth: 0.5)
                     .allowsHitTesting(false)
             }
@@ -58,9 +58,21 @@ extension View {
         fallbackMaterial: Material,
         cornerRadius: CGFloat
     ) -> some View {
+        chatTimelineAccessorySurface(
+            fallbackMaterial: fallbackMaterial,
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        )
+    }
+
+    /// Shape-based entry point for accessories that are not a rounded rectangle,
+    /// such as the one-line run-status capsule.
+    func chatTimelineAccessorySurface(
+        fallbackMaterial: Material,
+        in shape: some Shape
+    ) -> some View {
         modifier(ChatTimelineAccessorySurfaceModifier(
             fallbackMaterial: fallbackMaterial,
-            cornerRadius: cornerRadius
+            shape: shape
         ))
     }
 

--- a/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptSupportingViews.swift
@@ -1177,9 +1177,9 @@ struct PinnedLocalNoticeStack: View {
                 }
                 .padding(12)
                 .background(.ultraThinMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: ChatComposerMetrics.cardCornerRadius, style: .continuous))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    RoundedRectangle(cornerRadius: ChatComposerMetrics.cardCornerRadius, style: .continuous)
                         .stroke(Color(.separator).opacity(0.45), lineWidth: 0.5)
                 )
             }

--- a/HermesMobile/Features/Chat/ClarificationRequestCard.swift
+++ b/HermesMobile/Features/Chat/ClarificationRequestCard.swift
@@ -150,7 +150,7 @@ struct ClarificationRequestBar: View {
         .padding(.trailing, 8)
         .padding(.vertical, 8)
         .frame(maxWidth: 560)
-        .clarificationSurface(cornerRadius: 22)
+        .clarificationSurface(cornerRadius: ChatComposerMetrics.cardCornerRadius)
         .accessibilityElement(children: .contain)
     }
 }
@@ -177,7 +177,7 @@ struct ClarificationRequestCard: View {
     var body: some View {
         cardContent
             .frame(maxWidth: 560, alignment: .leading)
-            .clarificationSurface(cornerRadius: 24)
+            .clarificationSurface(cornerRadius: ChatComposerMetrics.cardCornerRadius)
             // Ideal height regardless of what the bar-sized overlay proposes.
             .fixedSize(horizontal: false, vertical: true)
             .accessibilityElement(children: .contain)

--- a/HermesMobile/Features/Chat/FilePathAutocompleteView.swift
+++ b/HermesMobile/Features/Chat/FilePathAutocompleteView.swift
@@ -43,9 +43,9 @@ struct FilePathAutocompleteView: View {
         .adaptiveGlass(
             .regular,
             fallbackMaterial: .ultraThinMaterial,
-            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+            in: RoundedRectangle(cornerRadius: ChatComposerMetrics.cardCornerRadius, style: .continuous)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: ChatComposerMetrics.cardCornerRadius, style: .continuous))
         .shadow(color: Color.black.opacity(0.15), radius: 12, y: 4)
         .frame(height: panelHeight)
         .task(id: query) {

--- a/HermesMobile/Features/Chat/SlashCommandAutocompleteView.swift
+++ b/HermesMobile/Features/Chat/SlashCommandAutocompleteView.swift
@@ -47,9 +47,9 @@ struct SlashCommandAutocompleteView: View {
         .adaptiveGlass(
             .regular,
             fallbackMaterial: .ultraThinMaterial,
-            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+            in: RoundedRectangle(cornerRadius: ChatComposerMetrics.cardCornerRadius, style: .continuous)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: ChatComposerMetrics.cardCornerRadius, style: .continuous))
         .shadow(color: Color.black.opacity(0.15), radius: 12, y: 4)
         .frame(height: panelHeight(for: results, parsed: parsed))
         .task(id: rankingInput) {


### PR DESCRIPTION
## Linked issue

Fixes #410

## What changed

With `/` or `@` typed, the panel above the composer had visibly tighter corners than the composer card. The clarification card, the "Steering hint delivered." notice, and the "Working for…" pill each used their own radius too, so the bottom stack read as a set of unrelated shapes.

The composer's private 26pt radius is now a shared `ChatComposerMetrics.cardCornerRadius`, and every full-width surface stacked above the composer reads it for its glass shape, clip, and stroke: the slash panel, the file panel, both clarification card states, and the pinned notice stack. The one-line run-status pill becomes a continuous capsule, matching the approval-bypass and jump-to-bottom pills beside it.

To draw that capsule, the shared `chatTimelineAccessorySurface` modifier gained a `Shape`-based overload; the existing `cornerRadius:` entry point forwards to it, so its other caller (the marker card) is unchanged.

Unchanged: the collapsed composer pill, transcript bubbles, tool and marker cards, the attachment strip and chips, the composer status banner, and the approval dialog.

## How it was tested

- Full XCTest suite via XcodeBuildMCP `test_sim` (scheme `HermesMobile`, iPhone 17): 2262 passed, 0 failed, 2 skipped.
- `grep cornerRadius` across the touched files confirms no literal radius remains for the in-scope surfaces.
- Owner manual check on the simulator: type `/` then `@` and compare panel corners to the composer; send a steering hint during a run; open and collapse a clarification prompt; confirm the "Working for…" pill is a capsule; repeat one in dark mode.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no networking changes)

Implemented by the `hermes-implementer` agent (Claude Opus) orchestrated by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiRThRAsnd8jVii7v71Yc3