### PR TITLE
feat(bots): show Desktop avatars and Profile identity in the Bots inbox

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		454454454454454454454432 /* ResponseSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454454454454454454454431 /* ResponseSelectionTests.swift */; };
 		E8812D2097AF431094460471 /* BotChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */; };
 		13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A712D3AE91645C9B8C27745 /* BotConnection.swift */; };
+		A4730000000000000000A001 /* BotAvatarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4730000000000000000A002 /* BotAvatarStore.swift */; };
 		C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */; };
 		013E4253ACC0484FA59DC45F /* BotConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */; };
 		7EF4120B486B4243AF54FCAF /* BotsInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE221A56F264309AF71E18B /* BotsInboxView.swift */; };
@@ -437,6 +438,7 @@
 		142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */; };
 		A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000002 /* BotModeGateTests.swift */; };
 		A496B07E0000000000000003 /* BotConnectionVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000004 /* BotConnectionVersionTests.swift */; };
+		A4730000000000000000A003 /* BotAvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4730000000000000000A004 /* BotAvatarTests.swift */; };
 		D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B04ED8E6164A75B069773D /* BotClientTests.swift */; };
 		785784DE20094BA78F432A9A /* BotChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */; };
 		D4E8321C0A744DE3A5B8C997 /* ChatComposerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */; };
@@ -900,6 +902,7 @@
 		454454454454454454454431 /* ResponseSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseSelectionTests.swift; sourceTree = "<group>"; };
 		27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatView.swift"; sourceTree = "<group>"; };
 		0A712D3AE91645C9B8C27745 /* BotConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnection.swift"; sourceTree = "<group>"; };
+		A4730000000000000000A002 /* BotAvatarStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotAvatarStore.swift"; sourceTree = "<group>"; };
 		40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnectionView.swift"; sourceTree = "<group>"; };
 		9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConversation.swift"; sourceTree = "<group>"; };
 		9FE221A56F264309AF71E18B /* BotsInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotsInboxView.swift"; sourceTree = "<group>"; };
@@ -909,6 +912,7 @@
 		EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotDraftTests.swift"; sourceTree = "<group>"; };
 		A496B07E0000000000000002 /* BotModeGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotModeGateTests.swift; sourceTree = "<group>"; };
 		A496B07E0000000000000004 /* BotConnectionVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotConnectionVersionTests.swift; sourceTree = "<group>"; };
+		A4730000000000000000A004 /* BotAvatarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotAvatarTests.swift; sourceTree = "<group>"; };
 		B0B04ED8E6164A75B069773D /* BotClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotClientTests.swift"; sourceTree = "<group>"; };
 		5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatComposerView.swift"; sourceTree = "<group>"; };
 		5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatComposerPresentation.swift"; sourceTree = "<group>"; };
@@ -1018,6 +1022,7 @@
 				EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */,
 				A496B07E0000000000000002 /* BotModeGateTests.swift */,
 				A496B07E0000000000000004 /* BotConnectionVersionTests.swift */,
+				A4730000000000000000A004 /* BotAvatarTests.swift */,
 				0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */,
 				C28702000000000000000004 /* ChatDraftStoreTests.swift */,
 				C28702000000000000000008 /* ChatDraftAttachmentStoreTests.swift */,
@@ -1240,6 +1245,7 @@
 				9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */,
 				40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */,
 				0A712D3AE91645C9B8C27745 /* BotConnection.swift */,
+				A4730000000000000000A002 /* BotAvatarStore.swift */,
 				27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */,
 				1A2B3C4D5E6F7000000000C4 /* Onboarding */,
 				C09300000000000000000010 /* Shared */,
@@ -1831,6 +1837,7 @@
 				013E4253ACC0484FA59DC45F /* BotConversation.swift in Sources */,
 				C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */,
 				13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */,
+				A4730000000000000000A001 /* BotAvatarStore.swift in Sources */,
 				E8812D2097AF431094460471 /* BotChatView.swift in Sources */,
 				1A2B3C4D5E6F700000000001 /* HermesMobileApp.swift in Sources */,
 				1A2B3C4D5E6F700000000002 /* ContentView.swift in Sources */,
@@ -2105,6 +2112,7 @@
 				142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */,
 				A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */,
 				A496B07E0000000000000003 /* BotConnectionVersionTests.swift in Sources */,
+				A4730000000000000000A003 /* BotAvatarTests.swift in Sources */,
 				9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */,
 				10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */,

