### PR TITLE
feat(bots): add Bot Mode preview behind a default-off toggle

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -426,6 +426,16 @@
 		454454454454454454454402 /* ResponseTextSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454454454454454454454401 /* ResponseTextSelection.swift */; };
 		454454454454454454454412 /* ResponseSelectionInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454454454454454454454411 /* ResponseSelectionInput.swift */; };
 		454454454454454454454432 /* ResponseSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454454454454454454454431 /* ResponseSelectionTests.swift */; };
+		E8812D2097AF431094460471 /* BotChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */; };
+		13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A712D3AE91645C9B8C27745 /* BotConnection.swift */; };
+		C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */; };
+		013E4253ACC0484FA59DC45F /* BotConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */; };
+		7EF4120B486B4243AF54FCAF /* BotsInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE221A56F264309AF71E18B /* BotsInboxView.swift */; };
+		A27FAACA0A9243C5AD4860BB /* BotClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2EA5336E9B431489F91A63 /* BotClient.swift */; };
+		A990ABE1D2654992AD262B77 /* BotProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5619C4EB852849D396C45F95 /* BotProtocol.swift */; };
+		9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */; };
+		142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */; };
+		D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B04ED8E6164A75B069773D /* BotClientTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -883,6 +893,16 @@
 		454454454454454454454401 /* ResponseTextSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseTextSelection.swift; sourceTree = "<group>"; };
 		454454454454454454454411 /* ResponseSelectionInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseSelectionInput.swift; sourceTree = "<group>"; };
 		454454454454454454454431 /* ResponseSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseSelectionTests.swift; sourceTree = "<group>"; };
+		27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatView.swift"; sourceTree = "<group>"; };
+		0A712D3AE91645C9B8C27745 /* BotConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnection.swift"; sourceTree = "<group>"; };
+		40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnectionView.swift"; sourceTree = "<group>"; };
+		9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConversation.swift"; sourceTree = "<group>"; };
+		9FE221A56F264309AF71E18B /* BotsInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotsInboxView.swift"; sourceTree = "<group>"; };
+		BF2EA5336E9B431489F91A63 /* BotClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotClient.swift"; sourceTree = "<group>"; };
+		5619C4EB852849D396C45F95 /* BotProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotProtocol.swift"; sourceTree = "<group>"; };
+		0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotConversationTests.swift"; sourceTree = "<group>"; };
+		EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotDraftTests.swift"; sourceTree = "<group>"; };
+		B0B04ED8E6164A75B069773D /* BotClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotClientTests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -983,6 +1003,9 @@
 		1A2B3C4D5E6F700000000034 /* HermesMobileTests */ = {
 			isa = PBXGroup;
 			children = (
+				B0B04ED8E6164A75B069773D /* BotClientTests.swift */,
+				EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */,
+				0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */,
 				C28702000000000000000004 /* ChatDraftStoreTests.swift */,
 				C28702000000000000000008 /* ChatDraftAttachmentStoreTests.swift */,
 				10CA110C0DE000000000C002 /* LocalizationCatalogTests.swift */,
@@ -1134,6 +1157,8 @@
 		1A2B3C4D5E6F7000000000C1 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				5619C4EB852849D396C45F95 /* BotProtocol.swift */,
+				BF2EA5336E9B431489F91A63 /* BotClient.swift */,
 				1A2B3C4D5E6F7000000000B2 /* APIClient.swift */,
 				C04000000000000000000011 /* APIClient+Sessions.swift */,
 				C04000000000000000000012 /* APIClient+Projects.swift */,
@@ -1197,6 +1222,11 @@
 		1A2B3C4D5E6F7000000000C3 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				9FE221A56F264309AF71E18B /* BotsInboxView.swift */,
+				9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */,
+				40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */,
+				0A712D3AE91645C9B8C27745 /* BotConnection.swift */,
+				27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */,
 				1A2B3C4D5E6F7000000000C4 /* Onboarding */,
 				C09300000000000000000010 /* Shared */,
 				1A2B3C4D5E6F7000000000C5 /* SessionList */,
@@ -1778,6 +1808,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A990ABE1D2654992AD262B77 /* BotProtocol.swift in Sources */,
+				A27FAACA0A9243C5AD4860BB /* BotClient.swift in Sources */,
+				7EF4120B486B4243AF54FCAF /* BotsInboxView.swift in Sources */,
+				013E4253ACC0484FA59DC45F /* BotConversation.swift in Sources */,
+				C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */,
+				13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */,
+				E8812D2097AF431094460471 /* BotChatView.swift in Sources */,
 				1A2B3C4D5E6F700000000001 /* HermesMobileApp.swift in Sources */,
 				1A2B3C4D5E6F700000000002 /* ContentView.swift in Sources */,
 				1A2B3C4D5E6F700000000338 /* HermexAppIntents.swift in Sources */,
@@ -2046,6 +2083,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */,
+				142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */,
+				9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */,
 				10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */,
 				B5A1000000000000000000A0 /* ServerRegistryTests.swift in Sources */,

--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -436,6 +436,9 @@
 		9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */; };
 		142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */; };
 		D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B04ED8E6164A75B069773D /* BotClientTests.swift */; };
+		785784DE20094BA78F432A9A /* BotChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */; };
+		D4E8321C0A744DE3A5B8C997 /* ChatComposerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */; };
+		A4C0A37288B742B9B284A67E /* BotChatPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -903,6 +906,9 @@
 		0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotConversationTests.swift"; sourceTree = "<group>"; };
 		EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotDraftTests.swift"; sourceTree = "<group>"; };
 		B0B04ED8E6164A75B069773D /* BotClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotClientTests.swift"; sourceTree = "<group>"; };
+		5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatComposerView.swift"; sourceTree = "<group>"; };
+		5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatComposerPresentation.swift"; sourceTree = "<group>"; };
+		26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotChatPresentationTests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1003,6 +1009,7 @@
 		1A2B3C4D5E6F700000000034 /* HermesMobileTests */ = {
 			isa = PBXGroup;
 			children = (
+				26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */,
 				B0B04ED8E6164A75B069773D /* BotClientTests.swift */,
 				EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */,
 				0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */,
@@ -1222,6 +1229,7 @@
 		1A2B3C4D5E6F7000000000C3 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */,
 				9FE221A56F264309AF71E18B /* BotsInboxView.swift */,
 				9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */,
 				40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */,
@@ -1307,6 +1315,7 @@
 		1A2B3C4D5E6F7000000000C6 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */,
 				1A2B3C4D5E6F7000000000BF /* ChatView.swift */,
 				C05100000000000000000011 /* ChatTranscriptView.swift */,
 				C05100000000000000000012 /* ChatMessageActions.swift */,
@@ -1808,6 +1817,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4E8321C0A744DE3A5B8C997 /* ChatComposerPresentation.swift in Sources */,
+				785784DE20094BA78F432A9A /* BotChatComposerView.swift in Sources */,
 				A990ABE1D2654992AD262B77 /* BotProtocol.swift in Sources */,
 				A27FAACA0A9243C5AD4860BB /* BotClient.swift in Sources */,
 				7EF4120B486B4243AF54FCAF /* BotsInboxView.swift in Sources */,
@@ -2083,6 +2094,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4C0A37288B742B9B284A67E /* BotChatPresentationTests.swift in Sources */,
 				D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */,
 				142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */,
 				9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */,

--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 		A990ABE1D2654992AD262B77 /* BotProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5619C4EB852849D396C45F95 /* BotProtocol.swift */; };
 		9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */; };
 		142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */; };
+		A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000002 /* BotModeGateTests.swift */; };
 		D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B04ED8E6164A75B069773D /* BotClientTests.swift */; };
 		785784DE20094BA78F432A9A /* BotChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */; };
 		D4E8321C0A744DE3A5B8C997 /* ChatComposerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */; };
@@ -905,6 +906,7 @@
 		5619C4EB852849D396C45F95 /* BotProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotProtocol.swift"; sourceTree = "<group>"; };
 		0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotConversationTests.swift"; sourceTree = "<group>"; };
 		EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotDraftTests.swift"; sourceTree = "<group>"; };
+		A496B07E0000000000000002 /* BotModeGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotModeGateTests.swift; sourceTree = "<group>"; };
 		B0B04ED8E6164A75B069773D /* BotClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotClientTests.swift"; sourceTree = "<group>"; };
 		5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatComposerView.swift"; sourceTree = "<group>"; };
 		5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatComposerPresentation.swift"; sourceTree = "<group>"; };
@@ -1012,6 +1014,7 @@
 				26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */,
 				B0B04ED8E6164A75B069773D /* BotClientTests.swift */,
 				EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */,
+				A496B07E0000000000000002 /* BotModeGateTests.swift */,
 				0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */,
 				C28702000000000000000004 /* ChatDraftStoreTests.swift */,
 				C28702000000000000000008 /* ChatDraftAttachmentStoreTests.swift */,
@@ -2097,6 +2100,7 @@
 				A4C0A37288B742B9B284A67E /* BotChatPresentationTests.swift in Sources */,
 				D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */,
 				142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */,
+				A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */,
 				9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */,
 				10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */,

--- a/HermesMobile/Auth/AuthManager.swift
+++ b/HermesMobile/Auth/AuthManager.swift
@@ -307,6 +307,7 @@ final class AuthManager {
             await attemptBestEffortServerLogout(server: active)
         }
 
+        await ChatDraftStore.shared.discardBotDrafts(server: active)
         advanceAfterRemoving(activeServer: active)
     }
 
@@ -316,6 +317,7 @@ final class AuthManager {
     /// headers, and cookies — leaving the active server's auth untouched (#17).
     func removeServer(_ account: ServerAccount) async {
         guard let serverURL = URL(string: account.urlString) else { return }
+        await ChatDraftStore.shared.discardBotDrafts(server: serverURL)
         let isActive = state.server?.absoluteString == account.id
 
         if isActive {
@@ -400,6 +402,7 @@ final class AuthManager {
     /// its cookies — without touching the registry or the global `server_url` key.
     private func clearLocalArtifacts(for server: URL) {
         try? keychain.delete(.customHeaders, scope: server.absoluteString)
+        try? keychain.delete(.botConnection, scope: server.absoluteString)
         clearSessionCookies(for: server)
     }
 

--- a/HermesMobile/Auth/KeychainStore.swift
+++ b/HermesMobile/Auth/KeychainStore.swift
@@ -25,6 +25,7 @@ struct KeychainStore: KeychainStoring {
         // URL is treated as a credential, so the registry
         // lives in the Keychain, not UserDefaults (#15).
         case servers = "servers"
+        case botConnection = "bot_connection"
     }
 
     private let keychain: Keychain

--- a/HermesMobile/Config/AppTheme.swift
+++ b/HermesMobile/Config/AppTheme.swift
@@ -314,6 +314,27 @@ enum SectionVisibilitySettings {
     }
 }
 
+/// App-wide preview gate for Bot Mode (#496). Default off so unfinished Bot UI
+/// never ships through a hotfix cut from `master`. Not per-server: it hides
+/// screens, it is not user data, and Bot connections and drafts stay in the
+/// Keychain while it is off. Delete this gate and its Settings row in the
+/// release PR that ships Bot Mode; see `docs/agents/bots.md`.
+enum BotModeGate {
+    static let isEnabledKey = "botMode.isEnabled"
+
+    static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: isEnabledKey)
+    }
+
+    /// The session list shows the Bots inbox only while the gate is on and the
+    /// user picked Bots. External routes (deep links, App Intents, shared
+    /// imports, Live Activity taps) clear the pick before this runs, so they
+    /// always land on Sessions regardless of the gate.
+    static func showsBotsInbox(isEnabled: Bool, userPickedBots: Bool) -> Bool {
+        isEnabled && userPickedBots
+    }
+}
+
 /// Pure helpers for the few *physical* layout values SwiftUI does not mirror on
 /// its own under right-to-left layout (issue #294 — app-wide RTL). Semantic edges
 /// (`.leading`/`.trailing`) and toolbar placements flip automatically; these cover

--- a/HermesMobile/Features/Bots/BotChatComposerView.swift
+++ b/HermesMobile/Features/Bots/BotChatComposerView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+/// Sessions presentation with Bot-owned draft and action rules. The same editor
+/// stays mounted through focus changes; no webui runtime controls are involved.
+struct BotChatComposerView: View {
+    let model: BotConversation
+    let onStop: () -> Void
+    let onReconnect: () -> Void
+    let onResolveHeldMessage: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @AppStorage(HeaderLogoColor.storageKey) private var themeHex = HeaderLogoColor.defaultHex
+    @AppStorage(PrimaryActionTintSettings.isEnabledKey) private var tintsPrimaryActions = false
+    @ScaledMetric(relativeTo: .body) private var actionIconSize: CGFloat = 16
+    @State private var isFocused = false
+    @State private var selection = ComposerSelection()
+    @State private var inputHeight: CGFloat = 22
+    @State private var measuredHeight: CGFloat = 0
+    @State private var keyboardIsVisible = false
+
+    private var showsStop: Bool { model.mayStop || model.turn == .stopping }
+    private var canSend: Bool {
+        model.maySend && !model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    private var actionDisabled: Bool { showsStop ? !model.mayStop : !canSend }
+    private var appearance: ChatComposerActionAppearance {
+        ChatComposerActionAppearance(
+            isStop: showsStop, isDisabled: actionDisabled, colorScheme: colorScheme,
+            tintsPrimaryActions: tintsPrimaryActions, themeHex: themeHex
+        )
+    }
+
+    var body: some View {
+        AdaptiveGlassContainer(spacing: 6) {
+            VStack(spacing: 0) {
+                BotChatStatusView(model: model, onReconnect: onReconnect, onResolveHeldMessage: onResolveHeldMessage)
+
+                HStack(alignment: .center, spacing: 4) {
+                    ComposerTextInputView(
+                        text: Binding(get: { model.draft }, set: { model.editDraft($0) }),
+                        selection: $selection, isFocused: $isFocused,
+                        inputHeight: $inputHeight, measuredHeight: $measuredHeight,
+                        isDisabled: !model.mayEditDraft, isCollapsed: !isFocused,
+                        isKeyboardSendEnabled: canSend, verticalPadding: 12,
+                        chipSkills: [], chipFilePaths: [], quotes: [],
+                        onKeyboardSend: send,
+                        onPasteFileProviders: { _ in }, onPasteFileURLs: { _ in },
+                        onPasteImageProviders: { _ in }, onPasteImages: { _ in },
+                        onTapChip: { _ in }, onTapQuote: { _ in }, onRemoveQuote: { _ in },
+                        placeholder: String(localized: "Message bot"), acceptsAttachments: false
+                    )
+                    if !isFocused { actionButton }
+                }
+                .padding(.trailing, isFocused ? 0 : ChatComposerMetrics.pillInset)
+                .padding(.vertical, isFocused ? 0 : ChatComposerMetrics.pillInset)
+                .padding(.top, isFocused ? 2 : 0)
+                .padding(.bottom, isFocused ? 4 : 0)
+                .modifier(ChatComposerSurfaceStyle(isExpanded: isFocused))
+                .padding(.horizontal, 16)
+
+                if isFocused {
+                    HStack {
+                        Spacer(minLength: 0)
+                        actionButton
+                    }
+                    .padding(.horizontal, 16)
+                    // Sessions adds a 6 pt stack gap before its 8 pt toolbar inset.
+                    .padding(.top, 14)
+                    .background(
+                        Color(.systemBackground)
+                            .padding(.top, -10).padding(.bottom, -12)
+                            .ignoresSafeArea(edges: .bottom)
+                    )
+                    .transition(ChatMotion.bottomOverlayTransition(reduceMotion: reduceMotion))
+                }
+            }
+            // Focus flips arrive from UIKit outside any withAnimation, so the
+            // pill-to-card morph and the row's insertion animate from here,
+            // exactly as the Sessions composer does.
+            .animation(ChatMotion.composerChrome(reduceMotion: reduceMotion), value: isFocused)
+        }
+        .padding(.bottom, keyboardIsVisible ? 10 : 0)
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+            keyboardIsVisible = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            keyboardIsVisible = false
+        }
+    }
+
+    private var actionButton: some View {
+        Button {
+            if showsStop { onStop() } else { send() }
+        } label: {
+            Image(systemName: showsStop ? "stop.fill" : "arrow.up")
+                .font(.system(size: actionIconSize, weight: .semibold))
+                .frame(width: ChatComposerMetrics.actionSize, height: ChatComposerMetrics.actionSize)
+                .background(appearance.background)
+                .foregroundStyle(appearance.foreground)
+                .clipShape(Circle())
+        }
+        .buttonStyle(.chatTactile(.icon))
+        .disabled(actionDisabled)
+        .accessibilityLabel(showsStop ? Text("Stop current work") : Text("Send"))
+        .keyboardShortcut(showsStop ? nil : KeyboardShortcut(.return, modifiers: .command))
+    }
+
+    private func send() {
+        guard canSend else { return }
+        Task { await model.send() }
+    }
+}
+
+/// Ready and connected has no status chrome. Recovery, work and failures appear
+/// immediately above the composer, including the existing Desktop-only actions.
+private struct BotChatStatusView: View {
+    let model: BotConversation
+    let onReconnect: () -> Void
+    let onResolveHeldMessage: () -> Void
+
+    var body: some View {
+        if model.connectionState != .connected || model.turn != .idle || model.errorMessage != nil || model.uncertainSend {
+            VStack(alignment: .leading, spacing: 6) {
+                if let connectionText { Text(connectionText) }
+                if let error = model.errorMessage { Text(error) }
+                if model.uncertainSend {
+                    Text("Send outcome unknown. Check the conversation in Desktop before sending again.")
+                    if model.connectionState == .connected {
+                        Button("Resolve held message…", action: onResolveHeldMessage)
+                    }
+                } else if model.turn == .needsAttention {
+                    // The model ranks a pending request above an unresolved Stop;
+                    // the Desktop instruction is the actionable line, so it wins here too.
+                    Text("Needs attention. Answer the request in Hermes Desktop on this same connection.")
+                } else if model.uncertainStop && model.turn != .stopping {
+                    Text("Outcome unknown")
+                } else if model.connectionState == .connected, let turnText {
+                    Text(turnText)
+                }
+                if model.connectionState == .disconnected {
+                    Button("Reconnect", action: onReconnect)
+                }
+            }
+            .font(AppFont.footnote())
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16).padding(.bottom, 8)
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("bot-chat-status")
+        }
+    }
+
+    private var connectionText: String? {
+        switch model.connectionState {
+        case .connected: return nil
+        case .recovering: return String(localized: "Loading current conversation…")
+        case .disconnected: return String(localized: "Disconnected · Last loaded conversation")
+        }
+    }
+
+    private var turnText: String? {
+        switch model.turn {
+        case .idle, .needsAttention: return nil
+        case .running: return String(localized: "Working")
+        case .submitting: return String(localized: "Sending…")
+        case .stopping: return String(localized: "Stopping…")
+        case .uncertain: return String(localized: "Outcome unknown")
+        case .interrupted: return String(localized: "Work was interrupted. The saved conversation is loaded.")
+        case .unknown: return String(localized: "Checking current work…")
+        }
+    }
+}

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -6,10 +6,16 @@ import SwiftUI
     @State private var stopAction: BotConversation.StopAction?
     @State private var confirmingDiscard = false
     @State private var recoveryID = UUID()
