### PR TITLE
feat(bots): show tools, reasoning and work progress in chat

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -429,6 +429,8 @@
 		E8812D2097AF431094460471 /* BotChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */; };
 		13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A712D3AE91645C9B8C27745 /* BotConnection.swift */; };
 		A4730000000000000000A001 /* BotAvatarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4730000000000000000A002 /* BotAvatarStore.swift */; };
+		A4750000000000000000B001 /* BotActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B002 /* BotActivity.swift */; };
+		A4750000000000000000B003 /* BotActivityViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B004 /* BotActivityViews.swift */; };
 		C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */; };
 		013E4253ACC0484FA59DC45F /* BotConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */; };
 		7EF4120B486B4243AF54FCAF /* BotsInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE221A56F264309AF71E18B /* BotsInboxView.swift */; };
@@ -439,6 +441,7 @@
 		A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000002 /* BotModeGateTests.swift */; };
 		A496B07E0000000000000003 /* BotConnectionVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000004 /* BotConnectionVersionTests.swift */; };
 		A4730000000000000000A003 /* BotAvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4730000000000000000A004 /* BotAvatarTests.swift */; };
+		A4750000000000000000B005 /* BotActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B006 /* BotActivityTests.swift */; };
 		D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B04ED8E6164A75B069773D /* BotClientTests.swift */; };
 		785784DE20094BA78F432A9A /* BotChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */; };
 		D4E8321C0A744DE3A5B8C997 /* ChatComposerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */; };
@@ -903,6 +906,8 @@
 		27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatView.swift"; sourceTree = "<group>"; };
 		0A712D3AE91645C9B8C27745 /* BotConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnection.swift"; sourceTree = "<group>"; };
 		A4730000000000000000A002 /* BotAvatarStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotAvatarStore.swift"; sourceTree = "<group>"; };
+		A4750000000000000000B002 /* BotActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotActivity.swift"; sourceTree = "<group>"; };
+		A4750000000000000000B004 /* BotActivityViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotActivityViews.swift"; sourceTree = "<group>"; };
 		40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnectionView.swift"; sourceTree = "<group>"; };
 		9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConversation.swift"; sourceTree = "<group>"; };
 		9FE221A56F264309AF71E18B /* BotsInboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotsInboxView.swift"; sourceTree = "<group>"; };
@@ -913,6 +918,7 @@
 		A496B07E0000000000000002 /* BotModeGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotModeGateTests.swift; sourceTree = "<group>"; };
 		A496B07E0000000000000004 /* BotConnectionVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotConnectionVersionTests.swift; sourceTree = "<group>"; };
 		A4730000000000000000A004 /* BotAvatarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotAvatarTests.swift; sourceTree = "<group>"; };
+		A4750000000000000000B006 /* BotActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotActivityTests.swift; sourceTree = "<group>"; };
 		B0B04ED8E6164A75B069773D /* BotClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotClientTests.swift"; sourceTree = "<group>"; };
 		5B87CE542BE84D09A7D1E276 /* BotChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotChatComposerView.swift"; sourceTree = "<group>"; };
 		5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatComposerPresentation.swift"; sourceTree = "<group>"; };
@@ -1023,6 +1029,7 @@
 				A496B07E0000000000000002 /* BotModeGateTests.swift */,
 				A496B07E0000000000000004 /* BotConnectionVersionTests.swift */,
 				A4730000000000000000A004 /* BotAvatarTests.swift */,
+				A4750000000000000000B006 /* BotActivityTests.swift */,
 				0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */,
 				C28702000000000000000004 /* ChatDraftStoreTests.swift */,
 				C28702000000000000000008 /* ChatDraftAttachmentStoreTests.swift */,
@@ -1246,6 +1253,8 @@
 				40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */,
 				0A712D3AE91645C9B8C27745 /* BotConnection.swift */,
 				A4730000000000000000A002 /* BotAvatarStore.swift */,
+				A4750000000000000000B002 /* BotActivity.swift */,
+				A4750000000000000000B004 /* BotActivityViews.swift */,
 				27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */,
 				1A2B3C4D5E6F7000000000C4 /* Onboarding */,
 				C09300000000000000000010 /* Shared */,
@@ -1838,6 +1847,8 @@
 				C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */,
 				13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */,
 				A4730000000000000000A001 /* BotAvatarStore.swift in Sources */,
+				A4750000000000000000B001 /* BotActivity.swift in Sources */,
+				A4750000000000000000B003 /* BotActivityViews.swift in Sources */,
 				E8812D2097AF431094460471 /* BotChatView.swift in Sources */,
 				1A2B3C4D5E6F700000000001 /* HermesMobileApp.swift in Sources */,
 				1A2B3C4D5E6F700000000002 /* ContentView.swift in Sources */,
@@ -2113,6 +2124,7 @@
 				A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */,
 				A496B07E0000000000000003 /* BotConnectionVersionTests.swift in Sources */,
 				A4730000000000000000A003 /* BotAvatarTests.swift in Sources */,
+				A4750000000000000000B005 /* BotActivityTests.swift in Sources */,
 				9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */,
 				10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */,