--- a/HermesMobile/Auth/AuthManager.swift
+++ b/HermesMobile/Auth/AuthManager.swift
@@ -398,10 +398,14 @@ final class AuthManager {
         }
     }
 
-    /// Deletes one server's local auth artifacts — its scoped custom headers and
-    /// its cookies — without touching the registry or the global `server_url` key.
+    /// Deletes one server's local auth artifacts — its scoped custom headers, its
+    /// Bot connection with that connection's cached avatars, and its cookies —
+    /// without touching the registry or the global `server_url` key.
     private func clearLocalArtifacts(for server: URL) {
         try? keychain.delete(.customHeaders, scope: server.absoluteString)
+        if let connection = try? BotConnectionStore(keychain: keychain).load(server: server) {
+            BotAvatarStore.shared.removeAll(connectionID: connection.id)
+        }
         try? keychain.delete(.botConnection, scope: server.absoluteString)
         clearSessionCookies(for: server)
     }

--- a/HermesMobile/Features/Bots/BotAvatarStore.swift
+++ b/HermesMobile/Features/Bots/BotAvatarStore.swift
@@ -1,0 +1,73 @@
+import ImageIO
+import UIKit
+
+/// Decoded Desktop avatars for the Bots inbox, read through `profiles.get_asset`.
+/// Keyed by connection UUID plus Profile name so equal Profile names on two hosts
+/// never share an image. Entries exist only for the current connection's roster
+/// and drop when the connection is replaced or removed; nothing is written to disk.
+@MainActor final class BotAvatarStore {
+    static let shared = BotAvatarStore()
+
+    /// Longest decoded edge in pixels: the 48pt row tile at 3x with headroom.
+    nonisolated static let maxPixelSize = 192
+    /// Largest data URL accepted from the host. The server caps assets at 2 MB before base64.
+    nonisolated static let maxPayloadBytes = 3_000_000
+
+    private struct Key: Hashable { let connectionID: UUID; let profile: String }
+    private struct Entry { let revision: Int?; let image: UIImage }
+    private var entries: [Key: Entry] = [:]
+
+    init() {}
+
+    /// Images for one connection's roster, keyed by Profile name.
+    func images(connectionID: UUID) -> [String: UIImage] {
+        var result: [String: UIImage] = [:]
+        for (key, entry) in entries where key.connectionID == connectionID { result[key.profile] = entry.image }
+        return result
+    }
+
+    func removeAll(connectionID: UUID) {
+        entries = entries.filter { $0.key.connectionID != connectionID }
+    }
+
+    /// Brings the store in line with a fresh roster for one connection. Every other
+    /// connection's images and rows no longer flagged `has_avatar` drop first, then
+    /// `onUpdate` fires so cached images paint before any fetch. Images whose look
+    /// revision is unchanged are kept; the rest, including entries without a
+    /// revision, are fetched one at a time and `onUpdate` fires after each decode.
+    /// The first failed call ends the pass silently: the roster never depends on it.
+    func refresh(_ profiles: [BotProfile], connectionID: UUID, using transport: any BotTransport, onUpdate: () -> Void) async {
+        let wanted = Set(profiles.filter(\.hasAvatar).map(\.id))
+        entries = entries.filter { $0.key.connectionID == connectionID && wanted.contains($0.key.profile) }
+        onUpdate()
+        for profile in profiles where wanted.contains(profile.id) {
+            let key = Key(connectionID: connectionID, profile: profile.id)
+            if let revision = entries[key]?.revision, revision == profile.lookRevision { continue }
+            guard let reply = try? await transport.call("profiles.get_asset", ["name": .string(profile.id), "asset": .string("avatar")]),
+                  !Task.isCancelled else { return }
+            let image = await Task.detached(priority: .utility) { Self.decode(reply) }.value
+            guard !Task.isCancelled else { return }
+            if let image { entries[key] = Entry(revision: profile.lookRevision, image: image) }
+            else { entries.removeValue(forKey: key) }
+            onUpdate()
+        }
+    }
+
+    /// Decodes a `profiles.get_asset` reply into a bounded thumbnail. Anything other
+    /// than a found, base64 image data URL within the size cap decodes to nil, and a
+    /// nil avatar means the row keeps its letter tile.
+    nonisolated static func decode(_ reply: BotJSON) -> UIImage? {
+        guard reply["found"].flag == true, let text = reply["data"].text, text.utf8.count <= maxPayloadBytes,
+              text.hasPrefix("data:image/"), let comma = text.firstIndex(of: ","),
+              text[..<comma].hasSuffix(";base64"),
+              let data = Data(base64Encoded: String(text[text.index(after: comma)...])),
+              let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ]
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else { return nil }
+        return UIImage(cgImage: thumbnail)
+    }
+}