+    @State private var followsLatest = true
+    @State private var isAtBottom = true
     @FocusState private var composerFocused: Bool
 
     init(server: URL, connection: BotConnection, profile: BotProfile) {
         _model = State(initialValue: BotConversation(server: server, connection: connection, profile: profile))
+    }
+
+    init(model: BotConversation) {
+        _model = State(initialValue: model)
     }
 
     var body: some View {
@@ -21,19 +27,45 @@ import SwiftUI
             }
             .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal)
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 20) {
-                    if model.messages.isEmpty && model.liveMessages.isEmpty && model.connectionState == .connected {
-                        Text("No messages yet").foregroundStyle(.secondary)
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 20) {
+                        if model.messages.isEmpty && model.liveMessages.isEmpty && model.connectionState == .connected {
+                            Text("No messages yet").foregroundStyle(.secondary)
+                        }
+                        ForEach(model.messages) { message in BotMessageRow(message: message) }
+                        ForEach(model.liveMessages) { message in BotMessageRow(message: message) }
+                        Color.clear.frame(height: 1).id("bot-transcript-bottom")
                     }
-                    ForEach(model.messages) { message in BotMessageRow(message: message, streaming: false) }
-                    ForEach(model.liveMessages) { message in BotMessageRow(message: message, streaming: true) }
+                    .padding()
                 }
-                .padding()
+                .defaultScrollAnchor(.bottom)
+                .scrollDismissesKeyboard(.interactively)
+                .onScrollGeometryChange(for: Bool.self) { geometry in
+                    geometry.contentOffset.y + geometry.containerSize.height
+                        >= geometry.contentSize.height + geometry.contentInsets.bottom - 48
+                } action: { _, atBottom in
+                    isAtBottom = atBottom
+                }
+                .onScrollPhaseChange { _, phase in
+                    if phase == .interacting { followsLatest = false }
+                    if phase == .idle && isAtBottom { followsLatest = true }
+                }
+                .onChange(of: model.messages.count) { followLatest(proxy) }
+                .onChange(of: model.liveMessages.last?.content) { followLatest(proxy) }
+                .onChange(of: model.connectionState) { followLatest(proxy) }
+                .overlay(alignment: .bottomTrailing) {
+                    if !followsLatest {
+                        Button("Latest", systemImage: "arrow.down") {
+                            followsLatest = true
+                            followLatest(proxy)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .padding()
+                    }
+                }
+                .safeAreaInset(edge: .bottom, spacing: 0) { composer }
             }
-            .defaultScrollAnchor(.bottom)
-            .scrollDismissesKeyboard(.interactively)
-            .safeAreaInset(edge: .bottom, spacing: 0) { composer }
         }
         .navigationTitle(model.profile.name)
         .navigationBarTitleDisplayMode(.inline)
@@ -64,6 +96,12 @@ import SwiftUI
         } message: {
             Text("First check whether Desktop received this message. Discarding removes the held text from Hermex. It does not stop or resend any work.")
         }
+    }
+
+    private func followLatest(_ proxy: ScrollViewProxy) {
+        guard followsLatest else { return }
+        // The stable trailing anchor follows growing output without animating every token.
+        proxy.scrollTo("bot-transcript-bottom", anchor: .bottom)
     }
 
     private var composer: some View {
@@ -128,7 +166,6 @@ import SwiftUI
 
 private struct BotMessageRow: View {
     let message: ChatMessage
-    let streaming: Bool
     var body: some View {
         if message.role == "user" {
             Text(message.content ?? "")
@@ -137,8 +174,9 @@ private struct BotMessageRow: View {
                 .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18))
                 .frame(maxWidth: .infinity, alignment: .trailing)
         } else {
-            // Reuse text rendering without webui media loaders or message actions.
-            MarkdownRenderer(content: message.content ?? "", isStreaming: streaming)
+            // Coalesced snapshots render synchronously: the deferred streaming
+            // renderer can leave the trailing viewport blank as its height changes.
+            MarkdownRenderer(content: message.content ?? "")
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
     }

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -8,7 +8,7 @@ import SwiftUI
     @State private var recoveryID = UUID()
     @State private var followsLatest = true
     @State private var isAtBottom = true
-    @FocusState private var composerFocused: Bool
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(server: URL, connection: BotConnection, profile: BotProfile) {
         _model = State(initialValue: BotConversation(server: server, connection: connection, profile: profile))
@@ -20,24 +20,18 @@ import SwiftUI
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(model.connection.name + " / " + model.profile.id)
-                    .font(.footnote).foregroundStyle(.secondary)
-                Text(connectionLabel).font(.caption)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal)
-
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 20) {
+                    LazyVStack(alignment: .leading, spacing: 8) {
                         if model.messages.isEmpty && model.liveMessages.isEmpty && model.connectionState == .connected {
                             Text("No messages yet").foregroundStyle(.secondary)
                         }
-                        ForEach(model.messages) { message in BotMessageRow(message: message) }
-                        ForEach(model.liveMessages) { message in BotMessageRow(message: message) }
+                        ForEach(model.messages) { message in MessageBubbleView(message: message, textOnly: true) }
+                        ForEach(model.liveMessages) { message in MessageBubbleView(message: message, textOnly: true) }
                         Color.clear.frame(height: 1).id("bot-transcript-bottom")
                     }
-                    .padding()
+                    .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 20 : 16)
+                    .padding(.vertical, 16)
                 }
                 .defaultScrollAnchor(.bottom)
                 .scrollDismissesKeyboard(.interactively)
@@ -105,79 +99,11 @@ import SwiftUI
     }
 
     private var composer: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            if let error = model.errorMessage { Text(error).font(.footnote).foregroundStyle(.secondary) }
-            if model.uncertainSend {
-                Text("Send outcome unknown. Check the conversation in Desktop before sending again.").font(.footnote)
-                if model.connectionState == .connected {
-                    Button("Resolve held message…") { confirmingDiscard = true }.font(.footnote)
-                }
-            } else if model.turn == .needsAttention {
-                Text("Needs attention. Answer the request in Hermes Desktop on this same connection.").font(.footnote)
-            }
-            if model.connectionState == .disconnected {
-                Button("Reconnect") { recoveryID = UUID() }
-            }
-            TextField("Message bot", text: Binding(get: { model.draft }, set: { model.editDraft($0) }), axis: .vertical)
-                .lineLimit(1...6)
-                .focused($composerFocused)
-                .disabled(model.uncertainSend || model.turn == .submitting)
-                .accessibilityLabel("Message bot")
-            HStack {
-                Text(turnLabel).font(.footnote).foregroundStyle(.secondary)
-                Spacer()
-                if model.mayStop {
-                    Button("Stop…", systemImage: "stop.fill") { stopAction = model.prepareStop() }
-                        .frame(minWidth: 44, minHeight: 44)
-                } else {
-                    Button("Send", systemImage: "arrow.up") { Task { await model.send() } }
-                        .keyboardShortcut(.return, modifiers: .command)
-                        .frame(minWidth: 44, minHeight: 44)
-                        .disabled(!model.maySend || model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                }
-            }
-        }
-        .padding(16)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24))
-        .padding(.horizontal, 12).padding(.bottom, 8)
-    }
-
-    private var connectionLabel: String {
-        switch model.connectionState {
-        case .connected: return String(localized: "Connected")
-        case .recovering: return String(localized: "Loading current conversation…")
-        case .disconnected: return String(localized: "Disconnected · Last loaded conversation")
-        }
-    }
-
-    private var turnLabel: String {
-        switch model.turn {
-        case .idle: return String(localized: "Ready")
-        case .running: return String(localized: "Working")
-        case .needsAttention: return String(localized: "Needs attention")
-        case .submitting: return String(localized: "Sending…")
-        case .stopping: return String(localized: "Stopping…")
-        case .uncertain: return String(localized: "Outcome unknown")
-        case .interrupted: return String(localized: "Work was interrupted. The saved conversation is loaded.")
-        case .unknown: return String(localized: "Checking current work…")
-        }
-    }
-}
-
-private struct BotMessageRow: View {
-    let message: ChatMessage
-    var body: some View {
-        if message.role == "user" {
-            Text(message.content ?? "")
-                .textSelection(.enabled)
-                .padding(12)
-                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18))
-                .frame(maxWidth: .infinity, alignment: .trailing)
-        } else {
-            // Coalesced snapshots render synchronously: the deferred streaming
-            // renderer can leave the trailing viewport blank as its height changes.
-            MarkdownRenderer(content: message.content ?? "")
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
+        BotChatComposerView(
+            model: model,
+            onStop: { stopAction = model.prepareStop() },
+            onReconnect: { recoveryID = UUID() },
+            onResolveHeldMessage: { confirmingDiscard = true }
+        )
     }
 }

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+@MainActor struct BotChatView: View {
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var model: BotConversation
+    @State private var stopAction: BotConversation.StopAction?
+    @State private var confirmingDiscard = false
+    @State private var recoveryID = UUID()
+    @FocusState private var composerFocused: Bool
+
+    init(server: URL, connection: BotConnection, profile: BotProfile) {
+        _model = State(initialValue: BotConversation(server: server, connection: connection, profile: profile))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(model.connection.name + " / " + model.profile.id)
+                    .font(.footnote).foregroundStyle(.secondary)
+                Text(connectionLabel).font(.caption)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 20) {
+                    if model.messages.isEmpty && model.liveMessages.isEmpty && model.connectionState == .connected {
+                        Text("No messages yet").foregroundStyle(.secondary)
+                    }
+                    ForEach(model.messages) { message in BotMessageRow(message: message, streaming: false) }
+                    ForEach(model.liveMessages) { message in BotMessageRow(message: message, streaming: true) }
+                }
+                .padding()
+            }
+            .defaultScrollAnchor(.bottom)
+            .scrollDismissesKeyboard(.interactively)
+            .safeAreaInset(edge: .bottom, spacing: 0) { composer }
+        }
+        .navigationTitle(model.profile.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .task(id: recoveryID) {
+            if scenePhase == .active { await model.recover() }
+        }
+        .onChange(of: scenePhase) {
+            if scenePhase == .active { recoveryID = UUID() }
+            else { stopAction = nil; model.suspend() }
+        }
+        .onDisappear { stopAction = nil; model.suspend() }
+        .confirmationDialog("Stop this bot’s current work?", isPresented: Binding(
+            get: { stopAction != nil }, set: { if !$0 { stopAction = nil } }
+        ), titleVisibility: .visible) {
+            if let action = stopAction {
+                Button("Stop current work", role: .destructive) {
+                    stopAction = nil
+                    Task { await model.stop(action) }
+                }
+            }
+        } message: {
+            Text("This stops current work in this conversation, including work started in Desktop, clears queued prompts and denies pending approvals. It also stops host speech playback. A command already sent may reach later Desktop work.")
+        }
+        .confirmationDialog("Discard the held message?", isPresented: $confirmingDiscard, titleVisibility: .visible) {
+            Button("I checked Desktop; discard held message", role: .destructive) {
+                Task { await model.discardUncertainSubmission() }
+            }
+        } message: {
+            Text("First check whether Desktop received this message. Discarding removes the held text from Hermex. It does not stop or resend any work.")
+        }
+    }
+
+    private var composer: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let error = model.errorMessage { Text(error).font(.footnote).foregroundStyle(.secondary) }
+            if model.uncertainSend {
+                Text("Send outcome unknown. Check the conversation in Desktop before sending again.").font(.footnote)
+                if model.connectionState == .connected {
+                    Button("Resolve held message…") { confirmingDiscard = true }.font(.footnote)
+                }
+            } else if model.turn == .needsAttention {
+                Text("Needs attention. Answer the request in Hermes Desktop on this same connection.").font(.footnote)
+            }
+            if model.connectionState == .disconnected {
+                Button("Reconnect") { recoveryID = UUID() }
+            }
+            TextField("Message bot", text: Binding(get: { model.draft }, set: { model.editDraft($0) }), axis: .vertical)
+                .lineLimit(1...6)
+                .focused($composerFocused)
+                .disabled(model.uncertainSend || model.turn == .submitting)
+                .accessibilityLabel("Message bot")
+            HStack {
+                Text(turnLabel).font(.footnote).foregroundStyle(.secondary)
+                Spacer()
+                if model.mayStop {
+                    Button("Stop…", systemImage: "stop.fill") { stopAction = model.prepareStop() }
+                        .frame(minWidth: 44, minHeight: 44)
+                } else {
+                    Button("Send", systemImage: "arrow.up") { Task { await model.send() } }
+                        .keyboardShortcut(.return, modifiers: .command)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .disabled(!model.maySend || model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+        .padding(16)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24))
+        .padding(.horizontal, 12).padding(.bottom, 8)
+    }
+
+    private var connectionLabel: String {
+        switch model.connectionState {
+        case .connected: return String(localized: "Connected")
+        case .recovering: return String(localized: "Loading current conversation…")
+        case .disconnected: return String(localized: "Disconnected · Last loaded conversation")
+        }
+    }
+
+    private var turnLabel: String {
+        switch model.turn {
+        case .idle: return String(localized: "Ready")
+        case .running: return String(localized: "Working")
+        case .needsAttention: return String(localized: "Needs attention")
+        case .submitting: return String(localized: "Sending…")
+        case .stopping: return String(localized: "Stopping…")
+        case .uncertain: return String(localized: "Outcome unknown")
+        case .interrupted: return String(localized: "Work was interrupted. The saved conversation is loaded.")
+        case .unknown: return String(localized: "Checking current work…")
+        }
+    }
+}
+
+private struct BotMessageRow: View {
+    let message: ChatMessage
+    let streaming: Bool
+    var body: some View {
+        if message.role == "user" {
+            Text(message.content ?? "")
+                .textSelection(.enabled)
+                .padding(12)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 18))
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        } else {
+            // Reuse text rendering without webui media loaders or message actions.
+            MarkdownRenderer(content: message.content ?? "", isStreaming: streaming)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/HermesMobile/Features/Bots/BotConnection.swift
+++ b/HermesMobile/Features/Bots/BotConnection.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+struct BotConnection: Codable, Equatable, Identifiable {
+    let id: UUID
+    var name: String
+    let address: URL
+    let username: String
+    var password: String
+
+    static func address(_ text: String) throws -> URL {
+        guard var parts = URLComponents(string: text.trimmingCharacters(in: .whitespacesAndNewlines)),
+              ["http", "https"].contains(parts.scheme?.lowercased() ?? ""),
+              let host = parts.host, !host.isEmpty,
+              parts.user == nil, parts.password == nil, parts.query == nil, parts.fragment == nil,
+              parts.path.isEmpty || parts.path == "/" else { throw BotFailure.invalidAddress }
+        parts.scheme = parts.scheme?.lowercased()
+        parts.host = host.lowercased()
+        parts.path = ""
+        guard let url = parts.url else { throw BotFailure.invalidAddress }
+        return url
+    }
+}
+
+/// One credential record per configured webui server. Replacing an endpoint or
+/// account mints a new identity even when Profile names happen to match.
+@MainActor struct BotConnectionStore {
+    var keychain: any KeychainStoring = KeychainStore()
+    func load(server: URL) throws -> BotConnection? {
+        guard let value = try keychain.load(.botConnection, scope: server.absoluteString) else { return nil }
+        return try JSONDecoder().decode(BotConnection.self, from: Data(value.utf8))
+    }
+    func save(_ connection: BotConnection, server: URL) throws {
+        let value = String(decoding: try JSONEncoder().encode(connection), as: UTF8.self)
+        try keychain.save(value, forKey: .botConnection, scope: server.absoluteString)
+    }
+    func remove(server: URL) throws {
+        try keychain.delete(.botConnection, scope: server.absoluteString)
+    }
+}
+
+struct BotProfile: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let preview: String?
+    let lastActive: Date?
+
+    init?(_ row: BotJSON) {
+        guard let profile = row["name"].text, !profile.isEmpty else { return nil }
+        id = profile
+        let displayName = row["display_name"].text ?? ""
+        name = displayName.isEmpty ? profile : displayName
+        preview = row["canonical_session"]["preview"].text
+        lastActive = row["canonical_session"]["last_active"].number.map(Date.init(timeIntervalSince1970:))
+    }
+}

--- a/HermesMobile/Features/Bots/BotConnectionView.swift
+++ b/HermesMobile/Features/Bots/BotConnectionView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+@MainActor struct BotConnectionView: View {
+    @Environment(\.dismiss) private var dismiss
+    let server: URL
+    @State private var saved: BotConnection?
+    @State private var name = ""
+    @State private var address = ""
+    @State private var username = ""
+    @State private var password = ""
+    @State private var errorMessage: String?
+    @State private var isConnecting = false
+    @State private var confirmingRemoval = false
+    @State private var client: BotClient?
+    @State private var connectTask: Task<Void, Never>?
+    private let store = BotConnectionStore()
+
+    var body: some View {
+        Form {
+            Section {
+                Text(server.host ?? server.absoluteString).font(.footnote).foregroundStyle(.secondary)
+                TextField("Name", text: $name)
+                TextField("Hermes address", text: $address)
+                    .keyboardType(.URL).textInputAutocapitalization(.never).autocorrectionDisabled()
+                TextField("Username", text: $username).textContentType(.username)
+                    .textInputAutocapitalization(.never).autocorrectionDisabled()
+                SecureField("Password", text: $password).textContentType(.password)
+            } header: { Text("Bot connection") } footer: {
+                Text("This connection belongs to the selected Hermex server. Use the address and password of your existing Hermes backend on LAN or Tailscale.")
+            }
+            Section {
+                if let errorMessage { Text(errorMessage).foregroundStyle(.red) }
+                Button(isConnecting ? String(localized: "Connecting…") : String(localized: "Connect")) {
+                    connectTask = Task { await connect() }
+                }
+                .disabled(isConnecting || address.isEmpty || username.isEmpty || password.isEmpty)
+            }
+            Section("Setup in Hermes Desktop") {
+                Text("Keep Hermes Desktop running. In Settings → Advanced, enable Keep computer awake. The display may dim.")
+                Text("In Settings → Plugins, enable Bots for the intended Profile. Applies to selects the Profile configuration being edited.")
+                Text("Desktop and Hermex must use the same password-protected backend. Remote gateway connects Desktop to a backend; it does not expose Desktop’s private local backend to your phone.")
+                Text("Open each bot’s Bot Chat in Desktop first. Do not start a second backend using the same Profile storage.")
+                Text("Connecting loads the bot roster and may recover archived Bot Chats. Opening a chat may resume unfinished work. Approvals are answered in Desktop.")
+            }
+            if saved != nil {
+                Section {
+                    Button("Remove bot connection…", role: .destructive) { confirmingRemoval = true }
+                }
+            }
+        }
+        .navigationTitle("Bot connection")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar { ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } } }
+        .task {
+            do {
+                saved = try store.load(server: server)
+                name = saved?.name ?? ""
+                address = saved?.address.absoluteString ?? ""
+                username = saved?.username ?? ""
+                password = saved?.password ?? ""
+            } catch { errorMessage = String(localized: "Could not read saved sign-in details.") }
+        }
+        .onDisappear { connectTask?.cancel(); client?.close(); client = nil }
+        .confirmationDialog("Remove this connection from Hermex?", isPresented: $confirmingRemoval, titleVisibility: .visible) {
+            Button("Remove bot connection", role: .destructive) {
+                Task {
+                    do {
+                        try store.remove(server: server)
+                        if let saved { await ChatDraftStore.shared.discardBotDrafts(server: server, connectionID: saved.id) }
+                        dismiss()
+                    } catch { errorMessage = String(localized: "Could not remove saved sign-in details.") }
+                }
+            }
+        } message: {
+            Text("Saved sign-in details and this connection’s drafts will be deleted. Bots and their work remain on the host.")
+        }
+    }
+
+    private func connect() async {
+        guard !isConnecting else { return }
+        isConnecting = true; errorMessage = nil
+        defer { if !Task.isCancelled { isConnecting = false } }
+        do {
+            let url = try BotConnection.address(address)
+            let sameAccount = saved?.address == url && saved?.username == username
+            let candidate = BotConnection(id: sameAccount ? saved!.id : UUID(),
+                                          name: name.isEmpty ? (url.host ?? "Hermes") : name,
+                                          address: url, username: username, password: password)
+            let wire = BotClient(connection: candidate)
+            client = wire
+            defer { wire.close() }
+            try await wire.connect()
+            guard !Task.isCancelled, client === wire else { return }
+            let result = try await wire.call("profiles.list", ["include_sessions": .bool(true)])
+            guard !Task.isCancelled, client === wire else { return }
+            guard result["profiles"].list != nil else { throw BotFailure.unsupported }
+            try store.save(candidate, server: server)
+            if let saved, saved.id != candidate.id {
+                await ChatDraftStore.shared.discardBotDrafts(server: server, connectionID: saved.id)
+            }
+            guard !Task.isCancelled, client === wire else { return }
+            saved = candidate
+            dismiss()
+        } catch {
+            guard !Task.isCancelled, client != nil else { return }
+            errorMessage = (error as? BotFailure)?.localizedDescription ?? String(localized: "Could not save sign-in details or connect to Hermes.")
+        }
+    }
+}

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -54,8 +54,10 @@ import Observation
             && !localOperation && !uncertainStop
     }
 
