### PR TITLE
chore(bots): hide Bot Mode behind a default-off Settings toggle

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 		A990ABE1D2654992AD262B77 /* BotProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5619C4EB852849D396C45F95 /* BotProtocol.swift */; };
 		9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */; };
 		142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */; };
+		A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000002 /* BotModeGateTests.swift */; };
 		D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B04ED8E6164A75B069773D /* BotClientTests.swift */; };
 		785784DE20094BA78F432A9A /* BotChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */; };
 		D4E8321C0A744DE3A5B8C997 /* ChatComposerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */; };
@@ -905,6 +906,7 @@
 		5619C4EB852849D396C45F95 /* BotProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotProtocol.swift"; sourceTree = "<group>"; };
 		0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotConversationTests.swift"; sourceTree = "<group>"; };
 		EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotDraftTests.swift"; sourceTree = "<group>"; };
+		A496B07E0000000000000002 /* BotModeGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotModeGateTests.swift; sourceTree = "<group>"; };
 		B0B04ED8E6164A75B069773D /* BotClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotClientTests.swift"; sourceTree = "<group>"; };
 		5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatComposerView.swift"; sourceTree = "<group>"; };
 		5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatComposerPresentation.swift"; sourceTree = "<group>"; };
@@ -1012,6 +1014,7 @@
 				26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */,
 				B0B04ED8E6164A75B069773D /* BotClientTests.swift */,
 				EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */,
+				A496B07E0000000000000002 /* BotModeGateTests.swift */,
 				0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */,
 				C28702000000000000000004 /* ChatDraftStoreTests.swift */,
 				C28702000000000000000008 /* ChatDraftAttachmentStoreTests.swift */,
@@ -2097,6 +2100,7 @@
 				A4C0A37288B742B9B284A67E /* BotChatPresentationTests.swift in Sources */,
 				D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */,
 				142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */,
+				A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */,
 				9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */,
 				10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */,

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -314,6 +314,27 @@ enum SectionVisibilitySettings {
     }
 }
 