--- a/HermesMobile/Features/Bots/BotConnection.swift
+++ b/HermesMobile/Features/Bots/BotConnection.swift
@@ -53,18 +53,39 @@ struct BotConnection: Codable, Equatable, Identifiable {
     }
 }
 
+/// One `profiles.list` row. Identity comes only from server fields: the Desktop
+/// title, then the core `display_name`, then the Profile name (`default` reads as
+/// Hermes, as in Desktop). Description follows the same Desktop-then-core order.
 struct BotProfile: Identifiable, Hashable {
     let id: String
     let name: String
+    let description: String?
     let preview: String?
     let lastActive: Date?
+    /// True when the host has an avatar asset, so the inbox fetches only rows that have one.
+    let hasAvatar: Bool
+    /// Desktop's compare-and-swap revision for this bot's look
+    /// (`ui_meta_revisions["hermes-bots"]`). Nil when the host or bot has none; the
+    /// avatar is then refetched on every roster load instead of served from memory.
+    let lookRevision: Int?
 
     init?(_ row: BotJSON) {
         guard let profile = row["name"].text, !profile.isEmpty else { return nil }
         id = profile
-        let displayName = row["display_name"].text ?? ""
-        name = displayName.isEmpty ? profile : displayName
+        let look = row["ui_meta"]["hermes-bots"]
+        name = Self.firstText(look["title"], row["display_name"]) ?? (profile == "default" ? "Hermes" : profile)
+        description = Self.firstText(look["description"], row["description"])
         preview = row["canonical_session"]["preview"].text
         lastActive = row["canonical_session"]["last_active"].number.map(Date.init(timeIntervalSince1970:))
+        hasAvatar = row["has_avatar"].flag == true
+        lookRevision = row["ui_meta_revisions"]["hermes-bots"].integer
+    }
+
+    private static func firstText(_ candidates: BotJSON...) -> String? {
+        for candidate in candidates {
+            let trimmed = candidate.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty { return trimmed }
+        }
+        return nil
     }
 }

--- a/HermesMobile/Features/Bots/BotConnectionView.swift
+++ b/HermesMobile/Features/Bots/BotConnectionView.swift
@@ -68,7 +68,10 @@ import SwiftUI
                 Task {
                     do {
                         try store.remove(server: server)
-                        if let saved { await ChatDraftStore.shared.discardBotDrafts(server: server, connectionID: saved.id) }
+                        if let saved {
+                            await ChatDraftStore.shared.discardBotDrafts(server: server, connectionID: saved.id)
+                            BotAvatarStore.shared.removeAll(connectionID: saved.id)
+                        }
                         dismiss()
                     } catch { errorMessage = String(localized: "Could not remove saved sign-in details.") }
                 }
@@ -100,6 +103,7 @@ import SwiftUI
             try store.save(candidate, server: server)
             if let saved, saved.id != candidate.id {
                 await ChatDraftStore.shared.discardBotDrafts(server: server, connectionID: saved.id)
+                BotAvatarStore.shared.removeAll(connectionID: saved.id)
             }
             guard !Task.isCancelled, client === wire else { return }
             saved = candidate

--- a/HermesMobile/Features/Bots/BotsInboxView.swift
+++ b/HermesMobile/Features/Bots/BotsInboxView.swift
@@ -46,7 +46,7 @@ import SwiftUI
                         BotChatView(server: server, connection: connection, profile: profile)
                             .id(profile.id + connection.id.uuidString)
                     } label: {
-                        BotInboxRow(profile: profile)
+                        BotInboxRow(profile: profile, avatar: avatars[profile.id])
                     }
                     .listRowSeparator(.hidden)
                     .padding(.vertical, 10)
@@ -109,31 +109,48 @@ import SwiftUI
     }
 }
 
