### PR TITLE
chore: remove unused code and obsolete tests

### DIFF
--- a/HermesMobile/Config/AppFont.swift
+++ b/HermesMobile/Config/AppFont.swift
@@ -5,10 +5,6 @@ enum AppFont {
         system(.body, weight: weight)
     }
 
-    static func callout(weight: Font.Weight? = nil) -> Font {
-        system(.callout, weight: weight)
-    }
-
     static func subheadline(weight: Font.Weight? = nil) -> Font {
         system(.subheadline, weight: weight)
     }
@@ -31,10 +27,6 @@ enum AppFont {
 
     static func title(weight: Font.Weight? = nil) -> Font {
         system(.title, weight: weight)
-    }
-
-    static func title2(weight: Font.Weight? = nil) -> Font {
-        system(.title2, weight: weight)
     }
 
     static func title3(weight: Font.Weight? = nil) -> Font {

--- a/HermesMobile/Features/Insights/UsageChartData.swift
+++ b/HermesMobile/Features/Insights/UsageChartData.swift
@@ -128,16 +128,6 @@ enum UsageChartSegment: String, Identifiable, CaseIterable {
     }
 }
 
-/// One Swift Charts mark: a bucket's contribution for one segment.
-struct UsageChartPoint: Identifiable, Equatable {
-    let bucketID: Int
-    let bucketLabel: String
-    let segment: UsageChartSegment
-    let value: Double
-
-    var id: String { "\(bucketID)-\(segment.rawValue)" }
-}
-
 /// The three lines of the hero figure above the chart.
 struct UsageHeroFigure: Equatable {
     let label: String
@@ -242,15 +232,6 @@ extension UsageBucket {
             }
         case let .hour(sessions):
             return [(.sessions, Double(sessions))]
-        }
-    }
-}
-
-/// Flattens buckets into chart marks, one per bucket and segment.
-func usageChartPoints(buckets: [UsageBucket], metric: UsageMetric) -> [UsageChartPoint] {
-    buckets.flatMap { bucket in
-        bucket.segments(for: metric).map {
-            UsageChartPoint(bucketID: bucket.id, bucketLabel: bucket.label, segment: $0.segment, value: $0.value)
         }
     }
 }

--- a/HermesMobile/Features/Kanban/KanbanFeatureState.swift
+++ b/HermesMobile/Features/Kanban/KanbanFeatureState.swift
@@ -527,10 +527,6 @@ final class KanbanFeatureState {
         selectedBoardSlug == nil && !boards.isEmpty
     }
 