+    var mayEditDraft: Bool { hydrated && !uncertainSend && !localOperation }
+
     func editDraft(_ text: String) {
-        guard hydrated, !uncertainSend, !localOperation else { return }
+        guard mayEditDraft else { return }
         draft = text
         drafts.setDraft(text, for: draftKey)
     }

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -1,0 +1,342 @@
+import Foundation
+import Observation
+
+@MainActor @Observable final class BotConversation {
+    enum ConnectionState { case disconnected, recovering, connected }
+    enum TurnState { case unknown, idle, submitting, running, needsAttention, stopping, uncertain, interrupted }
+    struct StopAction: Equatable { let generation: Int; let revision: Int; let runtime: String }
+
+    let profile: BotProfile
+    let connection: BotConnection
+    let server: URL
+    private(set) var connectionState = ConnectionState.disconnected
+    private(set) var turn = TurnState.unknown
+    private(set) var messages: [ChatMessage] = []
+    private(set) var liveMessages: [ChatMessage] = []
+    private(set) var errorMessage: String?
+    private(set) var draft = ""
+    private(set) var uncertainSend = false
+    private(set) var uncertainStop = false
+    private(set) var root: String?
+    private(set) var runtime: String?
+    private(set) var sequence = 0
+    private(set) var epoch: String?
+    private(set) var replayWasReset = false
+    private var tip: String?
+    private var generation = 0
+    private var turnRevision = 0
+    private var turnStartedAt: Double?
+    private var snapshotDirty = false
+    private var fullSnapshotNeeded = false
+    private var refreshTask: Task<Void, Never>?
+    private var stopAcknowledged = false
+    private var localOperation = false
+    private var hydrated = false
+    private let wire: any BotTransport
+    private let drafts: ChatDraftStore
+
+    init(server: URL, connection: BotConnection, profile: BotProfile,
+         wire: (any BotTransport)? = nil, drafts: ChatDraftStore? = nil) {
+        self.server = server; self.connection = connection; self.profile = profile
+        self.wire = wire ?? BotClient(connection: connection)
+        self.drafts = drafts ?? .shared
+        self.wire.onEvent = { [weak self] event in self?.observe(event) }
+        self.wire.onDisconnect = { [weak self] error in self?.disconnected(error) }
+    }
+
+    var draftKey: ChatDraftKey { .bot(server: server, connectionID: connection.id, profile: profile.id) }
+    var maySend: Bool {
+        hydrated && connectionState == .connected && [.idle, .interrupted].contains(turn)
+            && !localOperation && !uncertainSend && !uncertainStop
+    }
+    var mayStop: Bool {
+        connectionState == .connected && [.running, .needsAttention].contains(turn)
+            && !localOperation && !uncertainStop
+    }
+
+    func editDraft(_ text: String) {
+        guard hydrated, !uncertainSend, !localOperation else { return }
+        draft = text
+        drafts.setDraft(text, for: draftKey)
+    }
+
+    func recover() async {
+        suspend()
+        let owner = generation
+        connectionState = .recovering
+        errorMessage = nil
+        do {
+            if !hydrated {
+                let saved = await drafts.draft(for: draftKey)
+                try check(owner)
+                draft = saved?.text ?? ""
+                uncertainSend = saved?.botSubmissionUncertain ?? false
+                hydrated = true
+            }
+            try await wire.connect()
+            try check(owner)
+            let lookup = try await request("session.list", ["profile": .string(profile.id), "title": .string("Bot Chat"), "include_hidden": .bool(true)], owner: owner)
+            guard let rows = lookup["sessions"].list else { throw BotFailure.unsupported }
+            guard rows.count == 1 else { throw BotFailure.missingChat }
+            guard let foundRoot = rows[0]["id"].text, !foundRoot.isEmpty,
+                  let foundTip = rows[0]["resolved_id"].text, !foundTip.isEmpty else { throw BotFailure.unsupported }
+            // Resume can auto-continue. Reject a changed root before making that call.
+            if let root, root != foundRoot { throw BotFailure.wrongIdentity }
+            root = foundRoot; tip = foundTip
+            let first = try await request("session.resume", resumeParams(), owner: owner)
+            guard first["session_key"].text == foundTip, let foundRuntime = first["session_id"].text,
+                  !foundRuntime.isEmpty, let foundEpoch = wire.replayEpoch else { throw BotFailure.wrongIdentity }
+            replayWasReset = epoch != foundEpoch || runtime != foundRuntime
+            if replayWasReset { sequence = 0 }
+            runtime = foundRuntime; epoch = foundEpoch
+            let replay = try await request("session.events.since", ["session_id": .string(foundRuntime), "last_seen": .number(Double(sequence))], owner: owner)
+            try reconcileReplay(replay)
+            let current = try await request("session.resume", resumeParams(), owner: owner)
+            try applySnapshot(current, full: true)
+            try check(owner)
+            connectionState = .connected
+            scheduleRefresh()
+        } catch {
+            guard owner == generation, !Task.isCancelled else { return }
+            disconnected(error)
+        }
+    }
+
+    private func resumeParams(full: Bool = true) -> [String: BotJSON] {
+        var params: [String: BotJSON] = ["profile": .string(profile.id), "session_id": .string(tip ?? ""), "close_on_disconnect": .bool(false)]
+        if !full { params["omit_messages"] = .bool(true) }
+        return params
+    }
+
+    private func check(_ owner: Int) throws {
+        guard generation == owner, !Task.isCancelled else { throw BotFailure.stale }
+    }
+
+    private func request(_ method: String, _ params: [String: BotJSON], owner: Int, validateDispatch: (() throws -> Void)? = nil) async throws -> BotJSON {
+        try check(owner)
+        let reply = try await wire.call(method, params, validateDispatch: validateDispatch)
+        try check(owner)
+        return reply
+    }
+
+    private func reconcileReplay(_ reply: BotJSON) throws {
+        guard let latest = reply["latest_seq"].integer, latest >= 0,
+              let receivedEpoch = reply["epoch"].text, !receivedEpoch.isEmpty,
+              let truncated = reply["truncated"].flag, let events = reply["events"].list else { throw BotFailure.unsupported }
+        if epoch != receivedEpoch || truncated || latest < sequence { replayWasReset = true }
+        var cursor = sequence
+        for event in events {
+            guard event["session_id"].text == runtime else { throw BotFailure.wrongIdentity }
+            guard let next = event["seq"].integer, next > 0, next <= latest else { throw BotFailure.unsupported }
+            if next <= cursor { continue }
+            if next != cursor + 1 { replayWasReset = true }
+            cursor = next
+        }
+        if cursor < latest { replayWasReset = true }
+        epoch = receivedEpoch; sequence = latest
+        // Replay is only a continuity check. A full snapshot replaces text below.
+    }
+
+    private func applySnapshot(_ snapshot: BotJSON, full: Bool) throws {
+        guard snapshot["session_id"].text == runtime, snapshot["session_key"].text == tip,
+              let running = snapshot["running"].flag, snapshot["hydrating"].flag != true else { throw BotFailure.unsupported }
+        if let value = snapshot["info"]["profile_name"].text, value != profile.id { throw BotFailure.wrongIdentity }
+        if full {
+            guard let history = snapshot["messages"].list, snapshot["messages_omitted"].flag != true else { throw BotFailure.unsupported }
+            messages = history.enumerated().compactMap { index, row in
+                guard let role = row["role"].text, ["user", "assistant"].contains(role), let text = row["text"].text else { return nil }
+                return ChatMessage(role: role, content: text, timestamp: nil, messageId: "\(root ?? "")/\(index)")
+            }
+        }
+        let inflight = snapshot["inflight"]
+        let startedAt = inflight["started_at"].number ?? snapshot["turn_started_at"].number
+        if startedAt != turnStartedAt { turnRevision += 1; turnStartedAt = startedAt }
+        liveMessages = []
+        if let text = inflight["user"].text, !text.isEmpty {
+            liveMessages.append(ChatMessage(role: "user", content: text, timestamp: nil, messageId: "live-user"))
+        }
+        if let text = inflight["assistant"].text, !text.isEmpty {
+            liveMessages.append(ChatMessage(role: "assistant", content: text, timestamp: nil, messageId: "live-assistant"))
+        }
+        if !running { uncertainStop = false; stopAcknowledged = false }
+        let attention = snapshot["pending_approval"] != .null || snapshot["pending_clarify"] != .null
+        let continuation = snapshot["auto_continue"] != .null && snapshot["auto_continue"].flag != false
+        let queued = snapshot["queued"] != .null
+        if attention { turn = .needsAttention }
+        else if uncertainStop && stopAcknowledged { turn = .stopping }
+        else if uncertainSend || uncertainStop { turn = .uncertain }
+        else if localOperation { /* A snapshot cannot acknowledge a local command. */ }
+        else if running || continuation || queued { turn = .running }
+        else if inflight["error"] != .null || snapshot["status"].text == "interrupted" { turn = .interrupted }
+        else { turn = .idle }
+    }
+
+    func send() async {
+        guard maySend, !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, let runtime else { return }
+        let owner = generation
+        let text = draft
+        let revision = turnRevision
+        localOperation = true; turn = .submitting; uncertainSend = true
+        drafts.setBotSubmissionUncertain(true, for: draftKey)
+        do {
+            // No network dispatch until the durable ambiguity marker is on disk.
+            try await drafts.flush()
+            try check(owner)
+        } catch {
+            guard owner == generation else { return }
+            localOperation = false; uncertainSend = false
+            drafts.setBotSubmissionUncertain(false, for: draftKey)
+            turn = .idle; errorMessage = String(localized: "Could not save the draft. Your message was not sent.")
+            return
+        }
+        do {
+            _ = try await request("prompt.submit", ["session_id": .string(runtime), "text": .string(text)], owner: owner) { [weak self] in
+                guard let self else { throw BotFailure.stale }
+                try self.check(owner)
+                guard self.turnRevision == revision else { throw BotFailure.stale }
+            }
+            drafts.setDraft("", for: draftKey)
+            drafts.setBotSubmissionUncertain(false, for: draftKey)
+            try await drafts.flush()
+            try check(owner)
+            draft = ""; uncertainSend = false; localOperation = false; turn = .running
+            fullSnapshotNeeded = true; snapshotDirty = true; scheduleRefresh()
+        } catch {
+            guard owner == generation, !Task.isCancelled else { return }
+            localOperation = false
+            if error as? BotFailure == .stale {
+                uncertainSend = false
+                drafts.setBotSubmissionUncertain(false, for: draftKey)
+                try? await drafts.flush()
+            }
+            if case BotFailure.rejected(let code) = error {
+                // Only explicit admission/auth/parameter failures establish nonacceptance.
+                if [401, 403, 4090, -32601, -32602].contains(code) {
+                    uncertainSend = false
+                    drafts.setBotSubmissionUncertain(false, for: draftKey)
+                    try? await drafts.flush()
+                }
+            }
+            disconnected(error)
+        }
+    }
+
+    func prepareStop() -> StopAction? {
+        guard mayStop, let runtime else { return nil }
+        return StopAction(generation: generation, revision: turnRevision, runtime: runtime)
+    }
+
+    func stop(_ action: StopAction) async {
+        guard mayStop, action == prepareStop() else { return }
+        let owner = generation
+        localOperation = true; uncertainStop = true; turn = .stopping; turnRevision += 1
+        let revision = turnRevision
+        do {
+            _ = try await request("session.interrupt", ["session_id": .string(action.runtime)], owner: owner) { [weak self] in
+                guard let self else { throw BotFailure.stale }
+                try self.check(owner)
+                guard self.turnRevision == revision, self.runtime == action.runtime else { throw BotFailure.stale }
+            }
+            localOperation = false
+            stopAcknowledged = true
+            // Acknowledgement alone is not completion. Snapshot must establish idle.
+            snapshotDirty = true; fullSnapshotNeeded = true; scheduleRefresh()
+        } catch {
+            guard owner == generation, !Task.isCancelled else { return }
+            localOperation = false
+            if error as? BotFailure == .stale { uncertainStop = false }
+            disconnected(error)
+        }
+    }
+
+    /// Explicitly discard a held ambiguous prompt after the user checks Desktop.
+    /// The old text is never restored to the sendable composer.
+    func discardUncertainSubmission() async {
+        guard uncertainSend, connectionState == .connected, !localOperation else { return }
+        let owner = generation
+        drafts.setDraft("", for: draftKey)
+        drafts.setBotSubmissionUncertain(false, for: draftKey)
+        do {
+            try await drafts.flush()
+            try check(owner)
+            draft = ""; uncertainSend = false
+            await recover()
+        } catch {
+            if owner == generation {
+                drafts.setBotSubmissionUncertain(true, for: draftKey)
+                errorMessage = String(localized: "Could not save the draft. The held message is still unresolved.")
+            }
+        }
+    }
+
+    private func observe(_ event: BotJSON) {
+        guard connectionState != .disconnected, event["session_id"].text == runtime, runtime != nil else { return }
+        guard let next = event["seq"].integer, next > 0 else {
+            replayWasReset = true; snapshotDirty = true; fullSnapshotNeeded = true
+            turnRevision += 1
+            if !localOperation { turn = .unknown }
+            scheduleRefresh(); return
+        }
+        guard next != sequence else { return }
+        let discontinuity = next != sequence + 1
+        if discontinuity {
+            replayWasReset = true; fullSnapshotNeeded = true; turnRevision += 1
+            if !localOperation { turn = .unknown }
+        }
+        sequence = next
+        let type = event["type"].text ?? ""
+        if ["message.start", "message.complete", "session.info", "error", "approval.request", "clarify.request"].contains(type) {
+            turnRevision += 1
+            fullSnapshotNeeded = true
+            // Current state is pending reconciliation; don't dispatch new work.
+            if !localOperation { turn = .unknown }
+        }
+        if type == "message.delta", !discontinuity, !localOperation, !uncertainSend, !uncertainStop { turn = .running }
+        snapshotDirty = true
+        scheduleRefresh()
+    }
+
+    private func scheduleRefresh() {
+        guard snapshotDirty, connectionState == .connected, refreshTask == nil else { return }
+        let owner = generation
+        refreshTask = Task { [weak self] in
+            do {
+                // Coalesce event bursts. This is active-stream work only, not polling.
+                try await Task.sleep(for: .milliseconds(250))
+                guard let self else { return }
+                while self.snapshotDirty {
+                    try self.check(owner)
+                    self.snapshotDirty = false
+                    let full = self.fullSnapshotNeeded
+                    self.fullSnapshotNeeded = false
+                    let reply = try await self.request("session.resume", self.resumeParams(full: full), owner: owner)
+                    try self.applySnapshot(reply, full: full)
+                    if self.snapshotDirty { try await Task.sleep(for: .milliseconds(250)) }
+                }
+                self.refreshTask = nil
+            } catch {
+                guard let self, self.generation == owner, !Task.isCancelled else { return }
+                self.refreshTask = nil
+                self.disconnected(error)
+            }
+        }
+    }
+
+    private func disconnected(_ error: Error) {
+        wire.close()
+        refreshTask?.cancel(); refreshTask = nil
+        connectionState = .disconnected
+        turn = uncertainSend || uncertainStop ? .uncertain : .unknown
+        turnRevision += 1
+        errorMessage = (error as? BotFailure ?? .transport).localizedDescription
+    }
+
+    func suspend() {
+        generation += 1; turnRevision += 1
+        refreshTask?.cancel(); refreshTask = nil
+        wire.close()
+        localOperation = false
+        connectionState = .disconnected; turn = .unknown
+        Task { try? await drafts.flush() }
+    }
+}