+/// One roster row: the Desktop avatar when the host has one, otherwise a letter
+/// tile; the server name; and the canonical preview, else the description, else
+/// the Profile name. The avatar is decorative; VoiceOver reads the text as one element.
 private struct BotInboxRow: View {
     let profile: BotProfile
+    let avatar: UIImage?
     private var color: Color {
         let colors: [Color] = [.green, .orange, .purple, .pink, .blue, .teal]
         let value = profile.id.utf8.reduce(0) { ($0 + Int($1)) % colors.count }
         return colors[value]
     }
+    private var subline: String {
+        if let preview = profile.preview, !preview.isEmpty { return preview }
+        return profile.description ?? profile.id
+    }
     var body: some View {
         HStack(spacing: 16) {
-            Text(String(profile.name.prefix(1))).font(.title2.weight(.semibold))
-                .frame(width: 48, height: 48)
-                .background(color.opacity(0.2), in: RoundedRectangle(cornerRadius: 16))
-                .foregroundStyle(color).accessibilityHidden(true)
+            tile
             VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .firstTextBaseline) {
                     Text(profile.name).font(.headline)
                     Spacer()
                     if let date = profile.lastActive {
-                        Text(date, style: .date).font(.caption).foregroundStyle(.secondary)
+                        Text(SessionRelativeDateFormatter.shared.localizedString(for: date, relativeTo: Date())).font(.caption).foregroundStyle(.secondary)
                     }
                 }
-                Text(profile.preview?.isEmpty == false ? profile.preview! : profile.id)
-                    .font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
+                Text(subline).font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
             }
         }
         .accessibilityElement(children: .combine)
+    }
+    @ViewBuilder private var tile: some View {
+        if let avatar {
+            Image(uiImage: avatar).resizable().scaledToFill()
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .accessibilityHidden(true)
+        } else {
+            Text(String(profile.name.prefix(1))).font(.title2.weight(.semibold))
+                .frame(width: 48, height: 48)
+                .background(color.opacity(0.2), in: RoundedRectangle(cornerRadius: 16))
+                .foregroundStyle(color).accessibilityHidden(true)
+        }
     }
 }

--- a/HermesMobile/Features/Bots/BotsInboxView.swift
+++ b/HermesMobile/Features/Bots/BotsInboxView.swift
@@ -6,6 +6,7 @@ import SwiftUI
     let showSessions: () -> Void
     @State private var connection: BotConnection?
     @State private var profiles: [BotProfile] = []
+    @State private var avatars: [String: UIImage] = [:]
     @State private var search = ""
     @State private var errorMessage: String?
     @State private var loading = false
@@ -83,7 +84,7 @@ import SwiftUI
         // The stored client identity is the load owner; a replacement invalidates late results.
         do {
             let saved = try store.load(server: server)
-            if connection?.id != saved?.id { profiles = [] }
+            if connection?.id != saved?.id { profiles = []; avatars = [:] }
             connection = saved
             guard let saved else { return }
             let client = BotClient(connection: saved)
@@ -96,6 +97,9 @@ import SwiftUI
             guard let rows = roster["profiles"].list else { throw BotFailure.unsupported }
             var seen = Set<String>()
             profiles = rows.compactMap(BotProfile.init).filter { seen.insert($0.id).inserted }
+            await BotAvatarStore.shared.refresh(profiles, connectionID: saved.id, using: client) {
+                if wire === client { avatars = BotAvatarStore.shared.images(connectionID: saved.id) }
+            }
             client.close()
         } catch {
             guard !Task.isCancelled, loadOwner == owner else { return }

--- a/HermesMobile/Features/SessionList/SessionRowView.swift
+++ b/HermesMobile/Features/SessionList/SessionRowView.swift
@@ -552,7 +552,8 @@ private func nonEmpty(_ value: String?) -> String? {
     return trimmed.isEmpty ? nil : trimmed
 }
 
-private enum SessionRelativeDateFormatter {
+/// Shared "2h ago" formatter for session and Bot rows.
+enum SessionRelativeDateFormatter {
     static let shared: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated

--- a/HermesMobile/Networking/Bots/BotClient.swift
+++ b/HermesMobile/Networking/Bots/BotClient.swift
@@ -128,7 +128,7 @@ import Foundation
     }
 
     func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)? = nil) async throws -> BotJSON {
-        guard ["profiles.list", "session.list", "session.resume", "session.events.since", "prompt.submit", "session.interrupt"].contains(method)
+        guard ["profiles.list", "profiles.get_asset", "session.list", "session.resume", "session.events.since", "prompt.submit", "session.interrupt"].contains(method)
         else { throw BotFailure.unsupported }
         guard let socket, !Task.isCancelled else { throw BotFailure.stale }
         nextID += 1

--- a/HermesMobileTests/AuthManagerStateTests.swift
+++ b/HermesMobileTests/AuthManagerStateTests.swift
@@ -307,6 +307,25 @@ final class AuthManagerStateTests: XCTestCase {
         XCTAssertTrue(HTTPCookieStorage.shared.cookies(for: serverB)?.isEmpty ?? true)
     }
 
+    func testRemovingAServerPurgesItsBotConnectionAvatars() async throws {
+        let keychain = InMemoryKeychainStore()
+        let registry = ServerRegistry.inMemory(keychain: keychain)
+        let (manager, _, bAccount) = try await makeTwoServerManager(keychain: keychain, registry: registry)
+        let serverB = try XCTUnwrap(URL(string: "https://b.test"))
+        let connection = BotConnection(id: UUID(), name: "B", address: try XCTUnwrap(URL(string: "http://b.local:9120")), username: "u", password: "p")
+        try BotConnectionStore(keychain: keychain).save(connection, server: serverB)
+        let profile = try XCTUnwrap(BotProfile(.object(["name": .string("default"), "has_avatar": .bool(true)])))
+        let wire = BotAvatarFixtureWire()
+        wire.assets = ["default": .object(["found": .bool(true), "data": .string(botAvatarDataURL(side: 4))])]
+        await BotAvatarStore.shared.refresh([profile], connectionID: connection.id, using: wire) {}
+        XCTAssertEqual(BotAvatarStore.shared.images(connectionID: connection.id).count, 1)
+
+        await manager.removeServer(bAccount)
+
+        XCTAssertTrue(BotAvatarStore.shared.images(connectionID: connection.id).isEmpty)
+        XCTAssertNil(try BotConnectionStore(keychain: keychain).load(server: serverB))
+    }
+
     func testSignOutWithRemainingServerAutoSwitches() async throws {
         let keychain = InMemoryKeychainStore()
         let registry = ServerRegistry.inMemory(keychain: keychain)

--- a/HermesMobileTests/BotAvatarTests.swift
+++ b/HermesMobileTests/BotAvatarTests.swift
@@ -9,15 +9,7 @@ import XCTest
         return .object(fields)
     }
 
-    /// A tiny solid PNG the server would return for an avatar, as a data URL.
-    private func png(side: Int) -> String {
-        let format = UIGraphicsImageRendererFormat.default()
-        format.scale = 1
-        let image = UIGraphicsImageRenderer(size: CGSize(width: side, height: side), format: format).image { context in
-            UIColor.red.setFill(); context.fill(CGRect(x: 0, y: 0, width: side, height: side))
-        }
-        return "data:image/png;base64," + image.pngData()!.base64EncodedString()
-    }
+    private func png(side: Int) -> String { botAvatarDataURL(side: side) }
 
     private func found(_ dataURL: String) -> BotJSON {
         .object(["found": .bool(true), "mime": .string("image/png"), "size": .number(1), "data": .string(dataURL)])
@@ -129,8 +121,18 @@ import XCTest
     }
 }
 
