### PR TITLE
feat(chat): select response text in the transcript

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -422,6 +422,9 @@
 		C0366000000000000000005 /* ModelPickerSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0366000000000000000006 /* ModelPickerSheetTests.swift */; };
 		C0369000000000000000005 /* CronJobEditorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0369000000000000000006 /* CronJobEditorConfigurationTests.swift */; };
 		1050500000000000000000B1 /* OnboardingViewModelIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */; };
+		454454454454454454454402 /* ResponseTextSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454454454454454454454401 /* ResponseTextSelection.swift */; };
+		454454454454454454454412 /* ResponseSelectionInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454454454454454454454411 /* ResponseSelectionInput.swift */; };
+		454454454454454454454432 /* ResponseSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454454454454454454454431 /* ResponseSelectionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -875,6 +878,9 @@
 		C0366000000000000000006 /* ModelPickerSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPickerSheetTests.swift; sourceTree = "<group>"; };
 		C0369000000000000000006 /* CronJobEditorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CronJobEditorConfigurationTests.swift; sourceTree = "<group>"; };
 		1050500000000000000000B2 /* OnboardingViewModelIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModelIdentityTests.swift; sourceTree = "<group>"; };
+		454454454454454454454401 /* ResponseTextSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseTextSelection.swift; sourceTree = "<group>"; };
+		454454454454454454454411 /* ResponseSelectionInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseSelectionInput.swift; sourceTree = "<group>"; };
+		454454454454454454454431 /* ResponseSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseSelectionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1066,6 +1072,7 @@
 				C0AA02000000000000000F03 /* ToolCallSummaryFormatterTests.swift */,
 				C0AA020000000000000000F12 /* ReasoningSummaryFormatterTests.swift */,
 				C0AA020000000000000000F13 /* TranscriptLogRowBodyWindowTests.swift */,
+				454454454454454454454431 /* ResponseSelectionTests.swift */,
 				C0AA0208000000000000F002 /* ChatMessageActionMenuTests.swift */,
 				C0AA03000000000000000F02 /* TranscriptTurnFoldingTests.swift */,
 				C0AA07000000000000000F07 /* ChatTranscriptRowEntryTests.swift */,
@@ -1320,6 +1327,8 @@
 				C21200000000000000000002 /* StreamingWordDrain.swift */,
 				C21300000000000000000002 /* StreamingTextFade.swift */,
 				C21300000000000000000004 /* StreamingTextFadeRenderer.swift */,
+				454454454454454454454401 /* ResponseTextSelection.swift */,
+				454454454454454454454411 /* ResponseSelectionInput.swift */,
 				1A2B3C4D5E6F7000000000DB /* MarkdownRenderer.swift */,
 				C14300000000000000000002 /* StreamingMarkdownSupport.swift */,
 				C0DE34000000000000000002 /* TranscriptMedia.swift */,
@@ -1930,6 +1939,8 @@
 				1A2B3C4D5E6F7000000000E8 /* FilePreviewView.swift in Sources */,
 				1A2B3C4D5E6F7000000000EA /* FilePreviewViewModel.swift in Sources */,
 				BEEF02600000000000000001 /* FileExportSupport.swift in Sources */,
+				454454454454454454454402 /* ResponseTextSelection.swift in Sources */,
+				454454454454454454454412 /* ResponseSelectionInput.swift in Sources */,
 				1A2B3C4D5E6F7000000000DA /* MarkdownRenderer.swift in Sources */,
 				C14300000000000000000001 /* StreamingMarkdownSupport.swift in Sources */,
 				C0DE34000000000000000001 /* TranscriptMedia.swift in Sources */,
@@ -2120,6 +2131,7 @@
 				C0AA02000000000000000B03 /* ToolCallSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B12 /* ReasoningSummaryFormatterTests.swift in Sources */,
 				C0AA020000000000000000B13 /* TranscriptLogRowBodyWindowTests.swift in Sources */,
+				454454454454454454454432 /* ResponseSelectionTests.swift in Sources */,
 				C0AA0208000000000000B002 /* ChatMessageActionMenuTests.swift in Sources */,
 				C0AA03000000000000000B02 /* TranscriptTurnFoldingTests.swift in Sources */,
 				C0AA07000000000000000B07 /* ChatTranscriptRowEntryTests.swift in Sources */,