--- a/HermesMobile/Features/Bots/BotActivity.swift
+++ b/HermesMobile/Features/Bots/BotActivity.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+/// The bot's plan from `todo.updated` events and the snapshot's `todo_state`.
+/// Revision-monotonic: an older revision never replaces a newer one.
+struct BotPlan: Equatable {
+    struct Item: Identifiable, Equatable {
+        let id: String
+        let content: String
+        /// `pending`, `in_progress`, `completed` or `cancelled`; anything else reads as pending.
+        let status: String
+        var isDone: Bool { status == "completed" || status == "cancelled" }
+    }
+
+    static let itemLimit = 50
+
+    let items: [Item]
+    let revision: Int
+
+    /// `nil` when the payload is malformed or carries no items.
+    init?(_ json: BotJSON) {
+        guard let rows = json["todos"].list else { return nil }
+        let items: [Item] = rows.prefix(Self.itemLimit).enumerated().compactMap { index, row in
+            guard let content = row["content"].text?.trimmingCharacters(in: .whitespacesAndNewlines), !content.isEmpty else { return nil }
+            let id = row["id"].text.flatMap { $0.isEmpty ? nil : $0 } ?? "plan-\(index)"
+            return Item(id: id, content: content, status: row["status"].text ?? "pending")
+        }
+        guard !items.isEmpty else { return nil }
+        self.items = items
+        revision = max(0, json["revision"].integer ?? 0)
+    }
+
+    var completedCount: Int { items.filter(\.isDone).count }
+    var current: Item? { items.first { $0.status == "in_progress" } ?? items.first { !$0.isDone } }
+    var isFinished: Bool { items.allSatisfy(\.isDone) }
+}
+
+/// A keyed notice from `notification.show`; the same key replaces in place.
+struct BotNotice: Identifiable, Equatable {
+    let id: String
+    let text: String
+    let level: String?
+    var isWarning: Bool { level == "warn" || level == "error" }
+}
+
+/// One turn's live work reduced from gateway events: tool rows, model-supplied
+/// reasoning, keyed notices and memory review notes. Every collection is bounded
+/// and the oldest entries drop first. Pure, so replay and live delivery share it.
+struct BotTurnActivity: Equatable {
+    static let toolLimit = 64
+    static let reasoningLimit = 32_768
+    static let noticeLimit = 8
+
+    private(set) var toolCalls: [ToolCall] = []
+    private(set) var reasoning = ""
+    private(set) var notices: [BotNotice] = []
+    private(set) var memoryNotes: [String] = []
+
+    var hasTurnWork: Bool { !toolCalls.isEmpty || !reasoning.isEmpty }
+
+    /// Event types this reducer consumes; they never change the inflight text.
+    static func handles(_ type: String) -> Bool {
+        ["tool.start", "tool.complete", "thinking.delta", "reasoning.delta", "reasoning.available",
+         "notification.show", "notification.clear", "review.summary"].contains(type)
+    }
+
+    /// Applies one event; returns false for types this reducer does not consume.
+    @discardableResult
+    mutating func apply(type: String, payload: BotJSON) -> Bool {
+        switch type {
+        case "tool.start":
+            let id = Self.toolID(payload) ?? "bot-tool-\(toolCalls.count)"
+            let call = ToolCall(id: id, name: payload["name"].text, preview: nil, args: payload["args"].argumentDictionary)
+            if let index = toolCalls.firstIndex(where: { $0.id == id }) {
+                toolCalls[index].name = call.name ?? toolCalls[index].name
+                toolCalls[index].args = call.args ?? toolCalls[index].args
+            } else {
+                toolCalls.append(call)
+                if toolCalls.count > Self.toolLimit { toolCalls.removeFirst(toolCalls.count - Self.toolLimit) }
+            }
+        case "tool.complete":
+            let id = Self.toolID(payload)
+            let index = id.flatMap { id in toolCalls.firstIndex { $0.id == id } }
+            var call = index.map { toolCalls[$0] }
+                ?? ToolCall(id: id ?? "bot-tool-\(toolCalls.count)", name: nil, preview: nil, args: nil)
+            if let name = payload["name"].text, !name.isEmpty { call.name = name }
+            if let args = payload["args"].argumentDictionary { call.args = args }
+            call.preview = Self.resultPreview(payload["result"])
+            call.duration = payload["duration_s"].number
+            call.isCompleted = true
+            if let index { toolCalls[index] = call } else {
+                toolCalls.append(call)
+                if toolCalls.count > Self.toolLimit { toolCalls.removeFirst(toolCalls.count - Self.toolLimit) }
+            }
+        case "thinking.delta", "reasoning.delta", "reasoning.available":
+            guard let text = payload["text"].text, !text.isEmpty else { return true }
+            // `reasoning.available` is a whole block; keep it off the previous line.
+            if type == "reasoning.available", !reasoning.isEmpty, !reasoning.hasSuffix("\n") { reasoning.append("\n") }
+            reasoning.append(text)
+            if reasoning.count > Self.reasoningLimit { reasoning = String(reasoning.suffix(Self.reasoningLimit)) }
+        case "notification.show":
+            guard let text = payload["text"].text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else { return true }
+            let key = payload["key"].text ?? payload["id"].text ?? "notice-\(notices.count)"
+            let notice = BotNotice(id: key, text: text, level: payload["level"].text)
+            if let index = notices.firstIndex(where: { $0.id == key }) { notices[index] = notice } else {
+                notices.append(notice)
+                if notices.count > Self.noticeLimit { notices.removeFirst(notices.count - Self.noticeLimit) }
+            }
+        case "notification.clear":
+            guard let key = payload["key"].text else { return true }
+            notices.removeAll { $0.id == key }
+        case "review.summary":
+            guard let text = payload["text"].text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else { return true }
+            memoryNotes.append(text)
+            if memoryNotes.count > Self.noticeLimit { memoryNotes.removeFirst(memoryNotes.count - Self.noticeLimit) }
+        default:
+            return false
+        }
+        return true
+    }
+
+    /// Drops the turn's tool rows and reasoning once a settled snapshot carries
+    /// them. Notices and memory notes stay until the next turn starts.
+    mutating func clearTurnWork() {
+        toolCalls = []
+        reasoning = ""
+    }
+
+    private static func toolID(_ payload: BotJSON) -> String? {
+        guard let id = payload["tool_id"].text, !id.isEmpty else { return nil }
+        return id
+    }
+
+    /// The result as the text the shared tool row formatter parses: a string as
+    /// is, any other JSON re-encoded so envelope fields such as `error` are read.
+    static func resultPreview(_ result: BotJSON) -> String? {
+        switch result {
+        case .null: return nil
+        case .string(let text): return text.isEmpty ? nil : text
+        default:
+            guard let data = try? JSONEncoder().encode(result) else { return nil }
+            return String(decoding: data, as: UTF8.self)
+        }
+    }
+}
+
+/// Settled tool rows and reasoning from a resume snapshot, placed before the
+/// message they precede. `anchorMessageID == nil` means after the last message.
+struct BotSettledActivity: Identifiable, Equatable {
+    let id: String
+    let anchorMessageID: String?
+    let toolCalls: [ToolCall]
+    let reasoning: String?
+}
+
+/// Projects the snapshot's `messages` rows into text messages plus settled
+/// activity. Message identity stays `<root>/<row index>`, so ids are stable
+/// across refreshes and unaffected by how many tool rows sit between messages.
+enum BotTranscriptProjection {
+    static func project(history: [BotJSON], root: String) -> (messages: [ChatMessage], activity: [BotSettledActivity]) {
+        var messages: [ChatMessage] = []
+        var activity: [BotSettledActivity] = []
+        var pendingTools: [ToolCall] = []
+        var pendingReasoning: [String] = []
+        var pendingStart: Int?
+
+        func flush(anchor: String?) {
+            guard let start = pendingStart, !pendingTools.isEmpty || !pendingReasoning.isEmpty else { return }
+            activity.append(BotSettledActivity(
+                id: "\(root)/\(start)/activity", anchorMessageID: anchor, toolCalls: pendingTools,
+                reasoning: pendingReasoning.isEmpty ? nil : pendingReasoning.joined(separator: "\n\n")
+            ))
+            pendingTools = []; pendingReasoning = []; pendingStart = nil
+        }
+
+        for (index, row) in history.enumerated() {
+            guard let role = row["role"].text else { continue }
+            switch role {
+            case "tool":
+                pendingStart = pendingStart ?? index
+                pendingTools.append(ToolCall(
+                    id: "\(root)/\(index)", name: row["name"].text, preview: row["context"].text,
+                    args: row["args"].argumentDictionary, isCompleted: true
+                ))
+            case "assistant", "user":
+                if role == "assistant", let text = row["reasoning"].text ?? row["reasoning_content"].text,
+                   !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    pendingStart = pendingStart ?? index
+                    pendingReasoning.append(text)
+                }
+                guard let text = row["text"].text else { continue }
+                let id = "\(root)/\(index)"
+                flush(anchor: id)
+                messages.append(ChatMessage(role: role, content: text, timestamp: nil, messageId: id))
+            default:
+                continue
+            }
+        }
+        flush(anchor: nil)
+        return (messages, activity)
+    }
+}
+
+extension BotJSON {
+    /// Tool arguments in the shared transcript model's JSON type.
+    var argumentDictionary: [String: JSONValue]? {
+        guard case .object(let object) = self, !object.isEmpty else { return nil }
+        return object.mapValues(\.jsonValue)
+    }
+
+    var jsonValue: JSONValue {
+        switch self {
+        case .object(let value): return .object(value.mapValues(\.jsonValue))
+        case .array(let value): return .array(value.map(\.jsonValue))
+        case .string(let value): return .string(value)
+        case .number(let value): return .number(value)
+        case .bool(let value): return .bool(value)
+        case .null: return .null
+        }
+    }
+}