+/// A tiny solid PNG the server would return for an avatar, as a data URL.
+func botAvatarDataURL(side: Int) -> String {
+    let format = UIGraphicsImageRendererFormat.default()
+    format.scale = 1
+    let image = UIGraphicsImageRenderer(size: CGSize(width: side, height: side), format: format).image { context in
+        UIColor.red.setFill(); context.fill(CGRect(x: 0, y: 0, width: side, height: side))
+    }
+    return "data:image/png;base64," + image.pngData()!.base64EncodedString()
+}
+
 /// Answers `profiles.get_asset` from a scripted table; anything else is unsupported.
-@MainActor private final class BotAvatarFixtureWire: BotTransport {
+@MainActor final class BotAvatarFixtureWire: BotTransport {
     var replayEpoch: String? = "epoch"
     var onEvent: ((BotJSON) -> Void)?
     var onDisconnect: ((Error) -> Void)?

--- a/HermesMobileTests/BotAvatarTests.swift
+++ b/HermesMobileTests/BotAvatarTests.swift
@@ -1,0 +1,150 @@
+import UIKit
+import XCTest
+@testable import HermesMobile
+
+@MainActor final class BotAvatarTests: XCTestCase {
+    private func row(_ name: String, extra: [String: BotJSON] = [:]) -> BotJSON {
+        var fields: [String: BotJSON] = ["name": .string(name)]
+        fields.merge(extra) { _, new in new }
+        return .object(fields)
+    }
+
+    /// A tiny solid PNG the server would return for an avatar, as a data URL.
+    private func png(side: Int) -> String {
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let image = UIGraphicsImageRenderer(size: CGSize(width: side, height: side), format: format).image { context in
+            UIColor.red.setFill(); context.fill(CGRect(x: 0, y: 0, width: side, height: side))
+        }
+        return "data:image/png;base64," + image.pngData()!.base64EncodedString()
+    }
+
+    private func found(_ dataURL: String) -> BotJSON {
+        .object(["found": .bool(true), "mime": .string("image/png"), "size": .number(1), "data": .string(dataURL)])
+    }
+
+    func testIdentityUsesDesktopTitleThenDisplayNameThenProfileName() {
+        let bare = BotProfile(row("inbox-triage"))!
+        XCTAssertEqual(bare.name, "inbox-triage")
+        XCTAssertNil(bare.description)
+        XCTAssertFalse(bare.hasAvatar)
+        XCTAssertNil(bare.lookRevision)
+        XCTAssertEqual(BotProfile(row("default"))!.name, "Hermes")
+
+        let renamed = BotProfile(row("dev", extra: ["display_name": .string("  Dev Bot "), "description": .string("Ships code")]))!
+        XCTAssertEqual(renamed.name, "Dev Bot")
+        XCTAssertEqual(renamed.description, "Ships code")
+
+        let titled = BotProfile(row("dev", extra: [
+            "display_name": .string("Dev Bot"), "description": .string("Ships code"), "has_avatar": .bool(true),
+            "ui_meta": .object(["hermes-bots": .object(["title": .string("Codey"), "description": .string("Pairs on PRs"), "shape": .string("hexagon")])]),
+            "ui_meta_revisions": .object(["hermes-bots": .number(7)])
+        ]))!
+        XCTAssertEqual(titled.name, "Codey")
+        XCTAssertEqual(titled.description, "Pairs on PRs")
+        XCTAssertTrue(titled.hasAvatar)
+        XCTAssertEqual(titled.lookRevision, 7)
+
+        let blankTitle = BotProfile(row("dev", extra: ["display_name": .string("Dev Bot"), "ui_meta": .object(["hermes-bots": .object(["title": .string("   ")])])]))!
+        XCTAssertEqual(blankTitle.name, "Dev Bot")
+    }
+
+    func testRefreshFetchesOnlyFlaggedRowsAndKeepsTheRosterOnBadImages() async {
+        let store = BotAvatarStore()
+        let wire = BotAvatarFixtureWire()
+        wire.assets = [
+            "good": found(png(side: 4)),
+            "corrupt": found("data:image/png;base64,AAAA"),
+            "notImage": .object(["found": .bool(true), "data": .string("data:text/plain;base64,aGVsbG8=")]),
+            "gone": .object(["found": .bool(false)])
+        ]
+        let profiles = ["good", "corrupt", "notImage", "gone", "plain"].map { name in
+            BotProfile(row(name, extra: ["has_avatar": .bool(name != "plain")]))!
+        }
+        let connection = UUID()
+        var updates = 0
+        await store.refresh(profiles, connectionID: connection, using: wire) { updates += 1 }
+        XCTAssertEqual(wire.calls.map { $0.1["name"]?.text }, ["good", "corrupt", "notImage", "gone"])
+        XCTAssertEqual(wire.calls.map { $0.1["asset"]?.text }, Array(repeating: "avatar", count: 4))
+        XCTAssertEqual(Array(store.images(connectionID: connection).keys), ["good"])
+        XCTAssertEqual(updates, 5)
+    }
+
+    func testRevisionKeepsCachedImagesAndMissingRevisionRefetches() async {
+        let store = BotAvatarStore()
+        let wire = BotAvatarFixtureWire()
+        wire.assets = ["pinned": found(png(side: 4)), "loose": found(png(side: 4))]
+        let connection = UUID()
+        let pinned = BotProfile(row("pinned", extra: ["has_avatar": .bool(true), "ui_meta_revisions": .object(["hermes-bots": .number(3)])]))!
+        let loose = BotProfile(row("loose", extra: ["has_avatar": .bool(true)]))!
+        await store.refresh([pinned, loose], connectionID: connection, using: wire) {}
+        await store.refresh([pinned, loose], connectionID: connection, using: wire) {}
+        XCTAssertEqual(wire.calls.map { $0.1["name"]?.text }, ["pinned", "loose", "loose"])
+
+        let bumped = BotProfile(row("pinned", extra: ["has_avatar": .bool(true), "ui_meta_revisions": .object(["hermes-bots": .number(4)])]))!
+        let removed = BotProfile(row("loose", extra: ["has_avatar": .bool(false)]))!
+        await store.refresh([bumped, removed], connectionID: connection, using: wire) {}
+        XCTAssertEqual(wire.calls.map { $0.1["name"]?.text }, ["pinned", "loose", "loose", "pinned"])
+        XCTAssertEqual(Array(store.images(connectionID: connection).keys), ["pinned"])
+    }
+
+    func testSameProfileNameOnTwoConnectionsStaysSeparateAndReplacementDropsTheOld() async {
+        let store = BotAvatarStore()
+        let first = UUID(), second = UUID()
+        let profile = BotProfile(row("default", extra: ["has_avatar": .bool(true), "ui_meta_revisions": .object(["hermes-bots": .number(1)])]))!
+        let small = BotAvatarFixtureWire(); small.assets = ["default": found(png(side: 4))]
+        let large = BotAvatarFixtureWire(); large.assets = ["default": found(png(side: 16))]
+        await store.refresh([profile], connectionID: first, using: small) {}
+        XCTAssertEqual(store.images(connectionID: first)["default"]?.size.width, 4)
+        XCTAssertTrue(store.images(connectionID: second).isEmpty)
+
+        // Loading the replacement connection's roster drops the old connection's image.
+        await store.refresh([profile], connectionID: second, using: large) {}
+        XCTAssertEqual(store.images(connectionID: second)["default"]?.size.width, 16)
+        XCTAssertTrue(store.images(connectionID: first).isEmpty)
+
+        store.removeAll(connectionID: second)
+        XCTAssertTrue(store.images(connectionID: second).isEmpty)
+    }
+
+    func testFailedCallEndsThePassWithoutTouchingEarlierImages() async {
+        let store = BotAvatarStore()
+        let wire = BotAvatarFixtureWire()
+        wire.assets = ["ok": found(png(side: 4))]
+        wire.failure = .rejected(-32601)
+        let connection = UUID()
+        let profiles = ["ok", "unavailable", "never"].map { BotProfile(row($0, extra: ["has_avatar": .bool(true)]))! }
+        await store.refresh(profiles, connectionID: connection, using: wire) {}
+        XCTAssertEqual(wire.calls.map { $0.1["name"]?.text }, ["ok", "unavailable"])
+        XCTAssertEqual(Array(store.images(connectionID: connection).keys), ["ok"])
+    }
+
+    func testDecodeBoundsSizeAndRejectsOversizedPayloads() {
+        let image = BotAvatarStore.decode(found(png(side: 600)))
+        XCTAssertEqual(image?.size.width, CGFloat(BotAvatarStore.maxPixelSize))
+        let oversized = "data:image/png;base64," + String(repeating: "A", count: BotAvatarStore.maxPayloadBytes)
+        XCTAssertNil(BotAvatarStore.decode(found(oversized)))
+        XCTAssertNil(BotAvatarStore.decode(.object(["found": .bool(false)])))
+        XCTAssertNil(BotAvatarStore.decode(.object(["found": .bool(true), "data": .string("data:image/png,notbase64")])))
+    }
+}
+
+/// Answers `profiles.get_asset` from a scripted table; anything else is unsupported.
+@MainActor private final class BotAvatarFixtureWire: BotTransport {
+    var replayEpoch: String? = "epoch"
+    var onEvent: ((BotJSON) -> Void)?
+    var onDisconnect: ((Error) -> Void)?
+    var assets: [String: BotJSON] = [:]
+    /// Thrown for any Profile missing from `assets`.
+    var failure: BotFailure = .transport
+    var calls: [(String, [String: BotJSON])] = []
+    func connect() async throws {}
+    func close() {}
+    func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)?) async throws -> BotJSON {
+        try validateDispatch?()
+        calls.append((method, params))
+        guard method == "profiles.get_asset" else { throw BotFailure.unsupported }
+        guard let reply = assets[params["name"]?.text ?? ""] else { throw failure }
+        return reply
+    }
+}

