### PR TITLE
feat: add Files entry to the main screen session list

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		C15210000000000000000006 /* OnboardingConnectPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000006 /* OnboardingConnectPage.swift */; };
 		C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000007 /* OnboardingFlowTests.swift */; };
 		C0391000000000000000000F /* SessionListMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0390000000000000000000F /* SessionListMutationTests.swift */; };
+		C039100000000000000000A9 /* SessionListUsableSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C039000000000000000000A9 /* SessionListUsableSessionTests.swift */; };
 		C03910000000000000000019 /* SessionRowAttentionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03900000000000000000019 /* SessionRowAttentionStateTests.swift */; };
 		A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10900000000000000000012 /* SessionNavigationStateTests.swift */; };
 		19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */; };
@@ -542,6 +543,7 @@
 		C15200000000000000000006 /* OnboardingConnectPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConnectPage.swift; sourceTree = "<group>"; };
 		C15200000000000000000007 /* OnboardingFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowTests.swift; sourceTree = "<group>"; };
 		C0390000000000000000000F /* SessionListMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListMutationTests.swift; sourceTree = "<group>"; };
+		C039000000000000000000A9 /* SessionListUsableSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListUsableSessionTests.swift; sourceTree = "<group>"; };
 		C03900000000000000000019 /* SessionRowAttentionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowAttentionStateTests.swift; sourceTree = "<group>"; };
 		A10900000000000000000012 /* SessionNavigationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNavigationStateTests.swift; sourceTree = "<group>"; };
 		19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CliSessionsSyncModelTests.swift; sourceTree = "<group>"; };
@@ -1011,6 +1013,7 @@
 					C14600000000000000000001 /* ChatToolbarHeaderTests.swift */,
 					C15200000000000000000007 /* OnboardingFlowTests.swift */,
 				C0390000000000000000000F /* SessionListMutationTests.swift */,
+				C039000000000000000000A9 /* SessionListUsableSessionTests.swift */,
 				C03900000000000000000019 /* SessionRowAttentionStateTests.swift */,
 				A10900000000000000000012 /* SessionNavigationStateTests.swift */,
 				19C1150000000000000000A4 /* CliSessionsSyncModelTests.swift */,
@@ -2065,6 +2068,7 @@
 					C14600000000000000000002 /* ChatToolbarHeaderTests.swift in Sources */,
 					C15210000000000000000007 /* OnboardingFlowTests.swift in Sources */,
 				C0391000000000000000000F /* SessionListMutationTests.swift in Sources */,