+/// App-wide preview gate for Bot Mode (#496). Default off so unfinished Bot UI
+/// never ships through a hotfix cut from `master`. Not per-server: it hides
+/// screens, it is not user data, and Bot connections and drafts stay in the
+/// Keychain while it is off. Delete this gate and its Settings row in the
+/// release PR that ships Bot Mode; see `docs/agents/bots.md`.
+enum BotModeGate {
+    static let isEnabledKey = "botMode.isEnabled"
+
+    static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: isEnabledKey)
+    }
+
+    /// The session list shows the Bots inbox only while the gate is on and the
+    /// user picked Bots. External routes (deep links, App Intents, shared
+    /// imports, Live Activity taps) clear the pick before this runs, so they
+    /// always land on Sessions regardless of the gate.
+    static func showsBotsInbox(isEnabled: Bool, userPickedBots: Bool) -> Bool {
+        isEnabled && userPickedBots
+    }
+}
+
 /// Pure helpers for the few *physical* layout values SwiftUI does not mirror on
 /// its own under right-to-left layout (issue #294 — app-wide RTL). Semantic edges
 /// (`.leading`/`.trailing`) and toolbar placements flip automatically; these cover

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -73,6 +73,7 @@ struct SessionListView: View {
     @AppStorage(SessionIdentitySettings.displayNameKey) private var identityDisplayName = ""
     @AppStorage(SessionIdentitySettings.initialsKey) private var identityInitials = ""
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @AppStorage(BotModeGate.isEnabledKey) private var isBotModeEnabled = false
 
     init(
         authManager: AuthManager,
@@ -115,6 +116,7 @@ struct SessionListView: View {
             .onChange(of: pendingDeepLinkedSessionID) { if pendingDeepLinkedSessionID != nil { showsBots = false } }
             .onChange(of: requestedNewChat) { if requestedNewChat != nil { showsBots = false } }
             .onChange(of: pendingSharedImport?.reservationID) { if pendingSharedImport != nil { showsBots = false } }
+            .onChange(of: isBotModeEnabled) { if !isBotModeEnabled { showsBots = false } }
             .safeAreaInset(edge: .top, spacing: 0) {
                 if hasWaitingSharedImport {
                     waitingSharedImportBanner
@@ -332,9 +334,13 @@ struct SessionListView: View {
         .accessibilityElement(children: .contain)
     }
 
+    private var showsBotsInbox: Bool {
+        BotModeGate.showsBotsInbox(isEnabled: isBotModeEnabled, userPickedBots: showsBots)
+    }
+
     @ViewBuilder
     private var navigationContainer: some View {
-        if showsBots {
+        if showsBotsInbox {
             NavigationStack {
                 BotsInboxView(server: server) { showsBots = false }
             }
@@ -469,12 +475,14 @@ struct SessionListView: View {
             header
                 .sessionsTopChromeListRow()
 
-            Picker("Screen", selection: $showsBots) {
-                Text("Sessions").tag(false)
-                Text("Bots").tag(true)
+            if isBotModeEnabled {
+                Picker("Screen", selection: $showsBots) {
+                    Text("Sessions").tag(false)
+                    Text("Bots").tag(true)
+                }
+                .pickerStyle(.segmented)
+                .sessionsScreenListRow()
             }
-            .pickerStyle(.segmented)
-            .sessionsScreenListRow()
 
             if viewModel.isViewingCachedData {
                 OfflineCacheBanner()

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -94,6 +94,7 @@ struct SettingsView: View {
     @AppStorage(SectionVisibilitySettings.projectsKey) private var showsProjectsSection = true
     @AppStorage(SectionVisibilitySettings.chatFilesKey) private var showsChatFilesButton = true
     @AppStorage(SectionVisibilitySettings.chatGitKey) private var showsChatGitControls = true
+    @AppStorage(BotModeGate.isEnabledKey) private var isBotModeEnabled = false
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
 
@@ -389,6 +390,16 @@ struct SettingsView: View {
                     )
 
                     SettingsFootnote(String(localized: "Turn off the entries you never use to shorten the top of the session list. Each one is the only way into its screen, so turn it back on here when you need it again."))
+                }
+
+                SettingsCard(title: String(localized: "Preview")) {
+                    SettingsToggleRow(
+                        title: String(localized: "Bot Mode (beta)"),
+                        systemImage: "cpu",
+                        isOn: $isBotModeEnabled
+                    )
+
+                    SettingsFootnote(String(localized: "Bot Mode is unfinished. It adds a Sessions/Bots switch to the session list and a Bot connection row to each server."))
                 }
 
                 SettingsCard(title: String(localized: "Sessions")) {
@@ -2104,6 +2115,7 @@ private struct ServerDetailView: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @AppStorage(BotModeGate.isEnabledKey) private var isBotModeEnabled = false
     @State private var displayName: String
     @State private var initials: String
     @State private var colorHex: String
@@ -2135,7 +2147,7 @@ private struct ServerDetailView: View {
                     }
                 }
 
-                if let server = URL(string: account.urlString) {
+                if isBotModeEnabled, let server = URL(string: account.urlString) {
                     NavigationLink("Bot connection") { BotConnectionView(server: server) }
                         .frame(minHeight: 44)
                 }

--- a/HermesMobileTests/BotModeGateTests.swift
+++ b/HermesMobileTests/BotModeGateTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import HermesMobile
+
+/// The Bot Mode preview gate (#496): default off, and the Sessions/Bots switch
+/// plus the Bots inbox stay unreachable until it is on.
+final class BotModeGateTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "BotModeGateTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testGateDefaultsOffAndPersistsWhenTurnedOn() {
+        XCTAssertFalse(BotModeGate.isEnabled(in: defaults))
+        defaults.set(true, forKey: BotModeGate.isEnabledKey)
+        XCTAssertTrue(BotModeGate.isEnabled(in: defaults))
+    }
+
+    func testBotsInboxNeedsBothTheGateAndTheUsersPick() {
+        // Gate off: even a stale Bots pick (the flag was turned off while the
+        // inbox was open) resolves to Sessions.
+        XCTAssertFalse(BotModeGate.showsBotsInbox(isEnabled: false, userPickedBots: true))
+        XCTAssertFalse(BotModeGate.showsBotsInbox(isEnabled: false, userPickedBots: false))
+        // Gate on: Sessions until the user picks Bots.
+        XCTAssertFalse(BotModeGate.showsBotsInbox(isEnabled: true, userPickedBots: false))
+        XCTAssertTrue(BotModeGate.showsBotsInbox(isEnabled: true, userPickedBots: true))
+    }
+}

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -47,6 +47,14 @@ occurs after disconnect. Acknowledgement alone does not establish completion;
 current idle does. The accepted server race remains: a Stop already sent may reach
 later Desktop work because the ordinary RPC has no expected-turn guard.
 
+Bot Mode ships behind `BotModeGate`, one app-wide `@AppStorage` bool that is off
+by default and owned by the Settings "Bot Mode (beta)" row (#496). Off hides the
+Sessions/Bots switch, the Bots inbox and the per-server Bot connection row;
+nothing else changes, and Bot connections and drafts stay in the Keychain until
+it is turned on again. The gate is not per-server because it hides screens
+rather than storing user data. It is removed, together with its Settings row
+and `BotModeGateTests`, in the release PR that ships Bot Mode, not before.
+
 New Bot code belongs only to the main app and XCTest target. Share-extension,
 App Intent, deep-link and Live Activity commands still route to webui sessions.
 The Sessions/Bots switch returns to Sessions for existing external entry points.


### PR DESCRIPTION
## Linked issue

Fixes #496

## What changed

Bot Mode lands on `master` slice by slice, and `master` is the TestFlight and hotfix branch. Unfinished Bot UI must not reach the App Store through a hotfix.

This adds `BotModeGate`, one app-wide `@AppStorage` bool (`botMode.isEnabled`), default off, owned by a new Settings "Preview" card with a "Bot Mode (beta)" toggle and a one-sentence footnote. While it is off:

- the Sessions/Bots picker is not rendered on the session list, and the Bots inbox cannot be shown (a stale Bots pick resolves to Sessions and is cleared when the flag turns off);
- the per-server "Bot connection" row in Settings is hidden;
- nothing else changes, and Bot connections and drafts stay in the Keychain until it is turned on again.

External routes (deep links, App Intents, shared imports, Live Activity taps) already reset the pick to Sessions, so they land on Sessions regardless of the flag. `docs/agents/bots.md` gains a paragraph on the gate and the rule that the flag, its Settings row and `BotModeGateTests` are deleted in the release PR that ships Bot Mode, not before.

The new strings are not added to the String Catalog, matching the rest of the Bot copy on `bot-mode`; the gate copy is beta-only and will be deleted at release.

## How it was tested

- Full XCTest suite on iPhone 17 via XcodeBuildMCP `test_sim`: 2359 passed, 0 failed, 2 skipped.
- New `BotModeGateTests`: default off, persists when turned on, inbox needs both the flag and the user's pick.
- Signed Debug build installed and launched on the simulator via `build_run_sim`; `HermesShareExtension` and `HermesLiveActivityWidget` compiled in the same build.
- `git diff --check` clean; `scripts/check-swift-file-sizes` reports no new oversized files.
- Manual: with the flag off, no Bots switch on the session list and no Bot connection row under a server; on, the switch appears and opens the Bots inbox; the setting survives relaunch; turning it off while on the inbox lands on Sessions.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (none changed)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (no network changes)

Model and harness: Claude Fable 5.1, Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)