### PR TITLE
fix(chat): restore native composer text gestures

### DIFF
--- a/HermesMobile/Features/Chat/ComposerChipTextView.swift
+++ b/HermesMobile/Features/Chat/ComposerChipTextView.swift
@@ -3,7 +3,7 @@ import UniformTypeIdentifiers
 
 /// The composer's editor: a text view that draws known skill references as
 /// atomic chips while every value that leaves it stays the draft's own text.
-final class ComposerChipTextView: UITextView {
+final class ComposerChipTextView: UITextView, UIGestureRecognizerDelegate {
     var isKeyboardSendEnabled = false
     var onKeyboardSend: () -> Void = {}
     var onPasteFileProviders: ([NSItemProvider]) -> Void = { _ in }
@@ -38,6 +38,12 @@ final class ComposerChipTextView: UITextView {
     /// and nothing but this editor knows that.
     private(set) var renderedTokens: [ComposerChipToken] = []
     private var renderedStyle: ChipRenderStyle?
+    private lazy var chipTapRecognizer: UITapGestureRecognizer = {
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(handleChipTap))
+        recognizer.cancelsTouchesInView = false
+        recognizer.delegate = self
+        return recognizer
+    }()
 
     /// What the chips were drawn against. A chip is a baked image, so a change
     /// of appearance or text size has to redraw it even when the draft has not
@@ -52,12 +58,7 @@ final class ComposerChipTextView: UITextView {
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
 
-        // Rides alongside the text view's own tap rather than replacing it, so
-        // the caret still lands where the finger did and only a tap that
-        // actually covers a chip's glyph reports one.
-        let chipTap = UITapGestureRecognizer(target: self, action: #selector(handleChipTap))
-        chipTap.cancelsTouchesInView = false
-        addGestureRecognizer(chipTap)
+        addGestureRecognizer(chipTapRecognizer)
 
         registerForTraitChanges(
             [UITraitUserInterfaceStyle.self, UITraitAccessibilityContrast.self, UITraitPreferredContentSizeCategory.self]
@@ -100,6 +101,24 @@ final class ComposerChipTextView: UITextView {
     }
 
     // MARK: - Chips
+
+    /// Keeps the chip recognizer out of UIKit's gesture arbitration unless the
+    /// touch begins on a rendered chip. Ordinary text touches remain entirely
+    /// owned by the text view's native editing recognizers.
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        guard gestureRecognizer === chipTapRecognizer else { return true }
+        guard !renderedTokens.isEmpty else { return false }
+        return chipToken(at: touch.location(in: self)) != nil
+    }
+
+    /// A chip tap reports its action while UIKit continues handling the same
+    /// touch for caret placement and selection.
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        gestureRecognizer === chipTapRecognizer || otherGestureRecognizer === chipTapRecognizer
+    }
 
     private func rebuildChipCatalog() {
         chipCatalog = ComposerChipCatalog(skills: chipSkills, filePaths: chipFilePaths)

--- a/HermesMobileTests/ComposerChipTests.swift
+++ b/HermesMobileTests/ComposerChipTests.swift
@@ -381,6 +381,133 @@ final class ComposerChipDocumentTests: XCTestCase {
     }
 }
 
+@MainActor
+final class ComposerChipGestureTests: XCTestCase {
+    private final class TouchStub: UITouch {
+        private let point: CGPoint
+
+        init(point: CGPoint) {
+            self.point = point
+            super.init()
+        }
+
+        override func location(in view: UIView?) -> CGPoint {
+            point
+        }
+    }
+
+    private let skills = [
+        SkillSlashSuggestion(name: "ask-matt", category: nil, description: nil),
+        SkillSlashSuggestion(name: "babysit-pr", category: nil, description: nil)
+    ]
+
+    func testPlainTextDoesNotParticipateInChipRecognition() throws {
+        let textView = makeTextView(text: "ordinary editable text")
+        let recognizer = try chipRecognizer(in: textView)
+        let textRange = try XCTUnwrap(textView.textRange(from: NSRange(location: 2, length: 1)))
+        let textPoint = center(of: textView.firstRect(for: textRange))
+
+        XCTAssertTrue(textView.renderedTokens.isEmpty)
+        XCTAssertFalse(textView.gestureRecognizer(recognizer, shouldReceive: TouchStub(point: textPoint)))
+    }
+
+    func testOnlyTheChipGlyphParticipatesInChipRecognition() throws {
+        let textView = makeTextView(text: "/ask-matt editable text")
+        let recognizer = try chipRecognizer(in: textView)
+        let chip = try XCTUnwrap(chipRanges(in: textView).first)
+
+        XCTAssertTrue(
+            textView.gestureRecognizer(recognizer, shouldReceive: TouchStub(point: center(of: chip.rect)))
+        )
+
+        let spaceRange = try XCTUnwrap(textView.textRange(from: NSRange(location: chip.range.upperBound, length: 1)))
+        XCTAssertFalse(
+            textView.gestureRecognizer(
+                recognizer,
+                shouldReceive: TouchStub(point: center(of: textView.firstRect(for: spaceRange)))
+            )
+        )
+    }
+
+    func testMultipleWrappedChipsUseTheirOwnGlyphBounds() throws {
+        let textView = makeTextView(
+            width: 190,
+            text: "/ask-matt some text that wraps onto another line before /babysit-pr trailing text"
+        )
+        let recognizer = try chipRecognizer(in: textView)
+        let chips = chipRanges(in: textView)
+
+        XCTAssertEqual(chips.count, 2)
+        XCTAssertNotEqual(chips[0].rect.minY, chips[1].rect.minY)
+        XCTAssertTrue(
+            textView.gestureRecognizer(recognizer, shouldReceive: TouchStub(point: center(of: chips[0].rect)))
+        )
+        XCTAssertTrue(
+            textView.gestureRecognizer(recognizer, shouldReceive: TouchStub(point: center(of: chips[1].rect)))
+        )
+
+        let betweenRange = try XCTUnwrap(textView.textRange(from: NSRange(location: 2, length: 1)))
+        XCTAssertFalse(
+            textView.gestureRecognizer(
+                recognizer,
+                shouldReceive: TouchStub(point: center(of: textView.firstRect(for: betweenRange)))
+            )
+        )
+    }
+
+    func testChipRecognizerAllowsUIKitEditingRecognizersAlongsideIt() throws {
+        let textView = makeTextView(text: "/ask-matt editable text")
+        let recognizer = try chipRecognizer(in: textView)
+        let editingRecognizer = UITapGestureRecognizer()
+
+        XCTAssertTrue(recognizer.delegate === textView)
+        XCTAssertTrue(
+            textView.gestureRecognizer(
+                recognizer,
+                shouldRecognizeSimultaneouslyWith: editingRecognizer
+            )
+        )
+    }
+
+    private func makeTextView(width: CGFloat = 320, text: String) -> ComposerChipTextView {
+        let textView = ComposerChipTextView(frame: CGRect(x: 0, y: 0, width: width, height: 240))
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.chipSkills = skills
+        textView.replaceDocument(with: text)
+        textView.layoutManager.ensureLayout(for: textView.textContainer)
+        textView.layoutIfNeeded()
+        return textView
+    }
+
+    private func chipRecognizer(in textView: ComposerChipTextView) throws -> UITapGestureRecognizer {
+        try XCTUnwrap(
+            textView.gestureRecognizers?
+                .compactMap { $0 as? UITapGestureRecognizer }
+                .first { $0.delegate === textView }
+        )
+    }
+
+    private func chipRanges(in textView: ComposerChipTextView) -> [(range: NSRange, rect: CGRect)] {
+        var chips: [(range: NSRange, rect: CGRect)] = []
+        textView.textStorage.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: textView.textStorage.length)
+        ) { attachment, range, _ in
+            guard attachment is ComposerChipAttachment,
+                  let textRange = textView.textRange(from: range)
+            else {
+                return
+            }
+            chips.append((range, textView.firstRect(for: textRange)))
+        }
+        return chips
+    }
+
+    private func center(of rect: CGRect) -> CGPoint {
+        CGPoint(x: rect.midX, y: rect.midY)
+    }
+}
+
 final class ComposerDropRouteTests: XCTestCase {
     func testRoutesAMixOfFilesAndImages() throws {
         let route = try XCTUnwrap(


### PR DESCRIPTION
## Linked issue

Fixes #448

## What changed

The expanded composer intercepted ordinary text gestures, preventing native caret placement and word selection. The chip recognizer now rejects touches outside rendered chip glyphs and allows UIKit editing gestures alongside chip taps.

## How it was tested

- XcodeBuildMCP `test_sim`, focused `ComposerChipGestureTests`: 4 passed.
- XcodeBuildMCP `test_sim`, full XCTest suite: 2,303 passed, 2 skipped, 0 failures.
- XcodeBuildMCP `build_run_sim`: signed Debug build installed and launched on iPhone 17; signature verified.
- `git diff --check` and `scripts/check-swift-file-sizes` passed; the size check reports existing warnings.
- Owner confirmed "all works" after the manual checklist covering caret placement, selection, editing menu/paste, editing around wrapped chips, chip actions, selection handles, trackpad, autocomplete, marked text, and collapsed focus.

Validated tree is unchanged from the local test run. This restores interaction without changing visual layout; no before/after images were captured.

## Checklist

- [x] The full test suite passes locally.
- [x] New/changed `Codable` models decode tolerantly. No model changes.
- [x] No new third-party dependencies.
- [x] No invented API endpoints or JSON shapes. No wire-contract changes.

Implemented by GPT-5.6 Sol at medium effort, orchestrated and reviewed by GPT-6 Astra in Codex.