+				C039100000000000000000A9 /* SessionListUsableSessionTests.swift in Sources */,
 				C03910000000000000000019 /* SessionRowAttentionStateTests.swift in Sources */,
 				A10900000000000000000002 /* SessionNavigationStateTests.swift in Sources */,
 				19C1150000000000000000A3 /* CliSessionsSyncModelTests.swift in Sources */,

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -302,6 +302,7 @@ enum SectionVisibilitySettings {
     static let skillsKey = "sectionVisibility.skills"
     static let memoryKey = "sectionVisibility.memory"
     static let insightsKey = "sectionVisibility.insights"
+    static let filesKey = "sectionVisibility.files"
     static let activeProfileKey = "sectionVisibility.activeProfile"
     static let projectsKey = "sectionVisibility.projects"
     static let chatFilesKey = "sectionVisibility.chatFiles"

--- a/HermesMobile/Features/SessionList/SessionListComponents.swift
+++ b/HermesMobile/Features/SessionList/SessionListComponents.swift
@@ -83,6 +83,7 @@ struct SidebarSectionVisibility: Equatable {
     var skills: Bool
     var memory: Bool
     var insights: Bool
+    var files: Bool
     var activeProfile: Bool
     var projects: Bool
 
@@ -93,14 +94,15 @@ struct SidebarSectionVisibility: Equatable {
         skills: true,
         memory: true,
         insights: true,
+        files: true,
         activeProfile: true,
         projects: true
     )
 
-    /// The five plain links share one List row, so that row is dropped entirely
+    /// The six plain links share one List row, so that row is dropped entirely
     /// once all of them are hidden rather than leaving an empty padded gap.
     var showsAnyUtilityLink: Bool {
-        tasks || kanban || skills || memory || insights
+        tasks || kanban || skills || memory || insights || files
     }
 }
 
@@ -205,6 +207,12 @@ struct SessionSidebarUtilityRows: View {
             if sectionVisibility.memory {
                 SidebarNavButton(title: String(localized: "Memory"), assetImage: "LucideBrain") {
                     openDestination(.memory)
+                }
+            }
+
+            if sectionVisibility.files {
+                SidebarNavButton(title: String(localized: "Files"), assetImage: "LucideFolder") {
+                    openDestination(.files)
                 }
             }
 

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -59,6 +59,7 @@ struct SessionListView: View {
     @AppStorage(SectionVisibilitySettings.skillsKey) private var showsSkillsSection = true
     @AppStorage(SectionVisibilitySettings.memoryKey) private var showsMemorySection = true
     @AppStorage(SectionVisibilitySettings.insightsKey) private var showsInsightsSection = true
+    @AppStorage(SectionVisibilitySettings.filesKey) private var showsFilesSection = true
     @AppStorage(SectionVisibilitySettings.activeProfileKey) private var showsActiveProfileSection = true
     @AppStorage(SectionVisibilitySettings.projectsKey) private var showsProjectsSection = true
     // Per-server key (#19): the CLI toggle mirrors the active server's
@@ -428,6 +429,8 @@ struct SessionListView: View {
                 MemoryView(server: server, onAPIError: authManager.handleAPIError)
             case .insights:
                 InsightsView(server: server, onAPIError: authManager.handleAPIError)
+            case .files:
+                FilesDestinationView(server: server, viewModel: viewModel, onAPIError: authManager.handleAPIError)
             case .archived:
                 ArchivedSessionsView(server: server, onAPIError: authManager.handleAPIError)
             case .scheduled:
@@ -771,6 +774,7 @@ struct SessionListView: View {
             skills: showsSkillsSection,
             memory: showsMemorySection,
             insights: showsInsightsSection,
+            files: showsFilesSection,
             activeProfile: showsActiveProfileSection,
             projects: showsProjectsSection
         )
@@ -1484,11 +1488,39 @@ enum SessionListUtilityDestination: Hashable, Identifiable {
     case skills
     case memory
     case insights
+    /// Workspace file browser, reachable from the main screen. The WebUI file
+    /// API is session-scoped, so the browser binds to the most recent usable
+    /// session.
+    case files
     /// Archived sessions screen (issue #17), also reachable from Settings.
     case archived
     case scheduled
 
     var id: Self { self }
+}
+
+/// Main-screen Files entry: the workspace file browser bound to the most
+/// recent usable session. The WebUI file API is session-scoped (there is no
+/// session-less file listing yet), so the browser needs a session to read
+/// through; on single-workspace servers every session shows the same files.
+private struct FilesDestinationView: View {
+    let server: URL
+    let viewModel: SessionListViewModel
+    let onAPIError: (Error) -> Void
+
+    var body: some View {
+        Group {
+            if let session = viewModel.mostRecentUsableSession {
+                FileBrowserView(session: session, server: server, onAPIError: onAPIError)
+            } else {
+                ContentUnavailableView {
+                    Label("No Session Yet", systemImage: "folder")
+                } description: {
+                    Text("Files browses your server's workspace through a session. Start a chat first, then open Files from here.")
+                }
+            }
+        }
+    }
 }
 
 private struct SessionSearchTaskID: Hashable {

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -1511,7 +1511,16 @@ private struct FilesDestinationView: View {
     var body: some View {
         Group {
             if let session = viewModel.mostRecentUsableSession {
+                // Identified by session: the file API is session-scoped, so a
+                // refresh that swaps `mostRecentUsableSession` has to rebuild the
+                // browser rather than let its existing state keep reading the
+                // previous session's workspace.
                 FileBrowserView(session: session, server: server, onAPIError: onAPIError)
+                    .id(session.sessionId)
+            } else if isLoadingSessions {
+                // Without this the first load reads as "No Session Yet" before the
+                // session list has answered.
+                ProgressView("Loading sessions...")
             } else {
                 ContentUnavailableView {
                     Label("No Session Yet", systemImage: "folder")
@@ -1520,6 +1529,13 @@ private struct FilesDestinationView: View {
                 }
             }
         }
+        // FileBrowserView titles itself, but the loading and empty states show
+        // without it.
+        .navigationTitle("Files")
+    }
+
+    private var isLoadingSessions: Bool {
+        viewModel.isLoading && viewModel.sessions.isEmpty
     }
 }
 

--- a/HermesMobile/Features/SessionList/SessionListViewModel.swift
+++ b/HermesMobile/Features/SessionList/SessionListViewModel.swift
@@ -46,6 +46,18 @@ enum ActiveSessionStateRefreshResult: Equatable {
 @Observable
 final class SessionListViewModel {
     private(set) var sessions: [SessionSummary] = []
+
+    /// Newest session that can drive the workspace file browser: has a session
+    /// id, and a workspace binding is preferred (the file browser reads the
+    /// workspace of whatever session it is handed). Falls back to the newest
+    /// session even without a workspace so the Files entry still opens.
+    var mostRecentUsableSession: SessionSummary? {
+        let usable = sessions.filter { ($0.sessionId ?? "").isEmpty == false }
+        guard !usable.isEmpty else { return nil }
+        let newest = usable.sorted { timestamp(for: $0) > timestamp(for: $1) }
+        return newest.first { $0.workspace != nil } ?? newest.first
+    }
+
     private(set) var isLoading = false
     private(set) var isCreatingSession = false
     private(set) var isCreatingProject = false

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -89,6 +89,7 @@ struct SettingsView: View {
     @AppStorage(SectionVisibilitySettings.kanbanKey) private var showsKanbanSection = true
     @AppStorage(SectionVisibilitySettings.skillsKey) private var showsSkillsSection = true
     @AppStorage(SectionVisibilitySettings.memoryKey) private var showsMemorySection = true
+    @AppStorage(SectionVisibilitySettings.filesKey) private var showsFilesSection = true
     @AppStorage(SectionVisibilitySettings.insightsKey) private var showsInsightsSection = true
     @AppStorage(SectionVisibilitySettings.activeProfileKey) private var showsActiveProfileSection = true
     @AppStorage(SectionVisibilitySettings.projectsKey) private var showsProjectsSection = true
@@ -362,6 +363,14 @@ struct SettingsView: View {
                         title: String(localized: "Memory"),
                         systemImage: "brain",
                         isOn: $showsMemorySection
+                    )
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        title: String(localized: "Files"),
+                        systemImage: "folder",
+                        isOn: $showsFilesSection
                     )
 
                     SettingsDivider()

--- a/HermesMobileTests/SessionIdentityTests.swift
+++ b/HermesMobileTests/SessionIdentityTests.swift
@@ -384,6 +384,7 @@ final class SectionVisibilitySettingsTests: XCTestCase {
         SectionVisibilitySettings.skillsKey,
         SectionVisibilitySettings.memoryKey,
         SectionVisibilitySettings.insightsKey,
+        SectionVisibilitySettings.filesKey,
         SectionVisibilitySettings.activeProfileKey,
         SectionVisibilitySettings.projectsKey,
         SectionVisibilitySettings.chatFilesKey,
@@ -444,6 +445,7 @@ final class SidebarSectionVisibilityTests: XCTestCase {
         XCTAssertTrue(visibility.skills)
         XCTAssertTrue(visibility.memory)
         XCTAssertTrue(visibility.insights)
+        XCTAssertTrue(visibility.files)
         XCTAssertTrue(visibility.activeProfile)
         XCTAssertTrue(visibility.projects)
         XCTAssertTrue(visibility.showsAnyUtilityLink)
@@ -455,17 +457,19 @@ final class SidebarSectionVisibilityTests: XCTestCase {
         visibility.kanban = false
         visibility.skills = false
         visibility.memory = false
+        visibility.files = false
 
         XCTAssertTrue(visibility.showsAnyUtilityLink)
     }
 
-    func testUtilityLinkRowDropsOnlyWhenAllFiveAreHidden() {
+    func testUtilityLinkRowDropsOnlyWhenAllLinksAreHidden() {
         var visibility = SidebarSectionVisibility.showAll
         visibility.tasks = false
         visibility.kanban = false
         visibility.skills = false
         visibility.memory = false
         visibility.insights = false
+        visibility.files = false
 
         XCTAssertFalse(visibility.showsAnyUtilityLink)
     }

--- a/HermesMobileTests/SessionListUsableSessionTests.swift
+++ b/HermesMobileTests/SessionListUsableSessionTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import HermesMobile
+
+/// Covers `SessionListViewModel.mostRecentUsableSession`, the session the Files
+/// browser binds to in order to read a workspace. Picking the wrong one silently
+/// browses another workspace's files, so each rule gets its own case.
+final class SessionListUsableSessionTests: XCTestCase {
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func testPrefersTheNewestSessionThatCarriesAWorkspace() async throws {
+        let viewModel = try makeViewModel([
+            session(id: "older-with-workspace", title: "Older", workspace: "alpha", lastMessageAt: 100),
+            session(id: "newer-without-workspace", title: "Newer", lastMessageAt: 200)
+        ])
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.mostRecentUsableSession?.sessionId, "older-with-workspace")
+    }
+
+    @MainActor
+    func testFallsBackToTheNewestSessionWhenNoSessionCarriesAWorkspace() async throws {
+        let viewModel = try makeViewModel([
+            session(id: "older", title: "Older", lastMessageAt: 100),
+            session(id: "newer", title: "Newer", lastMessageAt: 200)
+        ])
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.mostRecentUsableSession?.sessionId, "newer")
+    }
+
+    @MainActor
+    func testOrdersCandidatesByLastMessageThenUpdatedThenCreated() async throws {
+        let viewModel = try makeViewModel([
+            session(id: "created-only", title: "Created", workspace: "alpha", createdAt: 500),
+            session(id: "updated", title: "Updated", workspace: "alpha", createdAt: 100, updatedAt: 600),
+            session(
+                id: "messaged",
+                title: "Messaged",
+                workspace: "alpha",
+                createdAt: 100,
+                updatedAt: 200,
+                lastMessageAt: 700
+            )
+        ])
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.mostRecentUsableSession?.sessionId, "messaged")
+    }
+
+    @MainActor
+    func testPrefersTheWorkspaceCarrierOverANewerSessionWithoutOne() async throws {
+        let viewModel = try makeViewModel([
+            session(id: "workspace", title: "Workspace", workspace: "alpha", createdAt: 100),
+            session(id: "newer-plain", title: "Newer plain", createdAt: 900)
+        ])
+
+        await viewModel.load()
+
+        XCTAssertEqual(viewModel.mostRecentUsableSession?.sessionId, "workspace")
+    }
+
+    @MainActor
+    func testIsNilWhenNoSessionHasAnIdentifier() async throws {
+        let viewModel = try makeViewModel([
+            session(id: nil, title: "No identifier", workspace: "alpha", lastMessageAt: 100),
+            session(id: "", title: "Blank identifier", workspace: "alpha", lastMessageAt: 200)
+        ])
+
+        await viewModel.load()
+
+        XCTAssertNil(viewModel.mostRecentUsableSession)
+    }
+
+    @MainActor
+    private func makeViewModel(_ sessionPayloads: [String]) throws -> SessionListViewModel {
+        let server = try XCTUnwrap(URL(string: "https://example.test"))
+        let client = try makeClient(server: server, sessionPayloads: sessionPayloads)
+
+        return SessionListViewModel(server: server, client: client)
+    }
+
+    private func makeClient(server: URL, sessionPayloads: [String]) throws -> APIClient {
+        MockURLProtocol.requestHandler = { request in
+            guard request.url?.path == "/api/sessions" else {
+                XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                throw URLError(.badURL)
+            }
+
+            let payload = """
+            {
+              "sessions": [
+                \(sessionPayloads.joined(separator: ",\n        "))
+              ],
+              "archived_count": 0
+            }
+            """
+
+            return apiTestJSONResponse(payload, for: request)
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+
+        return APIClient(baseURL: server, session: URLSession(configuration: configuration))
+    }
+
+    /// One `sessions[]` entry, carrying only the fields a case cares about. An
+    /// omitted `session_id` decodes to nil, which is not a usable browser session.
+    private func session(
+        id: String?,
+        title: String,
+        workspace: String? = nil,
+        createdAt: Double? = nil,
+        updatedAt: Double? = nil,
+        lastMessageAt: Double? = nil
+    ) -> String {
+        var fields: [String] = []
+
+        if let id {
+            fields.append("\"session_id\": \"\(id)\"")
+        }
+
+        fields.append("\"title\": \"\(title)\"")
+
+        if let workspace {
+            fields.append("\"workspace\": \"\(workspace)\"")
+        }
+
+        if let createdAt {
+            fields.append("\"created_at\": \(createdAt)")
+        }
+
+        if let updatedAt {
+            fields.append("\"updated_at\": \(updatedAt)")
+        }
+
+        if let lastMessageAt {
+            fields.append("\"last_message_at\": \(lastMessageAt)")
+        }
+
+        return "{ \(fields.joined(separator: ", ")) }"
+    }
+}


### PR DESCRIPTION
The workspace file browser was only reachable from inside a chat via the Files toolbar button. Add a Files row to the main screen's utility links (the Tasks/Kanban/Skills/Memory/Usage group), opening the same FileBrowserView with the formatted markdown previews.

The WebUI file API is session-scoped, so the entry binds the browser to the most recent usable session (preferring one bound to a workspace); with no sessions yet it shows an empty state pointing at the chat. The row follows the existing section-visibility pattern: a new sectionVisibility.files key that defaults to visible, a Settings toggle under Main Page, and tests updated for the new link.

<!-- Thanks for contributing! Please read CONTRIBUTING.md before opening a PR. -->

## Linked issue

<!-- Every PR should close an issue, e.g. "Fixes #123". If there is no issue yet, open one first. -->

Fixes #

## What changed

<!-- A short, plain-English summary of the change and why it's the right fix. -->

## How it was tested

<!-- e.g. full XCTest suite (command + result), manual simulator steps, screenshots for UI changes. -->

## Checklist

- [ ] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [ ] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [ ] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [ ] No invented API endpoints or JSON shapes (verified against upstream source or a running server)
