### PR TITLE
docs: correct i18n serializer, catalog membership, plural sets, and TestFlight shutdown guidance

### DIFF
--- a/TESTFLIGHT.md
+++ b/TESTFLIGHT.md
@@ -186,11 +186,16 @@ xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destinatio
 xcodebuild -project HermesMobile.xcodeproj -scheme HermesMobile -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
 ```
 
-If simulator launch is stale:
+If simulator launch is stale, shut down only the exact simulator you are
+about to use. Never run `simctl shutdown all`; a global shutdown is an
+owner-only manual action (AGENTS.md, "The three ways to hurt yourself").
+Capture the UDID, then test against that exact device:
 
 ```zsh
-xcrun simctl shutdown all
-xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'
+xcrun simctl list devices available
+# copy the exact UDID of the iPhone you will test on, then:
+xcrun simctl shutdown <udid>
+xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'id=<udid>'
 ```
 
 Exit criteria:
@@ -292,7 +297,7 @@ Version-train rule: once a version is approved for the App Store, Apple closes i
 - Bump `MARKETING_VERSION` (in `HermesMobile.xcodeproj/project.pbxproj`, all entries) on `master` right after each App Store release goes live, so the next upload always targets an open train.
 - The workflow preflights the train against App Store Connect before archiving (`ENFORCE_OPEN_TRAIN` in `ci/select_testflight_build_number.rb`) and fails in seconds with a bump instruction if the train is closed.
 
-Workflow path, if implemented:
+Workflow path (`.github/workflows/external-testflight.yml`, see Step 3):
 
 1. Run `External TestFlight` from GitHub Actions.
 2. Select `master`.

--- a/docs/agents/i18n.md
+++ b/docs/agents/i18n.md
@@ -1,9 +1,18 @@
 # Localization (String Catalog) — agent notes
 
 Hermex ships one String Catalog, `HermesMobile/Resources/Localizable.xcstrings`,
-included in the app, widget, and share-extension targets. Every user-facing
-literal is already externalized (`String(localized:)` / `LocalizedStringKey`), so
-adding a language is normally **translation-only** — no Swift edits.
+bundled in the app and Live Activity widget targets only. The Share Extension
+does not bundle it. Its five user-facing status strings are hardcoded English
+literals in `ShareViewController.swift`, so the share UI stays English.
+Localizing the extension requires deliberately adding the catalog to that
+target, then verifying the share UI in each language; that is a maintainer
+decision, not a default. In the app, every user-facing literal is already
+externalized (`String(localized:)` / `LocalizedStringKey`), so adding a
+language is normally **translation-only**, with no Swift edits. The widget is
+not quite there: its dynamic status strings (`activityText` and `excerptText`
+in `AgentRunLiveActivityWidget.swift`) flow through plain `String` values,
+which `Text` does not localize, and "Response is ready to review." /
+"Waiting for the next agent update." are not in the catalog at all.
 
 This file holds the non-obvious mechanics. It is not a tutorial.
 
@@ -22,38 +31,57 @@ string that never reaches the catalog is silently English-only forever.
 
 Tests are pinned to `en` in the scheme's TestAction. Do not change that.
 
-## Catalog file format is Xcode-exact
+## Catalog file format
 
-`Localizable.xcstrings` must round-trip byte-identically or every unrelated
-language churns in the diff. Xcode's serialization is:
+No `json.dumps` variant reproduces the catalog byte-for-byte, so do not claim
+a serializer. The file mixes Xcode's compact grouped style (several objects
+packed on one line) with expanded entries, and `strings` is in grouped-append
+order, not sorted; any full-file rewrite churns every unrelated language in
+the diff. A canonical full-file formatter would have to be added and tested
+byte-for-byte against the current catalog first.
 
-```python
-json.dumps(d, ensure_ascii=False, indent=2, sort_keys=True, separators=(',', ' : ')) + "\n"
-```
+The safe edit procedure is targeted insertion:
 
-Two traps:
-
-- **Do not rewrite the whole file** with a naive `json.dump` — it reorders keys.
-  Entries are in grouped-append order, not sorted. For a small batch of new
-  keys, append serialized entries (2-space indent, `" : "` separators) directly
-  before the `\n  },\n  "version" : "1.0"\n}` tail anchor.
-- **Verify with a parsed-subtree diff**, never the raw line diff. The raw diff
-  churns from key reordering even when nothing semantically changed. Assert that
-  no pre-existing language's parsed subtree changed.
+1. **Parse and validate** the JSON before touching bytes; fail closed on
+   malformed JSON.
+2. **Make a targeted insertion** that preserves every untouched byte, key
+   order, and formatting. For new keys, insert `,"\n    "<key>" : <entry>`
+   directly before the `\n  },\n  "version" : "1.0"\n}` tail anchor: the
+   leading comma joins the new entry to the last existing one, which has no
+   trailing comma of its own. `strings` members sit at 4-space indent with
+   2-space steps for nested content; match that, and use `" : "` separators.
+3. **Parse before and after**, then diff the parsed subtrees; never trust the
+   raw line diff, which churns from formatting even when nothing semantically
+   changed. Assert that only the intended keys/languages changed and that no
+   pre-existing language's parsed subtree changed.
 
 ## Plural categories differ per language
 
 The catalog's plural keys need the correct CLDR category set. Author these by