--- a/HermesMobile/Features/Bots/BotsInboxView.swift
+++ b/HermesMobile/Features/Bots/BotsInboxView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+@MainActor struct BotsInboxView: View {
+    @Environment(\.scenePhase) private var scenePhase
+    let server: URL
+    let showSessions: () -> Void
+    @State private var connection: BotConnection?
+    @State private var profiles: [BotProfile] = []
+    @State private var search = ""
+    @State private var errorMessage: String?
+    @State private var loading = false
+    @State private var showingSetup = false
+    @State private var revision = UUID()
+    @State private var loadOwner = UUID()
+    @State private var wire: BotClient?
+    private let store = BotConnectionStore()
+
+    private var filteredProfiles: [BotProfile] {
+        profiles.filter { search.isEmpty || $0.name.localizedStandardContains(search) }
+    }
+
+    var body: some View {
+        List {
+            Picker("Screen", selection: Binding(get: { true }, set: { if !$0 { showSessions() } })) {
+                Text("Sessions").tag(false)
+                Text("Bots").tag(true)
+            }
+            .pickerStyle(.segmented)
+            .listRowSeparator(.hidden)
+
+            if let connection {
+                Text(connection.name)
+                    .font(.footnote).foregroundStyle(.secondary)
+                    .listRowSeparator(.hidden)
+                if let errorMessage {
+                    Text(errorMessage).font(.callout)
+                    Button("Reconnect") { revision = UUID() }
+                } else if loading {
+                    Text("Connecting…")
+                } else if profiles.isEmpty {
+                    Text("No bots found. Create one in Hermes Desktop, then refresh.")
+                }
+                ForEach(filteredProfiles) { profile in
+                    NavigationLink {
+                        BotChatView(server: server, connection: connection, profile: profile)
+                            .id(profile.id + connection.id.uuidString)
+                    } label: {
+                        BotInboxRow(profile: profile)
+                    }
+                    .listRowSeparator(.hidden)
+                    .padding(.vertical, 10)
+                }
+            } else {
+                ContentUnavailableView("Connect to Hermes", systemImage: "bubble.left.and.bubble.right",
+                                       description: Text("Use your existing Hermes setup to talk to your bots."))
+                Button("Connect to Hermes") { showingSetup = true }
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle("Bots")
+        .searchable(text: $search, prompt: "Search bots")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Bot connection", systemImage: "gearshape") { showingSetup = true }
+            }
+        }
+        .sheet(isPresented: $showingSetup, onDismiss: { revision = UUID() }) {
+            NavigationStack { BotConnectionView(server: server) }
+        }
+        .task(id: revision) { await load() }
+        .refreshable { await load() }
+        .onChange(of: scenePhase) {
+            if scenePhase == .active { revision = UUID() }
+            else { wire?.close() }
+        }
+        .onDisappear { loadOwner = UUID(); wire?.close(); wire = nil }
+    }
+
+    private func load() async {
+        wire?.close()
+        let owner = UUID()
+        loadOwner = owner
+        // The stored client identity is the load owner; a replacement invalidates late results.
+        do {
+            let saved = try store.load(server: server)
+            if connection?.id != saved?.id { profiles = [] }
+            connection = saved
+            guard let saved else { return }
+            let client = BotClient(connection: saved)
+            wire = client; loading = true; errorMessage = nil
+            defer { if wire === client { loading = false } }
+            try await client.connect()
+            guard !Task.isCancelled, wire === client else { return }
+            let roster = try await client.call("profiles.list", ["include_sessions": .bool(true)])
+            guard !Task.isCancelled, wire === client else { return }
+            guard let rows = roster["profiles"].list else { throw BotFailure.unsupported }
+            var seen = Set<String>()
+            profiles = rows.compactMap(BotProfile.init).filter { seen.insert($0.id).inserted }
+            client.close()
+        } catch {
+            guard !Task.isCancelled, loadOwner == owner else { return }
+            errorMessage = (error as? BotFailure ?? .transport).localizedDescription
+            loading = false
+        }
+    }
+}
+
+private struct BotInboxRow: View {
+    let profile: BotProfile
+    private var color: Color {
+        let colors: [Color] = [.green, .orange, .purple, .pink, .blue, .teal]
+        let value = profile.id.utf8.reduce(0) { ($0 + Int($1)) % colors.count }
+        return colors[value]
+    }
+    var body: some View {
+        HStack(spacing: 16) {
+            Text(String(profile.name.prefix(1))).font(.title2.weight(.semibold))
+                .frame(width: 48, height: 48)
+                .background(color.opacity(0.2), in: RoundedRectangle(cornerRadius: 16))
+                .foregroundStyle(color).accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(profile.name).font(.headline)
+                    Spacer()
+                    if let date = profile.lastActive {
+                        Text(date, style: .date).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Text(profile.preview?.isEmpty == false ? profile.preview! : profile.id)
+                    .font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/HermesMobile/Features/Chat/ChatComposerPresentation.swift
+++ b/HermesMobile/Features/Chat/ChatComposerPresentation.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Shared geometry for Sessions and the text-only Bot composer.
+enum ChatComposerMetrics {
+    static let cardCornerRadius: CGFloat = 26
+    static let actionSize: CGFloat = 44
+    static let pillInset: CGFloat = 5
+}
+
+struct ChatComposerSurfaceStyle: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+    let isExpanded: Bool
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(
+            cornerRadius: isExpanded ? ChatComposerMetrics.cardCornerRadius
+                : (ChatComposerMetrics.actionSize + ChatComposerMetrics.pillInset * 2) / 2,
+            style: .continuous
+        )
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .adaptiveGlass(.regular, isInteractive: true, fallbackMaterial: .ultraThinMaterial, in: shape)
+            .clipShape(shape)
+            .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.28 : 0.12), radius: 14, y: 6)
+    }
+}
+
+struct ChatComposerActionAppearance {
+    let isStop: Bool
+    let isDisabled: Bool
+    let colorScheme: ColorScheme
+    let tintsPrimaryActions: Bool
+    let themeHex: String
+
+    private var usesTheme: Bool {
+        PrimaryActionTintSettings.usesThemeColor(
+            isEnabled: tintsPrimaryActions, controlIsEnabled: !isDisabled
+        )
+    }
+
+    var background: Color {
+        if isStop { return Color.red.opacity(colorScheme == .dark ? 0.22 : 0.14) }
+        if usesTheme { return HeaderLogoColor.color(for: themeHex) }
+        if isDisabled { return colorScheme == .dark ? Color.white.opacity(0.18) : Color.black.opacity(0.12) }
+        return colorScheme == .dark ? .white : .black
+    }
+
+    var foreground: Color {
+        if isStop { return .red }
+        if usesTheme { return HeaderLogoColor.prefersDarkForeground(for: themeHex) ? .black : .white }
+        if isDisabled { return Color(.secondaryLabel) }
+        return colorScheme == .dark ? .black : .white
+    }
+}