--- a/HermesMobile/Features/Bots/BotActivityViews.swift
+++ b/HermesMobile/Features/Bots/BotActivityViews.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Settled or live activity in the Sessions log-row style: the reasoning row
+/// above the tool rows, both behind the shared "Thinking and Tool Cards" setting.
+struct BotActivityBlocksView: View {
+    let id: String
+    let reasoning: String?
+    let toolCalls: [ToolCall]
+    var isLive = false
+
+    @AppStorage(ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey) private var showsCards = true
+
+    var body: some View {
+        if showsCards {
+            if let reasoning, !reasoning.isEmpty {
+                ReasoningBlockView(text: reasoning, liveStreamID: isLive ? "\(id)-reasoning" : nil)
+            }
+            if !toolCalls.isEmpty {
+                ToolActivityGroupView(group: ToolCallGroup(id: "\(id)-tools", anchorMessageID: nil, toolCalls: toolCalls), isLive: isLive)
+            }
+        }
+    }
+}
+
+/// The bot's plan as one log row: `Plan`, then `2 of 5 · current step`.
+/// Expanding lists every item with its state; long-press copies the list.
+struct BotPlanRowView: View {
+    let plan: BotPlan
+
+    @State private var isExpanded = false
+
+    private var detail: String {
+        let progress = String(localized: "\(plan.completedCount) of \(plan.items.count)")
+        guard let current = plan.current else { return progress }
+        return "\(progress) · \(current.content)"
+    }
+
+    var body: some View {
+        TranscriptLogRowView(
+            summary: String(localized: "Plan"),
+            detail: detail,
+            isExpanded: isExpanded,
+            accessibilityLabel: String(localized: "Plan, \(detail)"),
+            copyText: { plan.items.map { "\(Self.marker(for: $0)) \($0.content)" }.joined(separator: "\n") },
+            toggleExpansion: { isExpanded.toggle() }
+        ) {
+            Image(systemName: "checklist")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+        } status: {
+            EmptyView()
+        } expandedBody: {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(plan.items) { item in
+                    Label {
+                        Text(item.content)
+                            .strikethrough(item.isDone)
+                            .foregroundStyle(item.isDone ? .secondary : .primary)
+                    } icon: {
+                        Image(systemName: Self.symbol(for: item))
+                            .foregroundStyle(item.status == "in_progress" ? Color.accentColor : .secondary)
+                    }
+                    .font(AppFont.caption())
+                    .accessibilityLabel(Text("\(Self.stateLabel(for: item)): \(item.content)"))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private static func symbol(for item: BotPlan.Item) -> String {
+        switch item.status {
+        case "completed": "checkmark.circle.fill"
+        case "cancelled": "xmark.circle"
+        case "in_progress": "circle.lefthalf.filled"
+        default: "circle"
+        }
+    }
+
+    private static func marker(for item: BotPlan.Item) -> String {
+        switch item.status {
+        case "completed": "[x]"
+        case "cancelled": "[-]"
+        case "in_progress": "[~]"
+        default: "[ ]"
+        }
+    }
+
+    private static func stateLabel(for item: BotPlan.Item) -> String {
+        switch item.status {
+        case "completed": String(localized: "Done")
+        case "cancelled": String(localized: "Cancelled")
+        case "in_progress": String(localized: "In progress")
+        default: String(localized: "Pending")
+        }
+    }
+}

--- a/HermesMobile/Features/Bots/BotChatComposerView.swift
+++ b/HermesMobile/Features/Bots/BotChatComposerView.swift
@@ -120,9 +120,16 @@ private struct BotChatStatusView: View {
     let onResolveHeldMessage: () -> Void
 
     var body: some View {
-        if model.connectionState != .connected || model.turn != .idle || model.errorMessage != nil || model.uncertainSend {
+        if model.connectionState != .connected || model.turn != .idle || model.errorMessage != nil || model.uncertainSend
+            || !model.liveActivity.notices.isEmpty || !model.liveActivity.memoryNotes.isEmpty {
             VStack(alignment: .leading, spacing: 6) {
                 if let connectionText { Text(connectionText) }
+                ForEach(model.liveActivity.notices) { notice in
+                    Label(notice.text, systemImage: notice.isWarning ? "exclamationmark.triangle" : "info.circle")
+                }
+                ForEach(model.liveActivity.memoryNotes, id: \.self) { note in
+                    Label(note, systemImage: "brain")
+                }
                 if let error = model.errorMessage { Text(error) }
                 if model.uncertainSend {
                     Text("Send outcome unknown. Check the conversation in Desktop before sending again.")
@@ -162,7 +169,7 @@ private struct BotChatStatusView: View {
     private var turnText: String? {
         switch model.turn {
         case .idle, .needsAttention: return nil
-        case .running: return String(localized: "Working")
+        case .running: return model.workStatus ?? String(localized: "Working")
         case .submitting: return String(localized: "Sending…")
         case .stopping: return String(localized: "Stopping…")
         case .uncertain: return String(localized: "Outcome unknown")

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -26,8 +26,27 @@ import SwiftUI
                         if model.messages.isEmpty && model.liveMessages.isEmpty && model.connectionState == .connected {
                             Text("No messages yet").foregroundStyle(.secondary)
                         }
-                        ForEach(model.messages) { message in MessageBubbleView(message: message, textOnly: true) }
-                        ForEach(model.liveMessages) { message in MessageBubbleView(message: message, textOnly: true) }
+                        ForEach(model.messages) { message in
+                            settledActivity(anchoredTo: message.id)
+                            MessageBubbleView(message: message, textOnly: true)
+                        }
+                        settledActivity(anchoredTo: nil)
+                        // The live turn reads like a settled one: prompt, work, then reply.
+                        if let prompt = model.liveMessages.first(where: { $0.role == "user" }) {
+                            MessageBubbleView(message: prompt, textOnly: true)
+                        }
+                        if model.liveActivity.hasTurnWork {
+                            BotActivityBlocksView(
+                                id: "bot-live", reasoning: model.liveActivity.reasoning,
+                                toolCalls: model.liveActivity.toolCalls, isLive: true
+                            )
+                        }
+                        if let reply = model.liveMessages.first(where: { $0.role == "assistant" }) {
+                            MessageBubbleView(message: reply, textOnly: true)
+                        }
+                        if let plan = model.plan {
+                            BotPlanRowView(plan: plan).id("bot-plan")
+                        }
                         Color.clear.frame(height: 1).id("bot-transcript-bottom")
                     }
                     .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 20 : 16)
@@ -47,6 +66,8 @@ import SwiftUI
                 }
                 .onChange(of: model.messages.count) { followLatest(proxy) }
                 .onChange(of: model.liveMessages.last?.content) { followLatest(proxy) }
+                .onChange(of: model.liveActivity.toolCalls.count) { followLatest(proxy) }
+                .onChange(of: model.liveActivity.reasoning.count) { followLatest(proxy) }
                 .onChange(of: model.connectionState) { followLatest(proxy) }
                 .overlay(alignment: .bottomTrailing) {
                     if !followsLatest {
@@ -89,6 +110,13 @@ import SwiftUI
             }
         } message: {
             Text("First check whether Desktop received this message. Discarding removes the held text from Hermex. It does not stop or resend any work.")
+        }
+    }
+
+    @ViewBuilder
+    private func settledActivity(anchoredTo anchorID: String?) -> some View {
+        ForEach(model.settledActivity.filter { $0.anchorMessageID == anchorID }) { activity in
+            BotActivityBlocksView(id: activity.id, reasoning: activity.reasoning, toolCalls: activity.toolCalls)
         }
     }
 

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -51,8 +51,13 @@ import SwiftUI
                     }
                     .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 20 : 16)
                     .padding(.vertical, 16)
+                    // A tapped row must stay under the finger: stop following so
+                    // neither the size-change anchor nor the next activity update
+                    // moves the reader. Latest brings them back.
+                    .environment(\.chatDisclosureToggled) { followsLatest = false }
                 }
-                .defaultScrollAnchor(.bottom)
+                .defaultScrollAnchor(ChatScrollPolicy.initialTranscriptAnchor, for: .initialOffset)
+                .defaultScrollAnchor(ChatScrollPolicy.sizeChangeAnchor(shouldFollowLatestMessage: followsLatest), for: .sizeChanges)
                 .scrollDismissesKeyboard(.interactively)
                 .onScrollGeometryChange(for: Bool.self) { geometry in
                     geometry.contentOffset.y + geometry.containerSize.height

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -22,6 +22,11 @@ import Observation
     private(set) var sequence = 0
     private(set) var epoch: String?
     private(set) var replayWasReset = false
+    private(set) var settledActivity: [BotSettledActivity] = []
+    private(set) var liveActivity = BotTurnActivity()
+    private(set) var plan: BotPlan?
+    /// `status.update` text while the bot works (compacting, compressing); nil once ready.
+    private(set) var workStatus: String?
     private var tip: String?
     private var generation = 0
     private var turnRevision = 0
@@ -127,16 +132,48 @@ import Observation
               let truncated = reply["truncated"].flag, let events = reply["events"].list else { throw BotFailure.unsupported }
         if epoch != receivedEpoch || truncated || latest < sequence { replayWasReset = true }
         var cursor = sequence
+        var missed: [BotJSON] = []
         for event in events {
             guard event["session_id"].text == runtime else { throw BotFailure.wrongIdentity }
             guard let next = event["seq"].integer, next > 0, next <= latest else { throw BotFailure.unsupported }
             if next <= cursor { continue }
             if next != cursor + 1 { replayWasReset = true }
             cursor = next
+            missed.append(event)
         }
         if cursor < latest { replayWasReset = true }
         epoch = receivedEpoch; sequence = latest
-        // Replay is only a continuity check. A full snapshot replaces text below.
+        // Replay never appends text; the full snapshot below owns it. It does rebuild
+        // the current turn's activity: every missed event when the sequence was
+        // continuous, otherwise only the events after the last `message.start` the
+        // ring still holds, which is the whole current turn. Without either, the
+        // live rows are dropped rather than shown incomplete.
+        if replayWasReset {
+            guard let start = missed.lastIndex(where: { $0["type"].text == "message.start" }) else {
+                liveActivity.clearTurnWork(); return
+            }
+            missed.removeFirst(start)
+        }
+        for event in missed { applyActivity(type: event["type"].text ?? "", payload: event["payload"]) }
+    }
+
+    /// Feeds activity events to the live reducer, plan and work status. Returns
+    /// false for event types that carry conversation text or turn state instead.
+    @discardableResult
+    private func applyActivity(type: String, payload: BotJSON) -> Bool {
+        switch type {
+        case "message.start":
+            liveActivity = BotTurnActivity(); workStatus = nil
+            return false
+        case "todo.updated":
+            if let next = BotPlan(payload), next.revision >= (plan?.revision ?? 0) { plan = next }
+        case "status.update":
+            let text = payload["text"].text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            workStatus = payload["kind"].text == "ready" || text.isEmpty ? nil : text
+        default:
+            return liveActivity.apply(type: type, payload: payload)
+        }
+        return true
     }
 
     private func applySnapshot(_ snapshot: BotJSON, full: Bool) throws {
@@ -145,11 +182,11 @@ import Observation
         if let value = snapshot["info"]["profile_name"].text, value != profile.id { throw BotFailure.wrongIdentity }
         if full {
             guard let history = snapshot["messages"].list, snapshot["messages_omitted"].flag != true else { throw BotFailure.unsupported }
-            messages = history.enumerated().compactMap { index, row in
-                guard let role = row["role"].text, ["user", "assistant"].contains(role), let text = row["text"].text else { return nil }
-                return ChatMessage(role: role, content: text, timestamp: nil, messageId: "\(root ?? "")/\(index)")
-            }
+            let projected = BotTranscriptProjection.project(history: history, root: root ?? "")
+            messages = projected.messages
+            settledActivity = projected.activity
         }
+        if let next = BotPlan(snapshot["todo_state"]), next.revision >= (plan?.revision ?? 0) { plan = next }
         let inflight = snapshot["inflight"]
         let startedAt = inflight["started_at"].number ?? snapshot["turn_started_at"].number
         if startedAt != turnStartedAt { turnRevision += 1; turnStartedAt = startedAt }
@@ -160,7 +197,12 @@ import Observation
         if let text = inflight["assistant"].text, !text.isEmpty {
             liveMessages.append(ChatMessage(role: "assistant", content: text, timestamp: nil, messageId: "live-assistant"))
         }
-        if !running { uncertainStop = false; stopAcknowledged = false }
+        if !running {
+            uncertainStop = false; stopAcknowledged = false; workStatus = nil
+            // Only a full snapshot carries the settled rows, so live rows wait for it
+            // instead of vanishing on the inflight read that first reports idle.
+            if full { liveActivity.clearTurnWork() }
+        }
         let attention = snapshot["pending_approval"] != .null || snapshot["pending_clarify"] != .null
         let continuation = snapshot["auto_continue"] != .null && snapshot["auto_continue"].flag != false
         let queued = snapshot["queued"] != .null
@@ -276,6 +318,7 @@ import Observation
         guard let next = event["seq"].integer, next > 0 else {
             replayWasReset = true; snapshotDirty = true; fullSnapshotNeeded = true
             turnRevision += 1
+            liveActivity.clearTurnWork()
             if !localOperation { turn = .unknown }
             scheduleRefresh(); return
         }
@@ -283,10 +326,15 @@ import Observation
         let discontinuity = next != sequence + 1
         if discontinuity {
             replayWasReset = true; fullSnapshotNeeded = true; turnRevision += 1
+            // Missed events may hold tool rows; partial activity is worse than none.
+            liveActivity.clearTurnWork()
             if !localOperation { turn = .unknown }
         }
         sequence = next
         let type = event["type"].text ?? ""
+        // Activity events never change the inflight text, so a continuous stream
+        // during known work updates local state without another snapshot read.
+        if applyActivity(type: type, payload: event["payload"]), !discontinuity, turn == .running { return }
         if ["message.start", "message.complete", "session.info", "error", "approval.request", "clarify.request"].contains(type) {
             turnRevision += 1
             fullSnapshotNeeded = true

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -146,11 +146,12 @@ import Observation
         // Replay never appends text; the full snapshot below owns it. It does rebuild
         // the current turn's activity: every missed event when the sequence was
         // continuous, otherwise only the events after the last `message.start` the
-        // ring still holds, which is the whole current turn. Without either, the
-        // live rows are dropped rather than shown incomplete.
+        // ring still holds, which is the whole current turn. Without either, every
+        // live row and notice is dropped rather than shown incomplete or stale: a
+        // notice whose clear was in the gap has no snapshot state to reconcile it.
         if replayWasReset {
             guard let start = missed.lastIndex(where: { $0["type"].text == "message.start" }) else {
-                liveActivity.clearTurnWork(); return
+                liveActivity = BotTurnActivity(); return
             }
             missed.removeFirst(start)
         }
@@ -318,7 +319,7 @@ import Observation
         guard let next = event["seq"].integer, next > 0 else {
             replayWasReset = true; snapshotDirty = true; fullSnapshotNeeded = true
             turnRevision += 1
-            liveActivity.clearTurnWork()
+            liveActivity = BotTurnActivity()
             if !localOperation { turn = .unknown }
             scheduleRefresh(); return
         }
@@ -326,8 +327,9 @@ import Observation
         let discontinuity = next != sequence + 1
         if discontinuity {
             replayWasReset = true; fullSnapshotNeeded = true; turnRevision += 1
-            // Missed events may hold tool rows; partial activity is worse than none.
-            liveActivity.clearTurnWork()
+            // Missed events may hold tool rows or a notice's clear; partial or stale
+            // activity is worse than none.
+            liveActivity = BotTurnActivity()
             if !localOperation { turn = .unknown }
         }
         sequence = next

--- a/HermesMobileTests/BotActivityTests.swift
+++ b/HermesMobileTests/BotActivityTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import HermesMobile
+
+final class BotActivityTests: XCTestCase {
+    private func payload(_ pairs: [String: BotJSON]) -> BotJSON { .object(pairs) }
+
+    func testToolLifecycleUpdatesTheSameRowWithoutDuplicates() {
+        var activity = BotTurnActivity()
+        XCTAssertTrue(activity.apply(type: "tool.start", payload: payload([
+            "tool_id": .string("t1"), "name": .string("terminal"), "context": .string("git status"),
+            "args": .object(["command": .string("git status")])
+        ])))
+        XCTAssertEqual(activity.toolCalls.map(\.isCompleted), [false])
+        // A replayed start for the same id is idempotent.
+        activity.apply(type: "tool.start", payload: payload(["tool_id": .string("t1"), "name": .string("terminal")]))
+        XCTAssertEqual(activity.toolCalls.count, 1)
+        activity.apply(type: "tool.complete", payload: payload([
+            "tool_id": .string("t1"), "name": .string("terminal"), "duration_s": .number(1.5),
+            "result": .object(["output": .string("clean"), "exit_code": .number(0)])
+        ]))
+        XCTAssertEqual(activity.toolCalls.count, 1)
+        XCTAssertTrue(activity.toolCalls[0].isCompleted)
+        XCTAssertEqual(activity.toolCalls[0].duration, 1.5)
+        XCTAssertEqual(activity.toolCalls[0].args?["command"], .string("git status"))
+        let row = ToolCallSummaryFormatter.row(for: activity.toolCalls[0], isLive: true)
+        XCTAssertEqual(row?.status, .success)
+        XCTAssertEqual(row?.detail, "git status")
+    }
+
+    func testErrorEnvelopeReadsAsFailureAndStringResultsStayText() {
+        var activity = BotTurnActivity()
+        activity.apply(type: "tool.complete", payload: payload([
+            "tool_id": .string("t1"), "name": .string("read_file"), "result": .object(["error": .string("No such file")])
+        ]))
+        activity.apply(type: "tool.complete", payload: payload([
+            "tool_id": .string("t2"), "name": .string("web_search"), "result": .string("plain text result")
+        ]))
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: activity.toolCalls[0], isLive: false)?.status, .failure)
+        XCTAssertEqual(activity.toolCalls[1].preview, "plain text result")
+    }
+
+    func testMissingAndUnknownFieldsAreTolerated() {
+        var activity = BotTurnActivity()
+        activity.apply(type: "tool.start", payload: .null)
+        activity.apply(type: "tool.start", payload: payload(["name": .number(3), "args": .string("not an object")]))
+        activity.apply(type: "tool.complete", payload: payload(["tool_id": .string("never-started"), "result": .null]))
+        activity.apply(type: "thinking.delta", payload: payload(["text": .bool(true)]))
+        activity.apply(type: "notification.show", payload: payload(["level": .string("info")]))
+        activity.apply(type: "notification.clear", payload: .array([]))
+        activity.apply(type: "review.summary", payload: payload(["text": .string("   ")]))
+        XCTAssertFalse(activity.apply(type: "moa.reference", payload: payload(["text": .string("ignored")])))
+        XCTAssertEqual(activity.toolCalls.count, 3)
+        XCTAssertEqual(Set(activity.toolCalls.map(\.id)).count, 3, "generated ids stay unique")
+        XCTAssertTrue(activity.toolCalls[2].isCompleted)
+        XCTAssertEqual(activity.reasoning, "")
+        XCTAssertTrue(activity.notices.isEmpty)
+        XCTAssertTrue(activity.memoryNotes.isEmpty)
+    }
+
+    func testBoundsDropOldestToolsAndKeepReasoningTail() {
+        var activity = BotTurnActivity()
+        for index in 0..<(BotTurnActivity.toolLimit + 10) {
+            activity.apply(type: "tool.start", payload: payload(["tool_id": .string("t\(index)"), "name": .string("terminal")]))
+        }
+        XCTAssertEqual(activity.toolCalls.count, BotTurnActivity.toolLimit)
+        XCTAssertEqual(activity.toolCalls.first?.id, "t10")
+        for _ in 0..<40 {
+            activity.apply(type: "reasoning.delta", payload: payload(["text": .string(String(repeating: "a", count: 1_000))]))
+        }
+        activity.apply(type: "reasoning.delta", payload: payload(["text": .string("END")]))
+        XCTAssertEqual(activity.reasoning.count, BotTurnActivity.reasoningLimit)
+        XCTAssertTrue(activity.reasoning.hasSuffix("END"))
+        activity.apply(type: "reasoning.available", payload: payload(["text": .string("block")]))
+        XCTAssertTrue(activity.reasoning.hasSuffix("END\nblock"))
+        activity.clearTurnWork()
+        XCTAssertFalse(activity.hasTurnWork)
+    }
+
+    func testNoticesReplaceByKeyClearByKeyAndMemoryNotesAccumulate() {
+        var activity = BotTurnActivity()
+        activity.apply(type: "notification.show", payload: payload(["key": .string("credits"), "text": .string("Low credits"), "level": .string("warn")]))
+        activity.apply(type: "notification.show", payload: payload(["key": .string("credits"), "text": .string("Credits restored"), "level": .string("success")]))
+        activity.apply(type: "notification.show", payload: payload(["id": .string("agent"), "text": .string("Still starting")]))
+        XCTAssertEqual(activity.notices.map(\.text), ["Credits restored", "Still starting"])
+        XCTAssertFalse(activity.notices[0].isWarning)
+        activity.apply(type: "notification.clear", payload: payload(["key": .string("agent")]))
+        XCTAssertEqual(activity.notices.map(\.id), ["credits"])
+        for index in 0..<(BotTurnActivity.noticeLimit + 2) {
+            activity.apply(type: "review.summary", payload: payload(["text": .string("note \(index)")]))
+        }
+        XCTAssertEqual(activity.memoryNotes.count, BotTurnActivity.noticeLimit)
+        XCTAssertEqual(activity.memoryNotes.first, "note 2")
+    }
+
+    func testPlanParsesTolerantlyAndSkipsMalformedItems() {
+        let plan = BotPlan(payload([
+            "revision": .number(3),
+            "todos": .array([
+                .object(["id": .string("a"), "content": .string("Archive newsletters"), "status": .string("completed")]),
+                .object(["content": .string("Draft replies"), "status": .string("in_progress")]),
+                .object(["id": .string("c"), "content": .string(" "), "status": .string("pending")]),
+                .string("garbage"),
+                .object(["id": .string("d"), "content": .string("Report"), "status": .string("weird")])
+            ])
+        ]))
+        XCTAssertEqual(plan?.revision, 3)
+        XCTAssertEqual(plan?.items.map(\.content), ["Archive newsletters", "Draft replies", "Report"])
+        XCTAssertEqual(plan?.items[1].id, "plan-1")
+        XCTAssertEqual(plan?.completedCount, 1)
+        XCTAssertEqual(plan?.current?.content, "Draft replies")
+        XCTAssertFalse(plan?.isFinished ?? true)
+        XCTAssertNil(BotPlan(payload(["revision": .number(1), "todos": .array([])])))
+        XCTAssertNil(BotPlan(payload(["todos": .string("nope")])))
+        XCTAssertNil(BotPlan(.null))
+    }
+
+    func testSnapshotProjectionAnchorsWorkToTheMessageItPrecedesWithStableIDs() {
+        let history: [BotJSON] = [
+            .object(["role": .string("user"), "text": .string("Clear the inbox")]),
+            .object(["role": .string("assistant"), "reasoning": .string("Archive first")]),
+            .object(["role": .string("tool"), "name": .string("terminal"), "context": .string("himalaya move"), "args": .object(["command": .string("himalaya move")])]),
+            .object(["role": .string("tool"), "name": .string("write_file"), "context": .string("draft.md")]),
+            .object(["role": .string("assistant"), "text": .string("Archived 14 newsletters."), "reasoning_content": .string("Done")]),
+            .object(["role": .string("system"), "text": .string("hidden")]),
+            .object(["role": .string("tool"), "name": .string("read_file")]),
+            .object(["role": .string("mystery"), "text": .string("dropped")])
+        ]
+        let projected = BotTranscriptProjection.project(history: history, root: "root")
+        XCTAssertEqual(projected.messages.map(\.messageId), ["root/0", "root/4"])
+        XCTAssertEqual(projected.messages.map(\.content), ["Clear the inbox", "Archived 14 newsletters."])
+        XCTAssertEqual(projected.activity.map(\.id), ["root/1/activity", "root/6/activity"])
+        XCTAssertEqual(projected.activity[0].anchorMessageID, "root/4")
+        XCTAssertEqual(projected.activity[0].reasoning, "Archive first\n\nDone")
+        XCTAssertEqual(projected.activity[0].toolCalls.map(\.name), ["terminal", "write_file"])
+        XCTAssertEqual(projected.activity[0].toolCalls.map(\.id), ["root/2", "root/3"])
+        XCTAssertTrue(projected.activity[0].toolCalls.allSatisfy(\.isCompleted))
+        XCTAssertNil(projected.activity[1].anchorMessageID, "work after the last reply renders at the end")
+        XCTAssertEqual(ToolCallSummaryFormatter.row(for: projected.activity[0].toolCalls[1], isLive: false)?.detail, "draft.md")
+    }
+}

--- a/HermesMobileTests/BotChatPresentationTests.swift
+++ b/HermesMobileTests/BotChatPresentationTests.swift
@@ -143,6 +143,49 @@ import XCTest
         }
     }
 
+    /// The activity rows are the Sessions log rows, whose only motion is
+    /// `ChatMotion.disclosure`, which is nil under Reduce Motion (covered in
+    /// `TranscriptDisplayModelTests`); the Bot views add no animation of their own.
+    func testActivityRowsRenderAndFollowTheCardsSetting() async throws {
+        let defaults = UserDefaults.standard
+        let key = ChatTranscriptDisplaySettings.showsThinkingAndToolCardsKey
+        let previous = defaults.object(forKey: key)
+        defer { if let previous { defaults.set(previous, forKey: key) } else { defaults.removeObject(forKey: key) } }
+        defaults.set(true, forKey: key)
+        let wire = BotFixtureWire(); wire.running = true
+        wire.history = [
+            .object(["role": .string("user"), "text": .string("Summarize yesterday's inbox.")]),
+            .object(["role": .string("tool"), "name": .string("terminal"), "args": .object(["command": .string("himalaya list")])]),
+            .object(["role": .string("assistant"), "text": .string("Three messages need a reply."), "reasoning": .string("Three threads need replies")])
+        ]
+        wire.inflight = .object(["user": .string("Clear the inbox."), "assistant": .string("Archived 14 newsletters.")])
+        wire.todoState = .object(["revision": .number(1), "todos": .array([
+            .object(["id": .string("a"), "content": .string("Archive newsletters"), "status": .string("completed")]),
+            .object(["id": .string("b"), "content": .string("Draft the estimate reply"), "status": .string("in_progress")])
+        ])])
+        let model = make(wire)
+        let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .active))
+        defer { model.suspend(); close(window) }
+        await model.recover()
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("tool.start"),
+            "payload": .object(["tool_id": .string("t1"), "name": .string("write_file"), "args": .object(["path": .string("reply-delivery.md")])])
+        ]))
+        await renderFrames()
+        let shown = try screenshot(window, name: "bot-activity-cards-on")
+        XCTAssertTrue(shown.contains("Ran"), shown)
+        XCTAssertTrue(shown.contains("Thinking"), shown)
+        XCTAssertTrue(shown.contains("Updated"), shown)
+        XCTAssertTrue(shown.contains("Plan"), shown)
+        XCTAssertTrue(shown.contains("1 of 2"), shown)
+        defaults.set(false, forKey: key)
+        await renderFrames()
+        let hidden = try screenshot(window, name: "bot-activity-cards-off")
+        XCTAssertFalse(hidden.contains("Thinking"), hidden)
+        XCTAssertFalse(hidden.contains("Updated"), hidden)
+        XCTAssertTrue(hidden.contains("Plan"), "work progress stays visible with cards off: " + hidden)
+    }
+
     private func show<V: View>(_ view: V) throws -> UIWindow {
         let scene = try XCTUnwrap(UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
         let window = UIWindow(windowScene: scene)

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -387,22 +387,26 @@ import Vision
         await model.recover()
         XCTAssertTrue(model.replayWasReset)
         XCTAssertEqual(model.liveActivity.toolCalls.map(\.id), ["new"])
-        // Truncated without the start: partial rows are dropped rather than shown.
-        wire.replay = BotFixtureWire.replay(latest: 8, truncated: true, events: [
-            typed(8, "tool.start", .object(["tool_id": .string("partial"), "name": .string("terminal")]))
+        // Truncated without the start: partial rows and notices whose clear may sit
+        // in the gap are dropped rather than shown.
+        wire.onEvent?(typed(7, "notification.show", .object(["key": .string("credits"), "text": .string("Low credits")])))
+        XCTAssertEqual(model.liveActivity.notices.map(\.id), ["credits"])
+        wire.replay = BotFixtureWire.replay(latest: 9, truncated: true, events: [
+            typed(9, "tool.start", .object(["tool_id": .string("partial"), "name": .string("terminal")]))
         ])
         await model.recover()
         XCTAssertTrue(model.replayWasReset)
         XCTAssertFalse(model.liveActivity.hasTurnWork)
+        XCTAssertTrue(model.liveActivity.notices.isEmpty)
         // Duplicate sequence numbers in a replay never duplicate rows.
-        wire.replay = BotFixtureWire.replay(latest: 10, events: [
-            typed(9, "tool.start", .object(["tool_id": .string("t9"), "name": .string("terminal")])),
-            typed(9, "tool.start", .object(["tool_id": .string("t9"), "name": .string("terminal")])),
-            typed(10, "tool.start", .object(["tool_id": .string("t10"), "name": .string("terminal")]))
+        wire.replay = BotFixtureWire.replay(latest: 11, events: [
+            typed(10, "tool.start", .object(["tool_id": .string("t10"), "name": .string("terminal")])),
+            typed(10, "tool.start", .object(["tool_id": .string("t10"), "name": .string("terminal")])),
+            typed(11, "tool.start", .object(["tool_id": .string("t11"), "name": .string("terminal")]))
         ])
         await model.recover()
         XCTAssertFalse(model.replayWasReset)
-        XCTAssertEqual(model.liveActivity.toolCalls.map(\.id), ["t9", "t10"])
+        XCTAssertEqual(model.liveActivity.toolCalls.map(\.id), ["t10", "t11"])
         model.suspend()
     }
 

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -301,6 +301,122 @@ import Vision
         .object(["session_id": .string("runtime"), "seq": .number(Double(seq)), "type": .string("message.delta")])
     }
 
+    private func typed(_ seq: Int, _ type: String, _ payload: BotJSON = .null) -> BotJSON {
+        var object: [String: BotJSON] = ["session_id": .string("runtime"), "seq": .number(Double(seq)), "type": .string(type)]
+        if payload != .null { object["payload"] = payload }
+        return .object(object)
+    }
+
+    func testLongResponseInterleavesToolEventsThenSettlesWithoutDuplicateRows() async {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire); await model.recover()
+        wire.inflight = .object(["user": .string("Clear the inbox"), "assistant": .string("Archiving")])
+        wire.onEvent?(typed(1, "message.start"))
+        wire.onEvent?(typed(2, "thinking.delta", .object(["text": .string("Archive first")])))
+        wire.onEvent?(typed(3, "tool.start", .object(["tool_id": .string("t1"), "name": .string("terminal"), "args": .object(["command": .string("himalaya move")])])))
+        let streamed = expectation(description: "inflight snapshot published")
+        withObservationTracking { _ = model.liveMessages } onChange: { streamed.fulfill() }
+        wire.onEvent?(typed(4, "message.delta", .object(["text": .string("Archiving")])))
+        await fulfillment(of: [streamed], timeout: 3)
+        XCTAssertEqual(model.turn, .running)
+        let resumes = wire.calls.filter { $0.0 == "session.resume" }.count
+        wire.onEvent?(typed(5, "tool.complete", .object(["tool_id": .string("t1"), "name": .string("terminal"), "result": .object(["output": .string("ok")])])))
+        wire.onEvent?(typed(6, "todo.updated", .object(["revision": .number(2), "todos": .array([
+            .object(["id": .string("a"), "content": .string("Archive"), "status": .string("completed")]),
+            .object(["id": .string("b"), "content": .string("Draft"), "status": .string("in_progress")])
+        ])])))
+        wire.onEvent?(typed(7, "todo.updated", .object(["revision": .number(1), "todos": .array([.object(["id": .string("z"), "content": .string("stale"), "status": .string("pending")])])])))
+        wire.onEvent?(typed(8, "status.update", .object(["kind": .string("compacting"), "text": .string("Compacting context")])))
+        wire.onEvent?(typed(9, "review.summary", .object(["text": .string("Saved a memory")])))
+        XCTAssertEqual(model.liveMessages.map(\.content), ["Clear the inbox", "Archiving"])
+        XCTAssertEqual(model.liveActivity.reasoning, "Archive first")
+        XCTAssertEqual(model.liveActivity.toolCalls.map(\.isCompleted), [true])
+        XCTAssertEqual(model.plan?.revision, 2)
+        XCTAssertEqual(model.plan?.current?.content, "Draft")
+        XCTAssertEqual(model.workStatus, "Compacting context")
+        XCTAssertEqual(model.liveActivity.memoryNotes, ["Saved a memory"])
+        wire.inflight = .object(["user": .string("Clear the inbox"), "assistant": .string("Archiving done")])
+        let streamedAgain = expectation(description: "second inflight snapshot published")
+        withObservationTracking { _ = model.liveMessages } onChange: { streamedAgain.fulfill() }
+        wire.onEvent?(typed(10, "message.delta", .object(["text": .string(" done")])))
+        await fulfillment(of: [streamedAgain], timeout: 3)
+        XCTAssertEqual(wire.calls.filter { $0.0 == "session.resume" }.count, resumes + 1,
+                       "activity events during known work never add snapshot reads")
+        // Completion: the full snapshot carries the settled rows and the live rows go away.
+        wire.running = false; wire.inflight = .null
+        wire.history = [
+            .object(["role": .string("user"), "text": .string("Clear the inbox")]),
+            .object(["role": .string("tool"), "name": .string("terminal"), "context": .string("himalaya move")]),
+            .object(["role": .string("assistant"), "text": .string("Archiving done"), "reasoning": .string("Archive first")])
+        ]
+        let settled = expectation(description: "full snapshot published")
+        withObservationTracking { _ = model.messages } onChange: { settled.fulfill() }
+        wire.onEvent?(typed(11, "message.complete", .object(["text": .string("Archiving done")])))
+        await fulfillment(of: [settled], timeout: 3)
+        XCTAssertEqual(model.turn, .idle)
+        XCTAssertEqual(model.messages.map(\.content), ["Clear the inbox", "Archiving done"])
+        XCTAssertEqual(model.settledActivity.map(\.anchorMessageID), ["root/2"])
+        XCTAssertEqual(model.settledActivity[0].toolCalls.map(\.name), ["terminal"])
+        XCTAssertEqual(model.settledActivity[0].reasoning, "Archive first")
+        XCTAssertFalse(model.liveActivity.hasTurnWork, "settled rows replace the live rows, never both")
+        XCTAssertEqual(model.liveActivity.memoryNotes, ["Saved a memory"], "notes stay until the next turn starts")
+        XCTAssertNil(model.workStatus)
+        wire.onEvent?(typed(12, "message.start"))
+        XCTAssertTrue(model.liveActivity.memoryNotes.isEmpty)
+        model.suspend()
+    }
+
+    func testReplayRebuildsCurrentTurnActivityOnlyWhenTheRingHoldsIt() async {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire); await model.recover()
+        XCTAssertFalse(model.liveActivity.hasTurnWork)
+        // Continuous replay after a quiet socket: the missed events rebuild the rows.
+        wire.replay = BotFixtureWire.replay(latest: 2, events: [
+            typed(1, "tool.start", .object(["tool_id": .string("t1"), "name": .string("terminal")])),
+            typed(2, "tool.complete", .object(["tool_id": .string("t1"), "name": .string("terminal"), "result": .string("ok")]))
+        ])
+        await model.recover()
+        XCTAssertFalse(model.replayWasReset)
+        XCTAssertEqual(model.liveActivity.toolCalls.map(\.isCompleted), [true])
+        // A truncated ring that still holds the turn's start rebuilds from that start only.
+        wire.replay = BotFixtureWire.replay(latest: 6, truncated: true, events: [
+            typed(4, "tool.start", .object(["tool_id": .string("old"), "name": .string("terminal")])),
+            typed(5, "message.start"),
+            typed(6, "tool.start", .object(["tool_id": .string("new"), "name": .string("read_file")]))
+        ])
+        await model.recover()
+        XCTAssertTrue(model.replayWasReset)
+        XCTAssertEqual(model.liveActivity.toolCalls.map(\.id), ["new"])
+        // Truncated without the start: partial rows are dropped rather than shown.
+        wire.replay = BotFixtureWire.replay(latest: 8, truncated: true, events: [
+            typed(8, "tool.start", .object(["tool_id": .string("partial"), "name": .string("terminal")]))
+        ])
+        await model.recover()
+        XCTAssertTrue(model.replayWasReset)
+        XCTAssertFalse(model.liveActivity.hasTurnWork)
+        // Duplicate sequence numbers in a replay never duplicate rows.
+        wire.replay = BotFixtureWire.replay(latest: 10, events: [
+            typed(9, "tool.start", .object(["tool_id": .string("t9"), "name": .string("terminal")])),
+            typed(9, "tool.start", .object(["tool_id": .string("t9"), "name": .string("terminal")])),
+            typed(10, "tool.start", .object(["tool_id": .string("t10"), "name": .string("terminal")]))
+        ])
+        await model.recover()
+        XCTAssertFalse(model.replayWasReset)
+        XCTAssertEqual(model.liveActivity.toolCalls.map(\.id), ["t9", "t10"])
+        model.suspend()
+    }
+
+    func testSnapshotPlanIsRevisionMonotonic() async {
+        let wire = BotFixtureWire()
+        wire.todoState = .object(["revision": .number(5), "todos": .array([.object(["id": .string("a"), "content": .string("Ship"), "status": .string("pending")])])])
+        let model = make(wire); await model.recover()
+        XCTAssertEqual(model.plan?.revision, 5)
+        wire.todoState = .object(["revision": .number(4), "todos": .array([.object(["id": .string("b"), "content": .string("Older"), "status": .string("pending")])])])
+        await model.recover()
+        XCTAssertEqual(model.plan?.items.map(\.content), ["Ship"])
+        model.suspend()
+    }
+
     func testLongInflightResponseRemainsVisibleAtLatestEdge() async throws {
         let wire = BotFixtureWire()
         wire.running = true
@@ -387,6 +503,7 @@ actor BotMemoryDrafts: ChatDraftPersisting {
     var running = false
     var inflight = BotJSON.null
     var attention = false
+    var todoState = BotJSON.null
     var history: [BotJSON] = [.object(["role": .string("assistant"), "text": .string("saved")])]
     var replay = BotFixtureWire.replay()
     var lookupFailure: BotFailure?
@@ -413,6 +530,7 @@ actor BotMemoryDrafts: ChatDraftPersisting {
             return .object([
                 "session_id": .string("runtime"), "session_key": .string(tip), "running": .bool(running),
                 "messages": .array(history), "inflight": inflight, "pending_approval": attention ? .object(["id": .string("approval")]) : .null,
+                "todo_state": todoState,
                 "info": .object(["profile_name": .string("inbox-triage")])
             ])
         case "session.events.since": return replay

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -43,6 +43,27 @@ Markdown rendering without token reveal animations. The deferred streaming
 renderer can leave a growing Bot response's trailing viewport blank; an XCTest
 renders evolving snapshots and checks the actual visible output.
 
+Activity comes from two sources that never overlap. The full snapshot's
+`messages` rows already carry settled tool rows (`role: tool` with `name`,
+`context`, `args`) and assistant `reasoning`; `BotTranscriptProjection` turns
+them into `BotSettledActivity` anchored to the message each block precedes,
+keeping the `<root>/<row index>` identity. The live turn reduces gateway events
+in `BotTurnActivity`: `tool.start`/`tool.complete` keyed by `tool_id`,
+`thinking.delta`/`reasoning.delta`/`reasoning.available`, keyed
+`notification.show`/`clear`, and `review.summary` memory notes, bounded to 64
+rows, 32 KB of reasoning and 8 notices. `todo.updated` and the snapshot's
+`todo_state` feed a revision-monotonic `BotPlan`; `status.update` feeds
+`workStatus`. Activity events during known work update local state without a
+snapshot read. Replay rebuilds the current turn's rows when the sequence is
+continuous, or from the last `message.start` the ring still holds; otherwise the
+live rows are dropped and the next full snapshot shows the settled ones, so
+overlap never duplicates a card. Presentation reuses the Sessions log rows
+(`ReasoningBlockView`, `ToolActivityGroupView`, `TranscriptLogRowView`) and the
+global Chat display toggles; the plan row stays visible with cards off. Tool
+output is text only. `message.react` and `learning.frames` are deliberately
+not wired: the snapshot carries no reactions to show back, and the frames are
+terminal-sized renders.
+
 Bot drafts extend `ChatDraftStore` with server + connection UUID + Profile context.
 Before sending, the client flushes an unresolved marker to disk. An acknowledged
 send consumes the draft; explicit admission failures preserve its text. An


### PR DESCRIPTION
## Linked issue

Fixes #475

## What changed

Bot chat showed only user and assistant text; tool calls, model-supplied reasoning, plan progress, notices and memory notes were invisible, so an operator on the phone could not tell what the bot was doing.

Bot chat now renders the same log rows Sessions uses (thinking row, dense tool rows with `+N previous tool calls`, expand and long-press copy), plus a Plan row and notices above the composer. Variant A from the maintainer-selected mocks.

- **Settled turns** come from the resume snapshot, which already carries `role: tool` rows (`name`, `context`, `args`) and assistant `reasoning`. `BotTranscriptProjection` anchors them to the message they precede, keeping the `<root>/<row index>` identity.
- **Live turns** reduce gateway events in a bounded `BotTurnActivity`: `tool.start`/`tool.complete` keyed by `tool_id`, `thinking.delta`/`reasoning.delta`/`reasoning.available`, keyed `notification.show`/`clear`, `review.summary` memory notes (64 rows, 32 KB reasoning, 8 notices). `todo.updated` and `todo_state` feed a revision-monotonic `BotPlan`; `status.update` feeds the working label. Activity events during known work update local state without a snapshot read.
- **Replay** rebuilds the current turn when the sequence is continuous, or from the last `message.start` the ring still holds; otherwise the live rows are dropped and the next full snapshot shows the settled ones, so overlap never duplicates a card.
- Display follows the existing global Chat toggles (Thinking and Tool Cards, expand defaults); the Plan row stays visible with cards off. Tool output is text only.
- Deliberately not wired: `message.react` (the snapshot carries no reactions to show back, a one-way door) and `learning.frames` (terminal-sized renders).

Contract verified against hermes-agent `ee35a46` (0.21.1): `tui_gateway/tool_progress.py` (tool.start:191, tool.complete:211, todo.updated:244, reasoning.available:261), `agent_callbacks.py` (thinking.delta:93, notification.show:100), `server.py` (status.update:688, review.summary:931), `session_history.py:181` (`_history_to_messages` tool rows and reasoning), `event_replay.py` (512-event ring, `truncated`).

## How it was tested

- Full suite: `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17' -parallel-testing-enabled NO` → TEST SUCCEEDED, 2384 passed, 0 failed, 2 pre-existing skips.
- New focused tests: `BotActivityTests` (tool lifecycle without duplicates, error envelopes, missing/unknown fields, bounds, notices, plan parsing, snapshot projection with stable ids), `BotConversationTests` (long growing response with interleaved tool events that settles without duplicate rows and without extra snapshot reads, replay overlap/truncation/duplicate seq, plan revision), `BotChatPresentationTests` (rows render and follow the cards setting). Reduce Motion is covered at the `ChatMotion` helper level the reused rows go through; the Bot views add no motion of their own.
- Signed Debug build installed and launched on iPhone 17 via `build_run_sim`.
- Maintainer gate (#471): reconnect and replay proven on a physical iPhone through the Cloudflare tunnel after backgrounding past the idle timeout, 2026-09-11.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

Model and harness: Claude Fable 5.1, Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