--- a/HermesMobileTests/BotClientTests.swift
+++ b/HermesMobileTests/BotClientTests.swift
@@ -55,6 +55,29 @@ import XCTest
         XCTAssertEqual(sockets.map { $0.sentTextFrames }, [1, 1])
     }
 
+    func testAllowlistAdmitsAvatarReadsButNoAssetWrites() async throws {
+        BotHTTPFixture.handler = { request in
+            switch request.url!.path {
+            case "/api/status": return (200, .object(["auth_required": .bool(true), "auth_providers": .array([.string("basic")])]))
+            case "/auth/password-login": return (200, .object([:]))
+            case "/api/auth/me": return (200, .object(["provider": .string("basic")]))
+            case "/api/auth/ws-ticket": return (200, .object(["ticket": .string("ticket")]))
+            default: XCTFail("Unexpected HTTP endpoint"); return (404, .null)
+            }
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BotHTTPFixture.self]
+        let socket = BotScriptedSocket()
+        let client = BotClient(connection: connection(), configuration: configuration) { _, _ in socket }
+        try await client.connect()
+        _ = try await client.call("profiles.get_asset", ["name": .string("inbox-triage"), "asset": .string("avatar")])
+        XCTAssertEqual(socket.sentTextFrames, 1)
+        do { _ = try await client.call("profiles.set_asset", ["name": .string("inbox-triage"), "clear": .bool(true)]); XCTFail("Writes stay off the allowlist") }
+        catch { XCTAssertEqual(error as? BotFailure, .unsupported) }
+        XCTAssertEqual(socket.sentTextFrames, 1)
+        client.close()
+    }
+
     func testStatusWithoutVersionStillConnectsAndShowsNoNote() async throws {
         BotHTTPFixture.handler = { request in
             switch request.url!.path {

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -57,6 +57,19 @@ occurs after disconnect. Acknowledgement alone does not establish completion;
 current idle does. The accepted server race remains: a Stop already sent may reach
 later Desktop work because the ordinary RPC has no expected-turn guard.
 
+Roster identity is server-owned. `BotProfile` reads the Desktop title from
+`ui_meta["hermes-bots"]`, then the core `display_name`, then the Profile name
+(`default` reads as Hermes, as in Desktop); description follows the same order.
+`BotAvatarStore` fetches `profiles.get_asset` only for rows flagged `has_avatar`,
+decodes the data URL into a bounded thumbnail off the main actor, and keeps the
+image in memory keyed by connection UUID plus Profile with the Desktop look
+revision (`ui_meta_revisions["hermes-bots"]`). An unchanged revision skips the
+fetch; a missing revision refetches on every roster load. Loading a roster drops
+every other connection's images, and removing or replacing a connection purges
+its entries, so equal Profile names on two hosts never share a picture. A
+malformed, oversized or missing asset leaves the row on its letter tile. Desktop's
+animated faces are not ported; the phone shows the static asset only.
+
 Bot Mode ships behind `BotModeGate`, one app-wide `@AppStorage` bool that is off
 by default and owned by the Settings "Bot Mode (beta)" row (#496). Off hides the
 Sessions/Bots switch, the Bots inbox and the per-server Bot connection row;


### PR DESCRIPTION
## Linked issue

Fixes #473

## What changed

Bots in the inbox were unrecognisable: every row was a hashed colour and a first letter, and the custom names users set in Desktop never appeared. Now the row shows the bot's Desktop avatar, its Desktop title or display name, and the description as the fallback subline, so the same bot looks the same on the phone and in Desktop.

- `BotProfile` reads identity only from server fields: Desktop title, then `display_name`, then the Profile name (`default` reads as Hermes, as in Desktop). Description follows the same order.
- New `BotAvatarStore` calls `profiles.get_asset` only for rows flagged `has_avatar`, decodes the data URL into a thumbnail capped at 192 px off the main actor, and keeps images in memory keyed by connection UUID plus Profile with the Desktop look revision. Unchanged revision: no refetch. Missing revision: refetch on every roster load. Loading a roster drops other connections' images; replacing or removing a connection purges its entries, so equal Profile names on two hosts never share a picture.
- `BotClient` allowlists the read-only `profiles.get_asset` and nothing else.
- The inbox row shows the avatar in place of the letter tile when present, keeps the canonical preview, and uses the session list's relative "2h ago" timestamp. Static asset only; Desktop's animated faces are not ported.
- docs/agents/bots.md documents the fallbacks and cache rules.

Contract verified against the pinned hermes-agent source at `ee35a4624fa22237a90426f5e21d8b4f2ce3a49b`: `profiles.list` rows carry `display_name`, `description`, `has_avatar`, `ui_meta["hermes-bots"]` and `ui_meta_revisions`; `profiles.get_asset({name, asset: "avatar"})` returns `{found, mime, size, data}` or `{found: false}`.

Layout A from the mock set, with an after screenshot from the simulator at the bottom: https://ssdlrcs7gqh1.postplan.dev

## How it was tested

- `BotAvatarTests` (new): identity fallbacks with absent metadata, fetch only for flagged rows, corrupt and non-image assets leave the roster intact, revision reuse and missing-revision refetch, identical Profile names on two connections and replacement purge, failed call ends the pass, oversized payload rejected and thumbnail bounded.
- `BotClientTests`: `profiles.get_asset` dispatches, `profiles.set_asset` stays off the allowlist.
- Full suite, `-parallel-testing-enabled NO`: 2372 passed, 0 failed, 2 pre-existing photo-library skips.
- Signed Debug build installed and launched on iPhone 17; maintainer compared the roster against Desktop.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

Model and harness: Claude Fable 5.1, Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)