--- a/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerTextInputView.swift
@@ -38,7 +38,9 @@ struct ComposerTextInputView: View {
     let onTapQuote: (ComposerQuote) -> Void
     let onRemoveQuote: (UUID) -> Void
 
-    private let placeholder = String(localized: "Ask anything... /commands")
+    var placeholder = String(localized: "Ask anything... /commands")
+    /// Text-only clients reject file/image paste and drop before invoking callbacks.
+    var acceptsAttachments = true
     private let collapsedLineHeight: CGFloat = 22
     private let expandedMinimumHeight: CGFloat = 72
 
@@ -62,7 +64,9 @@ struct ComposerTextInputView: View {
                 onPasteFileProviders: onPasteFileProviders,
                 onPasteFileURLs: onPasteFileURLs,
                 onPasteImageProviders: onPasteImageProviders,
-                onPasteImages: onPasteImages
+                onPasteImages: onPasteImages,
+                acceptsAttachments: acceptsAttachments,
+                accessibilityLabel: placeholder
             )
             // The card editor is at least 72 pt of real text view, so a tap
             // anywhere in it lands on the editor rather than dead space.
@@ -185,6 +189,9 @@ private struct ComposerTextView: UIViewRepresentable {
     let onPasteImageProviders: ([NSItemProvider]) -> Void
     let onPasteImages: ([UIImage]) -> Void
 
+    let acceptsAttachments: Bool
+    let accessibilityLabel: String
+
     func makeCoordinator() -> Coordinator {
         Coordinator(
             text: $text,
@@ -212,13 +219,6 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.allowsEditingTextAttributes = false
         textView.isKeyboardSendEnabled = isKeyboardSendEnabled
         textView.onKeyboardSend = onKeyboardSend
-        textView.pasteConfiguration = UIPasteConfiguration(
-            acceptableTypeIdentifiers: [
-                UTType.fileURL.identifier,
-                UTType.image.identifier,
-                UTType.text.identifier
-            ]
-        )
         textView.onPasteFileProviders = onPasteFileProviders
         textView.onPasteFileURLs = onPasteFileURLs
         textView.onPasteImageProviders = onPasteImageProviders
@@ -240,6 +240,15 @@ private struct ComposerTextView: UIViewRepresentable {
         let isRTL = context.environment.layoutDirection == .rightToLeft
         textView.semanticContentAttribute = isRTL ? .forceRightToLeft : .unspecified
         textView.textAlignment = isRTL ? .right : .natural
+        textView.acceptsAttachments = acceptsAttachments
+        textView.accessibilityLabel = accessibilityLabel
+        let pasteTypes = acceptsAttachments
+            ? [UTType.fileURL.identifier, UTType.image.identifier, UTType.text.identifier]
+            : [UTType.plainText.identifier]
+        if textView.pasteConfiguration?.acceptableTypeIdentifiers != pasteTypes {
+            textView.pasteConfiguration = UIPasteConfiguration(acceptableTypeIdentifiers: pasteTypes)
+        }
+        context.coordinator.acceptsAttachments = acceptsAttachments
         textView.isEditable = !isDisabled
         textView.isSelectable = !isDisabled
         textView.textColor = isDisabled ? .secondaryLabel : .label
@@ -274,6 +283,7 @@ private struct ComposerTextView: UIViewRepresentable {
         @Binding var isFocused: Bool
         @Binding var renderedChips: [ComposerChipToken]
         var onHeightChange: (CGFloat) -> Void
+        var acceptsAttachments = true
         var onDropFileProviders: ([NSItemProvider]) -> Void = { _ in }
         var onDropImageProviders: ([NSItemProvider]) -> Void = { _ in }
         private var pendingFocusTarget: Bool?
@@ -529,6 +539,12 @@ private struct ComposerTextView: UIViewRepresentable {
             _ textDroppableView: UIView & UITextDroppable,
             proposalForDrop drop: UITextDropRequest
         ) -> UITextDropProposal {
+            if !acceptsAttachments {
+                let hasOnlyText = drop.dropSession.items.allSatisfy {
+                    $0.itemProvider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier)
+                }
+                return UITextDropProposal(operation: hasOnlyText ? .copy : .cancel)
+            }
             guard ComposerDropRoute(providers: drop.dropSession.items.map(\.itemProvider)) != nil else {
                 return drop.suggestedProposal
             }
@@ -543,7 +559,8 @@ private struct ComposerTextView: UIViewRepresentable {
             _ textDroppableView: UIView & UITextDroppable,
             willPerformDrop drop: UITextDropRequest
         ) {
-            guard let route = ComposerDropRoute(providers: drop.dropSession.items.map(\.itemProvider)) else {
+            guard acceptsAttachments,
+                  let route = ComposerDropRoute(providers: drop.dropSession.items.map(\.itemProvider)) else {
                 return
             }
 

--- a/HermesMobile/Features/Chat/ChatComposerView.swift
+++ b/HermesMobile/Features/Chat/ChatComposerView.swift
@@ -2,12 +2,6 @@ import SwiftUI
 import UIKit
 import PhotosUI
 
-/// Shape metrics for the composer stack: the expanded composer card and every
-/// full-width surface stacked above it share this radius so they read as one set.
-enum ChatComposerMetrics {
-    static let cardCornerRadius: CGFloat = 26
-}
-
 private struct ComposerStatusView: View {
     let text: String
     let isError: Bool
@@ -100,8 +94,8 @@ struct MessageComposerView: View {
 
     /// t3code sizing: every circle in the composer is 44 pt, which is also the
     /// minimum hit target, so no invisible hit padding is needed.
-    private let circleSize: CGFloat = 44
-    private let pillInset: CGFloat = 5
+    private let circleSize = ChatComposerMetrics.actionSize
+    private let pillInset = ChatComposerMetrics.pillInset
 
     @Binding var draftMessage: String
     @Binding var quotes: [ComposerQuote]
@@ -696,13 +690,6 @@ struct MessageComposerView: View {
             || showFileImporter
     }
 
-    private var composerSurfaceShape: RoundedRectangle {
-        RoundedRectangle(
-            cornerRadius: isExpanded ? ChatComposerMetrics.cardCornerRadius : (circleSize + pillInset * 2) / 2,
-            style: .continuous
-        )
-    }
-
     /// The glass surface: one text view in both states so focus and the draft
     /// survive the morph. Pill: text, thumbnails, mic, Stop/Send in a row.
     /// Card: strip above the editor, controls move to `toolbarRow` below.
@@ -761,14 +748,7 @@ struct MessageComposerView: View {
         }
         .padding(.top, isExpanded ? 2 : 0)
         .padding(.bottom, isExpanded ? 4 : 0)
-        .adaptiveGlass(
-            .regular,
-            isInteractive: true,
-            fallbackMaterial: .ultraThinMaterial,
-            in: composerSurfaceShape
-        )
-        .clipShape(composerSurfaceShape)
-        .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.28 : 0.12), radius: 14, y: 6)
+        .modifier(ChatComposerSurfaceStyle(isExpanded: isExpanded))
     }
 
     /// Card-state row under the surface: a scroller of secondary controls plus
@@ -1182,43 +1162,16 @@ struct MessageComposerView: View {
             || isUpdatingConfiguration
     }
 
-    private var actionButtonBackground: Color {
-        if showsStopButton {
-            return Color.red.opacity(colorScheme == .dark ? 0.22 : 0.14)
-        }
-
-        if PrimaryActionTintSettings.usesThemeColor(
-            isEnabled: tintsPrimaryActions,
-            controlIsEnabled: !isActionButtonDisabled
-        ) {
-            return HeaderLogoColor.color(for: headerLogoColorHex)
-        }
-
-        if isActionButtonDisabled {
-            return colorScheme == .dark ? Color.white.opacity(0.18) : Color.black.opacity(0.12)
-        }
-
-        return colorScheme == .dark ? .white : .black
+    private var actionAppearance: ChatComposerActionAppearance {
+        ChatComposerActionAppearance(
+            isStop: showsStopButton, isDisabled: isActionButtonDisabled,
+            colorScheme: colorScheme, tintsPrimaryActions: tintsPrimaryActions,
+            themeHex: headerLogoColorHex
+        )
     }
 
-    private var actionButtonForeground: Color {
-        if showsStopButton {
-            return Color.red
-        }
-
-        if PrimaryActionTintSettings.usesThemeColor(
-            isEnabled: tintsPrimaryActions,
-            controlIsEnabled: !isActionButtonDisabled
-        ) {
-            return HeaderLogoColor.prefersDarkForeground(for: headerLogoColorHex) ? .black : .white
-        }
-
-        if isActionButtonDisabled {
-            return Color(.secondaryLabel)
-        }
-
-        return colorScheme == .dark ? .black : .white
-    }
+    private var actionButtonBackground: Color { actionAppearance.background }
+    private var actionButtonForeground: Color { actionAppearance.foreground }
 
     private var trimmedDraftMessage: String {
         draftMessage.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/HermesMobile/Features/Chat/ComposerChipTextView.swift
+++ b/HermesMobile/Features/Chat/ComposerChipTextView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 /// The composer's editor: a text view that draws known skill references as
 /// atomic chips while every value that leaves it stays the draft's own text.
 final class ComposerChipTextView: UITextView, UIGestureRecognizerDelegate {
+    var acceptsAttachments = true
     var isKeyboardSendEnabled = false
     var onKeyboardSend: () -> Void = {}
     var onPasteFileProviders: ([NSItemProvider]) -> Void = { _ in }
@@ -422,7 +423,10 @@ final class ComposerChipTextView: UITextView, UIGestureRecognizerDelegate {
     }
 
     func canPasteItemProviders(_ itemProviders: [NSItemProvider]) -> Bool {
-        itemProviders.contains {
+        if !acceptsAttachments {
+            return itemProviders.contains { $0.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) }
+        }
+        return itemProviders.contains {
             $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
                 || $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
                 || $0.hasItemConformingToTypeIdentifier(UTType.text.identifier)
@@ -430,6 +434,7 @@ final class ComposerChipTextView: UITextView, UIGestureRecognizerDelegate {
     }
 
     func pasteItemProviders(_ itemProviders: [NSItemProvider]) {
+        guard acceptsAttachments else { paste(nil); return }
         let fileProviders = itemProviders.filter {
             $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
         }
@@ -465,6 +470,10 @@ final class ComposerChipTextView: UITextView, UIGestureRecognizerDelegate {
             return isKeyboardSendEnabled
         }
 
+        if action == #selector(paste(_:)), !acceptsAttachments {
+            return isEditable && UIPasteboard.general.hasStrings
+        }
+
         if action == #selector(paste(_:)), hasPasteboardContent {
             return true
         }
@@ -478,6 +487,11 @@ final class ComposerChipTextView: UITextView, UIGestureRecognizerDelegate {
     }
 
     override func paste(_ sender: Any?) {
+        guard acceptsAttachments else {
+            guard isEditable, let text = UIPasteboard.general.string else { return }
+            insertText(text)
+            return
+        }
         let fileProviders = pasteboardFileProviders
 
         if !fileProviders.isEmpty {

--- a/HermesMobile/Features/Chat/MessageBubbleView.swift
+++ b/HermesMobile/Features/Chat/MessageBubbleView.swift
@@ -13,6 +13,8 @@ struct MessageBubbleView: View {
     @AppStorage(ChatTranscriptDisplaySettings.hidesAttachmentPathsKey) private var hidesAttachmentPaths = true
     @AppStorage(ChatTranscriptDisplaySettings.showsResponseSpeedKey) private var showsResponseSpeed = false
 
+    /// Bot snapshots are text-only and must render synchronously while growing.
+    let textOnly: Bool
     let message: ChatMessage
     let loadAttachmentImage: ((String) async -> Data?)?
     let loadAttachmentData: ((String) async -> Data?)?
@@ -42,8 +44,10 @@ struct MessageBubbleView: View {
         isStreaming: Bool = false,
         liveTokensPerSecond: Double? = nil,
         onAskHermex: @escaping (String) -> Void = { _ in },
-        contextMenu: ChatMessageActionMenu? = nil
+        contextMenu: ChatMessageActionMenu? = nil,
+        textOnly: Bool = false
     ) {
+        self.textOnly = textOnly
         self.message = message
         self.loadAttachmentImage = loadAttachmentImage
         self.loadAttachmentData = loadAttachmentData
@@ -66,6 +70,9 @@ struct MessageBubbleView: View {
             localAssistantRow
         } else if isUserMessage {
             userMessageRow
+        } else if textOnly {
+            MarkdownRenderer(content: message.content ?? "")
+                .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             assistantMessageRow
         }
@@ -73,7 +80,7 @@ struct MessageBubbleView: View {
 
     private var userMessageRow: some View {
         VStack(alignment: .trailing, spacing: 8) {
-            if let attachments = message.attachments, !attachments.isEmpty {
+            if !textOnly, let attachments = message.attachments, !attachments.isEmpty {
                 attachmentPreviews
             }
 
@@ -246,7 +253,7 @@ struct MessageBubbleView: View {
     /// actions read `message.content`, which is always the exact text.
     private var userBubble: some View {
         let text = userBubbleText
-        let chips = userBubbleChips(in: text)
+        let chips = textOnly ? [] : userBubbleChips(in: text)
 
         return ComposerChipTextLine.text(text, tokens: chips, style: chipStyle)
             .font(.body)
@@ -289,14 +296,14 @@ struct MessageBubbleView: View {
 
     @ViewBuilder
     private var linkPreview: some View {
-        if let url = TranscriptLinkPreviewEligibility.previewURL(for: message, isStreaming: isStreaming) {
+        if !textOnly, let url = TranscriptLinkPreviewEligibility.previewURL(for: message, isStreaming: isStreaming) {
             TranscriptLinkPreviewView(url: url)
                 .frame(maxWidth: 300)
         }
     }
 
     private var hasLinkPreview: Bool {
-        TranscriptLinkPreviewEligibility.previewURL(for: message, isStreaming: isStreaming) != nil
+        !textOnly && TranscriptLinkPreviewEligibility.previewURL(for: message, isStreaming: isStreaming) != nil
     }
 
     // Audio attachments render as full-width Telegram-style player bars stacked
@@ -454,7 +461,7 @@ struct MessageBubbleView: View {
     /// sent payload are untouched.
     private var userBubbleText: String {
         let content = message.content ?? ""
-        guard hidesAttachmentPaths else { return content }
+        guard !textOnly, hidesAttachmentPaths else { return content }
         return MessageAttachment.contentWithoutAttachedFilesMarker(in: content)
     }
 

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -35,6 +35,7 @@ struct SessionListView: View {
     @State private var projectPendingDeletion: ProjectSummary?
     @State private var projectPendingRename: ProjectSummary?
     @State private var searchText = ""
+    @State private var showsBots = false
     @State private var isSearchVisible = false
     @State private var isSearchFocused = false
     @State private var searchChromeIsExpanded = false
@@ -111,6 +112,9 @@ struct SessionListView: View {
 
     var body: some View {
         navigationContainer
+            .onChange(of: pendingDeepLinkedSessionID) { if pendingDeepLinkedSessionID != nil { showsBots = false } }
+            .onChange(of: requestedNewChat) { if requestedNewChat != nil { showsBots = false } }
+            .onChange(of: pendingSharedImport?.reservationID) { if pendingSharedImport != nil { showsBots = false } }
             .safeAreaInset(edge: .top, spacing: 0) {
                 if hasWaitingSharedImport {
                     waitingSharedImportBanner
@@ -330,7 +334,11 @@ struct SessionListView: View {
 
     @ViewBuilder
     private var navigationContainer: some View {
-        if horizontalSizeClass == .regular {
+        if showsBots {
+            NavigationStack {
+                BotsInboxView(server: server) { showsBots = false }
+            }
+        } else if horizontalSizeClass == .regular {
             NavigationSplitView {
                 sessionListSurface
                     .navigationSplitViewColumnWidth(min: 280, ideal: 340, max: 420)
@@ -460,6 +468,13 @@ struct SessionListView: View {
         List {
             header
                 .sessionsTopChromeListRow()
+
+            Picker("Screen", selection: $showsBots) {
+                Text("Sessions").tag(false)
+                Text("Bots").tag(true)
+            }
+            .pickerStyle(.segmented)
+            .sessionsScreenListRow()
 
             if viewModel.isViewingCachedData {
                 OfflineCacheBanner()

--- a/HermesMobile/Features/SessionList/SessionListView.swift
+++ b/HermesMobile/Features/SessionList/SessionListView.swift
@@ -73,6 +73,7 @@ struct SessionListView: View {
     @AppStorage(SessionIdentitySettings.displayNameKey) private var identityDisplayName = ""
     @AppStorage(SessionIdentitySettings.initialsKey) private var identityInitials = ""
     @AppStorage(AppHaptics.isEnabledKey) private var isHapticsEnabled = true
+    @AppStorage(BotModeGate.isEnabledKey) private var isBotModeEnabled = false
 
     init(
         authManager: AuthManager,
@@ -115,6 +116,7 @@ struct SessionListView: View {
             .onChange(of: pendingDeepLinkedSessionID) { if pendingDeepLinkedSessionID != nil { showsBots = false } }
             .onChange(of: requestedNewChat) { if requestedNewChat != nil { showsBots = false } }
             .onChange(of: pendingSharedImport?.reservationID) { if pendingSharedImport != nil { showsBots = false } }
+            .onChange(of: isBotModeEnabled) { if !isBotModeEnabled { showsBots = false } }
             .safeAreaInset(edge: .top, spacing: 0) {
                 if hasWaitingSharedImport {
                     waitingSharedImportBanner
@@ -332,9 +334,13 @@ struct SessionListView: View {
         .accessibilityElement(children: .contain)
     }
 
+    private var showsBotsInbox: Bool {
+        BotModeGate.showsBotsInbox(isEnabled: isBotModeEnabled, userPickedBots: showsBots)
+    }
+
     @ViewBuilder
     private var navigationContainer: some View {
-        if showsBots {
+        if showsBotsInbox {
             NavigationStack {
                 BotsInboxView(server: server) { showsBots = false }
             }
@@ -469,12 +475,14 @@ struct SessionListView: View {
             header
                 .sessionsTopChromeListRow()
 
-            Picker("Screen", selection: $showsBots) {
-                Text("Sessions").tag(false)
-                Text("Bots").tag(true)
+            if isBotModeEnabled {
+                Picker("Screen", selection: $showsBots) {
+                    Text("Sessions").tag(false)
+                    Text("Bots").tag(true)
+                }
+                .pickerStyle(.segmented)
+                .sessionsScreenListRow()
             }
-            .pickerStyle(.segmented)
-            .sessionsScreenListRow()
 
             if viewModel.isViewingCachedData {
                 OfflineCacheBanner()

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -94,6 +94,7 @@ struct SettingsView: View {
     @AppStorage(SectionVisibilitySettings.projectsKey) private var showsProjectsSection = true
     @AppStorage(SectionVisibilitySettings.chatFilesKey) private var showsChatFilesButton = true
     @AppStorage(SectionVisibilitySettings.chatGitKey) private var showsChatGitControls = true
+    @AppStorage(BotModeGate.isEnabledKey) private var isBotModeEnabled = false
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
 
@@ -389,6 +390,16 @@ struct SettingsView: View {
                     )
 
                     SettingsFootnote(String(localized: "Turn off the entries you never use to shorten the top of the session list. Each one is the only way into its screen, so turn it back on here when you need it again."))
+                }
+
+                SettingsCard(title: String(localized: "Preview")) {
+                    SettingsToggleRow(
+                        title: String(localized: "Bot Mode (beta)"),
+                        systemImage: "cpu",
+                        isOn: $isBotModeEnabled
+                    )
+
+                    SettingsFootnote(String(localized: "Bot Mode is unfinished. It adds a Sessions/Bots switch to the session list and a Bot connection row to each server."))
                 }
 
                 SettingsCard(title: String(localized: "Sessions")) {
@@ -2104,6 +2115,7 @@ private struct ServerDetailView: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @AppStorage(BotModeGate.isEnabledKey) private var isBotModeEnabled = false
     @State private var displayName: String
     @State private var initials: String
     @State private var colorHex: String
@@ -2135,7 +2147,7 @@ private struct ServerDetailView: View {
                     }
                 }
 
-                if let server = URL(string: account.urlString) {
+                if isBotModeEnabled, let server = URL(string: account.urlString) {
                     NavigationLink("Bot connection") { BotConnectionView(server: server) }
                         .frame(minHeight: 44)
                 }

--- a/HermesMobile/Features/Settings/SettingsView.swift
+++ b/HermesMobile/Features/Settings/SettingsView.swift
@@ -2135,6 +2135,11 @@ private struct ServerDetailView: View {
                     }
                 }
 
+                if let server = URL(string: account.urlString) {
+                    NavigationLink("Bot connection") { BotConnectionView(server: server) }
+                        .frame(minHeight: 44)
+                }
+
                 SettingsCard(title: String(localized: "Identity")) {
                     ServerIdentityEditor(
                         displayName: $displayName,

--- a/HermesMobile/Networking/Bots/BotClient.swift
+++ b/HermesMobile/Networking/Bots/BotClient.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+/// One cookie jar and socket per connection owner. The receive loop multiplexes
+/// RPC replies and events, so a quiet tool never blocks a Stop request.
+@MainActor final class BotClient: BotTransport {
+    private let connection: BotConnection
+    private let session: URLSession
+    private var socket: (any BotSocket)?
+    private let socketFactory: ((URL, [String]) -> any BotSocket)?
+    private var reader: Task<Void, Never>?
+    private var generation = 0
+    private var nextID = 0
+    private var pending: [Int: CheckedContinuation<BotJSON, Error>] = [:]
+    private var deadlines: [Int: Task<Void, Never>] = [:]
+    private(set) var replayEpoch: String?
+    var onEvent: ((BotJSON) -> Void)?
+    var onDisconnect: ((Error) -> Void)?
+
+    init(connection: BotConnection, configuration: URLSessionConfiguration = .ephemeral,
+         socketFactory: ((URL, [String]) -> any BotSocket)? = nil) {
+        self.socketFactory = socketFactory
+        self.connection = connection
+        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForResource = 30
+        session = URLSession(configuration: configuration)
+    }
+
+    private func http(_ endpoint: BotEndpoint, body: BotJSON? = nil) async throws -> BotJSON {
+        var request = URLRequest(url: endpoint.url(base: connection.address))
+        if let body {
+            request.httpMethod = "POST"
+            request.httpBody = try JSONEncoder().encode(body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, response) = try await session.data(for: request)
+        guard let response = response as? HTTPURLResponse else { throw BotFailure.transport }
+        guard response.statusCode == 200 else { throw BotFailure.rejected(response.statusCode) }
+        return try JSONDecoder().decode(BotJSON.self, from: data)
+    }
+
+    func connect() async throws {
+        close()
+        let owner = generation
+        func check() throws {
+            guard owner == generation, !Task.isCancelled else { throw BotFailure.stale }
+        }
+        do {
+            let status = try await http(.status)
+            try check()
+            guard status["auth_required"].flag == true,
+                  status["auth_providers"].list?.contains(.string("basic")) == true else { throw BotFailure.unsupported }
+            _ = try await http(.login, body: .object([
+                "provider": .string("basic"), "username": .string(connection.username),
+                "password": .string(connection.password)
+            ]))
+            try check()
+            let identity = try await http(.identity)
+            try check()
+            guard identity["provider"].text == "basic" else { throw BotFailure.wrongIdentity }
+            let ticket = try await http(.ticket, body: .object([:]))
+            try check()
+            guard let token = ticket["ticket"].text, !token.isEmpty,
+                  var parts = URLComponents(url: BotEndpoint.socket.url(base: connection.address), resolvingAgainstBaseURL: false)
+            else { throw BotFailure.unsupported }
+            parts.scheme = connection.address.scheme == "https" ? "wss" : "ws"
+            guard let url = parts.url else { throw BotFailure.invalidAddress }
+            let protocols = ["hermes-gateway-v1", "hermes-gateway-ticket." + token]
+            let socket: any BotSocket
+            if let socketFactory { socket = socketFactory(url, protocols) }
+            else {
+                let task = session.webSocketTask(with: url, protocols: protocols)
+                task.maximumMessageSize = 16 * 1024 * 1024
+                task.resume()
+                socket = NativeBotSocket(task: task)
+            }
+            self.socket = socket
+            let ready = try await Self.receive(socket)
+            try check()
+            guard ready["method"].text == "event", ready["params"]["type"].text == "gateway.ready",
+                  let epoch = ready["params"]["payload"]["replay_epoch"].text, !epoch.isEmpty
+            else { throw BotFailure.unsupported }
+            replayEpoch = epoch
+            reader = Task { [weak self] in
+                do {
+                    while !Task.isCancelled {
+                        let frame = try await Self.receive(socket)
+                        guard let self, self.generation == owner else { return }
+                        self.consume(frame)
+                    }
+                } catch {
+                    guard let self, self.generation == owner else { return }
+                    self.close()
+                    self.onDisconnect?(error)
+                }
+            }
+        } catch {
+            if owner == generation { close() }
+            throw error
+        }
+    }
+
+    private static func receive(_ socket: any BotSocket) async throws -> BotJSON {
+        // Heartbeats keep a healthy quiet socket alive. Silence eventually becomes
+        // disconnected/unknown instead of leaving a permanent Working label.
+        try await withThrowingTaskGroup(of: BotJSON.self) { group in
+            group.addTask {
+                let frame = try await socket.receive()
+                let data: Data
+                switch frame {
+                case .string(let text): data = Data(text.utf8)
+                case .data(let bytes): data = bytes
+                @unknown default: throw BotFailure.unsupported
+                }
+                return try JSONDecoder().decode(BotJSON.self, from: data)
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(45))
+                socket.cancel()
+                throw BotFailure.transport
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else { throw BotFailure.transport }
+            return result
+        }
+    }
+
+    func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)? = nil) async throws -> BotJSON {
+        guard ["profiles.list", "session.list", "session.resume", "session.events.since", "prompt.submit", "session.interrupt"].contains(method)
+        else { throw BotFailure.unsupported }
+        guard let socket, !Task.isCancelled else { throw BotFailure.stale }
+        nextID += 1
+        let id = nextID
+        let owner = generation
+        let frame = BotJSON.object([
+            "jsonrpc": .string("2.0"), "id": .number(Double(id)),
+            "method": .string(method), "params": .object(params)
+        ])
+        let text = String(decoding: try JSONEncoder().encode(frame), as: UTF8.self)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                pending[id] = continuation
+                deadlines[id] = Task { [weak self] in
+                    do { try await Task.sleep(for: .seconds(30)) } catch { return }
+                    guard let self, self.generation == owner else { return }
+                    self.close()
+                    self.onDisconnect?(BotFailure.transport)
+                }
+                Task { [weak self] in
+                    guard let self, self.generation == owner, self.pending[id] != nil else { return }
+                    do {
+                        // Validate at the actual socket dispatch, after any executor delay.
+                        try validateDispatch?()
+                    } catch {
+                        self.deadlines.removeValue(forKey: id)?.cancel()
+                        self.pending.removeValue(forKey: id)?.resume(throwing: error)
+                        return
+                    }
+                    do { try await socket.send(.string(text)) }
+                    catch {
+                        guard self.generation == owner else { return }
+                        self.close()
+                        self.onDisconnect?(error)
+                    }
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                guard let self, self.generation == owner else { return }
+                self.close()
+            }
+        }
+    }
+
+    private func consume(_ frame: BotJSON) {
+        if frame["method"].text == "event" { onEvent?(frame["params"]); return }
+        guard let id = frame["id"].integer, let continuation = pending.removeValue(forKey: id) else { return }
+        deadlines.removeValue(forKey: id)?.cancel()
+        if let code = frame["error"]["code"].integer { continuation.resume(throwing: BotFailure.rejected(code)) }
+        else if frame["result"] != .null { continuation.resume(returning: frame["result"]) }
+        else { continuation.resume(throwing: BotFailure.unsupported) }
+    }
+
+    func close() {
+        generation += 1
+        reader?.cancel(); reader = nil
+        socket?.cancel(); socket = nil
+        for deadline in deadlines.values { deadline.cancel() }
+        deadlines.removeAll()
+        let interrupted = pending.values
+        pending.removeAll()
+        for continuation in interrupted { continuation.resume(throwing: BotFailure.transport) }
+    }
+}
+
+/// The socket boundary permits scripted frames without a backend or Profile storage.
+protocol BotSocket: Sendable {
+    func receive() async throws -> URLSessionWebSocketTask.Message
+    func send(_ message: URLSessionWebSocketTask.Message) async throws
+    func cancel()
+}
+
+private struct NativeBotSocket: BotSocket {
+    let task: URLSessionWebSocketTask
+    func receive() async throws -> URLSessionWebSocketTask.Message { try await task.receive() }
+    func send(_ message: URLSessionWebSocketTask.Message) async throws { try await task.send(message) }
+    func cancel() { task.cancel(with: .normalClosure, reason: nil) }
+}

--- a/HermesMobile/Networking/Bots/BotProtocol.swift
+++ b/HermesMobile/Networking/Bots/BotProtocol.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Direct Hermes payloads deliberately stay separate from webui endpoint models.
+/// Accessors tolerate absent and future fields; required capabilities are checked at use.
+indirect enum BotJSON: Codable, Equatable, Sendable {
+    case object([String: BotJSON]), array([BotJSON]), string(String), number(Double), bool(Bool), null
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null }
+        else if let v = try? c.decode(Bool.self) { self = .bool(v) }
+        else if let v = try? c.decode(String.self) { self = .string(v) }
+        else if let v = try? c.decode(Double.self) { self = .number(v) }
+        else if let v = try? c.decode([BotJSON].self) { self = .array(v) }
+        else { self = .object(try c.decode([String: BotJSON].self)) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .object(let v): try c.encode(v)
+        case .array(let v): try c.encode(v)
+        case .string(let v): try c.encode(v)
+        case .number(let v): try c.encode(v)
+        case .bool(let v): try c.encode(v)
+        case .null: try c.encodeNil()
+        }
+    }
+
+    subscript(_ key: String) -> BotJSON { if case .object(let v) = self { return v[key] ?? .null }; return .null }
+    var text: String? { if case .string(let v) = self { return v }; return nil }
+    var list: [BotJSON]? { if case .array(let v) = self { return v }; return nil }
+    var flag: Bool? { if case .bool(let v) = self { return v }; return nil }
+    var integer: Int? { if case .number(let v) = self { return Int(exactly: v) }; return nil }
+    var number: Double? { if case .number(let v) = self { return v }; return nil }
+}
+
+enum BotFailure: Error, Equatable, LocalizedError {
+    case stale, unsupported, missingChat, wrongIdentity, rejected(Int), transport, invalidAddress
+    var errorDescription: String? {
+        switch self {
+        case .stale: return String(localized: "This action is no longer current. Refresh the conversation.")
+        case .unsupported: return String(localized: "This Hermes connection does not support Bot chat here.")
+        case .missingChat: return String(localized: "Open this bot’s chat in Hermes Desktop, then refresh.")
+        case .wrongIdentity: return String(localized: "The conversation identity changed. Check this bot in Desktop.")
+        case .rejected(401), .rejected(403): return String(localized: "Sign in again. Check your Bot connection username and password.")
+        case .rejected(-32601): return String(localized: "This Hermes connection does not support Bot chat here.")
+        case .rejected(4090): return String(localized: "Another Hermes process owns this conversation. Resolve it on the host, then refresh.")
+        case .rejected(4130): return String(localized: "This conversation is too large to open here. Use Desktop.")
+        case .invalidAddress: return String(localized: "Enter a Hermes HTTP or HTTPS address without a path, credentials or query.")
+        default: return String(localized: "Connection lost. The bot may still be working. Reconnect to check its current conversation.")
+        }
+    }
+}
+
+enum BotEndpoint: String {
+    case status = "api/status", login = "auth/password-login", identity = "api/auth/me"
+    case ticket = "api/auth/ws-ticket", socket = "api/ws"
+    func url(base: URL) -> URL { base.appendingPathComponent(rawValue) }
+}
+
+@MainActor protocol BotTransport: AnyObject {
+    var replayEpoch: String? { get }
+    var onEvent: ((BotJSON) -> Void)? { get set }
+    var onDisconnect: ((Error) -> Void)? { get set }
+    func connect() async throws
+    func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)?) async throws -> BotJSON
+    func close()
+}
+
+extension BotTransport {
+    func call(_ method: String, _ params: [String: BotJSON]) async throws -> BotJSON {
+        try await call(method, params, validateDispatch: nil)
+    }
+}

--- a/HermesMobile/Persistence/ChatDraftStore.swift
+++ b/HermesMobile/Persistence/ChatDraftStore.swift
@@ -74,9 +74,11 @@ struct ChatDraft: Equatable, Sendable {
     var quotes: [ComposerQuote] = []
     var attachments: [ChatDraftAttachment] = []
     var settings: ChatDraftSettings?
+    // Written durably before Bot submission; acknowledgement loss must survive relaunch.
+    var botSubmissionUncertain = false
 
     var isEmpty: Bool {
-        text.isEmpty && quotes.isEmpty && attachments.isEmpty && (settings?.isEmpty ?? true)
+        text.isEmpty && quotes.isEmpty && attachments.isEmpty && (settings?.isEmpty ?? true) && !botSubmissionUncertain
     }
 }
 
@@ -136,6 +138,7 @@ enum ChatDraftSendReconciliation {
 struct ChatDraftKey: Hashable, Sendable {
     enum Context: Hashable, Sendable {
         case session(String)
+        case bot(connectionID: UUID, profile: String)
         case newChat
     }
 
@@ -144,6 +147,10 @@ struct ChatDraftKey: Hashable, Sendable {
 
     static func session(server: URL, sessionID: String) -> Self {
         Self(serverID: server.absoluteString, context: .session(sessionID))
+    }
+
+    static func bot(server: URL, connectionID: UUID, profile: String) -> Self {
+        Self(serverID: server.absoluteString, context: .bot(connectionID: connectionID, profile: profile))
     }
 
     static func newChat(server: URL) -> Self {
@@ -355,6 +362,9 @@ actor ChatDraftFilePersistence: ChatDraftPersisting {
         let quotes: [FailableQuote]?
         let attachments: [FailableAttachment]?
         let settings: SettingsRecord?
+        var connectionID: UUID?
+        var profile: String?
+        var botSubmissionUncertain: Bool?
 
         private enum CodingKeys: String, CodingKey {
             case serverID
@@ -363,7 +373,7 @@ actor ChatDraftFilePersistence: ChatDraftPersisting {
             case text
             case quotes
             case attachments
-            case settings
+            case settings, connectionID, profile, botSubmissionUncertain
         }
 
         init(key: ChatDraftKey, draft: ChatDraft) {
@@ -372,10 +382,16 @@ actor ChatDraftFilePersistence: ChatDraftPersisting {
             case .session(let sessionID):
                 context = "session"
                 self.sessionID = sessionID
+            case .bot(let connectionID, let profile):
+                context = "bot"
+                sessionID = nil
+                self.connectionID = connectionID
+                self.profile = profile
             case .newChat:
                 context = "newChat"
                 sessionID = nil
             }
+            botSubmissionUncertain = draft.botSubmissionUncertain
             text = draft.text
             quotes = draft.quotes.map { FailableQuote(value: QuoteRecord($0)) }
             attachments = draft.attachments.map { FailableAttachment(value: AttachmentRecord($0)) }
@@ -389,6 +405,10 @@ actor ChatDraftFilePersistence: ChatDraftPersisting {
             serverID = (try? container.decodeIfPresent(String.self, forKey: .serverID)) ?? nil
             context = (try? container.decodeIfPresent(String.self, forKey: .context)) ?? nil
             sessionID = (try? container.decodeIfPresent(String.self, forKey: .sessionID)) ?? nil
+            connectionID = try? container.decodeIfPresent(UUID.self, forKey: .connectionID)
+            profile = try? container.decodeIfPresent(String.self, forKey: .profile)
+            // A malformed uncertainty field fails closed for Bot records.
+            botSubmissionUncertain = (try? container.decodeIfPresent(Bool.self, forKey: .botSubmissionUncertain)) ?? (context == "bot" && container.contains(.botSubmissionUncertain))
             text = (try? container.decodeIfPresent(String.self, forKey: .text)) ?? nil
             quotes = (try? container.decodeIfPresent([FailableQuote].self, forKey: .quotes)) ?? nil
             attachments = (try? container.decodeIfPresent([FailableAttachment].self, forKey: .attachments)) ?? nil
@@ -414,6 +434,9 @@ actor ChatDraftFilePersistence: ChatDraftPersisting {
                     return nil
                 }
                 key = ChatDraftKey(serverID: serverID, context: .session(sessionID))
+            case "bot":
+                guard let connectionID, let profile, !profile.isEmpty else { return nil }
+                key = ChatDraftKey(serverID: serverID, context: .bot(connectionID: connectionID, profile: profile))
             case "newChat":
                 key = ChatDraftKey(serverID: serverID, context: .newChat)
             default:
@@ -424,17 +447,18 @@ actor ChatDraftFilePersistence: ChatDraftPersisting {
                 text: text ?? "",
                 quotes: (quotes ?? []).compactMap(\.value?.quote),
                 attachments: (attachments ?? []).compactMap(\.value?.attachment),
-                settings: settings?.settings
+                settings: settings?.settings,
+                botSubmissionUncertain: context == "bot" && (botSubmissionUncertain ?? false)
             )
             guard !draft.isEmpty else { return nil }
             return (key, draft)
         }
     }
 
-    private static let currentVersion = 3
+    private static let currentVersion = 4
     /// Older documents decode through the same schema because every field added
     /// after typed text is optional.
-    private static let readableVersions: Set<Int> = [1, 2, currentVersion]
+    private static let readableVersions: Set<Int> = [1, 2, 3, currentVersion]
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "HermesMobile",
         category: "ChatDraftStore"
@@ -547,6 +571,21 @@ final class ChatDraftStore {
     func setDraft(_ text: String, for key: ChatDraftKey) {
         markChangedBeforeLoad(key)
         updateDraft(for: key) { $0.text = text }
+    }
+
+    func setBotSubmissionUncertain(_ uncertain: Bool, for key: ChatDraftKey) {
+        guard case .bot = key.context else { return }
+        markChangedBeforeLoad(key)
+        updateDraft(for: key) { $0.botSubmissionUncertain = uncertain }
+    }
+
+    func discardBotDrafts(server: URL, connectionID: UUID? = nil) async {
+        await loadIfNeeded()
+        await discardDrafts { key in
+            guard key.serverID == server.absoluteString,
+                  case .bot(let id, _) = key.context else { return false }
+            return connectionID == nil || id == connectionID
+        }
     }
 
     /// Replaces explicit quoted passages without disturbing typed text,

--- a/HermesMobile/Resources/Info.plist
+++ b/HermesMobile/Resources/Info.plist
@@ -60,6 +60,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Hermex connects to your Hermes backend on your local network to load bots and chat.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Hermex needs microphone access to dictate text into the message composer.</string>
 	<key>NSCameraUsageDescription</key>

--- a/HermesMobileTests/BotChatPresentationTests.swift
+++ b/HermesMobileTests/BotChatPresentationTests.swift
@@ -1,0 +1,248 @@
+import Observation
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+import Vision
+import XCTest
+@testable import HermesMobile
+
+@MainActor final class BotChatPresentationTests: XCTestCase {
+    private func make(_ wire: BotFixtureWire) -> BotConversation {
+        BotConversation(
+            server: URL(string: "https://webui.example")!,
+            connection: BotConnection(id: UUID(), name: "Fixture Mac", address: URL(string: "http://hermes.local:9120")!, username: "fixture", password: "fixture"),
+            profile: BotProfile(.object(["name": .string("inbox-triage")]))!,
+            wire: wire, drafts: ChatDraftStore(persistence: BotMemoryDrafts())
+        )
+    }
+
+    func testReadyHasNoStatusAndDisconnectShowsRecoveryAboveComposer() async throws {
+        let wire = BotFixtureWire()
+        let model = make(wire)
+        await model.recover()
+        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}))
+        defer { model.suspend(); close(window) }
+        await renderFrames()
+        let ready = try screenshot(window, name: "ready-no-status")
+        XCTAssertFalse(ready.contains("Connected"))
+        XCTAssertFalse(ready.contains("Ready"))
+        XCTAssertTrue(ready.contains("Message bot"))
+        wire.onDisconnect?(BotFailure.transport)
+        await renderFrames()
+        let disconnected = try screenshot(window, name: "disconnected-status")
+        XCTAssertTrue(disconnected.contains("Disconnected"))
+        XCTAssertTrue(disconnected.contains("Reconnect"))
+        XCTAssertFalse(model.maySend)
+    }
+
+    func testBotEditorKeepsIdentityDraftAndKeyboardRulesThroughFocusAndWork() async throws {
+        let wire = BotFixtureWire()
+        let model = make(wire)
+        XCTAssertFalse(model.mayEditDraft)
+        await model.recover()
+        model.editDraft("Persistent text")
+        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}))
+        defer { model.suspend(); close(window) }
+        await renderFrames()
+        let editor = try XCTUnwrap(descendants(window).compactMap { $0 as? ComposerChipTextView }.first)
+        XCTAssertFalse(editor.acceptsAttachments)
+        XCTAssertTrue(editor.isKeyboardSendEnabled)
+        XCTAssertEqual(editor.accessibilityLabel, "Message bot")
+        XCTAssertTrue(editor.becomeFirstResponder())
+        await renderFrames()
+        XCTAssertTrue(editor.isFirstResponder)
+        editor.insertText(" survives focus")
+        await renderFrames()
+        XCTAssertEqual(model.draft, "Persistent text survives focus")
+        editor.resignFirstResponder()
+        await renderFrames()
+        XCTAssertTrue(descendants(window).contains { $0 === editor })
+        XCTAssertEqual(editor.sourceText, model.draft)
+        wire.running = true
+        await model.recover()
+        await renderFrames()
+        XCTAssertFalse(editor.isKeyboardSendEnabled, "Bot work never turns Command-Return into Stop or queued Send")
+        XCTAssertTrue(editor.isEditable, "Unsent drafts remain editable while the Bot works")
+        XCTAssertTrue(wire.calls.allSatisfy { $0.0 != "prompt.submit" && $0.0 != "session.interrupt" })
+    }
+
+    func testPendingRequestOutranksUncertainStopInStatus() async throws {
+        // A Stop whose acknowledgement was lost stays uncertain; if the next snapshot
+        // still carries a pending approval, the Desktop instruction must stay visible.
+        let wire = BotFixtureWire(); wire.running = true; wire.attention = true; wire.stopFailure = .transport
+        let model = make(wire)
+        await model.recover()
+        await model.stop(try XCTUnwrap(model.prepareStop()))
+        await model.recover()
+        XCTAssertTrue(model.uncertainStop)
+        XCTAssertEqual(model.turn, .needsAttention)
+        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}))
+        defer { model.suspend(); close(window) }
+        await renderFrames()
+        let status = try screenshot(window, name: "attention-over-uncertain-stop")
+        XCTAssertTrue(status.contains("Needs attention"))
+        XCTAssertFalse(status.contains("Outcome unknown"))
+    }
+
+    func testTextOnlyEditorRejectsAttachmentProviders() {
+        let editor = ComposerChipTextView()
+        let image = NSItemProvider(item: NSData(), typeIdentifier: UTType.png.identifier)
+        let text = NSItemProvider(object: "plain text" as NSString)
+        XCTAssertTrue(editor.canPasteItemProviders([image]), "Sessions retain attachment support")
+        editor.acceptsAttachments = false
+        XCTAssertFalse(editor.canPasteItemProviders([image]))
+        XCTAssertTrue(editor.canPasteItemProviders([text]))
+
+    }
+
+    func testBotFixturesAcrossAppearanceKeyboardAndLargerText() async throws {
+        for dark in [false, true] {
+            for large in [false, true] {
+                let wire = BotFixtureWire()
+                wire.history = [
+                    .object(["role": .string("user"), "text": .string("Summarize the inbox and list the next steps.")]),
+                    .object(["role": .string("assistant"), "text": .string("Three messages need a reply.\n\n**Next steps**\n1. Confirm the delivery date.\n2. Send the updated estimate.\n3. Reply to the meeting request.\n\nThe remaining messages can wait.")])
+                ]
+                let model = make(wire)
+                let window = try show(NavigationStack { BotChatView(model: model) }
+                    .environment(\.scenePhase, .active)
+                    .environment(\.dynamicTypeSize, large ? .accessibility1 : .large)
+                    .preferredColorScheme(dark ? .dark : .light))
+                defer { model.suspend(); close(window) }
+                await model.recover()
+                await renderFrames()
+                let name = "bot-\(dark ? "dark" : "light")-\(large ? "large" : "default")"
+                _ = try screenshot(window, name: name + "-closed")
+                let editor = try XCTUnwrap(descendants(window).compactMap { $0 as? ComposerChipTextView }.first)
+                XCTAssertTrue(editor.becomeFirstResponder())
+                await renderFrames()
+                editor.insertText("Draft a short reply.")
+                await renderFrames()
+                _ = try screenshot(window, name: name + "-keyboard")
+                XCTAssertEqual(model.draft, "Draft a short reply.")
+                XCTAssertTrue(wire.calls.allSatisfy { $0.0 != "prompt.submit" && $0.0 != "session.interrupt" })
+                close(window)
+                await renderFrames()
+                let focus = SessionFixtureFocus()
+                let reference = try show(NavigationStack { SessionChatPresentationFixture(focus: focus, messages: model.messages) }
+                    .environment(\.dynamicTypeSize, large ? .accessibility1 : .large)
+                    .preferredColorScheme(dark ? .dark : .light))
+                defer { close(reference) }
+                await renderFrames()
+                _ = try screenshot(reference, name: name.replacingOccurrences(of: "bot-", with: "sessions-") + "-closed")
+                let referenceEditor = try XCTUnwrap(descendants(reference).compactMap { $0 as? ComposerChipTextView }.first)
+                XCTAssertTrue(referenceEditor.acceptsAttachments)
+                focus.isFocused = true
+                await renderFrames()
+                XCTAssertTrue(referenceEditor.isFirstResponder)
+                XCTAssertGreaterThan(referenceEditor.bounds.height, 44)
+                referenceEditor.insertText("Draft a short reply.")
+                await renderFrames()
+                _ = try screenshot(reference, name: name.replacingOccurrences(of: "bot-", with: "sessions-") + "-keyboard")
+            }
+        }
+    }
+
+    private func show<V: View>(_ view: V) throws -> UIWindow {
+        let scene = try XCTUnwrap(UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: scene)
+        window.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        // Static comparisons must not capture an intermediate composer spring frame.
+        window.rootViewController = UIHostingController(rootView: view.transaction { $0.disablesAnimations = true })
+        window.makeKeyAndVisible()
+        return window
+    }
+
+    private func close(_ window: UIWindow) {
+        window.endEditing(true)
+        window.isHidden = true
+        window.rootViewController = nil
+    }
+
+    private func descendants(_ view: UIView) -> [UIView] {
+        [view] + view.subviews.flatMap(descendants)
+    }
+
+    private func renderFrames() async {
+        let rendered = expectation(description: "Layout committed")
+        let driver = BotRenderFrameDriver { rendered.fulfill() }
+        driver.start()
+        await fulfillment(of: [rendered], timeout: 10)
+        driver.stop()
+    }
+
+    @discardableResult
+    private func screenshot(_ window: UIWindow, name: String) throws -> String {
+        let image = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+        }
+        let attachment = XCTAttachment(image: image)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        let request = VNRecognizeTextRequest()
+        try VNImageRequestHandler(cgImage: XCTUnwrap(image.cgImage)).perform([request])
+        return request.results?.compactMap { $0.topCandidates(1).first?.string }.joined(separator: " ") ?? ""
+    }
+}
+
+/// The actual Sessions presentation components with inert fixture callbacks.
+/// No APIClient, active account or server data participates in these captures.
+@MainActor @Observable private final class SessionFixtureFocus {
+    var isFocused = false
+}
+
+private struct SessionChatPresentationFixture: View {
+    @Bindable var focus: SessionFixtureFocus
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @State private var draft = ""
+    @State private var quotes: [ComposerQuote] = []
+    @State private var paths = ComposerFilePathSearch()
+    @State private var git = GitWorkspaceAvailabilityViewModel(
+        session: SessionSummary(), server: URL(string: "https://webui.example")!
+    )
+    let messages: [ChatMessage]
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(messages) { message in MessageBubbleView(message: message) }
+            }
+            .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 20 : 16)
+            .padding(.vertical, 16)
+        }
+        .defaultScrollAnchor(.bottom)
+        .scrollDismissesKeyboard(.interactively)
+        .safeAreaInset(edge: .bottom, spacing: 0) { composer }
+        .navigationTitle("inbox-triage")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var composer: some View {
+        MessageComposerView(
+            draftMessage: $draft, quotes: $quotes, isFocused: $focus.isFocused,
+            isSending: false, isCompressingSession: false, isWaitingForStream: false,
+            isCancellingStream: false, readOnlyMessage: nil, errorMessage: nil,
+            configurationErrorMessage: nil, contextWindowSnapshot: nil, gitViewModel: git,
+            modelGroups: [], selectedModelID: nil, selectedModelProviderID: nil, selectedModelTitle: "Model",
+            workspaceRoots: [], selectedWorkspacePath: nil, workspaceSuggestions: [], workspaceManagementServer: nil,
+            personalitySuggestions: [], skillSuggestions: [], hasLoadedSkillSuggestions: true,
+            agentCommands: [], profileOptions: [], isSingleProfileMode: true,
+            selectedProfileName: nil, selectedProfileTitle: "Default", selectedReasoningEffort: nil,
+            supportedReasoningEfforts: nil, supportsReasoningEffort: false, showsReasoningControl: false,
+            isUpdatingConfiguration: false, pendingAttachments: [], isUploadingAttachment: false,
+            attachmentUploadCount: 0, attachmentUploadGeneration: 0, isSendingVoiceNote: false,
+            autoStartsVoiceInput: false, apiClient: nil, sessionID: nil, chipFilePaths: [],
+            filePathSearch: paths, uploadAttachmentErrorMessage: nil,
+            onSend: {}, onSendVoiceNote: { _, _ in }, onCancel: {}, onSelectModel: { _ in },
+            onModelPickerOpen: {}, onSelectReasoningEffort: { _ in }, onLoadWorkspaceSuggestions: { _ in },
+            onWorkspaceRegistryChanged: {}, onLoadPersonalitySuggestions: {}, onLoadSkillSuggestions: {},
+            onSelectWorkspace: { _ in }, onSelectProfile: { _ in }, onHeightChange: { _ in },
+            onPhotoItemSelected: { _ in }, onFileURLsSelected: { _ in }, onPasteFileProviders: { _ in },
+            onPasteFileURLs: { _ in }, onPasteImageProviders: { _ in }, onPasteImages: { _ in },
+            onRemoveAttachment: { _ in }, onPreviewAttachment: { _ in }, onDismissUploadAttachmentError: {},
+            onSelectFileReference: { _ in }, onOpenFileReference: { _ in }, onSelectGitBranch: { _ in },
+            onCreateGitBranch: { _ in }, onRefreshGitBranches: {}
+        )
+    }
+}

--- a/HermesMobileTests/BotClientTests.swift
+++ b/HermesMobileTests/BotClientTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import HermesMobile
+
+@MainActor final class BotClientTests: XCTestCase {
+    override func tearDown() {
+        BotHTTPFixture.handler = nil
+        super.tearDown()
+    }
+
+    func testPasswordGateIdentityAndFreshTicketsUseTextRPCOnEverySocket() async throws {
+        var tickets = 0
+        var paths: [String] = []
+        BotHTTPFixture.handler = { request in
+            let path = request.url!.path
+            paths.append(path)
+            switch path {
+            case "/api/status": return (200, .object(["auth_required": .bool(true), "auth_providers": .array([.string("basic")])]))
+            case "/auth/password-login":
+                XCTAssertEqual(request.httpMethod, "POST")
+                return (200, .object(["ok": .bool(true)]))
+            case "/api/auth/me": return (200, .object(["provider": .string("basic"), "future": .array([])]))
+            case "/api/auth/ws-ticket":
+                tickets += 1
+                return (200, .object(["ticket": .string("ticket-\(tickets)")]))
+            default: XCTFail("Unexpected HTTP endpoint"); return (404, .null)
+            }
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BotHTTPFixture.self]
+        var protocols: [[String]] = []
+        var sockets: [BotScriptedSocket] = []
+        let client = BotClient(connection: connection(), configuration: configuration) { url, names in
+            XCTAssertEqual(url.scheme, "wss")
+            XCTAssertEqual(url.path, "/api/ws")
+            XCTAssertNil(url.query)
+            protocols.append(names)
+            let socket = BotScriptedSocket()
+            sockets.append(socket)
+            return socket
+        }
+        for _ in 0..<2 {
+            try await client.connect()
+            let roster = try await client.call("profiles.list", [:])
+            XCTAssertEqual(roster["profiles"].list, [])
+            do {
+                _ = try await client.call("session.interrupt", ["session_id": .string("runtime")]) { throw BotFailure.stale }
+                XCTFail("A stale action must not dispatch")
+            } catch { XCTAssertEqual(error as? BotFailure, .stale) }
+            client.close()
+        }
+        XCTAssertEqual(tickets, 2)
+        XCTAssertEqual(protocols, [["hermes-gateway-v1", "hermes-gateway-ticket.ticket-1"], ["hermes-gateway-v1", "hermes-gateway-ticket.ticket-2"]])
+        XCTAssertEqual(paths.filter { $0 == "/api/auth/me" }.count, 2)
+        XCTAssertEqual(sockets.map { $0.sentTextFrames }, [1, 1])
+    }
+
+    func testMissingPasswordGateFailsBeforeCredentialsOrSocket() async {
+        BotHTTPFixture.handler = { request in
+            XCTAssertEqual(request.url?.path, "/api/status")
+            return (200, .object(["auth_required": .bool(false)]))
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BotHTTPFixture.self]
+        let client = BotClient(connection: connection(), configuration: configuration) { _, _ in
+            XCTFail("Must not open a socket")
+            return BotScriptedSocket()
+        }
+        do { try await client.connect(); XCTFail("Expected unsupported gate") }
+        catch { XCTAssertEqual(error as? BotFailure, .unsupported) }
+        client.close()
+    }
+
+    func testExpiredIdentityStopsBeforeTicket() async {
+        BotHTTPFixture.handler = { request in
+            switch request.url!.path {
+            case "/api/status": return (200, .object(["auth_required": .bool(true), "auth_providers": .array([.string("basic")])]))
+            case "/auth/password-login": return (200, .object([:]))
+            case "/api/auth/me": return (401, .object([:]))
+            default: XCTFail("Must not request a ticket"); return (500, .null)
+            }
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BotHTTPFixture.self]
+        let client = BotClient(connection: connection(), configuration: configuration)
+        do { try await client.connect(); XCTFail("Expected expired identity") }
+        catch { XCTAssertEqual(error as? BotFailure, .rejected(401)) }
+        client.close()
+    }
+
+    private func connection() -> BotConnection {
+        BotConnection(id: UUID(), name: "Fixture", address: URL(string: "https://hermes.example")!, username: "user", password: "fixture")
+    }
+}
+
+private final class BotHTTPFixture: URLProtocol {
+    static var handler: ((URLRequest) -> (Int, BotJSON))?
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        guard let handler = Self.handler else { client?.urlProtocol(self, didFailWithError: BotFailure.transport); return }
+        let (status, value) = handler(request)
+        let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: try! JSONEncoder().encode(value))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+/// Lock ownership protects the queued scripted frames and exactly one waiting reader.
+private final class BotScriptedSocket: BotSocket, @unchecked Sendable {
+    private let lock = NSLock()
+    private var frames: [URLSessionWebSocketTask.Message] = [
+        .string(#"{"method":"event","params":{"type":"gateway.ready","payload":{"replay_epoch":"epoch"}}}"#)
+    ]
+    private var waiter: CheckedContinuation<URLSessionWebSocketTask.Message, Error>?
+    private var closed = false
+    private(set) var sentTextFrames = 0
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            if closed { lock.unlock(); continuation.resume(throwing: BotFailure.transport) }
+            else if !frames.isEmpty { let frame = frames.removeFirst(); lock.unlock(); continuation.resume(returning: frame) }
+            else { waiter = continuation; lock.unlock() }
+        }
+    }
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        guard case .string(let text) = message else { XCTFail("JSON-RPC must use text frames"); throw BotFailure.unsupported }
+        let request = try JSONDecoder().decode(BotJSON.self, from: Data(text.utf8))
+        let response = BotJSON.object(["id": request["id"], "result": .object(["profiles": .array([])])])
+        let frame = URLSessionWebSocketTask.Message.string(String(decoding: try JSONEncoder().encode(response), as: UTF8.self))
+        enqueue(frame)
+    }
+    private func enqueue(_ frame: URLSessionWebSocketTask.Message) {
+        lock.lock(); sentTextFrames += 1
+        let waiting = waiter; waiter = nil
+        if waiting == nil { frames.append(frame) }
+        lock.unlock()
+        waiting?.resume(returning: frame)
+    }
+    func cancel() {
+        lock.lock(); closed = true
+        let waiting = waiter; waiter = nil
+        lock.unlock()
+        waiting?.resume(throwing: BotFailure.transport)
+    }
+}

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -355,7 +355,7 @@ import Vision
     }
 }
 
-@MainActor private final class BotRenderFrameDriver: NSObject {
+@MainActor final class BotRenderFrameDriver: NSObject {
     private let completion: () -> Void
     private var link: CADisplayLink?
     private var frames = 0

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -1,0 +1,362 @@
+import XCTest
+import Observation
+@testable import HermesMobile
+
+@MainActor final class BotConversationTests: XCTestCase {
+    private let server = URL(string: "https://webui.example")!
+    private var connection: BotConnection {
+        BotConnection(id: UUID(), name: "Mac", address: URL(string: "http://hermes.local:9120")!, username: "user", password: "fixture")
+    }
+    private var profile: BotProfile { BotProfile(.object(["name": .string("inbox-triage")]))! }
+
+    private func make(_ wire: BotFixtureWire, drafts: ChatDraftStore? = nil) -> BotConversation {
+        BotConversation(server: server, connection: connection, profile: profile, wire: wire,
+                        drafts: drafts ?? ChatDraftStore(persistence: BotMemoryDrafts(), debounceDuration: .seconds(60)))
+    }
+
+    func testOpenKeepsCanonicalRootTipAndRuntimeSeparate() async {
+        let wire = BotFixtureWire()
+        let model = make(wire)
+        await model.recover()
+        XCTAssertEqual(model.root, "root")
+        XCTAssertEqual(model.runtime, "runtime")
+        XCTAssertTrue(model.maySend)
+        XCTAssertEqual(model.messages.map(\.content), ["saved"])
+        XCTAssertEqual(wire.calls.map(\.0), ["session.list", "session.resume", "session.events.since", "session.resume"])
+        XCTAssertEqual(wire.calls[1].1["session_id"], .string("tip"))
+        XCTAssertEqual(wire.calls[1].1["close_on_disconnect"], .bool(false))
+        model.suspend()
+    }
+
+    func testChangedRootRejectedBeforeResumeAndSavedHistoryRetained() async {
+        let wire = BotFixtureWire(); let model = make(wire)
+        await model.recover()
+        wire.root = "replacement"; wire.calls = []
+        await model.recover()
+        XCTAssertEqual(wire.calls.map(\.0), ["session.list"])
+        XCTAssertEqual(model.messages.map(\.content), ["saved"])
+        XCTAssertFalse(model.maySend)
+        model.suspend()
+    }
+
+    func testCompactionLoadsNewTipWithStableRoot() async {
+        let wire = BotFixtureWire(); let model = make(wire)
+        await model.recover()
+        wire.tip = "compacted"; wire.history = [.object(["role": .string("assistant"), "text": .string("compacted history")])]
+        await model.recover()
+        XCTAssertEqual(model.root, "root")
+        XCTAssertEqual(model.messages.map(\.content), ["compacted history"])
+        XCTAssertTrue(model.maySend)
+        model.suspend()
+    }
+
+    func testMissingAndFailedLookupsNeverCreateReplacement() async {
+        for failure in [BotFailure.missingChat, .rejected(5000)] {
+            let wire = BotFixtureWire(); wire.lookupFailure = failure
+            let model = make(wire)
+            await model.recover()
+            XCTAssertFalse(model.maySend)
+            XCTAssertEqual(wire.calls.map(\.0), ["session.list"])
+            model.suspend()
+        }
+    }
+
+    func testExistingEmptyHistoryCanSend() async {
+        let wire = BotFixtureWire(); wire.history = []
+        let model = make(wire); await model.recover()
+        XCTAssertTrue(model.messages.isEmpty)
+        XCTAssertTrue(model.maySend)
+        model.suspend()
+    }
+
+    func testAmbiguousSendPersistsBeforeDispatchAndNeverRetriesAfterReopen() async throws {
+        let persistence = BotMemoryDrafts()
+        let drafts = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(60))
+        let wire = BotFixtureWire(); wire.submitFailure = .transport
+        let model = make(wire, drafts: drafts)
+        await model.recover(); model.editDraft("only once")
+        wire.beforeSubmit = {
+            let saved = await persistence.load()
+            XCTAssertTrue(saved.values.first?.botSubmissionUncertain == true)
+        }
+        await model.send()
+        XCTAssertTrue(model.uncertainSend)
+        XCTAssertFalse(model.maySend)
+        await model.recover()
+        await model.send()
+        XCTAssertEqual(wire.calls.filter { $0.0 == "prompt.submit" }.count, 1)
+        let restoredWire = BotFixtureWire()
+        let restored = BotConversation(server: server, connection: model.connection, profile: profile,
+                                       wire: restoredWire, drafts: ChatDraftStore(persistence: persistence))
+        await restored.recover()
+        XCTAssertTrue(restored.uncertainSend)
+        XCTAssertEqual(restored.draft, "only once")
+        XCTAssertFalse(restored.maySend)
+        model.suspend(); restored.suspend()
+    }
+
+    func testDefiniteRejectionPreservesSendableTextAfterRecovery() async {
+        let wire = BotFixtureWire(); wire.submitFailure = .rejected(4090)
+        let model = make(wire)
+        await model.recover(); model.editDraft("keep this")
+        await model.send()
+        XCTAssertEqual(model.draft, "keep this")
+        XCTAssertFalse(model.uncertainSend)
+        XCTAssertFalse(model.maySend)
+        await model.recover()
+        XCTAssertTrue(model.maySend)
+        model.suspend()
+    }
+
+    func testAcceptedSubmissionClearsPersistentDraft() async {
+        let wire = BotFixtureWire(); let model = make(wire)
+        await model.recover(); model.editDraft("accepted")
+        await model.send()
+        XCTAssertEqual(model.draft, "")
+        XCTAssertFalse(model.uncertainSend)
+        XCTAssertFalse(model.maySend)
+        XCTAssertEqual(wire.calls.filter { $0.0 == "prompt.submit" }.count, 1)
+        model.suspend()
+    }
+
+    func testStopAcknowledgementNeverClaimsIdleAndActionIsSingleUse() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire); await model.recover()
+        let action = try XCTUnwrap(model.prepareStop())
+        await model.stop(action)
+        XCTAssertFalse(model.maySend)
+        XCTAssertFalse(model.mayStop)
+        await model.stop(action)
+        XCTAssertEqual(wire.calls.filter { $0.0 == "session.interrupt" }.count, 1)
+        model.suspend()
+    }
+
+    func testLostStopDoesNotRetryAndRecoveredIdleClearsUncertainty() async throws {
+        let wire = BotFixtureWire(); wire.running = true; wire.stopFailure = .transport
+        let model = make(wire); await model.recover()
+        let action = try XCTUnwrap(model.prepareStop())
+        await model.stop(action)
+        await model.recover()
+        XCTAssertTrue(model.uncertainStop)
+        XCTAssertFalse(model.maySend)
+        await model.stop(action)
+        wire.running = false
+        await model.recover()
+        XCTAssertFalse(model.uncertainStop)
+        XCTAssertTrue(model.maySend)
+        XCTAssertEqual(wire.calls.filter { $0.0 == "session.interrupt" }.count, 1)
+        model.suspend()
+    }
+
+    func testStaleUnsentStopCannotAffectLaterDesktopWork() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire); await model.recover()
+        let action = try XCTUnwrap(model.prepareStop())
+        wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(1), "type": .string("message.complete")]))
+        await model.recover()
+        await model.stop(action)
+        XCTAssertTrue(wire.calls.allSatisfy { $0.0 != "session.interrupt" })
+        model.suspend()
+    }
+
+    func testPendingApprovalAndQuietWorkKeepStopAndBlockSend() async {
+        for attention in [false, true] {
+            let wire = BotFixtureWire(); wire.running = true; wire.attention = attention
+            let model = make(wire); await model.recover()
+            XCTAssertEqual(model.turn, attention ? .needsAttention : .running)
+            XCTAssertTrue(model.mayStop)
+            XCTAssertFalse(model.maySend)
+            model.suspend()
+        }
+    }
+
+    func testReplayFaultsReplaceHistoryWithoutAppendingOverlap() async {
+        let wire = BotFixtureWire(); let model = make(wire)
+        await model.recover()
+        for replay in [
+            BotFixtureWire.replay(latest: 3, truncated: true),
+            BotFixtureWire.replay(latest: 1),
+            BotFixtureWire.replay(latest: 0, epoch: "restart"),
+            BotFixtureWire.replay(latest: 4, events: [event(4), event(4)])
+        ] {
+            wire.replay = replay
+            await model.recover()
+            XCTAssertTrue(model.replayWasReset)
+            XCTAssertEqual(model.messages.map(\.content), ["saved"])
+        }
+        model.suspend()
+    }
+
+    func testAuthUnsupportedOwnershipAndOversizedHistoryBlockSend() async {
+        for code in [401, 403, -32601, 4090, 4130] {
+            let wire = BotFixtureWire(); wire.lookupFailure = .rejected(code)
+            let model = make(wire); await model.recover()
+            XCTAssertFalse(model.maySend)
+            XCTAssertNotNil(model.errorMessage)
+            model.suspend()
+        }
+    }
+
+    func testSuspendingDuringResumeRejectsLateHistoryAndCommands() async {
+        let wire = BotFixtureWire()
+        let reached = expectation(description: "resume requested")
+        var release: CheckedContinuation<Void, Never>?
+        wire.beforeResume = {
+            await withCheckedContinuation { continuation in release = continuation; reached.fulfill() }
+        }
+        let model = make(wire)
+        let task = Task { await model.recover() }
+        await fulfillment(of: [reached], timeout: 2)
+        model.suspend()
+        release?.resume()
+        await task.value
+        XCTAssertTrue(model.messages.isEmpty)
+        XCTAssertFalse(model.maySend)
+        XCTAssertEqual(wire.calls.map(\.0), ["session.list", "session.resume"])
+    }
+
+    func testLiveEventsReplaceInflightSnapshotsWithoutDuplicatingText() async {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire); await model.recover()
+        wire.inflight = .object(["user": .string("question"), "assistant": .string("first second")])
+        let updated = expectation(description: "inflight snapshot published")
+        withObservationTracking {
+            _ = model.liveMessages
+        } onChange: { updated.fulfill() }
+        wire.onEvent?(event(1))
+        wire.onEvent?(event(1))
+        wire.onEvent?(event(2))
+        await fulfillment(of: [updated], timeout: 3)
+        XCTAssertEqual(model.liveMessages.map(\.content), ["question", "first second"])
+        XCTAssertEqual(model.messages.map(\.content), ["saved"])
+        XCTAssertEqual(wire.calls.filter { $0.0 == "session.resume" && $0.1["omit_messages"] == .bool(true) }.count, 1)
+        model.suspend()
+        let retained = model.liveMessages
+        wire.inflight = .object(["assistant": .string("late old connection")])
+        wire.onEvent?(event(3))
+        XCTAssertEqual(model.liveMessages, retained)
+        XCTAssertEqual(model.turn, .unknown)
+    }
+
+    func testSwitchingConnectionWithSameProfileRejectsOldSubmissionResult() async {
+        let persistence = BotMemoryDrafts()
+        let drafts = ChatDraftStore(persistence: persistence)
+        let oldWire = BotFixtureWire()
+        let old = make(oldWire, drafts: drafts)
+        await old.recover(); old.editDraft("old connection")
+        let dispatched = expectation(description: "old send dispatched")
+        var release: CheckedContinuation<Void, Never>?
+        oldWire.beforeSubmit = {
+            await withCheckedContinuation { continuation in release = continuation; dispatched.fulfill() }
+        }
+        let task = Task { await old.send() }
+        await fulfillment(of: [dispatched], timeout: 2)
+        old.suspend()
+        let next = make(BotFixtureWire(), drafts: drafts)
+        await next.recover(); next.editDraft("new connection")
+        release?.resume(); await task.value
+        XCTAssertEqual(next.draft, "new connection")
+        XCTAssertTrue(next.maySend)
+        let held = await drafts.draft(for: old.draftKey)
+        XCTAssertTrue(held?.botSubmissionUncertain == true)
+        XCTAssertEqual(held?.text, "old connection")
+        next.suspend()
+    }
+
+    func testDesktopBoundaryBeforeSocketDispatchRejectsUnsentCommands() async throws {
+        for stopping in [false, true] {
+            let wire = BotFixtureWire(); wire.running = stopping
+            let model = make(wire); await model.recover()
+            wire.beforeDispatch = { method in
+                guard ["prompt.submit", "session.interrupt"].contains(method) else { return }
+                wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(1), "type": .string("message.start")]))
+            }
+            if stopping { await model.stop(try XCTUnwrap(model.prepareStop())) }
+            else { model.editDraft("not dispatched"); await model.send() }
+            XCTAssertTrue(wire.calls.allSatisfy { !["prompt.submit", "session.interrupt"].contains($0.0) })
+            XCTAssertFalse(model.uncertainSend)
+            XCTAssertFalse(model.uncertainStop)
+            if !stopping { XCTAssertEqual(model.draft, "not dispatched") }
+            model.suspend()
+        }
+    }
+
+    func testLiveSequenceRegressionInvalidatesPreparedStopUntilSnapshot() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        wire.replay = BotFixtureWire.replay(latest: 10)
+        let model = make(wire); await model.recover()
+        let action = try XCTUnwrap(model.prepareStop())
+        wire.onEvent?(event(1))
+        XCTAssertTrue(model.replayWasReset)
+        XCTAssertEqual(model.turn, .unknown)
+        XCTAssertFalse(model.mayStop)
+        await model.stop(action)
+        XCTAssertTrue(wire.calls.allSatisfy { $0.0 != "session.interrupt" })
+        model.suspend()
+    }
+
+    private func event(_ seq: Int) -> BotJSON {
+        .object(["session_id": .string("runtime"), "seq": .number(Double(seq)), "type": .string("message.delta")])
+    }
+}
+
+actor BotMemoryDrafts: ChatDraftPersisting {
+    var values: [ChatDraftKey: ChatDraft] = [:]
+    func load() -> [ChatDraftKey: ChatDraft] { values }
+    func write(_ drafts: [ChatDraftKey: ChatDraft]) { values = drafts }
+}
+
+@MainActor final class BotFixtureWire: BotTransport {
+    var replayEpoch: String? = "epoch"
+    var onEvent: ((BotJSON) -> Void)?
+    var onDisconnect: ((Error) -> Void)?
+    var calls: [(String, [String: BotJSON])] = []
+    var root = "root"
+    var tip = "tip"
+    var running = false
+    var inflight = BotJSON.null
+    var attention = false
+    var history: [BotJSON] = [.object(["role": .string("assistant"), "text": .string("saved")])]
+    var replay = BotFixtureWire.replay()
+    var lookupFailure: BotFailure?
+    var submitFailure: BotFailure?
+    var stopFailure: BotFailure?
+    var beforeDispatch: ((String) -> Void)?
+    var beforeSubmit: (() async -> Void)?
+    var beforeResume: (() async -> Void)?
+    func connect() async throws {}
+    func close() {}
+    func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)?) async throws -> BotJSON {
+        beforeDispatch?(method)
+        try validateDispatch?()
+        calls.append((method, params))
+        switch method {
+        case "session.list":
+            if let lookupFailure {
+                if lookupFailure == .missingChat { return .object(["sessions": .array([])]) }
+                throw lookupFailure
+            }
+            return .object(["sessions": .array([.object(["id": .string(root), "resolved_id": .string(tip)])])])
+        case "session.resume":
+            await beforeResume?()
+            return .object([
+                "session_id": .string("runtime"), "session_key": .string(tip), "running": .bool(running),
+                "messages": .array(history), "inflight": inflight, "pending_approval": attention ? .object(["id": .string("approval")]) : .null,
+                "info": .object(["profile_name": .string("inbox-triage")])
+            ])
+        case "session.events.since": return replay
+        case "prompt.submit":
+            await beforeSubmit?()
+            if let submitFailure { throw submitFailure }
+            running = true
+            return .object(["status": .string("streaming")])
+        case "session.interrupt":
+            if let stopFailure { throw stopFailure }
+            return .object(["interrupted": .bool(true)])
+        default: throw BotFailure.unsupported
+        }
+    }
+    static func replay(latest: Int = 0, truncated: Bool = false, epoch: String = "epoch", events: [BotJSON] = []) -> BotJSON {
+        .object(["latest_seq": .number(Double(latest)), "truncated": .bool(truncated), "epoch": .string(epoch), "events": .array(events)])
+    }
+}

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 import Observation
+import SwiftUI
+import Vision
 @testable import HermesMobile
 
 @MainActor final class BotConversationTests: XCTestCase {
@@ -297,6 +299,75 @@ import Observation
 
     private func event(_ seq: Int) -> BotJSON {
         .object(["session_id": .string("runtime"), "seq": .number(Double(seq)), "type": .string("message.delta")])
+    }
+
+    func testLongInflightResponseRemainsVisibleAtLatestEdge() async throws {
+        let wire = BotFixtureWire()
+        wire.running = true
+        wire.history = [.object(["role": .string("assistant"), "text": .string(
+            (1...300).map { "\($0) SAVED HISTORY" }.joined(separator: "\n")
+        )])]
+        wire.inflight = .object(["assistant": .string(
+            (1...100).map { "\($0) VISIBLE LIVE OUTPUT" }.joined(separator: "\n")
+        )])
+        let model = make(wire)
+        let host = UIHostingController(rootView: BotChatView(model: model).environment(\.scenePhase, .active))
+        let scene = try XCTUnwrap(UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: scene)
+        window.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { model.suspend(); window.isHidden = true; window.rootViewController = nil }
+        await model.recover()
+        await renderBotFrames()
+        for step in 1...12 {
+            wire.inflight = .object(["assistant": .string(
+                (1...(100 + step * 25)).map { "\($0) VISIBLE LIVE OUTPUT" }.joined(separator: "\n")
+            )])
+            let updated = expectation(description: "Stream snapshot published")
+            withObservationTracking { _ = model.liveMessages } onChange: { updated.fulfill() }
+            wire.onEvent?(event(step))
+            await fulfillment(of: [updated], timeout: 3)
+            await renderBotFrames()
+            try assertBotOutputVisible(window)
+        }
+    }
+
+    private func renderBotFrames() async {
+        let rendered = expectation(description: "Transcript layout committed")
+        let driver = BotRenderFrameDriver { rendered.fulfill() }
+        driver.start()
+        await fulfillment(of: [rendered], timeout: 10)
+        driver.stop()
+    }
+
+    private func assertBotOutputVisible(_ window: UIWindow) throws {
+        let screenshot = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+        }
+        let attachment = XCTAttachment(image: screenshot)
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        let request = VNRecognizeTextRequest()
+        try VNImageRequestHandler(cgImage: XCTUnwrap(screenshot.cgImage)).perform([request])
+        let visibleText = request.results?.compactMap { $0.topCandidates(1).first?.string }.joined(separator: " ") ?? ""
+        XCTAssertTrue(visibleText.contains("VISIBLE LIVE OUTPUT"), "Live response must be visible, got: \(visibleText)")
+    }
+}
+
+@MainActor private final class BotRenderFrameDriver: NSObject {
+    private let completion: () -> Void
+    private var link: CADisplayLink?
+    private var frames = 0
+    init(completion: @escaping () -> Void) { self.completion = completion }
+    func start() {
+        link = CADisplayLink(target: self, selector: #selector(tick))
+        link?.add(to: .main, forMode: .common)
+    }
+    func stop() { link?.invalidate(); link = nil }
+    @objc private func tick() {
+        frames += 1
+        if frames == 3 { stop(); completion() }
     }
 }
 

--- a/HermesMobileTests/BotDraftTests.swift
+++ b/HermesMobileTests/BotDraftTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import HermesMobile
+
+@MainActor final class BotDraftTests: XCTestCase {
+    private let one = URL(string: "https://one.example")!
+    private let two = URL(string: "https://two.example")!
+
+    func testDiskRoundTripSeparatesServersConnectionsProfilesAndWebui() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let persistence = ChatDraftFilePersistence(directoryURL: directory)
+        let connection = UUID()
+        let keys: [ChatDraftKey] = [
+            .bot(server: one, connectionID: connection, profile: "same"),
+            .bot(server: two, connectionID: connection, profile: "same"),
+            .bot(server: one, connectionID: UUID(), profile: "same"),
+            .bot(server: one, connectionID: connection, profile: "other"),
+            .session(server: one, sessionID: "same"), .newChat(server: one)
+        ]
+        let drafts = ChatDraftStore(persistence: persistence, debounceDuration: .seconds(60))
+        for (index, key) in keys.enumerated() { drafts.setDraft("draft \(index)", for: key) }
+        drafts.setBotSubmissionUncertain(true, for: keys[0])
+        try await drafts.flush()
+        let restored = await persistence.load()
+        XCTAssertEqual(restored.count, keys.count)
+        for (index, key) in keys.enumerated() {
+            XCTAssertEqual(restored[key]?.text, "draft \(index)")
+            XCTAssertEqual(restored[key]?.botSubmissionUncertain, index == 0)
+        }
+        await drafts.discardBotDrafts(server: one, connectionID: connection)
+        try await drafts.flush()
+        let afterConnectionRemoval = await persistence.load()
+        XCTAssertNil(afterConnectionRemoval[keys[0]])
+        XCTAssertNil(afterConnectionRemoval[keys[3]])
+        XCTAssertNotNil(afterConnectionRemoval[keys[1]])
+        XCTAssertNotNil(afterConnectionRemoval[keys[2]])
+        XCTAssertNotNil(afterConnectionRemoval[keys[4]])
+        await drafts.discardDrafts(for: one)
+        try await drafts.flush()
+        let afterServerRemoval = await persistence.load()
+        XCTAssertEqual(Set(afterServerRemoval.keys), [keys[1]])
+    }
+
+    func testOlderDraftCodecAndMalformedBotRecordsPreserveWebui() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let draftDirectory = directory.appendingPathComponent("ChatDrafts")
+        try FileManager.default.createDirectory(at: draftDirectory, withIntermediateDirectories: true)
+        let id = UUID()
+        let json = """
+        {"version": 3, "drafts": [
+          {"serverID":"https://one.example", "context":"session", "sessionID":"same", "text":"old webui"},
+          {"serverID":"https://one.example", "context":"bot", "connectionID":"\(id)", "profile":"same", "text":"held", "botSubmissionUncertain":"malformed"},
+          {"serverID":"https://one.example", "context":"bot", "connectionID":"not-uuid", "profile":"same", "text":"bad identity"},
+          {"serverID":"https://one.example", "context":"future", "text":"unknown"}
+        ]}
+        """
+        try Data(json.utf8).write(to: draftDirectory.appendingPathComponent("drafts.json"))
+        let restored = await ChatDraftFilePersistence(directoryURL: directory).load()
+        XCTAssertEqual(restored.count, 2)
+        XCTAssertEqual(restored[.session(server: one, sessionID: "same")]?.text, "old webui")
+        XCTAssertTrue(restored[.bot(server: one, connectionID: id, profile: "same")]?.botSubmissionUncertain == true)
+    }
+
+    func testConnectionKeychainScopesAndRemoval() throws {
+        let keychain = InMemoryKeychainStore()
+        let store = BotConnectionStore(keychain: keychain)
+        let first = BotConnection(id: UUID(), name: "One", address: try BotConnection.address("http://hermes.local:9120"), username: "first", password: "fixture-one")
+        let second = BotConnection(id: UUID(), name: "Two", address: first.address, username: "second", password: "fixture-two")
+        try store.save(first, server: one)
+        try store.save(second, server: two)
+        XCTAssertEqual(try store.load(server: one), first)
+        XCTAssertEqual(try store.load(server: two), second)
+        try store.remove(server: one)
+        XCTAssertNil(try store.load(server: one))
+        XCTAssertEqual(try store.load(server: two), second)
+    }
+
+    func testAddressValidationAndOptionalRosterMetadata() throws {
+        for text in ["https://user:password@host", "https://host/path", "https://host?ticket=x", "file:///tmp/host", "https://host#x"] {
+            XCTAssertThrowsError(try BotConnection.address(text))
+        }
+        XCTAssertEqual(try BotConnection.address(" HTTP://HERMES.LOCAL:9120/ ").absoluteString, "http://hermes.local:9120")
+        let profile = try XCTUnwrap(BotProfile(.object(["name": .string("same"), "future": .array([])])))
+        XCTAssertEqual(profile.name, "same")
+        XCTAssertNil(profile.preview)
+        XCTAssertNil(profile.lastActive)
+    }
+}

--- a/HermesMobileTests/BotModeGateTests.swift
+++ b/HermesMobileTests/BotModeGateTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import HermesMobile
+
+/// The Bot Mode preview gate (#496): default off, and the Sessions/Bots switch
+/// plus the Bots inbox stay unreachable until it is on.
+final class BotModeGateTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "BotModeGateTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testGateDefaultsOffAndPersistsWhenTurnedOn() {
+        XCTAssertFalse(BotModeGate.isEnabled(in: defaults))
+        defaults.set(true, forKey: BotModeGate.isEnabledKey)
+        XCTAssertTrue(BotModeGate.isEnabled(in: defaults))
+    }
+
+    func testBotsInboxNeedsBothTheGateAndTheUsersPick() {
+        // Gate off: even a stale Bots pick (the flag was turned off while the
+        // inbox was open) resolves to Sessions.
+        XCTAssertFalse(BotModeGate.showsBotsInbox(isEnabled: false, userPickedBots: true))
+        XCTAssertFalse(BotModeGate.showsBotsInbox(isEnabled: false, userPickedBots: false))
+        // Gate on: Sessions until the user picks Bots.
+        XCTAssertFalse(BotModeGate.showsBotsInbox(isEnabled: true, userPickedBots: false))
+        XCTAssertTrue(BotModeGate.showsBotsInbox(isEnabled: true, userPickedBots: true))
+    }
+}

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -1,0 +1,51 @@
+# Bot Mode
+
+Bots use the selected configured Hermex server's optional direct-Hermes connection.
+The connection is a separate Hermes Desktop HTTP/WebSocket backend, not webui.
+The connection record, credentials and stable UUID live in server-scoped Keychain
+storage. A different endpoint or username gets a new UUID. Password/name edits
+retain the identity. Removing the connection deletes its drafts; removing the
+configured server deletes both its connection and all its drafts.
+
+`BotClient` owns an ephemeral cookie session and one WebSocket. HTTP paths live in
+`BotEndpoint`. Password login requires the basic auth gate, verifies identity,
+and mints a fresh single-use ticket for each socket. JSON-RPC uses text frames
+with the `hermes-gateway-v1` and ticket subprotocols. There is no bootstrap-token,
+OAuth, webui fallback, server provisioning or competing-backend path.
+
+`BotConversation` owns one server/connection/Profile view lifetime. It resolves
+exact-title Bot Chat, keeps canonical root, compression tip and runtime IDs
+separate, and rejects a changed root before resume. Lookup can recover archived
+history; resume can auto-continue unfinished backend work. Neither is guaranteed
+to be read-only. Approvals remain in Desktop.
+
+History is memory-only. Open/recovery replaces it from a full resume snapshot.
+Replay detects discontinuity but never appends text to an overlapping snapshot.
+Live events coalesce inflight snapshot reads using `omit_messages`; that installed
+handler path avoids history database reads. Completion and session-state events
+request full history. There is no transcript cache or speculative REST adapter.
+Socket loss shows disconnected/unknown. Foreground and explicit reconnect reload
+canonical identity, history and current state before enabling commands.
+
+Bot drafts extend `ChatDraftStore` with server + connection UUID + Profile context.
+Before sending, the client flushes an unresolved marker to disk. An acknowledged
+send consumes the draft; explicit admission failures preserve its text. An
+ambiguous outcome stays held across navigation and relaunch. The user can check
+Desktop and explicitly discard the held text; that action never resends it.
+Identical text in recovered history cannot reliably attribute a submission.
+
+Stop affects current conversation work, including Desktop work, queued prompts,
+pending approvals and process-wide speech playback. Confirmation actions carry
+connection-generation and turn-revision guards and are single-use. No Stop retry
+occurs after disconnect. Acknowledgement alone does not establish completion;
+current idle does. The accepted server race remains: a Stop already sent may reach
+later Desktop work because the ordinary RPC has no expected-turn guard.
+
+New Bot code belongs only to the main app and XCTest target. Share-extension,
+App Intent, deep-link and Live Activity commands still route to webui sessions.
+The Sessions/Bots switch returns to Sessions for existing external entry points.
+
+The implementation issue links the installed contract evidence, signed-build and
+test results, and remaining manual gates. Physical-phone transport, native
+accessibility and integrated live behavior must be validated before declaring
+the MVP complete. Simulator or isolated fixtures are not physical-phone evidence.

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -47,6 +47,14 @@ occurs after disconnect. Acknowledgement alone does not establish completion;
 current idle does. The accepted server race remains: a Stop already sent may reach
 later Desktop work because the ordinary RPC has no expected-turn guard.
 
+Bot Mode ships behind `BotModeGate`, one app-wide `@AppStorage` bool that is off
+by default and owned by the Settings "Bot Mode (beta)" row (#496). Off hides the
+Sessions/Bots switch, the Bots inbox and the per-server Bot connection row;
+nothing else changes, and Bot connections and drafts stay in the Keychain until
+it is turned on again. The gate is not per-server because it hides screens
+rather than storing user data. It is removed, together with its Settings row
+and `BotModeGateTests`, in the release PR that ships Bot Mode, not before.
+
 New Bot code belongs only to the main app and XCTest target. Share-extension,
 App Intent, deep-link and Live Activity commands still route to webui sessions.
 The Sessions/Bots switch returns to Sessions for existing external entry points.

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -27,6 +27,12 @@ request full history. There is no transcript cache or speculative REST adapter.
 Socket loss shows disconnected/unknown. Foreground and explicit reconnect reload
 canonical identity, history and current state before enabling commands.
 
+The transcript follows a stable trailing anchor until the user scrolls into
+history; Latest resumes following. Coalesced text snapshots use synchronous
+Markdown rendering without token reveal animations. The deferred streaming
+renderer can leave a growing Bot response's trailing viewport blank; an XCTest
+renders evolving snapshots and checks the actual visible output.
+
 Bot drafts extend `ChatDraftStore` with server + connection UUID + Profile context.
 Before sending, the client flushes an unresolved marker to disk. An acknowledged
 send consumes the draft; explicit admission failures preserve its text. An

--- a/docs/agents/multi-server-state-isolation.md
+++ b/docs/agents/multi-server-state-isolation.md
@@ -108,3 +108,11 @@ server's content even if the purge fails.
 | Per-server custom headers | `CustomHeaderInjectionTests` (`testSSEStreamSourcesHeadersFromActiveServerStore`, `testLaunchMigratesLegacyGlobalHeadersToActiveServerScope`), `AuthManagerStateTests` (`testSignOutLeavesOtherServerHeadersAndRegistryIntact`, `testAddServerFailureKeepsActiveServerAndItsHeaders`) |
 | Per-server cookies | `AuthManagerStateTests` (`testSignOutClearsOnlyActiveServerCookies`, `testRemoveNonActiveServerClearsOnlyItsCookies`, `testUnauthorizedClearsOnlyActiveServerCookies`) |
 | Default model/profile | No persisted state to leak (server-fresh per active server); covered by the switch mechanism + `9.3` Settings tests. |
+
+## Bot connection and drafts
+
+Bot Mode has a separate per-server Keychain connection and ephemeral cookie jar.
+Bot drafts use configured server + connection UUID + Profile, independently of
+webui session IDs. Bot transcripts stay in memory. See [Bot Mode](bots.md) for
+identity, removal and recovery rules. `BotDraftTests` covers disk persistence,
+connection/server removal and compatibility with existing webui records.


### PR DESCRIPTION
## Linked issue

Fixes #496. Integration merge for the `bot-mode` branch, per the plan in #493.

## What changed

Bot Mode is a direct-Hermes client inside Hermex: a per-server optional connection to a Hermes Desktop backend, a Bots inbox, and a text-only canonical chat per Profile. It will be the headline of the next release, but it lands in slices and `master` is the TestFlight and hotfix branch. This PR brings the reviewed `bot-mode` branch into `master` behind an app-wide, default-off "Bot Mode (beta)" toggle so unfinished Bot UI cannot reach the App Store through a hotfix. With the flag off, the app is unchanged from `master` today.

The branch is four already-reviewed commits:

- `feat(bots): add direct-Hermes inbox and canonical chat` — `BotClient` (ticketed WebSocket JSON-RPC), `BotConversation` (resume, replay, Stop, held drafts), the Bots inbox, connection setup under each server in Settings, and Bot drafts in `ChatDraftStore`. Contract and behavior rules are in `docs/agents/bots.md`.
- `fix(bots): keep growing responses visible in chat` — trailing-anchor follow for coalesced text snapshots.
- #495 `feat(bots): match the regular Hermex chat interface` — Bot chat reuses `MessageBubbleView` and the shared composer presentation.
- #497 `chore(bots): hide Bot Mode behind a default-off Settings toggle` — `BotModeGate`, the Settings "Preview" card, gated picker, inbox and Bot connection row.

New Bot code is in the main app and test targets only. Share extension, App Intents, deep links and Live Activities still route to webui sessions. Bot connections and drafts are per-server Keychain records and are removed with their server. One new `Info.plist` key: `NSLocalNetworkUsageDescription`, needed to reach a LAN Hermes host.

Removal rule: the flag, its Settings row and `BotModeGateTests` are deleted in the release PR that ships Bot Mode, not before. From here every Bot subissue is one short branch and one PR against `master`.

## How it was tested

- Every slice passed the full XCTest suite and the Antigravity review before merging into `bot-mode`; the latest run on the branch head content (#497) was 2359 passed, 0 failed, 2 skipped on iPhone 17 via XcodeBuildMCP `test_sim`.
- `master` has moved by one composer fix (#459) since the branch point; `git merge-tree` reports a clean merge with no shared files. CI on this PR is the first run of the combined tree.
- Signed Debug build installed and launched on the simulator at the branch head; `HermesShareExtension` and `HermesLiveActivityWidget` compiled in the same build.
- Maintainer manual passes on the simulator against a LAN Hermes 0.21.1 host: login, roster, canonical chat, send and stream (#495), and the flag off/on/relaunch pass (#497).
- Physical-phone transport through the Cloudflare tunnel, backgrounding past the idle timeout, and accessibility remain open under #471 and are not claimed here; the flag keeps them off the release path.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (Bot wire models are optional-heavy and ignore unknown fields)
- [x] No new third-party dependencies (Apple `URLSessionWebSocketTask` only)
- [x] No invented API endpoints or JSON shapes (verified against the installed hermes-agent 0.21.1 sources and a running host; see `docs/agents/bots.md` and #493)

Model and harness: Claude Fable 5.1, Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)