--- a/HermesMobile/Features/Chat/ChatMessageActions.swift
+++ b/HermesMobile/Features/Chat/ChatMessageActions.swift
@@ -20,7 +20,6 @@ struct SelectableTextPresentation: Identifiable, Equatable {
 struct ChatMessageActionItem: Identifiable {
     enum Kind: String {
         case listen
-        case selectText
         case regenerate
         case edit
         case fork
@@ -45,7 +44,6 @@ struct ChatMessageActionMenu: View {
     let isEditingMessage: Bool
     let isForkingMessage: Bool
     let onToggleListening: (MessageActionContext) -> Void
-    let onSelectText: (MessageActionContext) -> Void
     let onRegenerate: (MessageActionContext) -> Void
     let onEdit: (MessageActionContext) -> Void
     let onFork: (MessageActionContext) -> Void
@@ -76,13 +74,6 @@ struct ChatMessageActionMenu: View {
                 perform: { onToggleListening(context) }
             ))
             items.append(ChatMessageActionItem(
-                kind: .selectText,
-                title: String(localized: "Select Text"),
-                systemImage: "text.cursor",
-                isEnabled: true,
-                perform: { onSelectText(context) }
-            ))
-            items.append(ChatMessageActionItem(
                 kind: .regenerate,
                 title: String(localized: "Regenerate Response"),
                 systemImage: "arrow.clockwise",
@@ -108,13 +99,15 @@ struct ChatMessageActionMenu: View {
             isEnabled: !(isViewingCachedData || hasActiveStream || isForkingMessage),
             perform: { onFork(context) }
         ))
-        items.append(ChatMessageActionItem(
-            kind: .copy,
-            title: String(localized: "Copy"),
-            systemImage: "doc.on.doc",
-            isEnabled: true,
-            perform: { onCopy(context) }
-        ))
+        if context.role == .user {
+            items.append(ChatMessageActionItem(
+                kind: .copy,
+                title: String(localized: "Copy"),
+                systemImage: "doc.on.doc",
+                isEnabled: true,
+                perform: { onCopy(context) }
+            ))
+        }
 
         return items
     }

--- a/HermesMobile/Features/Chat/ChatMessageMeta.swift
+++ b/HermesMobile/Features/Chat/ChatMessageMeta.swift
@@ -38,14 +38,15 @@ enum TranscriptMessageMetaPolicy {
     }
 }
 
-/// The row under a message bubble: the time it was sent and a copy button.
+/// The row under a message bubble: timestamp, copy, and completed-response actions.
 /// User rows read `[time][copy]` against the trailing edge, assistant rows
-/// `[copy][time]` against the leading edge, so the button always sits at the
+/// `[copy][actions][time]` against the leading edge, so Copy always sits at the
 /// outer edge and RTL mirrors both through the semantic alignments.
 struct ChatMessageMetaRow: View {
     let isUserMessage: Bool
     let timeText: String?
     let onCopy: (() -> Void)?
+    var actionMenu: ChatMessageActionMenu? = nil
 
     var body: some View {
         HStack(spacing: 4) {
@@ -54,6 +55,16 @@ struct ChatMessageMetaRow: View {
                 copyButton
             } else {
                 copyButton
+                if let actionMenu {
+                    Menu { actionMenu } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 13, weight: .medium))
+                            .frame(width: 28, height: 28)
+                            .chatMinimumHitTarget(in: Rectangle())
+                    }
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("More")
+                }
                 time
             }
         }

--- a/HermesMobile/Features/Chat/ChatMessageMeta.swift
+++ b/HermesMobile/Features/Chat/ChatMessageMeta.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
-/// Which transcript rows draw the `time · copy` row under their bubble. Every
-/// user message gets one. An assistant row gets one only as the reply that
-/// closes a settled turn: mid-turn replies, the turn a stream is still
-/// answering, and the message that is streaming show nothing, so the row only
-/// ever sits under text the user can act on.
+/// Timestamps belong to user messages and settled terminal replies. Actions
+/// remain reachable on every actionable message, including a turn still streaming.
 enum TranscriptMessageMetaPolicy {
+    static func showsRow(hasActions: Bool, hasTimestamp: Bool) -> Bool {
+        hasActions || hasTimestamp
+    }
+
     /// Render IDs of the last bubble-bearing reply of each settled assistant turn.
     static func terminalReplyRenderIDs(
         transcriptMessages: [TranscriptMessage],

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -74,7 +74,6 @@ struct ChatTranscriptView: View {
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
     let onPreviewTranscriptMedia: (TranscriptMediaReference) -> Void
     let onToggleListening: (MessageActionContext) -> Void
-    let onSelectText: (MessageActionContext) -> Void
     let onRegenerate: (MessageActionContext) -> Void
     let onEdit: (MessageActionContext) -> Void
     let onFork: (MessageActionContext) -> Void
@@ -312,7 +311,6 @@ struct ChatTranscriptView: View {
                     onPreviewAttachment: onPreviewAttachment,
                     onPreviewTranscriptMedia: onPreviewTranscriptMedia,
                     onToggleListening: onToggleListening,
-                    onSelectText: onSelectText,
                     onRegenerate: onRegenerate,
                     onEdit: onEdit,
                     onFork: onFork,
@@ -556,7 +554,6 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
     let onPreviewTranscriptMedia: (TranscriptMediaReference) -> Void
     let onToggleListening: (MessageActionContext) -> Void
-    let onSelectText: (MessageActionContext) -> Void
     let onRegenerate: (MessageActionContext) -> Void
     let onEdit: (MessageActionContext) -> Void
     let onFork: (MessageActionContext) -> Void
@@ -676,7 +673,6 @@ private struct ChatTranscriptMessageBlock: View, Equatable {
                     onPreviewAttachment: onPreviewAttachment,
                     onPreviewTranscriptMedia: onPreviewTranscriptMedia,
                     onToggleListening: onToggleListening,
-                    onSelectText: onSelectText,
                     onRegenerate: onRegenerate,
                     onEdit: onEdit,
                     onFork: onFork,
@@ -764,7 +760,6 @@ private struct ChatTranscriptMessageRow: View {
     let onPreviewAttachment: (MessageAttachment, Data?) -> Void
     let onPreviewTranscriptMedia: (TranscriptMediaReference) -> Void
     let onToggleListening: (MessageActionContext) -> Void
-    let onSelectText: (MessageActionContext) -> Void
     let onRegenerate: (MessageActionContext) -> Void
     let onEdit: (MessageActionContext) -> Void
     let onFork: (MessageActionContext) -> Void
@@ -786,7 +781,8 @@ private struct ChatTranscriptMessageRow: View {
                         timeText: metaTimeText,
                         onCopy: actionContext.map { context -> () -> Void in
                             { onCopy(context) }
-                        }
+                        },
+                        actionMenu: isUserMessage ? nil : actionMenu
                     )
                 }
             }
@@ -822,7 +818,7 @@ private struct ChatTranscriptMessageRow: View {
             onPreviewTranscriptMedia: onPreviewTranscriptMedia,
             isStreaming: isStreaming,
             liveTokensPerSecond: liveTokensPerSecond,
-            contextMenu: actionMenu
+            contextMenu: isUserMessage ? actionMenu : nil
         )
     }
 
@@ -837,7 +833,6 @@ private struct ChatTranscriptMessageRow: View {
             isEditingMessage: isEditingMessage,
             isForkingMessage: isForkingMessage,
             onToggleListening: onToggleListening,
-            onSelectText: onSelectText,
             onRegenerate: onRegenerate,
             onEdit: onEdit,
             onFork: onFork,

--- a/HermesMobile/Features/Chat/ChatTranscriptView.swift
+++ b/HermesMobile/Features/Chat/ChatTranscriptView.swift
@@ -793,15 +793,15 @@ private struct ChatTranscriptMessageRow: View {
         message.role == "user"
     }
 
-    /// Every user message carries the row; an assistant row only as the reply
-    /// that closes a settled turn, and never while it is still streaming.
+    /// Keep actions reachable for every actionable reply, including active turns.
     private var showsMetaRow: Bool {
-        guard metaTimeText != nil || actionContext != nil else { return false }
-        return isUserMessage || (isTerminalReply && !isStreaming)
+        TranscriptMessageMetaPolicy.showsRow(
+            hasActions: actionContext != nil, hasTimestamp: metaTimeText != nil
+        )
     }
 
     private var metaTimeText: String? {
-        guard showsTimestamps else { return nil }
+        guard showsTimestamps, isUserMessage || (isTerminalReply && !isStreaming) else { return nil }
         return ChatMessageTimestampFormatter.shortTime(forUnixTimestamp: message.timestamp)
     }
 

--- a/HermesMobile/Features/Chat/ChatView.swift
+++ b/HermesMobile/Features/Chat/ChatView.swift
@@ -313,7 +313,6 @@ struct ChatView: View {
     @State private var showEditDiscardConfirmation = false
     @State private var regenerateContext: MessageActionContext?
     @State private var showRegenerateDiscardConfirmation = false
-    @State private var selectableResponseText: SelectableTextPresentation?
     @State private var attachmentPreviewItem: ChatAttachmentPreviewItem?
     @State private var transcriptMediaPreviewItem: TranscriptMediaPreviewItem?
     @State private var transcriptMediaImageItem: TranscriptMediaPreviewItem?
@@ -835,9 +834,6 @@ struct ChatView: View {
             }
             .navigationDestination(item: $forkedSession) { session in
                 ChatView(session: session, server: server, onAPIError: onAPIError)
-            }
-            .fullScreenCover(item: $selectableResponseText) { selectableText in
-                SelectableTextPresentationView(selection: selectableText)
             }
             .sheet(item: $attachmentPreviewItem) { item in
                 ChatAttachmentPreviewView(
@@ -1430,9 +1426,6 @@ struct ChatView: View {
             },
             onToggleListening: { context in
                 viewModel.toggleListening(to: context)
-            },
-            onSelectText: { context in
-                selectableResponseText = SelectableTextPresentation(context: context)
             },
             onRegenerate: beginRegenerateResponse,
             onEdit: beginEditMessage,

--- a/HermesMobile/Features/Chat/MarkdownRenderer.swift
+++ b/HermesMobile/Features/Chat/MarkdownRenderer.swift
@@ -69,14 +69,14 @@ struct MarkdownRenderer: View {
                     }
                 }
             }
-            .textSelection(.enabled)
+            .responseTextSelectionPolicy()
         case .plain(let markdown):
             ChatMarkdownView(
                 content: markdown,
                 colorScheme: colorScheme,
                 isStreaming: isStreaming
             )
-            .textSelection(.enabled)
+            .responseTextSelectionPolicy()
         }
     }
 }
@@ -595,6 +595,7 @@ private struct PlainCodeBlockText: View {
             ForEach(lines) { line in
                 if wraps {
                     combinedText(for: line)
+                        .responseSelectableText(line.segments.map(\.text).joined())
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .multilineTextAlignment(.leading)
@@ -602,6 +603,7 @@ private struct PlainCodeBlockText: View {
                     HStack(alignment: .firstTextBaseline, spacing: 0) {
                         ForEach(line.segments) { segment in
                             Text(verbatim: segment.text)
+                                .responseSelectableText(segment.text, separator: segment.id == line.segments.last?.id ? "\n" : "")
                         }
                     }
                 }
@@ -633,6 +635,7 @@ private struct HighlightedCodeBlockText: View {
             ForEach(lines) { line in
                 if wraps {
                     combinedText(for: line)
+                        .responseSelectableText(line.segments.map { $0.attributedText.string }.joined())
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .multilineTextAlignment(.leading)
@@ -640,6 +643,7 @@ private struct HighlightedCodeBlockText: View {
                     HStack(alignment: .firstTextBaseline, spacing: 0) {
                         ForEach(line.segments) { segment in
                             Text(AttributedString(segment.attributedText))
+                                .responseSelectableText(segment.attributedText.string, separator: segment.id == line.segments.last?.id ? "\n" : "")
                         }
                     }
                 }
@@ -1167,10 +1171,11 @@ private struct PlainMarkdownFallbackView: View {
 
     var body: some View {
         Text(verbatim: content)
+            .responseSelectableText(content)
             .font(.body)
             .foregroundStyle(.primary)
             .fixedSize(horizontal: false, vertical: true)
-            .textSelection(.enabled)
+            .responseTextSelectionPolicy()
             .onAppear {
                 logger.info(
                     "Markdown plain fallback reason=\(reason.rawValue, privacy: .public) characters=\(content.count, privacy: .public) lines=\(MarkdownHighlightPolicy.lineCount(in: content), privacy: .public)"
@@ -1187,6 +1192,19 @@ private extension MarkdownUI.Theme {
                 BackgroundColor(nil)
                 FontSize(16)
             }
+            .paragraph { configuration in
+                configuration.label
+                    .responseSelectableText(configuration.content.renderPlainText().trimmingCharacters(in: .newlines), separator: "\n\n")
+                    .fixedSize(horizontal: false, vertical: true)
+                    .relativeLineSpacing(.em(0.25))
+                    .markdownMargin(top: 0, bottom: 16)
+            }
+            .heading1 { SelectableMarkdownHeading(configuration: $0, level: 1, colorScheme: colorScheme) }
+            .heading2 { SelectableMarkdownHeading(configuration: $0, level: 2, colorScheme: colorScheme) }
+            .heading3 { SelectableMarkdownHeading(configuration: $0, level: 3, colorScheme: colorScheme) }
+            .heading4 { SelectableMarkdownHeading(configuration: $0, level: 4, colorScheme: colorScheme) }
+            .heading5 { SelectableMarkdownHeading(configuration: $0, level: 5, colorScheme: colorScheme) }
+            .heading6 { SelectableMarkdownHeading(configuration: $0, level: 6, colorScheme: colorScheme) }
             .code {
                 FontFamilyVariant(.monospaced)
                 FontSize(.em(0.85))
@@ -1217,6 +1235,7 @@ private extension MarkdownUI.Theme {
                     maxWidth: ChatMarkdownTable.cellMaxWidth
                 ) {
                     configuration.label
+                        .responseSelectableText(configuration.content.renderPlainText().trimmingCharacters(in: .newlines), separator: "\t")
                         .markdownTextStyle {
                             if configuration.row == 0 {
                                 FontWeight(.semibold)
@@ -1329,4 +1348,44 @@ private extension Logger {
         subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile",
         category: "MarkdownRendering"
     )
+}
+
+/// Matches MarkdownUI's GitHub heading metrics, registering only the text label.
+private struct SelectableMarkdownHeading: View {
+    let configuration: BlockConfiguration
+    let level: Int
+    let colorScheme: ColorScheme
+
+    private var fontScale: Double { [2, 1.5, 1.25, 1, 0.875, 0.85][level - 1] }
+    private var tertiaryColor: SwiftUI.Color {
+        colorScheme == .dark
+            ? SwiftUI.Color(red: 109 / 255, green: 112 / 255, blue: 125 / 255)
+            : SwiftUI.Color(red: 107 / 255, green: 110 / 255, blue: 123 / 255)
+    }
+    private var dividerColor: SwiftUI.Color {
+        colorScheme == .dark
+            ? SwiftUI.Color(red: 51 / 255, green: 52 / 255, blue: 56 / 255)
+            : SwiftUI.Color(red: 208 / 255, green: 208 / 255, blue: 211 / 255)
+    }
+    var body: some View {
+        if level <= 2 {
+            VStack(alignment: .leading, spacing: 0) {
+                label.relativePadding(.bottom, length: .em(0.3))
+                Divider().overlay(dividerColor)
+            }
+        } else {
+            label
+        }
+    }
+    private var label: some View {
+        configuration.label
+            .responseSelectableText(configuration.content.renderPlainText().trimmingCharacters(in: .newlines), separator: "\n\n")
+            .relativeLineSpacing(.em(0.125))
+            .markdownMargin(top: 24, bottom: 16)
+            .markdownTextStyle {
+                FontWeight(.semibold)
+                FontSize(.em(fontScale))
+                if level == 6 { ForegroundColor(tertiaryColor) }
+            }
+    }
 }

--- a/HermesMobile/Features/Chat/MarkdownRenderer.swift
+++ b/HermesMobile/Features/Chat/MarkdownRenderer.swift
@@ -1235,7 +1235,7 @@ private extension MarkdownUI.Theme {
                     maxWidth: ChatMarkdownTable.cellMaxWidth
                 ) {
                     configuration.label
-                        .responseSelectableText(configuration.content.renderPlainText().trimmingCharacters(in: .newlines), separator: "\t")
+                        .responseSelectableText(configuration.content.renderPlainText().trimmingCharacters(in: .newlines), separator: "\t", tableColumn: configuration.column)
                         .markdownTextStyle {
                             if configuration.row == 0 {
                                 FontWeight(.semibold)

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -103,22 +103,16 @@ struct MessageBubbleView: View {
                 assistantTurnHeader
             }
 
-            if segments.containsTranscriptMedia {
-                TranscriptMediaContentView(
-                    segments: segments,
-                    cacheNamespace: transcriptMediaCacheNamespace,
-                    loadMediaImage: loadTranscriptMediaImage,
-                    loadMediaData: loadTranscriptMediaData,
-                    onPreviewMedia: onPreviewTranscriptMedia,
-                    isStreaming: isStreaming
-                )
+            if isStreaming {
+                assistantContent(segments: segments)
             } else {
-                MarkdownRenderer(content: messageText, isStreaming: isStreaming)
+                ResponseTextSelection(identity: messageText) {
+                    assistantContent(segments: segments)
+                }
             }
 
             linkPreview
         }
-        .chatMessageContextMenu(contextMenu)
         .frame(maxWidth: .infinity, alignment: .leading)
         // While this row is the active streaming message, animate its height
         // growth at the same curve as the bottom-follow scroll so the streaming
@@ -127,6 +121,22 @@ struct MessageBubbleView: View {
             isStreaming ? ChatMotion.streamingFollow(reduceMotion: reduceMotion) : nil,
             value: messageText
         )
+    }
+
+    @ViewBuilder
+    private func assistantContent(segments: [TranscriptMediaSegment]) -> some View {
+        if segments.containsTranscriptMedia {
+            TranscriptMediaContentView(
+                segments: segments,
+                cacheNamespace: transcriptMediaCacheNamespace,
+                loadMediaImage: loadTranscriptMediaImage,
+                loadMediaData: loadTranscriptMediaData,
+                onPreviewMedia: onPreviewTranscriptMedia,
+                isStreaming: isStreaming
+            )
+        } else {
+            MarkdownRenderer(content: messageText, isStreaming: isStreaming)
+        }
     }
 
     // MARK: - Assistant turn header (issue #258)

--- a/HermesMobile/Features/Chat/ResponseSelectionInput.swift
+++ b/HermesMobile/Features/Chat/ResponseSelectionInput.swift
@@ -1,0 +1,263 @@
+import UIKit
+
+/// Read-only UITextInput adapter. UIKit owns gestures, handles, and the edit menu;
+/// the existing SwiftUI leaves continue to own rendering and link interactions.
+final class ResponseSelectionInput: UIView, UITextInput, UITextInteractionDelegate {
+    let leaves = NSHashTable<ResponseSelectionLeafView>.weakObjects()
+    var leafOrder: [UUID] = []
+    let selectionInteraction = UITextInteraction(for: .nonEditable)
+    weak var inputDelegate: UITextInputDelegate?
+    lazy var tokenizer: UITextInputTokenizer = UITextInputStringTokenizer(textInput: self)
+    private var selection: UITextRange?
+    var selectedTextRange: UITextRange? {
+        get { selection }
+        set {
+            inputDelegate?.selectionWillChange(self)
+            selection = newValue
+            inputDelegate?.selectionDidChange(self)
+        }
+    }
+    var markedTextRange: UITextRange? { nil }
+    var markedTextStyle: [NSAttributedString.Key: Any]?
+    var beginningOfDocument: UITextPosition { ResponseTextPosition(0) }
+    var endOfDocument: UITextPosition { ResponseTextPosition(document.text.length) }
+    var hasText: Bool { document.text.length > 0 }
+    var isEditable: Bool { false }
+    var textInputView: UIView { subviews.first ?? self }
+    override var canBecomeFirstResponder: Bool { true }
+    // UITextInteraction promotes a UITextInput to an accessibility element.
+    // This adapter is a container; expose the hosted text and controls instead.
+    override var isAccessibilityElement: Bool {
+        get { false }
+        set {}
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        selectionInteraction.textInput = self
+        selectionInteraction.delegate = self
+        addInteraction(selectionInteraction)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil { selectedTextRange = nil }
+    }
+
+    func interactionShouldBegin(_ interaction: UITextInteraction, at point: CGPoint) -> Bool {
+        return document.glyphs.contains { $0.rect.contains(point) }
+    }
+
+    func interactionWillBegin(_ interaction: UITextInteraction) {
+        becomeFirstResponder()
+    }
+
+    /// Geometry is read at interaction time so horizontal code scrolling and
+    /// Dynamic Type never leave selection handles using stale screen positions.
+    private var document: (text: NSString, glyphs: [ResponseSelectionGlyph]) {
+        let indices = Dictionary(leafOrder.enumerated().map { ($0.element, $0.offset) }, uniquingKeysWith: min)
+        let ordered = leaves.allObjects.filter { $0.window != nil && $0.isDescendant(of: self) }.sorted {
+            if let leftIndex = indices[$0.id], let rightIndex = indices[$1.id] {
+                return leftIndex < rightIndex
+            }
+            let left = $0.convert($0.bounds, to: self)
+            let right = $1.convert($1.bounds, to: self)
+            if abs(left.minY - right.minY) > 2 { return left.minY < right.minY }
+            return $0.rightToLeft
+                ? left.minX > right.minX : left.minX < right.minX
+        }
+        var text = ""
+        var offset = 0
+        var glyphs: [ResponseSelectionGlyph] = []
+        for leaf in ordered {
+            let length = leaf.text.utf16.count
+            text += leaf.text + leaf.separator
+            var clip = bounds
+            var ancestor = leaf.superview
+            while let view = ancestor, view !== self {
+                if view.clipsToBounds { clip = clip.intersection(view.convert(view.bounds, to: self)) }
+                ancestor = view.superview
+            }
+            for glyph in leaf.geometry?.glyphs ?? [] where NSMaxRange(glyph.range) <= length {
+                let rect = leaf.convert(glyph.rect, to: self).intersection(clip)
+                guard !rect.isNull, !rect.isEmpty else { continue }
+                glyphs.append(ResponseSelectionGlyph(
+                    range: NSRange(location: offset + glyph.range.location, length: glyph.range.length),
+                    rect: rect,
+                    rightToLeft: glyph.rightToLeft
+                ))
+            }
+            offset += length + leaf.separator.utf16.count
+        }
+        return (text as NSString, glyphs)
+    }
+
+    func text(in range: UITextRange) -> String? {
+        guard let range = range as? ResponseTextRange else { return nil }
+        let text = document.text
+        guard range.range.location >= 0, NSMaxRange(range.range) <= text.length else { return nil }
+        return text.substring(with: range.range)
+    }
+
+    func textRange(from: UITextPosition, to: UITextPosition) -> UITextRange? {
+        guard let start = from as? ResponseTextPosition, let end = to as? ResponseTextPosition else { return nil }
+        return ResponseTextRange(NSRange(location: min(start.offset, end.offset), length: abs(end.offset - start.offset)))
+    }
+
+    func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
+        guard let position = position as? ResponseTextPosition else { return nil }
+        let value = position.offset + offset
+        guard value >= 0, value <= document.text.length else { return nil }
+        return ResponseTextPosition(value)
+    }
+
+    func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? {
+        if direction == .up || direction == .down {
+            let caret = caretRect(for: position)
+            return closestPosition(to: CGPoint(x: caret.midX, y: caret.midY + CGFloat(direction == .up ? -offset : offset) * caret.height))
+        }
+        let rtl = baseWritingDirection(for: position, in: .forward) == .rightToLeft
+        let forward = (direction == .right) != rtl
+        return self.position(from: position, offset: forward ? offset : -offset)
+    }
+
+    func compare(_ position: UITextPosition, to other: UITextPosition) -> ComparisonResult {
+        let distance = offset(from: position, to: other)
+        return distance == 0 ? .orderedSame : distance > 0 ? .orderedAscending : .orderedDescending
+    }
+
+    func offset(from: UITextPosition, to toPosition: UITextPosition) -> Int {
+        guard let start = from as? ResponseTextPosition, let end = toPosition as? ResponseTextPosition else { return 0 }
+        return end.offset - start.offset
+    }
+
+    func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? {
+        let rtl = baseWritingDirection(for: range.start, in: .forward) == .rightToLeft
+        switch direction {
+        case .left: return rtl ? range.end : range.start
+        case .right: return rtl ? range.start : range.end
+        case .up: return range.start
+        case .down: return range.end
+        @unknown default: return range.start
+        }
+    }
+
+    func characterRange(byExtending position: UITextPosition, in direction: UITextLayoutDirection) -> UITextRange? {
+        if direction == .left || direction == .right, let position = position as? ResponseTextPosition {
+            let rtl = baseWritingDirection(for: position, in: .forward) == .rightToLeft
+            let forward = (direction == .right) != rtl
+            let index = position.offset - (forward ? 0 : 1)
+            let text = document.text
+            guard index >= 0, index < text.length else { return nil }
+            return ResponseTextRange(text.rangeOfComposedCharacterSequence(at: index))
+        }
+        guard let end = self.position(from: position, in: direction, offset: 1) else { return nil }
+        return textRange(from: position, to: end)
+    }
+
+    func baseWritingDirection(for position: UITextPosition, in direction: UITextStorageDirection) -> NSWritingDirection {
+        guard let position = position as? ResponseTextPosition else { return .natural }
+        return nearestGlyph(to: position.offset, in: document.glyphs)?.rightToLeft == true ? .rightToLeft : .leftToRight
+    }
+
+    func firstRect(for range: UITextRange) -> CGRect { selectionRects(for: range).first?.rect ?? .zero }
+
+    func caretRect(for position: UITextPosition) -> CGRect {
+        guard let position = position as? ResponseTextPosition else { return .zero }
+        let glyphs = document.glyphs
+        guard let glyph = nearestGlyph(to: position.offset, in: glyphs) else { return .zero }
+        let atEnd = position.offset >= NSMaxRange(glyph.range)
+        let x = atEnd != glyph.rightToLeft ? glyph.rect.maxX : glyph.rect.minX
+        return CGRect(x: x, y: glyph.rect.minY, width: 2, height: glyph.rect.height)
+    }
+
+    func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {
+        guard let range = range as? ResponseTextRange, !range.isEmpty else { return [] }
+        // UIKit needs runs of selected text, not a separate highlight view for
+        // every glyph in a long response. Keep bidi runs and media gaps separate.
+        var runs: [ResponseSelectionGlyph] = []
+        for glyph in document.glyphs where NSIntersectionRange(glyph.range, range.range).length > 0 {
+            if let last = runs.last,
+               last.rightToLeft == glyph.rightToLeft,
+               abs(last.rect.minY - glyph.rect.minY) < 0.5,
+               abs(last.rect.height - glyph.rect.height) < 0.5,
+               (NSMaxRange(last.range) == glyph.range.location || NSMaxRange(glyph.range) == last.range.location),
+               (abs(last.rect.maxX - glyph.rect.minX) < 1 || abs(glyph.rect.maxX - last.rect.minX) < 1) {
+                runs[runs.count - 1] = ResponseSelectionGlyph(
+                    range: NSUnionRange(last.range, glyph.range),
+                    rect: last.rect.union(glyph.rect), rightToLeft: glyph.rightToLeft
+                )
+            } else {
+                runs.append(glyph)
+            }
+        }
+        let start = runs.map(\.range.location).min() ?? range.range.location
+        let end = runs.map { NSMaxRange($0.range) - 1 }.max() ?? start
+        return runs.map {
+            ResponseSelectionRect($0, starts: NSLocationInRange(start, $0.range),
+                                  ends: NSLocationInRange(end, $0.range))
+        }
+    }
+
+    /// Paragraph separators have no drawn glyph. Anchor their caret to the
+    /// nearest text boundary instead of jumping to the end of the response.
+    private func nearestGlyph(to offset: Int, in glyphs: [ResponseSelectionGlyph]) -> ResponseSelectionGlyph? {
+        if let exact = glyphs.first(where: { NSLocationInRange(offset, $0.range) }) { return exact }
+        return glyphs.min {
+            min(abs(offset - $0.range.location), abs(offset - NSMaxRange($0.range)))
+                < min(abs(offset - $1.range.location), abs(offset - NSMaxRange($1.range)))
+        }
+    }
+
+    func closestPosition(to point: CGPoint) -> UITextPosition? {
+        closestPosition(to: point, within: ResponseTextRange(NSRange(location: 0, length: document.text.length)))
+    }
+
+    func closestPosition(to point: CGPoint, within range: UITextRange) -> UITextPosition? {
+        guard let range = range as? ResponseTextRange else { return nil }
+        let candidates = document.glyphs.filter { NSIntersectionRange($0.range, range.range).length > 0 }
+        let nearest = candidates.min { distance(point, to: $0.rect) < distance(point, to: $1.rect) }
+        guard let nearest else { return range.start }
+        let after = (point.x > nearest.rect.midX) != nearest.rightToLeft
+        return ResponseTextPosition(min(NSMaxRange(range.range), max(range.range.location, after ? NSMaxRange(nearest.range) : nearest.range.location)))
+    }
+
+    func characterRange(at point: CGPoint) -> UITextRange? {
+        guard let position = closestPosition(to: point) as? ResponseTextPosition else { return nil }
+        let text = document.text
+        guard text.length > 0 else { return nil }
+        return ResponseTextRange(text.rangeOfComposedCharacterSequence(at: min(position.offset, text.length - 1)))
+    }
+
+    private func distance(_ point: CGPoint, to rect: CGRect) -> CGFloat {
+        let dx = max(rect.minX - point.x, 0, point.x - rect.maxX)
+        let dy = max(rect.minY - point.y, 0, point.y - rect.maxY)
+        return dx * dx + dy * dy * 16
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(copy(_:)) { return selectedTextRange?.isEmpty == false }
+        if action == #selector(selectAll(_:)) { return hasText }
+        return false
+    }
+
+    override func copy(_ sender: Any?) {
+        guard let selectedTextRange, let text = text(in: selectedTextRange) else { return }
+        UIPasteboard.general.string = text
+    }
+
+    override func selectAll(_ sender: Any?) {
+        selectedTextRange = textRange(from: beginningOfDocument, to: endOfDocument)
+    }
+
+    func replace(_ range: UITextRange, withText text: String) {}
+    func insertText(_ text: String) {}
+    func deleteBackward() {}
+    func setMarkedText(_ markedText: String?, selectedRange: NSRange) {}
+    func unmarkText() {}
+    func setBaseWritingDirection(_ writingDirection: NSWritingDirection, for range: UITextRange) {}
+}

--- a/HermesMobile/Features/Chat/ResponseSelectionInput.swift
+++ b/HermesMobile/Features/Chat/ResponseSelectionInput.swift
@@ -73,9 +73,17 @@ final class ResponseSelectionInput: UIView, UITextInput, UITextInteractionDelega
         var text = ""
         var offset = 0
         var glyphs: [ResponseSelectionGlyph] = []
-        for leaf in ordered {
+        for (index, leaf) in ordered.enumerated() {
             let length = leaf.text.utf16.count
-            text += leaf.text + leaf.separator
+            let nextColumn = index + 1 < ordered.count ? ordered[index + 1].tableColumn : nil
+            let separator: String
+            if leaf.tableColumn != nil {
+                // Cell coordinates preserve rows even when cells wrap or scroll.
+                separator = nextColumn.map { $0 == 0 ? "\n" : "\t" } ?? "\n\n"
+            } else {
+                separator = leaf.separator
+            }
+            text += leaf.text + separator
             var clip = bounds
             var ancestor = leaf.superview
             while let view = ancestor, view !== self {
@@ -91,7 +99,7 @@ final class ResponseSelectionInput: UIView, UITextInput, UITextInteractionDelega
                     rightToLeft: glyph.rightToLeft
                 ))
             }
-            offset += length + leaf.separator.utf16.count
+            offset += length + separator.utf16.count
         }
         return (text as NSString, glyphs)
     }

--- a/HermesMobile/Features/Chat/ResponseTextSelection.swift
+++ b/HermesMobile/Features/Chat/ResponseTextSelection.swift
@@ -88,20 +88,21 @@ extension View {
 
 extension View {
     /// Attach only to a leaf containing one resolved Text, not its block container.
-    func responseSelectableText(_ text: String, separator: String = "\n") -> some View {
-        modifier(ResponseSelectionLeaf(text: text, separator: separator))
+    func responseSelectableText(_ text: String, separator: String = "\n", tableColumn: Int? = nil) -> some View {
+        modifier(ResponseSelectionLeaf(text: text, separator: separator, tableColumn: tableColumn))
     }
 }
 
 private struct ResponseSelectionLeaf: ViewModifier {
     let text: String
     let separator: String
+    let tableColumn: Int?
     @Environment(\.responseSelectionScope) private var scope
 
     @ViewBuilder
     func body(content: Content) -> some View {
         if let scope {
-            content.modifier(RegisteredResponseSelectionLeaf(text: text, separator: separator, scope: scope))
+            content.modifier(RegisteredResponseSelectionLeaf(text: text, separator: separator, tableColumn: tableColumn, scope: scope))
         } else {
             content
         }
@@ -112,6 +113,7 @@ private struct ResponseSelectionLeaf: ViewModifier {
 private struct RegisteredResponseSelectionLeaf: ViewModifier {
     let text: String
     let separator: String
+    let tableColumn: Int?
     let scope: ResponseSelectionScope
     @State private var geometry = ResponseGlyphGeometry()
     @State private var id = UUID()
@@ -119,7 +121,7 @@ private struct RegisteredResponseSelectionLeaf: ViewModifier {
     func body(content: Content) -> some View {
         content
             .textRenderer(ResponseSelectionRenderer(geometry: geometry))
-            .background(ResponseSelectionMarker(scope: scope, id: id, text: text, separator: separator, geometry: geometry))
+            .background(ResponseSelectionMarker(scope: scope, id: id, text: text, separator: separator, tableColumn: tableColumn, geometry: geometry))
             .preference(key: ResponseSelectionOrderKey.self, value: [id])
     }
 }
@@ -178,6 +180,7 @@ private struct ResponseSelectionMarker: UIViewRepresentable {
     let id: UUID
     let text: String
     let separator: String
+    let tableColumn: Int?
     let geometry: ResponseGlyphGeometry
     @Environment(\.layoutDirection) private var layoutDirection
 
@@ -192,6 +195,7 @@ private struct ResponseSelectionMarker: UIViewRepresentable {
         view.id = id
         view.text = text
         view.separator = separator
+        view.tableColumn = tableColumn
         view.geometry = geometry
         view.rightToLeft = layoutDirection == .rightToLeft
     }
@@ -201,6 +205,7 @@ final class ResponseSelectionLeafView: UIView {
     var id = UUID()
     var text = ""
     var separator = "\n"
+    var tableColumn: Int?
     var geometry: ResponseGlyphGeometry?
     var rightToLeft = false
 }

--- a/HermesMobile/Features/Chat/ResponseTextSelection.swift
+++ b/HermesMobile/Features/Chat/ResponseTextSelection.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+import UIKit
+
+/// One native selection document around the existing response layout. Text leaves
+/// supply their actual glyph geometry; images, equations and controls never register.
+struct ResponseTextSelection<Content: View>: UIViewControllerRepresentable {
+    let identity: String
+    @ViewBuilder let content: () -> Content
+    @Environment(\.self) private var environment
+
+    func makeUIViewController(context: Context) -> ResponseSelectionController {
+        ResponseSelectionController()
+    }
+
+    func updateUIViewController(_ controller: ResponseSelectionController, context: Context) {
+        if controller.identity != identity {
+            controller.input.selectedTextRange = nil
+            controller.identity = identity
+        }
+        controller.host.rootView = AnyView(content()
+            .responseSelectionDocument(controller.scope)
+            .textSelection(.disabled)
+            .environment(\.self, environment))
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiViewController: ResponseSelectionController, context: Context) -> CGSize? {
+        guard let width = proposal.width, width > 0 else { return nil }
+        return uiViewController.host.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
+    }
+}
+
+final class ResponseSelectionController: UIViewController {
+    let input = ResponseSelectionInput()
+    lazy var scope = ResponseSelectionScope(input: input)
+    let host = UIHostingController(rootView: AnyView(EmptyView()))
+    var identity = ""
+
+    override func loadView() {
+        view = input
+        addChild(host)
+        host.view.backgroundColor = .clear
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        input.addSubview(host.view)
+        host.view.addInteraction(input.selectionInteraction)
+        input.accessibilityElements = [host.view!]
+        NSLayoutConstraint.activate([
+            host.view.leadingAnchor.constraint(equalTo: input.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: input.trailingAnchor),
+            host.view.topAnchor.constraint(equalTo: input.topAnchor),
+            host.view.bottomAnchor.constraint(equalTo: input.bottomAnchor)
+        ])
+        host.didMove(toParent: self)
+    }
+}
+
+/// The hosted SwiftUI tree must not retain its containing UIKit view.
+final class ResponseSelectionScope {
+    weak var input: ResponseSelectionInput?
+    init(input: ResponseSelectionInput) { self.input = input }
+}
+
+private struct ResponseSelectionScopeKey: EnvironmentKey {
+    static let defaultValue: ResponseSelectionScope? = nil
+}
+
+private struct ResponseSelectionOrderKey: PreferenceKey {
+    static let defaultValue: [UUID] = []
+    static func reduce(value: inout [UUID], nextValue: () -> [UUID]) {
+        value += nextValue()
+    }
+}
+
+extension EnvironmentValues {
+    var responseSelectionScope: ResponseSelectionScope? {
+        get { self[ResponseSelectionScopeKey.self] }
+        set { self[ResponseSelectionScopeKey.self] = newValue }
+    }
+}
+
+extension View {
+    func responseSelectionDocument(_ scope: ResponseSelectionScope) -> some View {
+        environment(\.responseSelectionScope, scope)
+            .onPreferenceChange(ResponseSelectionOrderKey.self) { [weak input = scope.input] order in
+                input?.leafOrder = order
+            }
+    }
+}
+
+extension View {
+    /// Attach only to a leaf containing one resolved Text, not its block container.
+    func responseSelectableText(_ text: String, separator: String = "\n") -> some View {
+        modifier(ResponseSelectionLeaf(text: text, separator: separator))
+    }
+}
+
+private struct ResponseSelectionLeaf: ViewModifier {
+    let text: String
+    let separator: String
+    @Environment(\.responseSelectionScope) private var scope
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let scope {
+            content.modifier(RegisteredResponseSelectionLeaf(text: text, separator: separator, scope: scope))
+        } else {
+            content
+        }
+    }
+}
+
+/// Allocate glyph storage only for completed responses, never the streaming path.
+private struct RegisteredResponseSelectionLeaf: ViewModifier {
+    let text: String
+    let separator: String
+    let scope: ResponseSelectionScope
+    @State private var geometry = ResponseGlyphGeometry()
+    @State private var id = UUID()
+
+    func body(content: Content) -> some View {
+        content
+            .textRenderer(ResponseSelectionRenderer(geometry: geometry))
+            .background(ResponseSelectionMarker(scope: scope, id: id, text: text, separator: separator, geometry: geometry))
+            .preference(key: ResponseSelectionOrderKey.self, value: [id])
+    }
+}
+
+struct ResponseSelectionGlyph {
+    let range: NSRange
+    let rect: CGRect
+    let rightToLeft: Bool
+}
+
+/// TextRenderer can draw off the main actor. Geometry is published without
+/// invalidating SwiftUI state or scheduling a second rendering pass.
+final class ResponseGlyphGeometry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [ResponseSelectionGlyph] = []
+
+    var glyphs: [ResponseSelectionGlyph] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func replace(_ glyphs: [ResponseSelectionGlyph]) {
+        lock.lock()
+        storage = glyphs
+        lock.unlock()
+    }
+}
+
+private struct ResponseSelectionRenderer: TextRenderer {
+    let geometry: ResponseGlyphGeometry
+
+    func draw(layout: Text.Layout, in context: inout GraphicsContext) {
+        let indices = layout.flatMap { $0.flatMap { $0.characterIndices } }
+        guard let start = indices.min() else { return }
+        var glyphs: [ResponseSelectionGlyph] = []
+        for line in layout {
+            context.draw(line)
+            for run in line {
+                for slice in run {
+                    guard let lower = slice.characterIndices.min(), let upper = slice.characterIndices.max() else { continue }
+                    glyphs.append(ResponseSelectionGlyph(
+                        range: NSRange(location: start.distance(to: lower), length: lower.distance(to: upper) + 1),
+                        rect: slice.typographicBounds.rect,
+                        rightToLeft: run.layoutDirection == .rightToLeft
+                    ))
+                }
+            }
+        }
+        geometry.replace(glyphs)
+    }
+}
+
+private struct ResponseSelectionMarker: UIViewRepresentable {
+    let scope: ResponseSelectionScope
+    let id: UUID
+    let text: String
+    let separator: String
+    let geometry: ResponseGlyphGeometry
+    @Environment(\.layoutDirection) private var layoutDirection
+
+    func makeUIView(context: Context) -> ResponseSelectionLeafView {
+        let view = ResponseSelectionLeafView()
+        view.isUserInteractionEnabled = false
+        scope.input?.leaves.add(view)
+        return view
+    }
+
+    func updateUIView(_ view: ResponseSelectionLeafView, context: Context) {
+        view.id = id
+        view.text = text
+        view.separator = separator
+        view.geometry = geometry
+        view.rightToLeft = layoutDirection == .rightToLeft
+    }
+}
+
+final class ResponseSelectionLeafView: UIView {
+    var id = UUID()
+    var text = ""
+    var separator = "\n"
+    var geometry: ResponseGlyphGeometry?
+    var rightToLeft = false
+}
+
+final class ResponseTextPosition: UITextPosition {
+    let offset: Int
+    init(_ offset: Int) { self.offset = offset }
+}
+
+final class ResponseTextRange: UITextRange {
+    let range: NSRange
+    init(_ range: NSRange) { self.range = range }
+    override var start: UITextPosition { ResponseTextPosition(range.location) }
+    override var end: UITextPosition { ResponseTextPosition(NSMaxRange(range)) }
+    override var isEmpty: Bool { range.length == 0 }
+}
+
+final class ResponseSelectionRect: UITextSelectionRect {
+    let glyph: ResponseSelectionGlyph
+    let starts: Bool
+    let ends: Bool
+    init(_ glyph: ResponseSelectionGlyph, starts: Bool, ends: Bool) {
+        self.glyph = glyph
+        self.starts = starts
+        self.ends = ends
+    }
+    override var rect: CGRect { glyph.rect }
+    override var writingDirection: NSWritingDirection { glyph.rightToLeft ? .rightToLeft : .leftToRight }
+    override var containsStart: Bool { starts }
+    override var containsEnd: Bool { ends }
+    override var isVertical: Bool { false }
+}
+
+private struct ResponseTextSelectionPolicy: ViewModifier {
+    @Environment(\.responseSelectionScope) private var scope
+    @ViewBuilder func body(content: Content) -> some View {
+        if scope == nil { content.textSelection(.enabled) }
+        else { content.textSelection(.disabled) }
+    }
+}
+
+extension View {
+    func responseTextSelectionPolicy() -> some View { modifier(ResponseTextSelectionPolicy()) }
+}

--- a/HermesMobileTests/ChatMessageActionMenuTests.swift
+++ b/HermesMobileTests/ChatMessageActionMenuTests.swift
@@ -5,7 +5,7 @@ final class ChatMessageActionMenuTests: XCTestCase {
     func testAssistantMenuListsAssistantActionsInOrder() throws {
         let menu = try makeMenu(role: "assistant")
 
-        XCTAssertEqual(menu.items.map(\.kind), [.listen, .selectText, .regenerate, .fork, .copy])
+        XCTAssertEqual(menu.items.map(\.kind), [.listen, .regenerate, .fork])
         XCTAssertTrue(menu.items.allSatisfy(\.isEnabled))
     }
 
@@ -22,8 +22,6 @@ final class ChatMessageActionMenuTests: XCTestCase {
         XCTAssertEqual(enabledByKind[.regenerate], false)
         XCTAssertEqual(enabledByKind[.fork], false)
         XCTAssertEqual(enabledByKind[.listen], true)
-        XCTAssertEqual(enabledByKind[.selectText], true)
-        XCTAssertEqual(enabledByKind[.copy], true)
 
         let uiMenu = menu.uiMenu()
         let disabledTitles = uiMenu.children.compactMap { $0 as? UIAction }
@@ -40,6 +38,16 @@ final class ChatMessageActionMenuTests: XCTestCase {
         XCTAssertEqual(listening.items.first?.title, "Stop Listening")
     }
 
+    func testCachedResponseRetainsListenButDisablesServerMutations() throws {
+        let menu = try makeMenu(role: "assistant", isViewingCachedData: true)
+        XCTAssertEqual(menu.items.filter(\.isEnabled).map(\.kind), [.listen])
+    }
+
+    func testPendingResponseMutationsAreDisabled() throws {
+        let menu = try makeMenu(role: "assistant", isMutating: true)
+        XCTAssertEqual(menu.items.filter(\.isEnabled).map(\.kind), [.listen])
+    }
+
     func testPerformRoutesToTheMatchingCallback() throws {
         var copied: MessageActionContext?
         let menu = try makeMenu(role: "user", onCopy: { copied = $0 })
@@ -54,6 +62,8 @@ final class ChatMessageActionMenuTests: XCTestCase {
         role: String,
         listeningMessageID: String? = nil,
         hasActiveStream: Bool = false,
+        isViewingCachedData: Bool = false,
+        isMutating: Bool = false,
         onCopy: @escaping (MessageActionContext) -> Void = { _ in }
     ) throws -> ChatMessageActionMenu {
         let message = ChatMessage(
@@ -68,13 +78,12 @@ final class ChatMessageActionMenuTests: XCTestCase {
         return ChatMessageActionMenu(
             context: context,
             listeningMessageID: listeningMessageID,
-            isViewingCachedData: false,
+            isViewingCachedData: isViewingCachedData,
             hasActiveStream: hasActiveStream,
-            isRegeneratingMessage: false,
+            isRegeneratingMessage: isMutating,
             isEditingMessage: false,
-            isForkingMessage: false,
+            isForkingMessage: isMutating,
             onToggleListening: { _ in },
-            onSelectText: { _ in },
             onRegenerate: { _ in },
             onEdit: { _ in },
             onFork: { _ in },

--- a/HermesMobileTests/ChatMessageActionMenuTests.swift
+++ b/HermesMobileTests/ChatMessageActionMenuTests.swift
@@ -2,6 +2,12 @@ import XCTest
 @testable import HermesMobile
 
 final class ChatMessageActionMenuTests: XCTestCase {
+    func testActionRowsRemainAvailableWithoutSettledTurnTimestamp() {
+        XCTAssertTrue(TranscriptMessageMetaPolicy.showsRow(hasActions: true, hasTimestamp: false))
+        XCTAssertTrue(TranscriptMessageMetaPolicy.showsRow(hasActions: false, hasTimestamp: true))
+        XCTAssertFalse(TranscriptMessageMetaPolicy.showsRow(hasActions: false, hasTimestamp: false))
+    }
+
     func testAssistantMenuListsAssistantActionsInOrder() throws {
         let menu = try makeMenu(role: "assistant")
 

--- a/HermesMobileTests/ResponseSelectionTests.swift
+++ b/HermesMobileTests/ResponseSelectionTests.swift
@@ -76,6 +76,7 @@ final class ResponseSelectionTests: XCTestCase {
         for expected in ["Heading", "First paragraph with a link.", "List entry", "Another entry", "let value = 1", "Column", "Value", "Row", "Cell"] {
             XCTAssertTrue(text.contains(expected), "Missing \(expected) in \(text)")
         }
+        XCTAssertTrue(text.contains("Column\tValue\nRow\tCell\n\n"), text)
         XCTAssertFalse(text.contains("x^2"))
         XCTAssertFalse(text.contains("x²"))
         XCTAssertFalse(text.contains("Copy code"))

--- a/HermesMobileTests/ResponseSelectionTests.swift
+++ b/HermesMobileTests/ResponseSelectionTests.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import XCTest
+@testable import HermesMobile
+
+@MainActor
+final class ResponseSelectionTests: XCTestCase {
+    func testSwiftUIResponseBoundaryRegistersItsHostedText() async throws {
+        let controller = UIHostingController(rootView: ResponseTextSelection(identity: "response") {
+            Text("A completed response").responseSelectableText("A completed response")
+        })
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 400))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        let rendered = expectation(description: "SwiftUI boundary rendered")
+        DispatchQueue.main.async {
+            controller.view.layoutIfNeeded()
+            _ = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            rendered.fulfill()
+        }
+        await fulfillment(of: [rendered], timeout: 5)
+        func selectionInput(in view: UIView) -> ResponseSelectionInput? {
+            if let input = view as? ResponseSelectionInput { return input }
+            return view.subviews.lazy.compactMap { selectionInput(in: $0) }.first
+        }
+        let input = try XCTUnwrap(selectionInput(in: controller.view))
+        input.selectAll(nil)
+        let range = try XCTUnwrap(input.selectedTextRange)
+        XCTAssertEqual(input.text(in: range), "A completed response\n")
+        let rect = try XCTUnwrap(input.selectionRects(for: range).first).rect
+        XCTAssertTrue(input.interactionShouldBegin(UITextInteraction(for: .nonEditable), at: CGPoint(x: rect.midX, y: rect.midY)))
+        XCTAssertFalse(input.isAccessibilityElement)
+        XCTAssertFalse(try XCTUnwrap(input.accessibilityElements).isEmpty)
+    }
+
+    func testRealMarkdownRegistersHeadingsListsCodeAndTableButNotEquations() async throws {
+        let markdown = """
+        # Heading
+
+        First **paragraph** with a [link](https://example.com).
+
+        - List entry
+        - Another entry
+
+        ```
+        let value = 1
+        ```
+
+        $$x^2$$
+
+        | Column | Value |
+        | --- | --- |
+        | Row | Cell |
+        """
+        let controller = ResponseSelectionController()
+        controller.loadViewIfNeeded()
+        controller.host.rootView = AnyView(MarkdownRenderer(content: markdown)
+            .responseSelectionDocument(controller.scope))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 900))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        let rendered = expectation(description: "Markdown laid out and drawn")
+        DispatchQueue.main.async {
+            controller.view.layoutIfNeeded()
+            _ = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            rendered.fulfill()
+        }
+        await fulfillment(of: [rendered], timeout: 5)
+        controller.input.selectAll(nil)
+        let text = try XCTUnwrap(controller.input.text(in: XCTUnwrap(controller.input.selectedTextRange)))
+        for expected in ["Heading", "First paragraph with a link.", "List entry", "Another entry", "let value = 1", "Column", "Value", "Row", "Cell"] {
+            XCTAssertTrue(text.contains(expected), "Missing \(expected) in \(text)")
+        }
+        XCTAssertFalse(text.contains("x^2"))
+        XCTAssertFalse(text.contains("x²"))
+        XCTAssertFalse(text.contains("Copy code"))
+        XCTAssertFalse(controller.input.selectionRects(for: try XCTUnwrap(controller.input.selectedTextRange)).isEmpty)
+    }
+
+    func testSelectionSpansTextLeavesAndExcludesOtherViewsAndResponses() async throws {
+        let controller = ResponseSelectionController()
+        controller.loadViewIfNeeded()
+        controller.host.rootView = AnyView(VStack(alignment: .leading) {
+            Text("First paragraph").responseSelectableText("First paragraph", separator: "\n\n")
+            Text("An equation image").accessibilityLabel("Equation")
+            Text("let value = 1").font(.system(.body, design: .monospaced))
+                .responseSelectableText("let value = 1")
+        }.responseSelectionDocument(controller.scope))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        let rendered = expectation(description: "Hosted response laid out and drawn")
+        DispatchQueue.main.async {
+            controller.view.layoutIfNeeded()
+            _ = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            rendered.fulfill()
+        }
+        await fulfillment(of: [rendered], timeout: 5)
+
+        let input = controller.input
+        input.selectAll(nil)
+        let selection = try XCTUnwrap(input.selectedTextRange)
+        XCTAssertEqual(input.text(in: selection), "First paragraph\n\nlet value = 1\n")
+        XCTAssertFalse(input.selectionRects(for: selection).isEmpty)
+        XCTAssertTrue(input.canPerformAction(#selector(UIResponderStandardEditActions.copy(_:)), withSender: nil))
+
+        let another = ResponseSelectionInput()
+        XCTAssertFalse(another.hasText)
+        XCTAssertNil(another.selectedTextRange)
+    }
+
+    func testRenderedGlyphOffsetsMatchUTF16IncludingEmojiAndCombiningCharacters() async throws {
+        let text = "A 👩🏽‍💻 é שלום"
+        let controller = ResponseSelectionController()
+        controller.loadViewIfNeeded()
+        controller.host.rootView = AnyView(Text(verbatim: text).responseSelectableText(text)
+            .responseSelectionDocument(controller.scope))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 200))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        let rendered = expectation(description: "Unicode text rendered")
+        DispatchQueue.main.async {
+            controller.view.layoutIfNeeded()
+            _ = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            rendered.fulfill()
+        }
+        await fulfillment(of: [rendered], timeout: 5)
+        let leaf = try XCTUnwrap(controller.input.leaves.allObjects.first)
+        let glyphs = try XCTUnwrap(leaf.geometry).glyphs
+        XCTAssertFalse(glyphs.isEmpty)
+        XCTAssertEqual(glyphs.map { NSMaxRange($0.range) }.max(), text.utf16.count)
+        XCTAssertTrue(glyphs.contains(where: \.rightToLeft))
+        let emoji = try XCTUnwrap(controller.input.characterRange(byExtending: ResponseTextPosition(2), in: .right))
+        XCTAssertEqual(controller.input.text(in: emoji), "👩🏽‍💻")
+    }
+}


### PR DESCRIPTION
## Linked issue

Fixes #454

## What changed

Selecting part of an assistant response used to open a separate screen. Completed responses now support native selection directly in the transcript, across paragraphs, lists, and code, with Select All confined to that response. Images and rendered equations stay outside the selection.

A menu beside Copy holds Listen/Stop Listening, Regenerate Response, and Fork From Here. Copy and More remain available on streaming and mid-turn replies, with existing mutation restrictions. User-message menus are preserved. The existing Markdown renderer supplies text geometry to a read-only UIKit selection document.

## How it was tested

- Full XCTest suite through XcodeBuildMCP `test_sim`, iPhone 17, `-parallel-testing-enabled NO`: **2310 passed, 0 failed, 2 skipped**.
- Added rendered selection tests covering response boundaries, Markdown registration, Unicode/RTL offsets, hosted-view registration, and accessibility containment; updated action-menu tests, including action rows before turn settlement and copied table row boundaries.
- Signed Debug build installed and launched through `build_run_sim`. Owner tested it and reported “works.”
- Disposable native fixture verified long-press handles, Select All, and copied text spanning paragraphs without selecting surrounding content.
- `git diff --check` passed; Swift file-size check completed with existing size warnings.
- Approved layout mock: https://b8a59wxhx8f0.postplan.dev/ (design reference, not a runtime screenshot). Runtime fixture captures are local; GitHub attachments are not available through this CLI.

## Checklist

- [x] The full test suite passes locally
- [x] New/changed `Codable` models decode tolerantly (no model changes)
- [x] No new third-party dependencies
- [x] No invented API endpoints or JSON shapes (no wire-contract changes)

Implemented with GPT-6 in the Codex desktop harness.