-hand — do not delegate them:
+hand; do not delegate them. There is no safe language-family shortcut
+("Romance" is not a rule: Romanian has `few`). Derive the category set per
+locale from current Apple/CLDR tooling, such as Xcode's plural variations
+editor or the current CLDR cardinal rules, for every locale you touch, and
+re-verify whenever a locale is added.
 
-| Languages | Categories |
-|---|---|
-| Romance, German, Dutch, Turkish | `one`, `other` |
-| Polish, Russian | `one`, `few`, `many`, `other` |
-| Japanese, Chinese, Korean | `other` only |
-| Arabic | `zero`, `one`, `two`, `few`, `many`, `other` |
-| Hebrew | `one`, `two`, `many`, `other` |
-| Urdu | `one`, `other` |
+The sets for the currently shipped locales, verified against current CLDR
+cardinal rules:
+
+| Locale | Categories | Notes |
+|---|---|---|
+| `de`, `en`, `nl`, `tr`, `ur` | `one`, `other` | |
+| `es`, `fr`, `it`, `pt-BR` | `one`, `many`, `other` | `many` fires only at exact multiples of 1,000,000 or compact notation, so the catalog's `one`/`other`-only entries still cover ordinary counters; include `many` in new keys |
+| `he` | `one`, `two`, `other` | Hebrew cardinal `many` was removed in CLDR 42 (2022) |
+| `pl`, `ru` | `one`, `few`, `many`, `other` | |
+| `ar` | `zero`, `one`, `two`, `few`, `many`, `other` | |
+| `ja`, `ko`, `zh-Hans`, `zh-Hant`, `zh-HK` | `other` only | |
+
+The catalog does not match these sets everywhere yet. Eleven Hebrew plural
+keys carry a `many` variation authored under the pre-CLDR-42 rule set; it is
+dead, the runtime can never select it, and it is byte-identical to `other` in
+every case. Other keys are missing categories or carry dead duplicates. Do
+not preserve or copy any of it: the table above is the source of truth, not
+existing entries.
 
 ## Locale-aware casing
 


### PR DESCRIPTION
Fixes #308

## What changed

Documentation-only correction of the four authority defects from #308. No Swift, catalog, or project-file changes; nothing reopens the #305 consolidation. (Cross-link for #305 readers: this PR resolves the four factual corrections that review surfaced.)

1. **Removed the false String Catalog serializer claim** (`docs/agents/i18n.md`). The doc claimed a `json.dumps` one-liner reproduces `Localizable.xcstrings` byte-identically. Verified false: both `sort_keys` variants produce ~4.0 MB against the real ~3.8 MB; the file mixes compact grouped lines with expanded entries and its `strings` keys are in grouped-append order, so no `json.dumps` variant can round-trip it. Replaced with the issue's safe procedure: parse/validate, targeted insertion preserving untouched bytes (with the exact working insertion, leading comma included), and a parsed before/after subtree diff asserting only intended keys/languages changed.
2. **Corrected catalog target membership** (`docs/agents/i18n.md`). Verified in `project.pbxproj`: the catalog ships in the app and Live Activity widget only; the Share Extension's Resources phase contains only `PrivacyInfo.xcprivacy`, and its five status strings are hardcoded English literals. The doc now says exactly that and states the Share Extension localization policy.
3. **Replaced the unsafe plural-category family table** (`docs/agents/i18n.md`). "Romance, German, Dutch, Turkish → one, other" and "Hebrew → one, two, many, other" are stale: `es`/`fr`/`it`/`pt-BR` gained `many` in 2021, Hebrew cardinal `many` was removed in CLDR 42 (2022), and Romanian has `few`, so family shortcuts mislead. Replaced with verified per-locale sets for all 18 shipped locales, a derive-and-verify instruction per locale, and a note that the 11 existing Hebrew `many` variations are dead (byte-identical to `other`) and must not be preserved or copied.
4. **Reconciled TESTFLIGHT.md with AGENTS.md.** Step 7's `xcrun simctl shutdown all` now targets the exact captured simulator UDID and retests against `id=<udid>`. Step 12's "Workflow path, if implemented:" now names `.github/workflows/external-testflight.yml`, which exists and is active per Step 3.

## How it was tested

- Every corrected claim was re-verified programmatically before editing: serializer round-trip attempt (both `sort_keys` variants fail), Resources-phase membership in `project.pbxproj`, an 18-locale plural audit against current CLDR cardinal rules (incl. the Hebrew `many` entries), the working catalog-insertion recipe (parse-tested), and workflow existence. `git diff --check` is clean.
- The full `xcodebuild test` suite was not run: the authoring machine has Xcode Command Line Tools only. This diff touches two markdown files and no build inputs. By design, `pr-ci.yml`'s docs-only path skips the macOS Build and Test job for exactly this change; the required "CI Gate" check still runs and passes on a legitimate skip. Happy to run the full suite on request if the maintainer prefers a non-skipped run.

## Checklist

- [ ] The full test suite passes locally — not run; docs-only diff (two markdown files), no Xcode on the authoring machine, and CI's docs-only path skips the suite by design. Maintainer can request a full run.
- [x] New/changed `Codable` models decode tolerantly — N/A, no code or models changed.
- [x] No new third-party dependencies.
- [x] No invented API endpoints or JSON shapes — every documentation claim was verified against the tree and current CLDR data.

Built with an AI coding agent (Prime Agent, GLM).

After merge, I will comment the correction link on #305 per the issue's acceptance note.