-    func canArchiveBoard(_ board: KanbanBoard) -> Bool {
-        canManageBoards && normalizedOptional(board.slug) != "default"
-    }
-
     var selectedCardCount: Int { selectedCardIDs.count }
 
     var bulkActionsAvailability: KanbanBulkActionsAvailability {
@@ -1410,18 +1406,6 @@ final class KanbanFeatureState {
 
     func setTenantFilter(_ tenant: String?) async {
         selectedTenant = normalized(tenant)
-        await refreshBoard(usingCursor: false)
-    }
-
-    func setIncludeArchived(_ included: Bool) async {
-        includeArchived = included
-        if !included, selectedStatus == "archived" { selectedStatus = "triage" }
-        await refreshBoard(usingCursor: false)
-    }
-
-    func setOnlyMine(_ enabled: Bool) async {
-        onlyMine = enabled
-        if enabled { selectedProfile = nil }
         await refreshBoard(usingCursor: false)
     }
 

--- a/HermesMobile/Features/Workspace/GitWorkspaceViewModel.swift
+++ b/HermesMobile/Features/Workspace/GitWorkspaceViewModel.swift
@@ -452,10 +452,6 @@ struct GitWriteAvailability: Equatable {
     var fetchDisabled: Bool { isViewingCachedData }
 }
 
-enum GitToolbarStatusDot: Equatable {
-    case gray
-}
-
 /// Pure presentation state for the toolbar menu, kept outside UIKit so its edge cases are testable.
 struct GitToolbarPresentation: Equatable {
     let hasRepository: Bool
@@ -463,12 +459,6 @@ struct GitToolbarPresentation: Equatable {
     let info: GitInfo?
     let status: GitStatus?
     let statusFailed: Bool
-
-    var statusDot: GitToolbarStatusDot? {
-        guard hasRepository else { return nil }
-        if (info?.dirty ?? 0) > 0 || (info?.behind ?? 0) > 0 { return .gray }
-        return nil
-    }
 
     var accessibilityValue: String {
         guard hasRepository else { return String(localized: "Repository status unavailable") }
@@ -481,13 +471,6 @@ struct GitToolbarPresentation: Equatable {
         if behind { return String(localized: "Remote branch ahead of local branch") }
         if ahead { return String(localized: "Local branch ahead of remote") }
         return String(localized: "Repository up to date")
-    }
-
-    var changesTitle: String {
-        if statusFailed { return String(localized: "Changes unavailable") }
-        guard let status else { return String(localized: "No changes") }
-        guard status.changedCount > 0 else { return String(localized: "No changes") }
-        return "+\(status.totalAdditions) −\(status.totalDeletions)  \(status.changedCount)"
     }
 
     var changesAreEnabled: Bool { !isLoading && (status != nil || statusFailed) }

--- a/HermesMobile/Models/Skills.swift
+++ b/HermesMobile/Models/Skills.swift
@@ -279,8 +279,3 @@ struct SkillDetailResponse: Decodable, Equatable {
         }
     }
 }
-
-struct SkillLinkedFileResponse: Decodable, Equatable {
-    let content: String?
-    let path: String?
-}

--- a/HermesMobile/Persistence/CacheStore.swift
+++ b/HermesMobile/Persistence/CacheStore.swift
@@ -183,19 +183,6 @@ enum CacheStore {
         try context.save()
     }
 
-    @MainActor
-    static func clearAll(in context: ModelContext) throws {
-        for cachedSession in try context.fetch(FetchDescriptor<CachedSession>()) {
-            context.delete(cachedSession)
-        }
-
-        for cachedMessage in try context.fetch(FetchDescriptor<CachedMessage>()) {
-            context.delete(cachedMessage)
-        }
-
-        try context.save()
-    }
-
     /// Deletes only the cached sessions and messages belonging to `serverURL`,
     /// leaving every other configured server's offline data intact (#18). Backs
     /// the Settings "Clear Offline Cache" action (active server) and the purge

--- a/HermesMobileTests/CacheStoreTests.swift
+++ b/HermesMobileTests/CacheStoreTests.swift
@@ -576,46 +576,6 @@ final class CacheStoreTests: XCTestCase {
         XCTAssertNotNil(cachedMessages.first { $0.messageId == "message-\(CachePolicy.maxMessages)" })
     }
 
-    func testClearAllDeletesCachedSessionsAndMessages() throws {
-        let context = try makeContext()
-        let serverURL = URL(string: "https://example.test")!
-        let cachedAt = Date(timeIntervalSince1970: 1_770_000_000)
-        let response = try decodeSessions("""
-        {
-          "sessions": [
-            {"session_id": "abc123", "title": "Cached", "last_message_at": 1770000000, "archived": false}
-          ]
-        }
-        """)
-
-        try CacheStore.cacheSessions(
-            try XCTUnwrap(response.sessions),
-            serverURL: serverURL,
-            in: context,
-            cachedAt: cachedAt
-        )
-
-        try CacheStore.cacheMessages(
-            [
-                ChatMessage(
-                    role: "user",
-                    content: "Cached message",
-                    timestamp: 1_770_000_000,
-                    messageId: "m1"
-                )
-            ],
-            serverURL: serverURL,
-            sessionID: "abc123",
-            in: context,
-            cachedAt: cachedAt
-        )
-
-        try CacheStore.clearAll(in: context)
-
-        XCTAssertTrue(try fetchCachedSessions(in: context).isEmpty)
-        XCTAssertTrue(try fetchCachedMessages(in: context).isEmpty)
-    }
-
     func testCacheMessagesRoundTripsAttachments() throws {
         let context = try makeContext()
         let serverURL = URL(string: "https://example.test")!

--- a/HermesMobileTests/GitWorkspaceViewModelTests.swift
+++ b/HermesMobileTests/GitWorkspaceViewModelTests.swift
@@ -183,23 +183,6 @@ final class GitWorkspaceViewModelTests: APIClientTestCase {
         XCTAssertNil(viewModel.lastError)
     }
 
-    func testToolbarPresentationMapsRepositoryStates() throws {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        func info(_ json: String) throws -> GitInfo? {
-            try decoder.decode(GitInfoResponse.self, from: Data(json.utf8)).git
-        }
-
-        let dirty = try info(#"{"git":{"is_git":true,"dirty":2,"behind":0}}"#)
-        let behind = try info(#"{"git":{"is_git":true,"dirty":0,"behind":1}}"#)
-        let clean = try info(#"{"git":{"is_git":true,"dirty":0,"behind":0}}"#)
-
-        XCTAssertEqual(GitToolbarPresentation(hasRepository: true, isLoading: false, info: dirty, status: nil, statusFailed: false).statusDot, .gray)
-        XCTAssertEqual(GitToolbarPresentation(hasRepository: true, isLoading: false, info: behind, status: nil, statusFailed: false).statusDot, .gray)
-        XCTAssertNil(GitToolbarPresentation(hasRepository: true, isLoading: false, info: clean, status: nil, statusFailed: false).statusDot)
-        XCTAssertNil(GitToolbarPresentation(hasRepository: false, isLoading: false, info: dirty, status: nil, statusFailed: false).statusDot)
-    }
-
     func testToolbarPresentationEnablesChangesAfterStatusFailure() {
         let failed = GitToolbarPresentation(
             hasRepository: true,

--- a/docs/agents/multi-server-state-isolation.md
+++ b/docs/agents/multi-server-state-isolation.md
@@ -94,9 +94,6 @@ view layer (which holds the SwiftData `modelContext`) rather than in
 because the cache is server-keyed, a leftover row can never surface as another
 server's content even if the purge fails.
 
-`CacheStore.clearAll(in:)` (delete every server's cache) is retained as a tested
-utility but is no longer wired to any user action.
-
 ## Where isolation is tested
 
 | Dimension | Tests |


### PR DESCRIPTION
## Linked issue

Maintainer-requested repository audit and cleanup; no linked issue.

## What changed

Unused declarations and tests of dead APIs added maintenance work without supporting app behavior. Remove 138 lines across nine files after inspecting every major directory and checking references across the app, extensions, and tests.

- Remove unused font helpers, chart-point model/builder, Kanban methods, Git toolbar properties, and skill response type.
- Remove the obsolete global cache-clear API and the two tests that only exercised removed APIs. Keep server-scoped cache clearing, chart segments, filter transitions, toolbar availability, and their behavior tests.
- Remove the obsolete cache documentation paragraph.

The active UI and server contract are unchanged. Rebased onto the latest `origin/master` before opening.

## How it was tested

- Focused XCTest: 149 passed across cache, Insights, Kanban, and Git workspace tests.
- Full XCTest after rebase: 2,303 passed, zero failures; two opt-in Photos integration tests skipped as expected.
- `ruby ci/select_testflight_build_number_test.rb`: 17 tests, 34 assertions, no failures.
- `git diff --check`, Swift syntax checks for all eight changed Swift files, project plist lint, shell/Ruby syntax checks, and 106 resource/configuration parser checks passed.
- `scripts/check-swift-file-sizes` passed with existing warning-only oversized files. SwiftLint is not configured.

Full-suite command on iPhone 17 / iOS 26.5:

```sh
xcodebuildmcp simulator test --project-path HermesMobile.xcodeproj --scheme HermesMobile --simulator-name 'iPhone 17' --extra-args '-parallel-testing-enabled' 'NO' --output json
```

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly; only an unused model was removed
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes

Implemented with GPT-6 in Codex desktop, with read-only audit subagents.
