### PR TITLE
fix(chat): keep profile chip inside composer clip

### DIFF
--- a/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
+++ b/HermesMobile/Features/Chat/ChatComposerSelectorControls.swift
@@ -56,25 +56,7 @@ struct ComposerProfileSelectorMenu: View {
     }
 
     private var profileMenu: some View {
-        Menu {
-            if profileOptions.isEmpty {
-                Text("No profiles available")
-            } else {
-                Section("Profile") {
-                    ForEach(profileOptions, id: \.self) { profile in
-                        Button {
-                            onSelectProfile(profile)
-                        } label: {
-                            if profile.name == selectedProfileName {
-                                Label(profile.displayName, systemImage: "checkmark")
-                            } else {
-                                Text(profile.displayName)
-                            }
-                        }
-                    }
-                }
-            }
-        } label: {
+        ChatUIKitMenuButton {
             ComposerInlineControlLabel(
                 title: selectedProfileTitle,
                 systemImage: "person.crop.circle",
@@ -82,11 +64,40 @@ struct ComposerProfileSelectorMenu: View {
                 controlFont: controlFont,
                 chevronFont: chevronFont
             )
+        } menu: {
+            makeMenu()
         }
-        .buttonStyle(.chatTactile(.compactControl))
         .tint(color)
         .disabled(isDisabled)
         .accessibilityLabel("Choose profile")
+    }
+
+    func makeMenu() -> UIMenu {
+        guard !profileOptions.isEmpty else {
+            return UIMenu(children: [
+                UIAction(
+                    title: String(localized: "No profiles available"),
+                    attributes: .disabled
+                ) { _ in }
+            ])
+        }
+
+        return UIMenu(children: [
+            UIMenu(
+                title: String(localized: "Profile"),
+                options: [.displayInline],
+                children: profileOptions.map { profile in
+                    UIAction(
+                        title: profile.displayName,
+                        state: profile.name == selectedProfileName ? .on : .off
+                    ) { _ in
+                        Task { @MainActor in
+                            onSelectProfile(profile)
+                        }
+                    }
+                }
+            )
+        ])
     }
 }
 

--- a/HermesMobileTests/ComposerToolbarScrollerTests.swift
+++ b/HermesMobileTests/ComposerToolbarScrollerTests.swift
@@ -162,4 +162,60 @@ final class ComposerToolbarScrollerTests: XCTestCase {
         XCTAssertEqual(selection.committedEffort, "high")
         XCTAssertEqual(selection.title, "o4-mini · High")
     }
+
+    func testProfileMenuMarksTheSelectedProfile() throws {
+        let defaultProfile = profile(named: "default")
+        let reviewProfile = profile(named: "review")
+        let menu = profileSelector(
+            profiles: [defaultProfile, reviewProfile],
+            selectedName: reviewProfile.name
+        ).makeMenu()
+
+        let section = try XCTUnwrap(menu.children.first as? UIMenu)
+        let actions = try XCTUnwrap(section.children as? [UIAction])
+
+        XCTAssertEqual(section.title, String(localized: "Profile"))
+        XCTAssertTrue(section.options.contains(.displayInline))
+        XCTAssertEqual(actions.map(\.title), [defaultProfile.displayName, reviewProfile.displayName])
+        XCTAssertEqual(actions.map(\.state), [.off, .on])
+    }
+
+    func testProfileMenuDisablesItsEmptyState() throws {
+        let menu = profileSelector(profiles: [], selectedName: nil).makeMenu()
+        let action = try XCTUnwrap(menu.children.first as? UIAction)
+
+        XCTAssertEqual(action.title, String(localized: "No profiles available"))
+        XCTAssertTrue(action.attributes.contains(.disabled))
+    }
+
+    private func profileSelector(
+        profiles: [ProfileSummary],
+        selectedName: String?
+    ) -> ComposerProfileSelectorMenu {
+        ComposerProfileSelectorMenu(
+            profileOptions: profiles,
+            selectedProfileName: selectedName,
+            selectedProfileTitle: "Profile",
+            isStatic: false,
+            isDisabled: false,
+            color: .primary,
+            controlFont: .body,
+            chevronFont: .caption,
+            onSelectProfile: { _ in }
+        )
+    }
+
+    private func profile(named name: String) -> ProfileSummary {
+        ProfileSummary(
+            name: name,
+            path: nil,
+            isDefault: nil,
+            isActive: nil,
+            gatewayRunning: nil,
+            model: nil,
+            provider: nil,
+            hasEnv: nil,
+            skillCount: nil
+        )
+    }
 }


### PR DESCRIPTION
## Linked issue

Fixes #458

## What changed

On iOS 27, the SwiftUI `Menu` used by the composer profile chip can escape the toolbar scroller's mask and draw over Send or Stop.

This routes the multi-profile chip through the existing UIKit-backed menu button used by the other composer controls. It preserves the static single-profile state, selected-profile checkmark, empty state, disabled state, and accessibility label. Focused tests cover the generated UIKit menu's selection and empty-state behavior.

## How it was tested

- `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:HermesMobileTests/ComposerToolbarScrollerTests` — passed.
- `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'` — full suite passed.
- `xcodebuild -project HermesMobile.xcodeproj -scheme HermesMobile -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO MARKETING_VERSION=1.6.1 build` — passed.
- External-capable TestFlight upload: Hermex 1.6.1 build `202609082203`, processed and ready for tester assignment.
- iOS 27 visual validation is pending tester approval before merge because an iOS 27 simulator is unavailable locally.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly — no models changed.
- [x] No new third-party dependencies.
- [x] No invented API endpoints or JSON shapes — no server contract changed.

Implemented by GPT-5.6 Sol in T3 Code using the Codex harness.
