### PR TITLE
feat(bots): answer approvals, questions and credential prompts from the phone

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A712D3AE91645C9B8C27745 /* BotConnection.swift */; };
 		A4730000000000000000A001 /* BotAvatarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4730000000000000000A002 /* BotAvatarStore.swift */; };
 		A4750000000000000000B001 /* BotActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B002 /* BotActivity.swift */; };
+		A4750000000000000000B0A1 /* BotPendingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B0A2 /* BotPendingRequest.swift */; };
 		A4750000000000000000B003 /* BotActivityViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B004 /* BotActivityViews.swift */; };
 		C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */; };
 		013E4253ACC0484FA59DC45F /* BotConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */; };
@@ -437,6 +438,7 @@
 		A27FAACA0A9243C5AD4860BB /* BotClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2EA5336E9B431489F91A63 /* BotClient.swift */; };
 		A990ABE1D2654992AD262B77 /* BotProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5619C4EB852849D396C45F95 /* BotProtocol.swift */; };
 		9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */; };
+		9510188AE84E41D9BAE025FA /* BotPendingRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D7A /* BotPendingRequestTests.swift */; };
 		142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */; };
 		A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000002 /* BotModeGateTests.swift */; };
 		A496B07E0000000000000003 /* BotConnectionVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000004 /* BotConnectionVersionTests.swift */; };
@@ -907,6 +909,7 @@
 		0A712D3AE91645C9B8C27745 /* BotConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnection.swift"; sourceTree = "<group>"; };
 		A4730000000000000000A002 /* BotAvatarStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotAvatarStore.swift"; sourceTree = "<group>"; };
 		A4750000000000000000B002 /* BotActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotActivity.swift"; sourceTree = "<group>"; };
+		A4750000000000000000B0A2 /* BotPendingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotPendingRequest.swift"; sourceTree = "<group>"; };
 		A4750000000000000000B004 /* BotActivityViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotActivityViews.swift"; sourceTree = "<group>"; };
 		40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnectionView.swift"; sourceTree = "<group>"; };
 		9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConversation.swift"; sourceTree = "<group>"; };
@@ -914,6 +917,7 @@
 		BF2EA5336E9B431489F91A63 /* BotClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotClient.swift"; sourceTree = "<group>"; };
 		5619C4EB852849D396C45F95 /* BotProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotProtocol.swift"; sourceTree = "<group>"; };
 		0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotConversationTests.swift"; sourceTree = "<group>"; };
+		0B077A87C9D846D7A9D27D7A /* BotPendingRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotPendingRequestTests.swift"; sourceTree = "<group>"; };
 		EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotDraftTests.swift"; sourceTree = "<group>"; };
 		A496B07E0000000000000002 /* BotModeGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotModeGateTests.swift; sourceTree = "<group>"; };
 		A496B07E0000000000000004 /* BotConnectionVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotConnectionVersionTests.swift; sourceTree = "<group>"; };
@@ -1031,6 +1035,7 @@
 				A4730000000000000000A004 /* BotAvatarTests.swift */,
 				A4750000000000000000B006 /* BotActivityTests.swift */,
 				0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */,
+				0B077A87C9D846D7A9D27D7A /* BotPendingRequestTests.swift */,
 				C28702000000000000000004 /* ChatDraftStoreTests.swift */,
 				C28702000000000000000008 /* ChatDraftAttachmentStoreTests.swift */,
 				10CA110C0DE000000000C002 /* LocalizationCatalogTests.swift */,
@@ -1254,6 +1259,7 @@
 				0A712D3AE91645C9B8C27745 /* BotConnection.swift */,
 				A4730000000000000000A002 /* BotAvatarStore.swift */,
 				A4750000000000000000B002 /* BotActivity.swift */,
+				A4750000000000000000B0A2 /* BotPendingRequest.swift */,
 				A4750000000000000000B004 /* BotActivityViews.swift */,
 				27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */,
 				1A2B3C4D5E6F7000000000C4 /* Onboarding */,
@@ -1848,6 +1854,7 @@
 				13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */,
 				A4730000000000000000A001 /* BotAvatarStore.swift in Sources */,
 				A4750000000000000000B001 /* BotActivity.swift in Sources */,
+				A4750000000000000000B0A1 /* BotPendingRequest.swift in Sources */,
 				A4750000000000000000B003 /* BotActivityViews.swift in Sources */,
 				E8812D2097AF431094460471 /* BotChatView.swift in Sources */,
 				1A2B3C4D5E6F700000000001 /* HermesMobileApp.swift in Sources */,
@@ -2126,6 +2133,7 @@
 				A4730000000000000000A003 /* BotAvatarTests.swift in Sources */,
 				A4750000000000000000B005 /* BotActivityTests.swift in Sources */,
 				9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */,
+				9510188AE84E41D9BAE025FA /* BotPendingRequestTests.swift in Sources */,
 				10CA110C0DE000000000C001 /* LocalizationCatalogTests.swift in Sources */,
 				1A2B3C4D5E6F7000000000AC /* APIClientTests.swift in Sources */,
 				B5A1000000000000000000A0 /* ServerRegistryTests.swift in Sources */,

--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		A04200000000000000000003 /* ApprovalRequestOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04200000000000000000004 /* ApprovalRequestOverlay.swift */; };
 		C1A042000000000000000001 /* Clarification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000002 /* Clarification.swift */; };
 		C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000004 /* ClarificationRequestCard.swift */; };
+		C1A0420000000000000000A3 /* PendingRequestSurfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0420000000000000000A4 /* PendingRequestSurfaces.swift */; };
 		C1A042000000000000000005 /* ClarificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A042000000000000000006 /* ClarificationTests.swift */; };
 		A02400000000000000000001 /* Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02400000000000000000002 /* Goal.swift */; };
 		C04600000000000000000001 /* ChatStreamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04600000000000000000002 /* ChatStreamCoordinator.swift */; };
@@ -430,6 +431,7 @@
 		13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A712D3AE91645C9B8C27745 /* BotConnection.swift */; };
 		A4730000000000000000A001 /* BotAvatarStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4730000000000000000A002 /* BotAvatarStore.swift */; };
 		A4750000000000000000B001 /* BotActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B002 /* BotActivity.swift */; };
+		A4750000000000000000B0A3 /* BotPendingRequestCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B0A4 /* BotPendingRequestCard.swift */; };
 		A4750000000000000000B0A1 /* BotPendingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B0A2 /* BotPendingRequest.swift */; };
 		A4750000000000000000B003 /* BotActivityViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4750000000000000000B004 /* BotActivityViews.swift */; };
 		C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */; };
@@ -616,6 +618,7 @@
 		A04200000000000000000004 /* ApprovalRequestOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequestOverlay.swift; sourceTree = "<group>"; };
 		C1A042000000000000000002 /* Clarification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clarification.swift; sourceTree = "<group>"; };
 		C1A042000000000000000004 /* ClarificationRequestCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationRequestCard.swift; sourceTree = "<group>"; };
+		C1A0420000000000000000A4 /* PendingRequestSurfaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingRequestSurfaces.swift; sourceTree = "<group>"; };
 		C1A042000000000000000006 /* ClarificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClarificationTests.swift; sourceTree = "<group>"; };
 		A02400000000000000000002 /* Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Goal.swift; sourceTree = "<group>"; };
 		C04600000000000000000002 /* ChatStreamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamCoordinator.swift; sourceTree = "<group>"; };
@@ -909,6 +912,7 @@
 		0A712D3AE91645C9B8C27745 /* BotConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnection.swift"; sourceTree = "<group>"; };
 		A4730000000000000000A002 /* BotAvatarStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotAvatarStore.swift"; sourceTree = "<group>"; };
 		A4750000000000000000B002 /* BotActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotActivity.swift"; sourceTree = "<group>"; };
+		A4750000000000000000B0A4 /* BotPendingRequestCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotPendingRequestCard.swift"; sourceTree = "<group>"; };
 		A4750000000000000000B0A2 /* BotPendingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotPendingRequest.swift"; sourceTree = "<group>"; };
 		A4750000000000000000B004 /* BotActivityViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotActivityViews.swift"; sourceTree = "<group>"; };
 		40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotConnectionView.swift"; sourceTree = "<group>"; };
@@ -1259,6 +1263,7 @@
 				0A712D3AE91645C9B8C27745 /* BotConnection.swift */,
 				A4730000000000000000A002 /* BotAvatarStore.swift */,
 				A4750000000000000000B002 /* BotActivity.swift */,
+				A4750000000000000000B0A4 /* BotPendingRequestCard.swift */,
 				A4750000000000000000B0A2 /* BotPendingRequest.swift */,
 				A4750000000000000000B004 /* BotActivityViews.swift */,
 				27E21E4E9C8B44DFA6B8DFFB /* BotChatView.swift */,
@@ -1375,6 +1380,7 @@
 				105050000000000000000002 /* ComposerModelPickerSectionExpansionState.swift */,
 				A04200000000000000000004 /* ApprovalRequestOverlay.swift */,
 				C1A042000000000000000004 /* ClarificationRequestCard.swift */,
+				C1A0420000000000000000A4 /* PendingRequestSurfaces.swift */,
 				1A2B3C4D5E6F7000000000D9 /* MessageBubbleView.swift */,
 				C03190000000000000F002 /* InlineAudioPlayerView.swift */,
 				BEEF02400000000000000002 /* ChatAttachmentPreviewView.swift */,
@@ -1854,6 +1860,7 @@
 				13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */,
 				A4730000000000000000A001 /* BotAvatarStore.swift in Sources */,
 				A4750000000000000000B001 /* BotActivity.swift in Sources */,
+				A4750000000000000000B0A3 /* BotPendingRequestCard.swift in Sources */,
 				A4750000000000000000B0A1 /* BotPendingRequest.swift in Sources */,
 				A4750000000000000000B003 /* BotActivityViews.swift in Sources */,
 				E8812D2097AF431094460471 /* BotChatView.swift in Sources */,
@@ -2071,6 +2078,7 @@
 				A04200000000000000000003 /* ApprovalRequestOverlay.swift in Sources */,
 				C1A042000000000000000001 /* Clarification.swift in Sources */,
 				C1A042000000000000000003 /* ClarificationRequestCard.swift in Sources */,
+				C1A0420000000000000000A3 /* PendingRequestSurfaces.swift in Sources */,
 				A02400000000000000000001 /* Goal.swift in Sources */,
 				D600000000000000000002 /* CronRunHistory.swift in Sources */,
 				D6000000000000000000A2 /* CronRecentCompletion.swift in Sources */,

--- a/HermesMobile/Features/Bots/BotChatComposerView.swift
+++ b/HermesMobile/Features/Bots/BotChatComposerView.swift
@@ -7,6 +7,8 @@ struct BotChatComposerView: View {
     let onStop: () -> Void
     let onReconnect: () -> Void
     let onResolveHeldMessage: () -> Void
+    /// Scrolls the transcript back to the pending request card.
+    let onShowRequest: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -34,7 +36,10 @@ struct BotChatComposerView: View {
     var body: some View {
         AdaptiveGlassContainer(spacing: 6) {
             VStack(spacing: 0) {
-                BotChatStatusView(model: model, onReconnect: onReconnect, onResolveHeldMessage: onResolveHeldMessage)
+                BotChatStatusView(
+                    model: model, onReconnect: onReconnect,
+                    onResolveHeldMessage: onResolveHeldMessage, onShowRequest: onShowRequest
+                )
 
                 HStack(alignment: .center, spacing: 4) {
                     ComposerTextInputView(
@@ -118,6 +123,7 @@ private struct BotChatStatusView: View {
     let model: BotConversation
     let onReconnect: () -> Void
     let onResolveHeldMessage: () -> Void
+    let onShowRequest: () -> Void
 
     var body: some View {
         if model.connectionState != .connected || model.turn != .idle || model.errorMessage != nil || model.uncertainSend
@@ -137,9 +143,22 @@ private struct BotChatStatusView: View {
                         Button("Resolve held message…", action: onResolveHeldMessage)
                     }
                 } else if model.turn == .needsAttention {
-                    // The model ranks a pending request above an unresolved Stop;
-                    // the Desktop instruction is the actionable line, so it wins here too.
-                    Text("Needs attention. Answer the request in Hermes Desktop on this same connection.")
+                    // The model ranks a pending request above an unresolved Stop, so
+                    // the actionable line wins here too. The card is in the transcript
+                    // and may be scrolled away, so this doubles as the way back to it.
+                    if model.pendingRequest != nil {
+                        Button(action: onShowRequest) {
+                            Label(
+                                model.pendingRequest?.isAnswerable == true
+                                    ? String(localized: "Waiting for your answer")
+                                    : String(localized: "Needs attention in Hermes Desktop"),
+                                systemImage: "arrow.down.circle"
+                            )
+                        }
+                    } else {
+                        // A request the phone cannot address has no card to show.
+                        Text("Needs attention. Answer the request in Hermes Desktop on this same connection.")
+                    }
                 } else if model.uncertainStop && model.turn != .stopping {
                     Text("Outcome unknown")
                 } else if model.connectionState == .connected, let turnText {

--- a/HermesMobile/Features/Bots/BotChatComposerView.swift
+++ b/HermesMobile/Features/Bots/BotChatComposerView.swift
@@ -148,12 +148,7 @@ private struct BotChatStatusView: View {
                     // and may be scrolled away, so this doubles as the way back to it.
                     if model.pendingRequest != nil {
                         Button(action: onShowRequest) {
-                            Label(
-                                model.pendingRequest?.isAnswerable == true
-                                    ? String(localized: "Waiting for your answer")
-                                    : String(localized: "Hermes Desktop is handling this"),
-                                systemImage: "arrow.down.circle"
-                            )
+                            Label(requestText, systemImage: "arrow.down.circle")
                         }
                     } else {
                         // A pending key the phone could not read has no card to show.
@@ -175,6 +170,15 @@ private struct BotChatStatusView: View {
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("bot-chat-status")
         }
+    }
+
+    /// What the blocked bot is waiting on. "Handling this" is only true where
+    /// there is nothing to do: a request the phone can answer or decline has an
+    /// action on its card, and saying it is handled would hide that.
+    private var requestText: String {
+        if model.pendingRequest?.isAnswerable == true { return String(localized: "Waiting for your answer") }
+        if model.mayDecline { return String(localized: "Waiting on Hermes Desktop") }
+        return String(localized: "Hermes Desktop is handling this")
     }
 
     private var connectionText: String? {

--- a/HermesMobile/Features/Bots/BotChatComposerView.swift
+++ b/HermesMobile/Features/Bots/BotChatComposerView.swift
@@ -151,12 +151,12 @@ private struct BotChatStatusView: View {
                             Label(
                                 model.pendingRequest?.isAnswerable == true
                                     ? String(localized: "Waiting for your answer")
-                                    : String(localized: "Needs attention in Hermes Desktop"),
+                                    : String(localized: "Hermes Desktop is handling this"),
                                 systemImage: "arrow.down.circle"
                             )
                         }
                     } else {
-                        // A request the phone cannot address has no card to show.
+                        // A pending key the phone could not read has no card to show.
                         Text("Needs attention. Answer the request in Hermes Desktop on this same connection.")
                     }
                 } else if model.uncertainStop && model.turn != .stopping {

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -63,6 +63,7 @@ import SwiftUI
                                 resolution: resolution(for: request),
                                 onApprove: approve, onAnswer: answer, onSkip: skip,
                                 onCredential: sendCredential,
+                                canDecline: model.mayDecline, onDecline: decline,
                                 onStop: { stopAction = model.prepareStop() }
                             )
                             .id(BotChatView.requestAnchor)
@@ -177,6 +178,11 @@ import SwiftUI
     private func sendCredential(_ value: String) {
         guard let action = model.prepareAnswer() else { return }
         Task { await model.answerCredential(action, value: value) }
+    }
+
+    private func decline() {
+        guard let action = model.prepareAnswer() else { return }
+        Task { await model.declineDesktopTask(action) }
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -58,7 +58,8 @@ import SwiftUI
                         if let request = model.pendingRequest {
                             BotPendingRequestCard(
                                 request: request, identity: identity,
-                                isEnabled: model.mayAnswer, isAnswering: model.answeringRequestID != nil,
+                                isEnabled: model.mayAnswer, canStop: model.mayStop,
+                                isAnswering: model.answeringRequestID != nil,
                                 resolution: resolution(for: request),
                                 onApprove: approve, onAnswer: answer, onSkip: skip,
                                 onStop: { stopAction = model.prepareStop() }

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
 @MainActor struct BotChatView: View {
+    /// Scroll anchor for the pending request card, so the status line can bring
+    /// the user back to it from anywhere in the transcript.
+    fileprivate static let requestAnchor = "bot-pending-request"
+
     @Environment(\.scenePhase) private var scenePhase
     @State private var model: BotConversation
     @State private var stopAction: BotConversation.StopAction?
@@ -8,6 +12,8 @@ import SwiftUI
     @State private var recoveryID = UUID()
     @State private var followsLatest = true
     @State private var isAtBottom = true
+    /// Bumped by the status line's Review action; the transcript scrolls on change.
+    @State private var showRequestID = UUID()
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(server: URL, connection: BotConnection, profile: BotProfile) {
@@ -47,6 +53,18 @@ import SwiftUI
                         if let plan = model.plan {
                             BotPlanRowView(plan: plan).id("bot-plan")
                         }
+                        // The blocking request sits where the work stopped, so the
+                        // command reads under the tool row that asked for it.
+                        if let request = model.pendingRequest {
+                            BotPendingRequestCard(
+                                request: request, identity: identity,
+                                isEnabled: model.mayAnswer, isAnswering: model.answeringRequestID != nil,
+                                resolution: resolution(for: request),
+                                onApprove: approve, onAnswer: answer, onSkip: skip,
+                                onStop: { stopAction = model.prepareStop() }
+                            )
+                            .id(BotChatView.requestAnchor)
+                        }
                         Color.clear.frame(height: 1).id("bot-transcript-bottom")
                     }
                     .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 20 : 16)
@@ -74,6 +92,13 @@ import SwiftUI
                 .onChange(of: model.liveActivity.toolCalls.count) { followLatest(proxy) }
                 .onChange(of: model.liveActivity.reasoning.count) { followLatest(proxy) }
                 .onChange(of: model.connectionState) { followLatest(proxy) }
+                // A request that needs the user wins over where they had scrolled.
+                .onChange(of: model.pendingRequest?.requestID) { _, id in
+                    guard id != nil else { return }
+                    followsLatest = true
+                    proxy.scrollTo(BotChatView.requestAnchor, anchor: .bottom)
+                }
+                .onChange(of: showRequestID) { proxy.scrollTo(BotChatView.requestAnchor, anchor: .bottom) }
                 .overlay(alignment: .bottomTrailing) {
                     if !followsLatest {
                         Button("Latest", systemImage: "arrow.down") {
@@ -118,6 +143,33 @@ import SwiftUI
         }
     }
 
+    /// Which bot on which connection, so two hosts with equal Profile names
+    /// never produce an anonymous card.
+    private var identity: String {
+        String(localized: "\(model.profile.name) on \(model.connection.name)")
+    }
+
+    /// The verdict for the request on screen, and only that one.
+    private func resolution(for request: BotPendingRequest) -> BotRequestResolution? {
+        guard let resolution = model.requestResolution, resolution.requestID == request.requestID else { return nil }
+        return resolution
+    }
+
+    private func approve(_ choice: BotApprovalRequest.Choice) {
+        guard let action = model.prepareAnswer() else { return }
+        Task { await model.respond(action, choice: choice) }
+    }
+
+    private func answer(_ answers: [BotQuestionAnswer]) {
+        guard let action = model.prepareAnswer() else { return }
+        Task { await model.answerQuestion(action, answers) }
+    }
+
+    private func skip() {
+        guard let action = model.prepareAnswer() else { return }
+        Task { await model.skipQuestion(action) }
+    }
+
     @ViewBuilder
     private func settledActivity(anchoredTo anchorID: String?) -> some View {
         ForEach(model.settledActivity.filter { $0.anchorMessageID == anchorID }) { activity in
@@ -136,7 +188,8 @@ import SwiftUI
             model: model,
             onStop: { stopAction = model.prepareStop() },
             onReconnect: { recoveryID = UUID() },
-            onResolveHeldMessage: { confirmingDiscard = true }
+            onResolveHeldMessage: { confirmingDiscard = true },
+            onShowRequest: { showRequestID = UUID() }
         )
     }
 }

--- a/HermesMobile/Features/Bots/BotChatView.swift
+++ b/HermesMobile/Features/Bots/BotChatView.swift
@@ -62,6 +62,7 @@ import SwiftUI
                                 isAnswering: model.answeringRequestID != nil,
                                 resolution: resolution(for: request),
                                 onApprove: approve, onAnswer: answer, onSkip: skip,
+                                onCredential: sendCredential,
                                 onStop: { stopAction = model.prepareStop() }
                             )
                             .id(BotChatView.requestAnchor)
@@ -169,6 +170,13 @@ import SwiftUI
     private func skip() {
         guard let action = model.prepareAnswer() else { return }
         Task { await model.skipQuestion(action) }
+    }
+
+    /// The typed value goes straight from the field to the dispatch. An empty
+    /// one is the Skip button, which the host reads as a decline.
+    private func sendCredential(_ value: String) {
+        guard let action = model.prepareAnswer() else { return }
+        Task { await model.answerCredential(action, value: value) }
     }
 
     @ViewBuilder

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -5,6 +5,10 @@ import Observation
     enum ConnectionState { case disconnected, recovering, connected }
     enum TurnState { case unknown, idle, submitting, running, needsAttention, stopping, uncertain, interrupted }
     struct StopAction: Equatable { let generation: Int; let revision: Int; let runtime: String }
+    /// The identity an answer is bound to, captured when the user taps and
+    /// revalidated at the socket write so a stale card cannot answer a newer
+    /// request or a replaced runtime.
+    struct AnswerAction: Equatable { let generation: Int; let runtime: String; let requestID: String }
 
     let profile: BotProfile
     let connection: BotConnection
@@ -27,6 +31,17 @@ import Observation
     private(set) var plan: BotPlan?
     /// `status.update` text while the bot works (compacting, compressing); nil once ready.
     private(set) var workStatus: String?
+    /// The approval or question from the last snapshot's `pending_approval` /
+    /// `pending_clarify`. Snapshot-owned, so an answer given in Desktop clears it
+    /// on the next read without the phone polling for it.
+    private(set) var blockingRequest: BotPendingRequest?
+    /// A request only Desktop can answer. These never appear in a snapshot, so
+    /// they live and die with the event stream.
+    private(set) var desktopOnlyRequest: BotDesktopOnlyRequest?
+    /// Set while an answer is in flight, to keep the card's controls inert.
+    private(set) var answeringRequestID: String?
+    /// The verdict on the request currently on screen, if it has one.
+    private(set) var requestResolution: BotRequestResolution?
     private var tip: String?
     private var generation = 0
     private var turnRevision = 0
@@ -60,6 +75,23 @@ import Observation
     }
 
     var mayEditDraft: Bool { hydrated && !uncertainSend && !localOperation }
+
+    /// The one request blocking this conversation. A clarify or approval wins over
+    /// a Desktop-only kind: it is the outer blocker and the only one the phone can clear.
+    var pendingRequest: BotPendingRequest? {
+        blockingRequest ?? desktopOnlyRequest.map(BotPendingRequest.desktopOnly)
+    }
+
+    /// True when the user may answer the request on screen. A resolved or expired
+    /// request stays inert; an uncertain one is answerable again once reconnected,
+    /// because a second deliberate tap is the user's decision, not an automatic replay.
+    var mayAnswer: Bool {
+        guard connectionState == .connected, !localOperation, answeringRequestID == nil,
+              let request = pendingRequest, request.isAnswerable,
+              let id = request.requestID else { return false }
+        if let resolution = requestResolution, resolution.requestID == id { return !resolution.blocksFurtherAnswers }
+        return true
+    }
 
     func editDraft(_ text: String) {
         guard mayEditDraft else { return }
@@ -164,7 +196,7 @@ import Observation
     private func applyActivity(type: String, payload: BotJSON) -> Bool {
         switch type {
         case "message.start":
-            liveActivity = BotTurnActivity(); workStatus = nil
+            liveActivity = BotTurnActivity(); workStatus = nil; desktopOnlyRequest = nil
             return false
         case "todo.updated":
             if let next = BotPlan(payload), next.revision >= (plan?.revision ?? 0) { plan = next }
@@ -200,11 +232,16 @@ import Observation
         }
         if !running {
             uncertainStop = false; stopAcknowledged = false; workStatus = nil
+            desktopOnlyRequest = nil
             // Only a full snapshot carries the settled rows, so live rows wait for it
             // instead of vanishing on the inflight read that first reports idle.
             if full { liveActivity.clearTurnWork() }
         }
-        let attention = snapshot["pending_approval"] != .null || snapshot["pending_clarify"] != .null
+        applyPendingRequest(snapshot)
+        // A request the phone cannot address still blocks the bot. Claiming the
+        // turn is running would be the lie; attention without a card is the truth.
+        let attention = pendingRequest != nil
+            || snapshot["pending_approval"] != .null || snapshot["pending_clarify"] != .null
         let continuation = snapshot["auto_continue"] != .null && snapshot["auto_continue"].flag != false
         let queued = snapshot["queued"] != .null
         if attention { turn = .needsAttention }
@@ -214,6 +251,21 @@ import Observation
         else if running || continuation || queued { turn = .running }
         else if inflight["error"] != .null || snapshot["status"].text == "interrupted" { turn = .interrupted }
         else { turn = .idle }
+    }
+
+    /// Installs the snapshot's pending approval or question. A clarify outranks an
+    /// approval because approvals resolve inside a tool batch while a clarify blocks
+    /// the whole turn. A different request id drops the previous request's verdict
+    /// so a new card is never born inert.
+    private func applyPendingRequest(_ snapshot: BotJSON) {
+        let question = BotQuestionRequest(snapshot["pending_clarify"]).map(BotPendingRequest.question)
+        let approval = BotApprovalRequest(snapshot["pending_approval"]).map(BotPendingRequest.approval)
+        let next = question ?? approval
+        if next?.requestID != blockingRequest?.requestID {
+            answeringRequestID = nil
+            if requestResolution?.requestID != next?.requestID { requestResolution = nil }
+        }
+        blockingRequest = next
     }
 
     func send() async {
@@ -294,6 +346,113 @@ import Observation
         }
     }
 
+    /// Captures what an answer is validated against, or nil when the request on
+    /// screen cannot be answered right now.
+    func prepareAnswer() -> AnswerAction? {
+        guard mayAnswer, let runtime, let id = pendingRequest?.requestID else { return nil }
+        return AnswerAction(generation: generation, runtime: runtime, requestID: id)
+    }
+
+    /// Answers a command approval with one of the choices the host itself offered.
+    func respond(_ action: AnswerAction, choice: BotApprovalRequest.Choice) async {
+        guard case .approval(let request)? = pendingRequest, request.requestID == action.requestID,
+              request.choices.contains(choice), action == prepareAnswer() else { return }
+        await deliver(action) {
+            let reply = try await self.request("approval.respond", [
+                "session_id": .string(action.runtime), "request_id": .string(action.requestID),
+                "choice": .string(choice.rawValue)
+            ], owner: action.generation, validateDispatch: self.answerGuard(action))
+            // `resolved` counts what the host actually unblocked. Zero means the
+            // queue no longer held this request: an action failure, not a delivery one.
+            return (reply["resolved"].integer ?? 0) > 0 ? .answered : .alreadyResolved
+        }
+    }
+
+    /// Answers a clarify question. A batch sends one `clarify.respond` per question
+    /// id in order; the host locks each answer and the last one releases the turn.
+    func answerQuestion(_ action: AnswerAction, _ answers: [BotQuestionAnswer]) async {
+        guard case .question(let request)? = pendingRequest, request.requestID == action.requestID,
+              !answers.isEmpty, action == prepareAnswer() else { return }
+        let offered = Set(request.questions.compactMap(\.wireID))
+        guard answers.allSatisfy({ answer in
+            answer.questionID.map(offered.contains) ?? !request.isBatch
+        }) else { return }
+        await dispatchAnswers(answers, for: action)
+    }
+
+    /// Declines to answer, the way Desktop's cancel does: one unkeyed empty answer
+    /// releases the whole request, batch or not. It is a real answer, so it is
+    /// deliberate and never automatic.
+    func skipQuestion(_ action: AnswerAction) async {
+        guard case .question(let request)? = pendingRequest, request.requestID == action.requestID,
+              action == prepareAnswer() else { return }
+        await dispatchAnswers([BotQuestionAnswer(questionID: nil, text: "")], for: action)
+    }
+
+    private func dispatchAnswers(_ answers: [BotQuestionAnswer], for action: AnswerAction) async {
+        await deliver(action) {
+            for answer in answers {
+                var params: [String: BotJSON] = [
+                    "request_id": .string(action.requestID), "answer": .string(answer.text)
+                ]
+                if let id = answer.questionID { params["question_id"] = .string(id) }
+                let reply = try await self.request("clarify.respond", params, owner: action.generation,
+                                                   validateDispatch: self.answerGuard(action))
+                // A late answer to a prompt the host already dropped comes back as
+                // `expired`; nothing was locked, so the rest have nothing to lock either.
+                if reply["status"].text == "expired" { return .alreadyResolved }
+            }
+            return .answered
+        }
+    }
+
+    /// Revalidates at the socket write, after any executor delay: the same
+    /// connection, the same runtime, and still the same request on screen.
+    private func answerGuard(_ action: AnswerAction) -> () throws -> Void {
+        { [weak self] in
+            guard let self else { throw BotFailure.stale }
+            try self.check(action.generation)
+            guard self.runtime == action.runtime,
+                  self.pendingRequest?.requestID == action.requestID else { throw BotFailure.stale }
+        }
+    }
+
+    /// Runs one answer dispatch under the rules every request kind shares. The
+    /// closure returns the host's verdict; a throw is a delivery problem, and only
+    /// a lost socket leaves the outcome unknown.
+    private func deliver(_ action: AnswerAction,
+                         _ dispatch: () async throws -> BotRequestResolution.Outcome) async {
+        localOperation = true
+        answeringRequestID = action.requestID
+        errorMessage = nil
+        do {
+            let outcome = try await dispatch()
+            guard action.generation == generation, !Task.isCancelled else { return }
+            localOperation = false; answeringRequestID = nil
+            requestResolution = BotRequestResolution(requestID: action.requestID, outcome: outcome)
+            // The host owns what happens next; read the snapshot instead of
+            // assuming the turn resumed.
+            turnRevision += 1
+            turn = .unknown
+            fullSnapshotNeeded = true; snapshotDirty = true; scheduleRefresh()
+        } catch {
+            guard action.generation == generation, !Task.isCancelled else { return }
+            localOperation = false; answeringRequestID = nil
+            // A stale action is rejected before the write, so nothing is in doubt.
+            if error as? BotFailure == .stale { return }
+            if case BotFailure.rejected(let code) = error {
+                // The host replied over a live socket, so the answer definitively
+                // did not take effect and the connection is still usable.
+                errorMessage = [401, 403, -32601].contains(code)
+                    ? BotFailure.rejected(code).localizedDescription
+                    : String(localized: "The bot could not accept that answer. Check this bot in Desktop.")
+                return
+            }
+            requestResolution = BotRequestResolution(requestID: action.requestID, outcome: .uncertain)
+            disconnected(error)
+        }
+    }
+
     /// Explicitly discard a held ambiguous prompt after the user checks Desktop.
     /// The old text is never restored to the sendable composer.
     func discardUncertainSubmission() async {
@@ -319,7 +478,7 @@ import Observation
         guard let next = event["seq"].integer, next > 0 else {
             replayWasReset = true; snapshotDirty = true; fullSnapshotNeeded = true
             turnRevision += 1
-            liveActivity = BotTurnActivity()
+            liveActivity = BotTurnActivity(); desktopOnlyRequest = nil
             if !localOperation { turn = .unknown }
             scheduleRefresh(); return
         }
@@ -327,17 +486,20 @@ import Observation
         let discontinuity = next != sequence + 1
         if discontinuity {
             replayWasReset = true; fullSnapshotNeeded = true; turnRevision += 1
-            // Missed events may hold tool rows or a notice's clear; partial or stale
-            // activity is worse than none.
-            liveActivity = BotTurnActivity()
+            // Missed events may hold tool rows, a notice's clear or a Desktop-only
+            // request's expiry; partial or stale state is worse than none.
+            liveActivity = BotTurnActivity(); desktopOnlyRequest = nil
             if !localOperation { turn = .unknown }
         }
         sequence = next
         let type = event["type"].text ?? ""
+        let desktopOnlyChanged = applyDesktopOnly(type: type, payload: event["payload"])
         // Activity events never change the inflight text, so a continuous stream
         // during known work updates local state without another snapshot read.
-        if applyActivity(type: type, payload: event["payload"]), !discontinuity, turn == .running { return }
-        if ["message.start", "message.complete", "session.info", "error", "approval.request", "clarify.request"].contains(type) {
+        if !desktopOnlyChanged, applyActivity(type: type, payload: event["payload"]),
+           !discontinuity, turn == .running { return }
+        if desktopOnlyChanged
+            || ["message.start", "message.complete", "session.info", "error", "approval.request", "clarify.request"].contains(type) {
             turnRevision += 1
             fullSnapshotNeeded = true
             // Current state is pending reconciliation; don't dispatch new work.
@@ -346,6 +508,22 @@ import Observation
         if type == "message.delta", !discontinuity, !localOperation, !uncertainSend, !uncertainStop { turn = .running }
         snapshotDirty = true
         scheduleRefresh()
+    }
+
+    /// Tracks the Desktop-only request the event stream is announcing or tearing
+    /// down. These never reach a resume snapshot, so the stream is the only record
+    /// of them; returns true when the current one changed.
+    private func applyDesktopOnly(type: String, payload: BotJSON) -> Bool {
+        if let request = BotDesktopOnlyRequest.requested(eventType: type, payload: payload) {
+            guard desktopOnlyRequest != request else { return false }
+            desktopOnlyRequest = request
+            return true
+        }
+        if let kind = BotDesktopOnlyRequest.expired(eventType: type), desktopOnlyRequest?.kind == kind {
+            desktopOnlyRequest = nil
+            return true
+        }
+        return false
     }
 
     private func scheduleRefresh() {
@@ -377,6 +555,9 @@ import Observation
     private func disconnected(_ error: Error) {
         wire.close()
         refreshTask?.cancel(); refreshTask = nil
+        // A Desktop-only request lives only in the stream, so a lost socket makes
+        // its state unknowable. The card goes rather than lying about it.
+        desktopOnlyRequest = nil; answeringRequestID = nil
         connectionState = .disconnected
         turn = uncertainSend || uncertainStop ? .uncertain : .unknown
         turnRevision += 1
@@ -388,6 +569,7 @@ import Observation
         refreshTask?.cancel(); refreshTask = nil
         wire.close()
         localOperation = false
+        desktopOnlyRequest = nil; answeringRequestID = nil
         connectionState = .disconnected; turn = .unknown
         Task { try? await drafts.flush() }
     }

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -83,13 +83,26 @@ import Observation
         blockingRequest ?? streamRequest?.pending
     }
 
-    /// True when the user may answer the request on screen. A resolved or expired
-    /// request stays inert; an uncertain one is answerable again once reconnected,
-    /// because a second deliberate tap is the user's decision, not an automatic replay.
+    /// True when the user may answer the request on screen.
     var mayAnswer: Bool {
+        guard let request = pendingRequest, request.isAnswerable else { return false }
+        return mayDispatchAnswer(for: request.requestID)
+    }
+
+    /// True when the request on screen can be called off from here. Separate
+    /// from `mayAnswer`: a Desktop task is never answerable, but the one kind
+    /// with a person in the loop can still be declined rather than waited out.
+    var mayDecline: Bool {
+        guard case .desktopTask(let task)? = pendingRequest, task.kind.isDeclinable else { return false }
+        return mayDispatchAnswer(for: task.requestID)
+    }
+
+    /// A resolved or expired request stays inert; an uncertain one is actionable
+    /// again once reconnected, because a second deliberate tap is the user's
+    /// decision, not an automatic replay.
+    private func mayDispatchAnswer(for requestID: String?) -> Bool {
         guard connectionState == .connected, !localOperation, answeringRequestID == nil,
-              let request = pendingRequest, request.isAnswerable,
-              let id = request.requestID else { return false }
+              let id = requestID else { return false }
         if let resolution = requestResolution, resolution.requestID == id { return !resolution.blocksFurtherAnswers }
         return true
     }
@@ -347,10 +360,10 @@ import Observation
         }
     }
 
-    /// Captures what an answer is validated against, or nil when the request on
-    /// screen cannot be answered right now.
+    /// Captures what an answer or a decline is validated against, or nil when
+    /// the request on screen cannot be acted on right now.
     func prepareAnswer() -> AnswerAction? {
-        guard mayAnswer, let runtime, let id = pendingRequest?.requestID else { return nil }
+        guard mayAnswer || mayDecline, let runtime, let id = pendingRequest?.requestID else { return nil }
         return AnswerAction(generation: generation, runtime: runtime, requestID: id)
     }
 
@@ -412,6 +425,21 @@ import Observation
     /// the honest outcome and far better than parking the bot until it times out.
     func skipCredential(_ action: AnswerAction) async {
         await answerCredential(action, value: "")
+    }
+
+    /// Calls off a Desktop task the phone cannot answer but can decline. The
+    /// host reads `declined` as a final no and its tool is told never to re-ask,
+    /// so the bot moves on now instead of parking for the full deadline.
+    func declineDesktopTask(_ action: AnswerAction) async {
+        guard case .desktopTask(let task)? = pendingRequest, task.requestID == action.requestID,
+              task.kind.isDeclinable, action == prepareAnswer() else { return }
+        await deliver(action) {
+            let reply = try await self.request(task.kind.respondMethod, [
+                "request_id": .string(action.requestID),
+                "result": .string(BotDesktopTaskRequest.declinedResult)
+            ], owner: action.generation, validateDispatch: self.answerGuard(action))
+            return reply["status"].text == "expired" ? .alreadyResolved : .answered
+        }
     }
 
     private func dispatchAnswers(_ answers: [BotQuestionAnswer], for action: AnswerAction) async {

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -201,7 +201,14 @@ import Observation
             }
             missed.removeFirst(start)
         }
-        for event in missed { applyActivity(type: event["type"].text ?? "", payload: event["payload"]) }
+        for event in missed {
+            let type = event["type"].text ?? ""
+            // Credential and Desktop-task prompts reach no snapshot, so while the
+            // ring still holds them replay is the only way back to one after a
+            // reconnect. Dropping them here left a blocked bot looking idle.
+            if applyStreamRequest(type: type, payload: event["payload"]) { continue }
+            applyActivity(type: type, payload: event["payload"])
+        }
     }
 
     /// Feeds activity events to the live reducer, plan and work status. Returns
@@ -391,6 +398,13 @@ import Observation
         guard answers.allSatisfy({ answer in
             answer.questionID.map(offered.contains) ?? !request.isBatch
         }) else { return }
+        // The host locks every answer it is handed and reads an empty one as a
+        // skip, so a partial batch would silently skip the questions the user
+        // never touched. All of them, or none: `skipQuestion` is the none.
+        if request.isBatch {
+            let outstanding = Set(request.questions.filter { !$0.isAnswered }.compactMap(\.wireID))
+            guard Set(answers.compactMap(\.questionID)) == outstanding else { return }
+        }
         await dispatchAnswers(answers, for: action)
     }
 

--- a/HermesMobile/Features/Bots/BotConversation.swift
+++ b/HermesMobile/Features/Bots/BotConversation.swift
@@ -35,9 +35,9 @@ import Observation
     /// `pending_clarify`. Snapshot-owned, so an answer given in Desktop clears it
     /// on the next read without the phone polling for it.
     private(set) var blockingRequest: BotPendingRequest?
-    /// A request only Desktop can answer. These never appear in a snapshot, so
-    /// they live and die with the event stream.
-    private(set) var desktopOnlyRequest: BotDesktopOnlyRequest?
+    /// A credential prompt or a Desktop-renderer task. Neither appears in a
+    /// snapshot, so they live and die with the event stream.
+    private(set) var streamRequest: BotStreamRequest?
     /// Set while an answer is in flight, to keep the card's controls inert.
     private(set) var answeringRequestID: String?
     /// The verdict on the request currently on screen, if it has one.
@@ -77,9 +77,10 @@ import Observation
     var mayEditDraft: Bool { hydrated && !uncertainSend && !localOperation }
 
     /// The one request blocking this conversation. A clarify or approval wins over
-    /// a Desktop-only kind: it is the outer blocker and the only one the phone can clear.
+    /// a stream request: it is the outer blocker, and the host resolves the inner
+    /// one on its own deadline either way.
     var pendingRequest: BotPendingRequest? {
-        blockingRequest ?? desktopOnlyRequest.map(BotPendingRequest.desktopOnly)
+        blockingRequest ?? streamRequest?.pending
     }
 
     /// True when the user may answer the request on screen. A resolved or expired
@@ -196,7 +197,7 @@ import Observation
     private func applyActivity(type: String, payload: BotJSON) -> Bool {
         switch type {
         case "message.start":
-            liveActivity = BotTurnActivity(); workStatus = nil; desktopOnlyRequest = nil
+            liveActivity = BotTurnActivity(); workStatus = nil; streamRequest = nil
             return false
         case "todo.updated":
             if let next = BotPlan(payload), next.revision >= (plan?.revision ?? 0) { plan = next }
@@ -232,7 +233,7 @@ import Observation
         }
         if !running {
             uncertainStop = false; stopAcknowledged = false; workStatus = nil
-            desktopOnlyRequest = nil
+            streamRequest = nil
             // Only a full snapshot carries the settled rows, so live rows wait for it
             // instead of vanishing on the inflight read that first reports idle.
             if full { liveActivity.clearTurnWork() }
@@ -389,6 +390,30 @@ import Observation
         await dispatchAnswers([BotQuestionAnswer(questionID: nil, text: "")], for: action)
     }
 
+    /// Sends the value the user typed for a `sudo.request` or `secret.request`.
+    /// The value is passed straight to the dispatch and never stored on the model,
+    /// so nothing retains it once the write completes.
+    func answerCredential(_ action: AnswerAction, value: String) async {
+        guard case .credential(let request)? = pendingRequest, request.requestID == action.requestID,
+              action == prepareAnswer() else { return }
+        await deliver(action) {
+            let reply = try await self.request(request.kind.respondMethod, [
+                "request_id": .string(action.requestID),
+                request.kind.valueKey: .string(value)
+            ], owner: action.generation, validateDispatch: self.answerGuard(action))
+            // The host tolerates a late answer to a prompt it already dropped and
+            // says so rather than erroring; nothing was applied.
+            return reply["status"].text == "expired" ? .alreadyResolved : .answered
+        }
+    }
+
+    /// Declines to supply the value. An empty string is the host's own skip: the
+    /// secret tool records a skip and the sudo command is left to fail, which is
+    /// the honest outcome and far better than parking the bot until it times out.
+    func skipCredential(_ action: AnswerAction) async {
+        await answerCredential(action, value: "")
+    }
+
     private func dispatchAnswers(_ answers: [BotQuestionAnswer], for action: AnswerAction) async {
         await deliver(action) {
             for answer in answers {
@@ -430,6 +455,10 @@ import Observation
             guard action.generation == generation, !Task.isCancelled else { return }
             localOperation = false; answeringRequestID = nil
             requestResolution = BotRequestResolution(requestID: action.requestID, outcome: outcome)
+            // Snapshots clear an approval or question; a stream request has no
+            // snapshot to clear it and the host emits `.expire` only on timeout,
+            // so an answered one is retired here or the card would outlive it.
+            if streamRequest?.pending.requestID == action.requestID { streamRequest = nil }
             // The host owns what happens next; read the snapshot instead of
             // assuming the turn resumed.
             turnRevision += 1
@@ -478,7 +507,7 @@ import Observation
         guard let next = event["seq"].integer, next > 0 else {
             replayWasReset = true; snapshotDirty = true; fullSnapshotNeeded = true
             turnRevision += 1
-            liveActivity = BotTurnActivity(); desktopOnlyRequest = nil
+            liveActivity = BotTurnActivity(); streamRequest = nil
             if !localOperation { turn = .unknown }
             scheduleRefresh(); return
         }
@@ -486,19 +515,19 @@ import Observation
         let discontinuity = next != sequence + 1
         if discontinuity {
             replayWasReset = true; fullSnapshotNeeded = true; turnRevision += 1
-            // Missed events may hold tool rows, a notice's clear or a Desktop-only
+            // Missed events may hold tool rows, a notice's clear or a stream
             // request's expiry; partial or stale state is worse than none.
-            liveActivity = BotTurnActivity(); desktopOnlyRequest = nil
+            liveActivity = BotTurnActivity(); streamRequest = nil
             if !localOperation { turn = .unknown }
         }
         sequence = next
         let type = event["type"].text ?? ""
-        let desktopOnlyChanged = applyDesktopOnly(type: type, payload: event["payload"])
+        let streamRequestChanged = applyStreamRequest(type: type, payload: event["payload"])
         // Activity events never change the inflight text, so a continuous stream
         // during known work updates local state without another snapshot read.
-        if !desktopOnlyChanged, applyActivity(type: type, payload: event["payload"]),
+        if !streamRequestChanged, applyActivity(type: type, payload: event["payload"]),
            !discontinuity, turn == .running { return }
-        if desktopOnlyChanged
+        if streamRequestChanged
             || ["message.start", "message.complete", "session.info", "error", "approval.request", "clarify.request"].contains(type) {
             turnRevision += 1
             fullSnapshotNeeded = true
@@ -510,17 +539,20 @@ import Observation
         scheduleRefresh()
     }
 
-    /// Tracks the Desktop-only request the event stream is announcing or tearing
-    /// down. These never reach a resume snapshot, so the stream is the only record
-    /// of them; returns true when the current one changed.
-    private func applyDesktopOnly(type: String, payload: BotJSON) -> Bool {
-        if let request = BotDesktopOnlyRequest.requested(eventType: type, payload: payload) {
-            guard desktopOnlyRequest != request else { return false }
-            desktopOnlyRequest = request
+    /// Tracks the credential or Desktop-task request the event stream is
+    /// announcing or tearing down. These never reach a resume snapshot, so the
+    /// stream is the only record of them; returns true when the current one changed.
+    private func applyStreamRequest(type: String, payload: BotJSON) -> Bool {
+        if let request = BotStreamRequest.requested(eventType: type, payload: payload) {
+            guard streamRequest != request else { return false }
+            // A new prompt inherits nothing from the one it replaces.
+            answeringRequestID = nil
+            if requestResolution?.requestID != request.pending.requestID { requestResolution = nil }
+            streamRequest = request
             return true
         }
-        if let kind = BotDesktopOnlyRequest.expired(eventType: type), desktopOnlyRequest?.kind == kind {
-            desktopOnlyRequest = nil
+        if let prefix = BotStreamRequest.expiredPrefix(eventType: type), streamRequest?.eventPrefix == prefix {
+            streamRequest = nil
             return true
         }
         return false
@@ -555,9 +587,9 @@ import Observation
     private func disconnected(_ error: Error) {
         wire.close()
         refreshTask?.cancel(); refreshTask = nil
-        // A Desktop-only request lives only in the stream, so a lost socket makes
-        // its state unknowable. The card goes rather than lying about it.
-        desktopOnlyRequest = nil; answeringRequestID = nil
+        // A stream request lives only in the stream, so a lost socket makes its
+        // state unknowable. The card goes rather than lying about it.
+        streamRequest = nil; answeringRequestID = nil
         connectionState = .disconnected
         turn = uncertainSend || uncertainStop ? .uncertain : .unknown
         turnRevision += 1
@@ -569,7 +601,7 @@ import Observation
         refreshTask?.cancel(); refreshTask = nil
         wire.close()
         localOperation = false
-        desktopOnlyRequest = nil; answeringRequestID = nil
+        streamRequest = nil; answeringRequestID = nil
         connectionState = .disconnected; turn = .unknown
         Task { try? await drafts.flush() }
     }

--- a/HermesMobile/Features/Bots/BotPendingRequest.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequest.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+/// A request that parks a bot's work until someone answers it.
+///
+/// Approvals and questions are read from the resume snapshot (`pending_approval`,
+/// `pending_clarify`), so an answer given in Desktop clears them on the next read
+/// and nothing has to poll. The Desktop-only kinds exist only as live gateway
+/// events; the phone names them and never answers them.
+enum BotPendingRequest: Equatable {
+    case approval(BotApprovalRequest)
+    case question(BotQuestionRequest)
+    case desktopOnly(BotDesktopOnlyRequest)
+
+    /// The host's id for this request. Nil only for a Desktop-only event that
+    /// omitted one, which the phone never answers anyway.
+    var requestID: String? {
+        switch self {
+        case .approval(let request): return request.requestID
+        case .question(let request): return request.requestID
+        case .desktopOnly(let request): return request.requestID
+        }
+    }
+
+    /// False for the kinds the phone must send to Desktop instead of answering.
+    var isAnswerable: Bool {
+        if case .desktopOnly = self { return false }
+        return true
+    }
+}
+
+/// One pending dangerous-command approval. The host precomputes `choices` from
+/// its own smart-approval and permanent-allow policy, so the phone offers exactly
+/// what the host offered rather than inventing a fifth option.
+struct BotApprovalRequest: Equatable {
+    /// The host's wire vocabulary for `approval.respond`'s `choice`.
+    enum Choice: String, Equatable, CaseIterable {
+        case once, session, always, deny
+
+        /// True for the choice that writes a permanent rule into the host's config.
+        var isPermanent: Bool { self == .always }
+    }
+
+    let requestID: String
+    /// The command as the host redacted it. Nil when the gate was not command-shaped.
+    let command: String?
+    /// Why the host flagged this action, from `description`.
+    let consequence: String?
+    /// Server order, `once` first and `deny` last. Never empty.
+    let choices: [Choice]
+
+    /// Nil when the payload carries no usable request id: without one the phone
+    /// cannot address `approval.respond` and must not guess FIFO order.
+    init?(_ json: BotJSON) {
+        guard let id = json["request_id"].text, !id.isEmpty else { return nil }
+        requestID = id
+        command = Self.trimmed(json["command"])
+        consequence = Self.trimmed(json["description"])
+        let offered = (json["choices"].list ?? []).compactMap { $0.text.flatMap(Choice.init(rawValue:)) }
+        // Older hosts may omit `choices`; rebuild the same set the gateway would.
+        if offered.isEmpty {
+            var rebuilt: [Choice] = [.once]
+            if json["smart_denied"].flag != true, json["allow_session"].flag != false {
+                rebuilt.append(.session)
+                if json["allow_permanent"].flag != false { rebuilt.append(.always) }
+            }
+            choices = rebuilt + [.deny]
+        } else {
+            choices = offered.contains(.deny) ? offered : offered + [.deny]
+        }
+    }
+
+    private static func trimmed(_ json: BotJSON) -> String? {
+        let value = json.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
+    }
+}
+
+/// One pending clarify request: either the single-question shape
+/// (`question`/`choices`/`multi_select`) or the batch shape (`questions`), which
+/// locks one answer per question id and carries the locked ones back on reconnect.
+struct BotQuestionRequest: Equatable {
+    /// One offered answer. `wireLabel` goes back to the host verbatim; the host
+    /// strips its own "(Recommended)" suffix, so presentation never leaks into
+    /// the answer and the phone never has to reconstruct a label.
+    struct Choice: Identifiable, Equatable {
+        static let recommendedSuffix = "(Recommended)"
+
+        let id: Int
+        let wireLabel: String
+        let label: String
+        let isRecommended: Bool
+
+        init(id: Int, wireLabel: String) {
+            self.id = id
+            self.wireLabel = wireLabel
+            let trimmed = wireLabel.trimmingCharacters(in: .whitespaces)
+            isRecommended = trimmed.lowercased().hasSuffix(Self.recommendedSuffix.lowercased())
+            label = isRecommended
+                ? String(trimmed.dropLast(Self.recommendedSuffix.count)).trimmingCharacters(in: .whitespaces)
+                : trimmed
+        }
+    }
+
+    struct Question: Identifiable, Equatable {
+        /// The host's `qid`. Nil for the single-question shape, whose
+        /// `clarify.respond` carries no `question_id`.
+        let wireID: String?
+        let prompt: String
+        /// Empty means open-ended: free text is the only answer.
+        let choices: [Choice]
+        let allowsMultipleChoices: Bool
+        /// An answer already locked on the host, replayed so a reconnect restores it.
+        let lockedAnswer: String?
+
+        var id: String { wireID ?? "" }
+        var isAnswered: Bool { lockedAnswer != nil }
+    }
+
+    let requestID: String
+    let questions: [Question]
+
+    /// True when the host used the batch shape, which needs one `clarify.respond`
+    /// per question id instead of a single unkeyed answer.
+    var isBatch: Bool { questions.first?.wireID != nil }
+    var unansweredCount: Int { questions.filter { !$0.isAnswered }.count }
+
+    /// Nil when the payload has no request id or no readable question, which is
+    /// how a host that carries the key but no content degrades to "no card".
+    init?(_ json: BotJSON) {
+        guard let id = json["request_id"].text, !id.isEmpty else { return nil }
+        let locked = json["answers"]
+        if let rows = json["questions"].list, !rows.isEmpty {
+            let parsed: [Question] = rows.compactMap { row in
+                guard let qid = row["qid"].text ?? row["id"].text, !qid.isEmpty,
+                      let prompt = Self.trimmed(row["question"]) else { return nil }
+                return Question(
+                    wireID: qid, prompt: prompt, choices: Self.choices(row["choices"]),
+                    allowsMultipleChoices: row["multi_select"].flag == true,
+                    lockedAnswer: locked[qid].text
+                )
+            }
+            guard !parsed.isEmpty else { return nil }
+            requestID = id
+            questions = parsed
+            return
+        }
+        guard let prompt = Self.trimmed(json["question"]) else { return nil }
+        requestID = id
+        questions = [Question(
+            wireID: nil, prompt: prompt, choices: Self.choices(json["choices"]),
+            allowsMultipleChoices: json["multi_select"].flag == true, lockedAnswer: nil
+        )]
+    }
+
+    private static func choices(_ json: BotJSON) -> [Choice] {
+        (json.list ?? []).enumerated().compactMap { index, row in
+            guard let label = trimmed(row) else { return nil }
+            return Choice(id: index, wireLabel: label)
+        }
+    }
+
+    private static func trimmed(_ json: BotJSON) -> String? {
+        let value = json.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
+    }
+}
+
+/// A blocking request only Hermes Desktop can answer: it needs a credential, the
+/// Mac's device context, or the Desktop renderer itself. The phone names the kind
+/// so the block is legible, and offers no input, shell or credential fallback.
+struct BotDesktopOnlyRequest: Equatable {
+    /// The gateway event prefix, so `<raw>.request` and `<raw>.expire` both map here.
+    enum Kind: String, Equatable, CaseIterable {
+        case sudo, secret, tour
+        case terminalRead = "terminal.read"
+        case windowRead = "window.read"
+        case mcpSetup = "mcp.setup"
+        case previewRead = "preview.read"
+        case previewAct = "preview.act"
+
+        /// What the bot is asking for, in the user's words rather than the wire name.
+        var title: String {
+            switch self {
+            case .sudo: return String(localized: "This bot is asking for an administrator password.")
+            case .secret: return String(localized: "This bot is asking for a stored secret.")
+            case .terminalRead: return String(localized: "This bot is asking to read a Desktop terminal.")
+            case .windowRead: return String(localized: "This bot is asking to read a window on the Mac.")
+            case .mcpSetup: return String(localized: "This bot is asking to finish an MCP setup.")
+            case .previewRead: return String(localized: "This bot is asking to read the Desktop preview.")
+            case .previewAct: return String(localized: "This bot is asking to act in the Desktop preview.")
+            case .tour: return String(localized: "This bot is asking to run a Desktop tour.")
+            }
+        }
+    }
+
+    let kind: Kind
+    let requestID: String?
+
+    /// The kind a `<prefix>.request` event announces, or nil for any other event.
+    static func requested(eventType: String, payload: BotJSON) -> BotDesktopOnlyRequest? {
+        guard let kind = kind(eventType: eventType, suffix: "request") else { return nil }
+        return BotDesktopOnlyRequest(kind: kind, requestID: payload["request_id"].text)
+    }
+
+    /// The kind a `<prefix>.expire` event tears down, or nil for any other event.
+    static func expired(eventType: String) -> Kind? { kind(eventType: eventType, suffix: "expire") }
+
+    private static func kind(eventType: String, suffix: String) -> Kind? {
+        guard eventType.hasSuffix("." + suffix) else { return nil }
+        return Kind(rawValue: String(eventType.dropLast(suffix.count + 1)))
+    }
+}
+
+/// One question's answer on its way to `clarify.respond`. `questionID` is the
+/// host's `qid` for a batch and nil for the single-question shape.
+struct BotQuestionAnswer: Equatable {
+    let questionID: String?
+    let text: String
+
+    /// Multi-select answers go over the wire as a JSON array string; the host
+    /// parses that, a bare array is not part of the contract.
+    init(questionID: String?, selections: [String]) {
+        self.questionID = questionID
+        let data = try? JSONSerialization.data(withJSONObject: selections)
+        text = data.map { String(decoding: $0, as: UTF8.self) } ?? selections.joined(separator: ", ")
+    }
+
+    init(questionID: String?, text: String) {
+        self.questionID = questionID
+        self.text = text
+    }
+}
+
+/// Why the request on screen can no longer be acted on, scoped to the request it
+/// describes so a newer request never inherits an older verdict.
+struct BotRequestResolution: Equatable {
+    enum Outcome: Equatable {
+        /// The host accepted the answer. The next snapshot removes the request.
+        case answered
+        /// The host had nothing left to resolve: answered on another surface, or expired.
+        case alreadyResolved
+        /// Delivery failed in a way that cannot distinguish sent from not sent.
+        case uncertain
+    }
+
+    let requestID: String
+    let outcome: Outcome
+
+    /// True while the request must stay inert. An uncertain outcome warns instead
+    /// of locking the user out: the phone never resends, but a deliberate second
+    /// answer after checking Desktop is the user's call, not a replay.
+    var blocksFurtherAnswers: Bool { outcome != .uncertain }
+
+    var message: String {
+        switch outcome {
+        case .answered: return String(localized: "Answer sent.")
+        case .alreadyResolved: return String(localized: "This request was already answered or has expired.")
+        case .uncertain: return String(localized: "Answer outcome unknown. Check this bot in Desktop before answering again.")
+        }
+    }
+}

--- a/HermesMobile/Features/Bots/BotPendingRequest.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequest.swift
@@ -4,26 +4,32 @@ import Foundation
 ///
 /// Approvals and questions are read from the resume snapshot (`pending_approval`,
 /// `pending_clarify`), so an answer given in Desktop clears them on the next read
-/// and nothing has to poll. The Desktop-only kinds exist only as live gateway
-/// events; the phone names them and never answers them.
+/// and nothing has to poll. Credential and Desktop-task requests exist only as
+/// live gateway events, because the host's snapshot does not carry them.
+///
+/// Only `desktopTask` is unanswerable, and not for want of a credential path: the
+/// answer is data Hermes Desktop's own window holds, so no client without that
+/// window can produce one.
 enum BotPendingRequest: Equatable {
     case approval(BotApprovalRequest)
     case question(BotQuestionRequest)
-    case desktopOnly(BotDesktopOnlyRequest)
+    case credential(BotCredentialRequest)
+    case desktopTask(BotDesktopTaskRequest)
 
-    /// The host's id for this request. Nil only for a Desktop-only event that
-    /// omitted one, which the phone never answers anyway.
+    /// The host's id for this request. Nil only for a Desktop-task event that
+    /// omitted one, which nobody answers from here anyway.
     var requestID: String? {
         switch self {
         case .approval(let request): return request.requestID
         case .question(let request): return request.requestID
-        case .desktopOnly(let request): return request.requestID
+        case .credential(let request): return request.requestID
+        case .desktopTask(let request): return request.requestID
         }
     }
 
-    /// False for the kinds the phone must send to Desktop instead of answering.
+    /// False only for the kinds whose answer lives in the Desktop renderer.
     var isAnswerable: Bool {
-        if case .desktopOnly = self { return false }
+        if case .desktopTask = self { return false }
         return true
     }
 }
@@ -165,50 +171,174 @@ struct BotQuestionRequest: Equatable {
     }
 }
 
-/// A blocking request only Hermes Desktop can answer: it needs a credential, the
-/// Mac's device context, or the Desktop renderer itself. The phone names the kind
-/// so the block is legible, and offers no input, shell or credential fallback.
-struct BotDesktopOnlyRequest: Equatable {
+/// A blocking request the phone learns about only from the live event stream.
+/// `session.resume` carries `pending_approval` and `pending_clarify` and nothing
+/// else, so a gap in the stream loses these rather than leaving a stale card up.
+enum BotStreamRequest: Equatable {
+    case credential(BotCredentialRequest)
+    case desktopTask(BotDesktopTaskRequest)
+
+    var pending: BotPendingRequest {
+        switch self {
+        case .credential(let request): return .credential(request)
+        case .desktopTask(let request): return .desktopTask(request)
+        }
+    }
+
+    /// The gateway event prefix this was announced under, so the matching
+    /// `<prefix>.expire` tears down this card and not a different one.
+    var eventPrefix: String {
+        switch self {
+        case .credential(let request): return request.kind.rawValue
+        case .desktopTask(let request): return request.kind.rawValue
+        }
+    }
+
+    /// The request a `<prefix>.request` event announces, or nil for any other event.
+    static func requested(eventType: String, payload: BotJSON) -> BotStreamRequest? {
+        guard let prefix = prefix(eventType: eventType, suffix: "request") else { return nil }
+        if let kind = BotCredentialRequest.Kind(rawValue: prefix) {
+            // Without a request id there is nothing to address `*.respond` to, and
+            // guessing one would answer somebody else's prompt.
+            guard let id = payload["request_id"].text, !id.isEmpty else { return nil }
+            return .credential(BotCredentialRequest(
+                kind: kind, requestID: id,
+                envVar: trimmed(payload["env_var"]), prompt: trimmed(payload["prompt"])
+            ))
+        }
+        guard let kind = BotDesktopTaskRequest.Kind(rawValue: prefix) else { return nil }
+        return .desktopTask(BotDesktopTaskRequest(kind: kind, requestID: payload["request_id"].text))
+    }
+
+    /// The event prefix a `<prefix>.expire` event tears down, or nil for any other event.
+    static func expiredPrefix(eventType: String) -> String? { prefix(eventType: eventType, suffix: "expire") }
+
+    private static func prefix(eventType: String, suffix: String) -> String? {
+        guard eventType.hasSuffix("." + suffix) else { return nil }
+        return String(eventType.dropLast(suffix.count + 1))
+    }
+
+    private static func trimmed(_ json: BotJSON) -> String? {
+        let value = json.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
+    }
+}
+
+/// A value only the person can supply: the Mac's administrator password, or a
+/// secret the bot asked for by name.
+///
+/// The phone answers these. `sudo.respond` and `secret.respond` take a
+/// `request_id` from any connected client — the host's own terminal UI answers
+/// them over the same methods — so routing them to Desktop was a choice, not a
+/// constraint, and it is the wrong one for someone away from their Mac. An empty
+/// value is the host's documented skip and releases the bot without one.
+struct BotCredentialRequest: Equatable {
+    /// The gateway event prefix, which is also the `*.respond` method's stem.
+    enum Kind: String, Equatable, CaseIterable {
+        case sudo, secret
+
+        var respondMethod: String { "\(rawValue).respond" }
+
+        /// The param `*.respond` carries the typed value in. The host reads one
+        /// name per kind; a mismatched key answers with an empty string.
+        var valueKey: String {
+            switch self {
+            case .sudo: return "password"
+            case .secret: return "value"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .sudo: return String(localized: "Administrator password needed")
+            case .secret: return String(localized: "Secret needed")
+            }
+        }
+
+        /// What skipping costs, so declining is an informed choice too.
+        var skipConsequence: String {
+            switch self {
+            case .sudo: return String(localized: "Skip to let the command fail instead.")
+            case .secret: return String(localized: "Skip to continue without it.")
+            }
+        }
+    }
+
+    let kind: Kind
+    let requestID: String
+    /// `secret` only: the name the host stores the value under.
+    let envVar: String?
+    /// `secret` only: the host's own words for what it wants.
+    let prompt: String?
+
+    /// What the bot is asking for, preferring the host's wording when it sent any.
+    var detail: String {
+        switch kind {
+        case .sudo:
+            return String(localized: "A command on this Mac needs an administrator password to run.")
+        case .secret:
+            return prompt ?? String(localized: "This bot needs a secret value to carry on.")
+        }
+    }
+
+    /// Where the value ends up, stated before it is typed. `sudo` is used for the
+    /// one command and never written down; `secret` is saved on the host under
+    /// `envVar`. Neither is ever stored by Hermex.
+    var handling: String {
+        switch kind {
+        case .sudo:
+            return String(localized: "Sent to this bot's Mac to run this command. Hermex never saves it.")
+        case .secret:
+            guard let envVar else {
+                return String(localized: "Saved on this bot's Mac. Hermex never saves it.")
+            }
+            return String(localized: "Saved on this bot's Mac as \(envVar). Hermex never saves it.")
+        }
+    }
+}
+
+/// Work Hermes Desktop's own window performs and answers by itself: serializing
+/// its terminal scrollback, the OS window beneath it, its preview pane.
+///
+/// Nobody types an answer to these, on the phone or at the Mac. Each carries a
+/// host-side deadline — 30s for the reads, 45s for the preview and tour, ten
+/// minutes for an MCP setup — after which the tool takes an empty answer and the
+/// bot carries on. So the phone reports the wait rather than sending anyone to a
+/// desk they are not sitting at.
+struct BotDesktopTaskRequest: Equatable {
     /// The gateway event prefix, so `<raw>.request` and `<raw>.expire` both map here.
     enum Kind: String, Equatable, CaseIterable {
-        case sudo, secret, tour
+        case tour
         case terminalRead = "terminal.read"
         case windowRead = "window.read"
         case mcpSetup = "mcp.setup"
         case previewRead = "preview.read"
         case previewAct = "preview.act"
 
-        /// What the bot is asking for, in the user's words rather than the wire name.
+        /// What is happening, in the user's words rather than the wire name.
         var title: String {
             switch self {
-            case .sudo: return String(localized: "This bot is asking for an administrator password.")
-            case .secret: return String(localized: "This bot is asking for a stored secret.")
-            case .terminalRead: return String(localized: "This bot is asking to read a Desktop terminal.")
-            case .windowRead: return String(localized: "This bot is asking to read a window on the Mac.")
-            case .mcpSetup: return String(localized: "This bot is asking to finish an MCP setup.")
-            case .previewRead: return String(localized: "This bot is asking to read the Desktop preview.")
-            case .previewAct: return String(localized: "This bot is asking to act in the Desktop preview.")
-            case .tour: return String(localized: "This bot is asking to run a Desktop tour.")
+            case .terminalRead: return String(localized: "This bot is reading a terminal on the Mac.")
+            case .windowRead: return String(localized: "This bot is reading a window on the Mac.")
+            case .previewRead: return String(localized: "This bot is reading the preview pane on the Mac.")
+            case .previewAct: return String(localized: "This bot is using the preview pane on the Mac.")
+            case .tour: return String(localized: "This bot is running a tour in Hermes Desktop.")
+            case .mcpSetup: return String(localized: "This bot is waiting for an MCP server to be set up in Hermes Desktop.")
             }
+        }
+
+        /// True for the one kind a person actually walks through at the Mac.
+        var needsSomeoneAtTheMac: Bool { self == .mcpSetup }
+
+        var detail: String {
+            needsSomeoneAtTheMac
+                ? String(localized: "Hermes Desktop walks someone through this on the Mac. The bot gives up after about ten minutes if nobody does.")
+                : String(localized: "Hermes Desktop answers this by itself, and the bot carries on without it if it cannot. There is nothing to do here or at the Mac.")
         }
     }
 
     let kind: Kind
     let requestID: String?
-
-    /// The kind a `<prefix>.request` event announces, or nil for any other event.
-    static func requested(eventType: String, payload: BotJSON) -> BotDesktopOnlyRequest? {
-        guard let kind = kind(eventType: eventType, suffix: "request") else { return nil }
-        return BotDesktopOnlyRequest(kind: kind, requestID: payload["request_id"].text)
-    }
-
-    /// The kind a `<prefix>.expire` event tears down, or nil for any other event.
-    static func expired(eventType: String) -> Kind? { kind(eventType: eventType, suffix: "expire") }
-
-    private static func kind(eventType: String, suffix: String) -> Kind? {
-        guard eventType.hasSuffix("." + suffix) else { return nil }
-        return Kind(rawValue: String(eventType.dropLast(suffix.count + 1)))
-    }
 }
 
 /// One question's answer on its way to `clarify.respond`. `questionID` is the

--- a/HermesMobile/Features/Bots/BotPendingRequest.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequest.swift
@@ -61,17 +61,22 @@ struct BotApprovalRequest: Equatable {
         requestID = id
         command = Self.trimmed(json["command"])
         consequence = Self.trimmed(json["description"])
-        let offered = (json["choices"].list ?? []).compactMap { $0.text.flatMap(Choice.init(rawValue:)) }
-        // Older hosts may omit `choices`; rebuild the same set the gateway would.
-        if offered.isEmpty {
+        // A present `choices` is the host speaking, and nothing may be added to
+        // what it offered. If a newer host renames the lot so none of it parses,
+        // Deny is the only thing left that is safe to offer: rebuilding here
+        // would invent an Always allow the host never sanctioned.
+        if let list = json["choices"].list {
+            let offered = list.compactMap { $0.text.flatMap(Choice.init(rawValue:)) }
+            if offered.isEmpty { choices = [.deny] }
+            else { choices = offered.contains(.deny) ? offered : offered + [.deny] }
+        } else {
+            // Only an absent `choices` is an older host; rebuild what it would send.
             var rebuilt: [Choice] = [.once]
             if json["smart_denied"].flag != true, json["allow_session"].flag != false {
                 rebuilt.append(.session)
                 if json["allow_permanent"].flag != false { rebuilt.append(.always) }
             }
             choices = rebuilt + [.deny]
-        } else {
-            choices = offered.contains(.deny) ? offered : offered + [.deny]
         }
     }
 

--- a/HermesMobile/Features/Bots/BotPendingRequest.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequest.swift
@@ -330,12 +330,27 @@ struct BotDesktopTaskRequest: Equatable {
         /// True for the one kind a person actually walks through at the Mac.
         var needsSomeoneAtTheMac: Bool { self == .mcpSetup }
 
+        /// True for the kind the phone can call off outright. Declining is not
+        /// answering: the setup card's work still only happens in Desktop, but
+        /// saying no to it is a decision, and the host takes that from here.
+        /// The rest have nothing to decline — the renderer answers or the
+        /// deadline passes, and either way nobody is kept waiting.
+        var isDeclinable: Bool { self == .mcpSetup }
+
+        var respondMethod: String { "\(rawValue).respond" }
+
         var detail: String {
             needsSomeoneAtTheMac
-                ? String(localized: "Hermes Desktop walks someone through this on the Mac. The bot gives up after about ten minutes if nobody does.")
+                ? String(localized: "Hermes Desktop walks someone through this on the Mac. Skip it here and the bot carries on without the server.")
                 : String(localized: "Hermes Desktop answers this by itself, and the bot carries on without it if it cannot. There is nothing to do here or at the Mac.")
         }
     }
+
+    /// The `result` an explicit decline carries. The host passes the object
+    /// straight through to the tool, which reads `declined` as a final no and
+    /// is told never to re-ask — unlike an unanswered card, which only means
+    /// the ten-minute deadline passed.
+    static let declinedResult = #"{"status":"declined"}"#
 
     let kind: Kind
     let requestID: String?

--- a/HermesMobile/Features/Bots/BotPendingRequestCard.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequestCard.swift
@@ -16,6 +16,9 @@ struct BotPendingRequestCard: View {
     /// names never produce an anonymous card.
     let identity: String
     let isEnabled: Bool
+    /// Stop is gated separately: a Desktop-only request is never answerable, but
+    /// stopping the work it blocks is exactly what the phone still owns.
+    let canStop: Bool
     let isAnswering: Bool
     let resolution: BotRequestResolution?
     let onApprove: (BotApprovalRequest.Choice) -> Void
@@ -38,7 +41,7 @@ struct BotPendingRequestCard: View {
                 )
             case .desktopOnly(let desktopOnly):
                 BotDesktopOnlyRequestBody(
-                    desktopOnly: desktopOnly, identity: identity, isEnabled: isEnabled, onStop: onStop
+                    desktopOnly: desktopOnly, identity: identity, canStop: canStop, onStop: onStop
                 )
             }
             if let resolution {
@@ -166,7 +169,7 @@ private struct BotQuestionRequestBody: View {
     let onSkip: () -> Void
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-    @ScaledMetric(relativeTo: .body) private var submitButtonSize: CGFloat = 40
+    @Environment(\.colorScheme) private var colorScheme
     /// Choice ids picked per question id, and the free text typed for it.
     @State private var picked: [String: Set<Int>] = [:]
     @State private var typed: [String: String] = [:]
@@ -177,6 +180,8 @@ private struct BotQuestionRequestBody: View {
     }
 
     private var unanswered: [BotQuestionRequest.Question] { question.questions.filter { !$0.isAnswered } }
+
+    private var canSubmit: Bool { isEnabled && !isAnswering && hasAnswer }
 
     private var hasAnswer: Bool {
         unanswered.contains { item in
@@ -221,7 +226,7 @@ private struct BotQuestionRequestBody: View {
                     Label("Send answers", systemImage: "arrow.up.circle.fill").frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.chatDecision(.primary))
-                .disabled(!isEnabled || isAnswering || !hasAnswer)
+                .disabled(!canSubmit)
 
                 Button(action: onSkip) {
                     Text("Skip").frame(maxWidth: .infinity)
@@ -274,28 +279,16 @@ private struct BotQuestionRequestBody: View {
             TextField("Type a response", text: binding(for: item), axis: .vertical)
                 .textFieldStyle(.plain)
                 .lineLimit(2...5)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .pendingRequestBlockSurface()
+                .tint(PendingRequestSubmitButton.fill(canSubmit: canSubmit, colorScheme: colorScheme))
+                .pendingRequestFieldSurface()
                 .disabled(!isEnabled || isAnswering)
 
+            // A batch or multi-select answer is sent by the Send control below,
+            // which speaks for every question at once.
             if submitsOnTap {
-                Button { onAnswer(answers()) } label: {
-                    submitLabel.frame(width: submitButtonSize, height: submitButtonSize)
-                }
-                .buttonStyle(.chatTactile(.icon))
-                .disabled(!isEnabled || isAnswering || !hasAnswer)
-                .accessibilityLabel("Send answer")
+                PendingRequestSubmitButton(isBusy: isAnswering, canSubmit: canSubmit) { onAnswer(answers()) }
+                    .accessibilityLabel("Send answer")
             }
-        }
-    }
-
-    @ViewBuilder
-    private var submitLabel: some View {
-        if isAnswering {
-            ProgressView().scaleEffect(0.82)
-        } else {
-            Image(systemName: "arrow.up.circle.fill").font(.system(size: 24, weight: .semibold))
         }
     }
 
@@ -337,7 +330,7 @@ private struct BotQuestionRequestBody: View {
 private struct BotDesktopOnlyRequestBody: View {
     let desktopOnly: BotDesktopOnlyRequest
     let identity: String
-    let isEnabled: Bool
+    let canStop: Bool
     let onStop: () -> Void
 
     var body: some View {
@@ -357,7 +350,7 @@ private struct BotDesktopOnlyRequestBody: View {
             Label("Stop current work", systemImage: "stop.fill").frame(maxWidth: .infinity)
         }
         .buttonStyle(.chatDecision(.destructive))
-        .disabled(!isEnabled)
+        .disabled(!canStop)
     }
 }
 

--- a/HermesMobile/Features/Bots/BotPendingRequestCard.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequestCard.swift
@@ -1,0 +1,382 @@
+import SwiftUI
+import UIKit
+
+/// The request blocking a bot, rendered in the transcript where its work
+/// stopped, so the command sits under the tool row that asked for it.
+///
+/// Placement is the only thing Bot-specific here: the surfaces, choice buttons,
+/// decision buttons and copy are the Sessions approval and clarification
+/// vocabulary. `isEnabled` false is a resolved, expired or in-flight request:
+/// the card stays readable and stops acting.
+struct BotPendingRequestCard: View {
+    static let cornerRadius: CGFloat = 14
+
+    let request: BotPendingRequest
+    /// Which bot on which connection is asking, so two hosts with equal Profile
+    /// names never produce an anonymous card.
+    let identity: String
+    let isEnabled: Bool
+    let isAnswering: Bool
+    let resolution: BotRequestResolution?
+    let onApprove: (BotApprovalRequest.Choice) -> Void
+    let onAnswer: ([BotQuestionAnswer]) -> Void
+    let onSkip: () -> Void
+    let onStop: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            switch request {
+            case .approval(let approval):
+                BotApprovalRequestBody(
+                    approval: approval, identity: identity, isEnabled: isEnabled,
+                    isAnswering: isAnswering, onApprove: onApprove
+                )
+            case .question(let question):
+                BotQuestionRequestBody(
+                    question: question, identity: identity, isEnabled: isEnabled,
+                    isAnswering: isAnswering, onAnswer: onAnswer, onSkip: onSkip
+                )
+            case .desktopOnly(let desktopOnly):
+                BotDesktopOnlyRequestBody(
+                    desktopOnly: desktopOnly, identity: identity, isEnabled: isEnabled, onStop: onStop
+                )
+            }
+            if let resolution {
+                Text(resolution.message)
+                    .font(.caption)
+                    .foregroundStyle(resolution.outcome == .answered ? .secondary : Color.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: 560, alignment: .leading)
+        .pendingRequestCardSurface(cornerRadius: Self.cornerRadius)
+        .accessibilityElement(children: .contain)
+        .onChange(of: request.requestID, initial: true) { announce() }
+    }
+
+    /// One announcement per request; re-renders and answers stay silent.
+    private func announce() {
+        guard UIAccessibility.isVoiceOverRunning else { return }
+        let summary: String
+        switch request {
+        case .approval(let approval):
+            summary = approval.consequence ?? approval.command ?? String(localized: "Approval required")
+        case .question(let question):
+            summary = question.questions.first?.prompt ?? String(localized: "Input needed")
+        case .desktopOnly(let desktopOnly):
+            summary = desktopOnly.kind.title
+        }
+        AccessibilityNotification.Announcement(String(localized: "Input needed: \(summary)")).post()
+    }
+}
+
+/// A command approval. Only the choices the host actually offered are shown:
+/// a smart-denied or permanent-allow-blocked request legitimately has fewer.
+private struct BotApprovalRequestBody: View {
+    let approval: BotApprovalRequest
+    let identity: String
+    let isEnabled: Bool
+    let isAnswering: Bool
+    let onApprove: (BotApprovalRequest.Choice) -> Void
+
+    var body: some View {
+        BotRequestHeader(
+            systemImage: "exclamationmark.triangle.fill", tint: .yellow,
+            title: String(localized: "Approval required"), identity: identity
+        )
+        if let consequence = approval.consequence {
+            Text(consequence)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        if let command = approval.command {
+            // Horizontally scrollable and selectable, so a long command is
+            // readable in full before it is approved.
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(command)
+                    .font(.system(.footnote, design: .monospaced))
+                    .textSelection(.enabled)
+            }
+            .pendingRequestBlockSurface()
+        }
+        VStack(spacing: 8) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: 8) {
+                    ForEach(row, id: \.self) { choice in
+                        Button(role: choice == .deny ? .destructive : nil) {
+                            onApprove(choice)
+                        } label: {
+                            Label(Self.title(for: choice), systemImage: Self.symbol(for: choice))
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.chatDecision(Self.emphasis(for: choice)))
+                        .disabled(!isEnabled || isAnswering)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Two per row, in the host's order, so Allow once and Deny stay reachable
+    /// without the layout changing when a choice is withheld.
+    private var rows: [[BotApprovalRequest.Choice]] {
+        stride(from: 0, to: approval.choices.count, by: 2).map {
+            Array(approval.choices[$0..<min($0 + 2, approval.choices.count)])
+        }
+    }
+
+    private static func title(for choice: BotApprovalRequest.Choice) -> String {
+        switch choice {
+        case .once: return String(localized: "Allow once")
+        case .session: return String(localized: "Allow session")
+        case .always: return String(localized: "Always allow")
+        case .deny: return String(localized: "Deny")
+        }
+    }
+
+    private static func symbol(for choice: BotApprovalRequest.Choice) -> String {
+        switch choice {
+        case .once: return "checkmark.circle.fill"
+        case .session: return "lock.open"
+        case .always: return "star.fill"
+        case .deny: return "xmark.circle.fill"
+        }
+    }
+
+    private static func emphasis(for choice: BotApprovalRequest.Choice) -> ChatDecisionButtonStyle.Emphasis {
+        switch choice {
+        case .once: return .primary
+        case .deny: return .destructive
+        default: return .secondary
+        }
+    }
+}
+
+/// One or many clarify questions. A single single-select question submits on
+/// tap, as the Sessions card does; multi-select and batches need a deliberate
+/// Send because no one tap can express the whole answer.
+private struct BotQuestionRequestBody: View {
+    let question: BotQuestionRequest
+    let identity: String
+    let isEnabled: Bool
+    let isAnswering: Bool
+    let onAnswer: ([BotQuestionAnswer]) -> Void
+    let onSkip: () -> Void
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @ScaledMetric(relativeTo: .body) private var submitButtonSize: CGFloat = 40
+    /// Choice ids picked per question id, and the free text typed for it.
+    @State private var picked: [String: Set<Int>] = [:]
+    @State private var typed: [String: String] = [:]
+
+    /// True when one tap is the whole answer, so no Send control is needed.
+    private var submitsOnTap: Bool {
+        !question.isBatch && question.questions.first?.allowsMultipleChoices == false
+    }
+
+    private var unanswered: [BotQuestionRequest.Question] { question.questions.filter { !$0.isAnswered } }
+
+    private var hasAnswer: Bool {
+        unanswered.contains { item in
+            !(picked[item.id]?.isEmpty ?? true)
+                || !(typed[item.id] ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    var body: some View {
+        BotRequestHeader(
+            systemImage: "questionmark.circle", tint: .secondary,
+            title: question.questions.count > 1
+                ? String(localized: "\(question.questions.count) questions")
+                : String(localized: "Clarification Required"),
+            identity: question.questions.count > 1
+                ? String(localized: "\(question.unansweredCount) still to answer · \(identity)")
+                : identity
+        )
+        ForEach(question.questions) { item in
+            VStack(alignment: .leading, spacing: 10) {
+                Text(item.prompt)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .pendingRequestBlockSurface()
+                if let locked = item.lockedAnswer {
+                    Label(locked, systemImage: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel(Text("Already answered: \(locked)"))
+                } else {
+                    ForEach(item.choices) { choice in
+                        choiceButton(choice, in: item)
+                    }
+                    responseField(for: item)
+                }
+            }
+        }
+        if !submitsOnTap {
+            HStack(spacing: 8) {
+                Button { onAnswer(answers()) } label: {
+                    Label("Send answers", systemImage: "arrow.up.circle.fill").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.chatDecision(.primary))
+                .disabled(!isEnabled || isAnswering || !hasAnswer)
+
+                Button(action: onSkip) {
+                    Text("Skip").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.chatDecision(.secondary))
+                .disabled(!isEnabled || isAnswering)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func choiceButton(_ choice: BotQuestionRequest.Choice, in item: BotQuestionRequest.Question) -> some View {
+        let isPicked = picked[item.id]?.contains(choice.id) == true
+        Button {
+            if submitsOnTap {
+                onAnswer([BotQuestionAnswer(questionID: item.wireID, text: choice.wireLabel)])
+            } else {
+                toggle(choice, in: item)
+            }
+        } label: {
+            HStack(spacing: 8) {
+                if !submitsOnTap {
+                    Image(systemName: selectionSymbol(isPicked: isPicked, item: item))
+                        .foregroundStyle(isPicked ? Color.accentColor : .secondary)
+                        .accessibilityHidden(true)
+                }
+                Text(choice.label)
+                    .font(.callout.weight(.semibold))
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                if choice.isRecommended {
+                    Text("Recommended")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .foregroundStyle(.primary)
+            .pendingRequestChoiceSurface(reduceTransparency: reduceTransparency)
+        }
+        .buttonStyle(.chatTactile(.capsule))
+        .disabled(!isEnabled || isAnswering)
+        .accessibilityAddTraits(isPicked ? .isSelected : [])
+    }
+
+    private func responseField(for item: BotQuestionRequest.Question) -> some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            TextField("Type a response", text: binding(for: item), axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(2...5)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .pendingRequestBlockSurface()
+                .disabled(!isEnabled || isAnswering)
+
+            if submitsOnTap {
+                Button { onAnswer(answers()) } label: {
+                    submitLabel.frame(width: submitButtonSize, height: submitButtonSize)
+                }
+                .buttonStyle(.chatTactile(.icon))
+                .disabled(!isEnabled || isAnswering || !hasAnswer)
+                .accessibilityLabel("Send answer")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var submitLabel: some View {
+        if isAnswering {
+            ProgressView().scaleEffect(0.82)
+        } else {
+            Image(systemName: "arrow.up.circle.fill").font(.system(size: 24, weight: .semibold))
+        }
+    }
+
+    private func selectionSymbol(isPicked: Bool, item: BotQuestionRequest.Question) -> String {
+        if item.allowsMultipleChoices { return isPicked ? "checkmark.square.fill" : "square" }
+        return isPicked ? "largecircle.fill.circle" : "circle"
+    }
+
+    private func binding(for item: BotQuestionRequest.Question) -> Binding<String> {
+        Binding(get: { typed[item.id] ?? "" }, set: { typed[item.id] = $0 })
+    }
+
+    private func toggle(_ choice: BotQuestionRequest.Choice, in item: BotQuestionRequest.Question) {
+        var selection = picked[item.id] ?? []
+        if item.allowsMultipleChoices {
+            if selection.contains(choice.id) { selection.remove(choice.id) } else { selection.insert(choice.id) }
+        } else {
+            selection = selection.contains(choice.id) ? [] : [choice.id]
+        }
+        picked[item.id] = selection
+    }
+
+    /// One answer per question the host has not already locked. A blank one is a
+    /// deliberate skip for that question, which is what the host's tool reads it as.
+    private func answers() -> [BotQuestionAnswer] {
+        unanswered.map { item in
+            let labels = item.choices.filter { picked[item.id]?.contains($0.id) == true }.map(\.wireLabel)
+            let free = (typed[item.id] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if item.allowsMultipleChoices {
+                return BotQuestionAnswer(questionID: item.wireID, selections: labels + (free.isEmpty ? [] : [free]))
+            }
+            return BotQuestionAnswer(questionID: item.wireID, text: free.isEmpty ? (labels.first ?? "") : free)
+        }
+    }
+}
+
+/// A request the phone must not answer. It names the kind, says why, and offers
+/// only the two things the phone legitimately owns: go to Desktop, or stop the work.
+private struct BotDesktopOnlyRequestBody: View {
+    let desktopOnly: BotDesktopOnlyRequest
+    let identity: String
+    let isEnabled: Bool
+    let onStop: () -> Void
+
+    var body: some View {
+        BotRequestHeader(
+            systemImage: "desktopcomputer", tint: .secondary,
+            title: String(localized: "Only Hermes Desktop can answer this"), identity: identity
+        )
+        Text(desktopOnly.kind.title)
+            .font(.subheadline)
+            .foregroundStyle(.primary)
+            .fixedSize(horizontal: false, vertical: true)
+        Text("Hermex never collects passwords, secrets or device context. Answer this in Hermes Desktop on the same Mac, or stop the bot's current work.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        Button(role: .destructive, action: onStop) {
+            Label("Stop current work", systemImage: "stop.fill").frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.chatDecision(.destructive))
+        .disabled(!isEnabled)
+    }
+}
+
+private struct BotRequestHeader: View {
+    let systemImage: String
+    let tint: Color
+    let title: String
+    let identity: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: systemImage)
+                .foregroundStyle(tint)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(.headline)
+                Text(identity).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+        }
+    }
+}

--- a/HermesMobile/Features/Bots/BotPendingRequestCard.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequestCard.swift
@@ -30,6 +30,9 @@ struct BotPendingRequestCard: View {
     let onSkip: () -> Void
     /// Sends a typed sudo password or secret. Empty is the host's skip.
     let onCredential: (String) -> Void
+    /// Calls off a Desktop task that can be declined. Only `mcp.setup` can.
+    let canDecline: Bool
+    let onDecline: () -> Void
     let onStop: () -> Void
 
     var body: some View {
@@ -52,7 +55,8 @@ struct BotPendingRequestCard: View {
                 )
             case .desktopTask(let task):
                 BotDesktopTaskRequestBody(
-                    task: task, identity: identity, canStop: canStop, onStop: onStop
+                    task: task, identity: identity, canStop: canStop,
+                    canDecline: canDecline, onDecline: onDecline, onStop: onStop
                 )
             }
             if let resolution {
@@ -415,6 +419,8 @@ private struct BotDesktopTaskRequestBody: View {
     let task: BotDesktopTaskRequest
     let identity: String
     let canStop: Bool
+    let canDecline: Bool
+    let onDecline: () -> Void
     let onStop: () -> Void
 
     var body: some View {
@@ -433,6 +439,15 @@ private struct BotDesktopTaskRequestBody: View {
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
+        // Declining beats stopping where it is offered: it calls off this one
+        // request and lets the bot finish its work, where Stop ends the work.
+        if task.kind.isDeclinable {
+            Button(action: onDecline) {
+                Text("Skip this setup").frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.chatDecision(.secondary))
+            .disabled(!canDecline)
+        }
         Button(role: .destructive, action: onStop) {
             Label("Stop current work", systemImage: "stop.fill").frame(maxWidth: .infinity)
         }

--- a/HermesMobile/Features/Bots/BotPendingRequestCard.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequestCard.swift
@@ -200,8 +200,11 @@ private struct BotQuestionRequestBody: View {
 
     private var canSubmit: Bool { isEnabled && !isAnswering && hasAnswer }
 
+    /// Every outstanding question, not just one. A partial send would lock the
+    /// untouched questions as skipped, so Send waits for the whole batch and
+    /// Skip stays the deliberate way to decline all of it.
     private var hasAnswer: Bool {
-        unanswered.contains { item in
+        !unanswered.isEmpty && unanswered.allSatisfy { item in
             !(picked[item.id]?.isEmpty ?? true)
                 || !(typed[item.id] ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }

--- a/HermesMobile/Features/Bots/BotPendingRequestCard.swift
+++ b/HermesMobile/Features/Bots/BotPendingRequestCard.swift
@@ -8,6 +8,10 @@ import UIKit
 /// decision buttons and copy are the Sessions approval and clarification
 /// vocabulary. `isEnabled` false is a resolved, expired or in-flight request:
 /// the card stays readable and stops acting.
+///
+/// Only the Desktop-task body has no input, because its answer is data the
+/// Desktop renderer holds. Everything else — approvals, questions, sudo and
+/// secret prompts — is answered from here.
 struct BotPendingRequestCard: View {
     static let cornerRadius: CGFloat = 14
 
@@ -24,6 +28,8 @@ struct BotPendingRequestCard: View {
     let onApprove: (BotApprovalRequest.Choice) -> Void
     let onAnswer: ([BotQuestionAnswer]) -> Void
     let onSkip: () -> Void
+    /// Sends a typed sudo password or secret. Empty is the host's skip.
+    let onCredential: (String) -> Void
     let onStop: () -> Void
 
     var body: some View {
@@ -39,9 +45,14 @@ struct BotPendingRequestCard: View {
                     question: question, identity: identity, isEnabled: isEnabled,
                     isAnswering: isAnswering, onAnswer: onAnswer, onSkip: onSkip
                 )
-            case .desktopOnly(let desktopOnly):
-                BotDesktopOnlyRequestBody(
-                    desktopOnly: desktopOnly, identity: identity, canStop: canStop, onStop: onStop
+            case .credential(let credential):
+                BotCredentialRequestBody(
+                    credential: credential, identity: identity, isEnabled: isEnabled,
+                    isAnswering: isAnswering, onCredential: onCredential
+                )
+            case .desktopTask(let task):
+                BotDesktopTaskRequestBody(
+                    task: task, identity: identity, canStop: canStop, onStop: onStop
                 )
             }
             if let resolution {
@@ -67,8 +78,10 @@ struct BotPendingRequestCard: View {
             summary = approval.consequence ?? approval.command ?? String(localized: "Approval required")
         case .question(let question):
             summary = question.questions.first?.prompt ?? String(localized: "Input needed")
-        case .desktopOnly(let desktopOnly):
-            summary = desktopOnly.kind.title
+        case .credential(let credential):
+            summary = credential.kind.title
+        case .desktopTask(let task):
+            summary = task.kind.title
         }
         AccessibilityNotification.Announcement(String(localized: "Input needed: \(summary)")).post()
     }
@@ -325,10 +338,81 @@ private struct BotQuestionRequestBody: View {
     }
 }
 
-/// A request the phone must not answer. It names the kind, says why, and offers
-/// only the two things the phone legitimately owns: go to Desktop, or stop the work.
-private struct BotDesktopOnlyRequestBody: View {
-    let desktopOnly: BotDesktopOnlyRequest
+/// A sudo password or a secret the bot asked for. Masked, sent straight to the
+/// host and never held on the model, in a draft or anywhere else on the phone.
+/// Skip is a first-class answer: it releases the bot immediately instead of
+/// leaving it parked until the host's deadline.
+private struct BotCredentialRequestBody: View {
+    let credential: BotCredentialRequest
+    let identity: String
+    let isEnabled: Bool
+    let isAnswering: Bool
+    let onCredential: (String) -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var value = ""
+
+    private var canSubmit: Bool { isEnabled && !isAnswering && !value.isEmpty }
+
+    var body: some View {
+        BotRequestHeader(
+            systemImage: credential.kind == .sudo ? "lock.shield.fill" : "key.fill",
+            tint: .secondary, title: credential.kind.title, identity: identity
+        )
+        Text(credential.detail)
+            .font(.subheadline)
+            .foregroundStyle(.primary)
+            .fixedSize(horizontal: false, vertical: true)
+        if let envVar = credential.envVar {
+            // The name the host will store it under, so the user knows which of
+            // their keys to paste before they paste one.
+            Text(envVar)
+                .font(.system(.footnote, design: .monospaced))
+                .textSelection(.enabled)
+                .pendingRequestBlockSurface()
+        }
+        HStack(alignment: .bottom, spacing: 10) {
+            SecureField(credential.kind == .sudo ? "Administrator password" : "Secret value", text: $value)
+                .textContentType(credential.kind == .sudo ? .password : nil)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.send)
+                .onSubmit(submit)
+                .tint(PendingRequestSubmitButton.fill(canSubmit: canSubmit, colorScheme: colorScheme))
+                .pendingRequestFieldSurface()
+                .disabled(!isEnabled || isAnswering)
+
+            PendingRequestSubmitButton(isBusy: isAnswering, canSubmit: canSubmit, action: submit)
+                .accessibilityLabel(credential.kind == .sudo ? "Send password" : "Send secret")
+        }
+        Text(credential.handling)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        Button { onCredential("") } label: {
+            Text("Skip").frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.chatDecision(.secondary))
+        .disabled(!isEnabled || isAnswering)
+        .accessibilityHint(Text(credential.kind.skipConsequence))
+    }
+
+    private func submit() {
+        guard canSubmit else { return }
+        let outgoing = value
+        // Dropped from the view the moment it is handed over; the model never
+        // holds it either, so no layer of the phone keeps the value around.
+        value = ""
+        onCredential(outgoing)
+    }
+}
+
+/// Work the Desktop renderer does and answers itself. There is no input because
+/// there is no answer a person gives — not here, and not at the Mac either. The
+/// host releases the bot on its own deadline, so the card reports the wait and
+/// keeps Stop for the user who does not want to wait it out.
+private struct BotDesktopTaskRequestBody: View {
+    let task: BotDesktopTaskRequest
     let identity: String
     let canStop: Bool
     let onStop: () -> Void
@@ -336,13 +420,16 @@ private struct BotDesktopOnlyRequestBody: View {
     var body: some View {
         BotRequestHeader(
             systemImage: "desktopcomputer", tint: .secondary,
-            title: String(localized: "Only Hermes Desktop can answer this"), identity: identity
+            title: task.kind.needsSomeoneAtTheMac
+                ? String(localized: "Waiting on Hermes Desktop")
+                : String(localized: "Hermes Desktop is handling this"),
+            identity: identity
         )
-        Text(desktopOnly.kind.title)
+        Text(task.kind.title)
             .font(.subheadline)
             .foregroundStyle(.primary)
             .fixedSize(horizontal: false, vertical: true)
-        Text("Hermex never collects passwords, secrets or device context. Answer this in Hermes Desktop on the same Mac, or stop the bot's current work.")
+        Text(task.kind.detail)
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)

--- a/HermesMobile/Features/Chat/ClarificationRequestCard.swift
+++ b/HermesMobile/Features/Chat/ClarificationRequestCard.swift
@@ -150,7 +150,7 @@ struct ClarificationRequestBar: View {
         .padding(.trailing, 8)
         .padding(.vertical, 8)
         .frame(maxWidth: 560)
-        .clarificationSurface(cornerRadius: ChatComposerMetrics.cardCornerRadius)
+        .pendingRequestCardSurface(cornerRadius: ChatComposerMetrics.cardCornerRadius)
         .accessibilityElement(children: .contain)
     }
 }
@@ -177,7 +177,7 @@ struct ClarificationRequestCard: View {
     var body: some View {
         cardContent
             .frame(maxWidth: 560, alignment: .leading)
-            .clarificationSurface(cornerRadius: ChatComposerMetrics.cardCornerRadius)
+            .pendingRequestCardSurface(cornerRadius: ChatComposerMetrics.cardCornerRadius)
             // Ideal height regardless of what the bar-sized overlay proposes.
             .fixedSize(horizontal: false, vertical: true)
             .accessibilityElement(children: .contain)
@@ -227,13 +227,7 @@ struct ClarificationRequestCard: View {
             .font(.subheadline)
             .foregroundStyle(.primary)
             .fixedSize(horizontal: false, vertical: true)
-            .padding(12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(questionBackground, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(.primary.opacity(0.06), lineWidth: 1)
-            )
+            .pendingRequestBlockSurface()
     }
 
     private var choicesList: some View {
@@ -379,14 +373,10 @@ struct ClarificationRequestCard: View {
                 .padding(.vertical, 10)
                 .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
                 .foregroundStyle(.primary)
-                .choiceButtonSurface(reduceTransparency: reduceTransparency)
+                .pendingRequestChoiceSurface(reduceTransparency: reduceTransparency)
         }
         .buttonStyle(.chatTactile(.capsule))
         .disabled(isResponding)
-    }
-
-    private var questionBackground: Color {
-        colorScheme == .dark ? Color.white.opacity(0.07) : Color.black.opacity(0.04)
     }
 
     private var textFieldBackground: Color {
@@ -468,44 +458,5 @@ struct ClarificationRequestCard: View {
     private func nonEmpty(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
-    }
-}
-
-private extension View {
-    /// Opaque on purpose: the bar and card float over live transcript text,
-    /// and a translucent surface would render the question on top of whatever
-    /// message happens to sit underneath.
-    func clarificationSurface(cornerRadius: CGFloat) -> some View {
-        background(
-            Color(.secondarySystemBackground),
-            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .stroke(.primary.opacity(0.10), lineWidth: 1)
-        )
-    }
-
-    @ViewBuilder
-    func choiceButtonSurface(reduceTransparency: Bool) -> some View {
-        if reduceTransparency {
-            background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(Color(.separator), lineWidth: 1)
-                )
-        } else if #available(iOS 26.0, *) {
-            // Fixed corner radius (not .capsule): a capsule's radius grows with the
-            // button's height, so on tall multi-line options the curved ends bow
-            // inward and clip the text. A fixed radius keeps the outline clear of
-            // the label at any line count and matches the fallbacks below.
-            glassEffect(.regular.interactive(), in: .rect(cornerRadius: 14))
-        } else {
-            background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(.primary.opacity(0.10), lineWidth: 1)
-                )
-        }
     }
 }

--- a/HermesMobile/Features/Chat/ClarificationRequestCard.swift
+++ b/HermesMobile/Features/Chat/ClarificationRequestCard.swift
@@ -165,7 +165,6 @@ struct ClarificationRequestCard: View {
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorScheme) private var colorScheme
-    @ScaledMetric(relativeTo: .body) private var submitButtonSize: CGFloat = 40
     @ScaledMetric(relativeTo: .body) private var collapseButtonSize: CGFloat = 28
     @State private var bodyContentHeight: CGFloat?
 
@@ -269,27 +268,16 @@ struct ClarificationRequestCard: View {
             TextField("Type a response", text: $draftResponse, axis: .vertical)
                 .textFieldStyle(.plain)
                 .lineLimit(2...5)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .tint(actionButtonBackground)
-                .background(textFieldBackground, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .overlay(textFieldBorder)
+                .tint(PendingRequestSubmitButton.fill(canSubmit: canSubmit, colorScheme: colorScheme))
+                .pendingRequestFieldSurface()
                 .disabled(isResponding)
 
-            Button {
-                submitDraft()
-            } label: {
-                submitButtonLabel
-                    .frame(width: submitButtonSize, height: submitButtonSize)
-                    .background(actionButtonBackground)
-                    .foregroundStyle(actionButtonForeground)
-                    .clipShape(Circle())
-            }
-            .buttonStyle(.chatTactile(.icon))
-            .disabled(isResponding || trimmedDraft.isEmpty)
-            .accessibilityLabel("Submit clarification")
+            PendingRequestSubmitButton(isBusy: isResponding, canSubmit: canSubmit, action: submitDraft)
+                .accessibilityLabel("Submit clarification")
         }
     }
+
+    private var canSubmit: Bool { !isResponding && !trimmedDraft.isEmpty }
 
     @ViewBuilder
     private var footer: some View {
@@ -349,18 +337,6 @@ struct ClarificationRequestCard: View {
     }
 
     @ViewBuilder
-    private var submitButtonLabel: some View {
-        if isResponding {
-            ProgressView()
-                .tint(actionButtonForeground)
-                .scaleEffect(0.82)
-        } else {
-            Image(systemName: "arrow.up")
-                .font(.system(size: 15, weight: .semibold))
-        }
-    }
-
-    @ViewBuilder
     private func choiceButton(_ choice: String) -> some View {
         Button {
             onSubmit(choice)
@@ -377,31 +353,6 @@ struct ClarificationRequestCard: View {
         }
         .buttonStyle(.chatTactile(.capsule))
         .disabled(isResponding)
-    }
-
-    private var textFieldBackground: Color {
-        colorScheme == .dark ? Color.white.opacity(0.055) : Color.black.opacity(0.045)
-    }
-
-    private var textFieldBorder: some View {
-        RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .stroke(.primary.opacity(colorScheme == .dark ? 0.13 : 0.10), lineWidth: 1)
-    }
-
-    private var actionButtonBackground: Color {
-        if isResponding || trimmedDraft.isEmpty {
-            return colorScheme == .dark ? Color.white.opacity(0.18) : Color.black.opacity(0.12)
-        }
-
-        return colorScheme == .dark ? .white : .black
-    }
-
-    private var actionButtonForeground: Color {
-        if isResponding || trimmedDraft.isEmpty {
-            return Color(.secondaryLabel)
-        }
-
-        return colorScheme == .dark ? .black : .white
     }
 
     private var progressFill: Color {

--- a/HermesMobile/Features/Chat/PendingRequestSurfaces.swift
+++ b/HermesMobile/Features/Chat/PendingRequestSurfaces.swift
@@ -24,6 +24,11 @@ extension View {
         modifier(PendingRequestBlockSurface())
     }
 
+    /// The free-text response field's surface, including its padding.
+    func pendingRequestFieldSurface() -> some View {
+        modifier(PendingRequestFieldSurface())
+    }
+
     @ViewBuilder
     func pendingRequestChoiceSurface(reduceTransparency: Bool) -> some View {
         if reduceTransparency {
@@ -45,6 +50,70 @@ extension View {
                         .stroke(.primary.opacity(0.10), lineWidth: 1)
                 )
         }
+    }
+}
+
+/// The round submit control beside a response field: filled while there is
+/// something to send, recessed when there is not, and a spinner in flight.
+struct PendingRequestSubmitButton: View {
+    let isBusy: Bool
+    let canSubmit: Bool
+    let action: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @ScaledMetric(relativeTo: .body) private var size: CGFloat = 40
+
+    /// Also the response field's caret colour, so the pair reads as one control.
+    static func fill(canSubmit: Bool, colorScheme: ColorScheme) -> Color {
+        guard canSubmit else {
+            return colorScheme == .dark ? Color.white.opacity(0.18) : Color.black.opacity(0.12)
+        }
+        return colorScheme == .dark ? .white : .black
+    }
+
+    var body: some View {
+        Button(action: action) {
+            label
+                .frame(width: size, height: size)
+                .background(Self.fill(canSubmit: canSubmit, colorScheme: colorScheme))
+                .foregroundStyle(foreground)
+                .clipShape(Circle())
+        }
+        .buttonStyle(.chatTactile(.icon))
+        .disabled(isBusy || !canSubmit)
+    }
+
+    @ViewBuilder
+    private var label: some View {
+        if isBusy {
+            ProgressView().tint(foreground).scaleEffect(0.82)
+        } else {
+            Image(systemName: "arrow.up").font(.system(size: 15, weight: .semibold))
+        }
+    }
+
+    private var foreground: Color {
+        guard canSubmit else { return Color(.secondaryLabel) }
+        return colorScheme == .dark ? .black : .white
+    }
+}
+
+private struct PendingRequestFieldSurface: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(fill, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(.primary.opacity(colorScheme == .dark ? 0.13 : 0.10), lineWidth: 1)
+            )
+    }
+
+    private var fill: Color {
+        colorScheme == .dark ? Color.white.opacity(0.055) : Color.black.opacity(0.045)
     }
 }
 

--- a/HermesMobile/Features/Chat/PendingRequestSurfaces.swift
+++ b/HermesMobile/Features/Chat/PendingRequestSurfaces.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// The surfaces a pending approval or clarification card is built from, shared
+/// by the Sessions cards and the Bot one. Placement differs per surface: the
+/// Sessions clarification pins above the composer, the Bot card sits in the
+/// transcript. What the user reads and taps does not.
+extension View {
+    /// Opaque on purpose: these cards float over live transcript text, and a
+    /// translucent surface would render the request on top of whatever message
+    /// happens to sit underneath.
+    func pendingRequestCardSurface(cornerRadius: CGFloat) -> some View {
+        background(
+            Color(.secondarySystemBackground),
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .stroke(.primary.opacity(0.10), lineWidth: 1)
+        )
+    }
+
+    /// The recessed block a question or a command sits in, inside a card.
+    func pendingRequestBlockSurface() -> some View {
+        modifier(PendingRequestBlockSurface())
+    }
+
+    @ViewBuilder
+    func pendingRequestChoiceSurface(reduceTransparency: Bool) -> some View {
+        if reduceTransparency {
+            background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(Color(.separator), lineWidth: 1)
+                )
+        } else if #available(iOS 26.0, *) {
+            // Fixed corner radius (not .capsule): a capsule's radius grows with the
+            // button's height, so on tall multi-line options the curved ends bow
+            // inward and clip the text. A fixed radius keeps the outline clear of
+            // the label at any line count and matches the fallbacks below.
+            glassEffect(.regular.interactive(), in: .rect(cornerRadius: 14))
+        } else {
+            background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(.primary.opacity(0.10), lineWidth: 1)
+                )
+        }
+    }
+}
+
+private struct PendingRequestBlockSurface: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(fill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(.primary.opacity(0.06), lineWidth: 1)
+            )
+    }
+
+    private var fill: Color {
+        colorScheme == .dark ? Color.white.opacity(0.07) : Color.black.opacity(0.04)
+    }
+}

--- a/HermesMobile/Networking/Bots/BotClient.swift
+++ b/HermesMobile/Networking/Bots/BotClient.swift
@@ -128,7 +128,8 @@ import Foundation
     }
 
     func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)? = nil) async throws -> BotJSON {
-        guard ["profiles.list", "profiles.get_asset", "session.list", "session.resume", "session.events.since", "prompt.submit", "session.interrupt"].contains(method)
+        guard ["profiles.list", "profiles.get_asset", "session.list", "session.resume", "session.events.since",
+               "prompt.submit", "session.interrupt", "approval.respond", "clarify.respond"].contains(method)
         else { throw BotFailure.unsupported }
         guard let socket, !Task.isCancelled else { throw BotFailure.stale }
         nextID += 1

--- a/HermesMobile/Networking/Bots/BotClient.swift
+++ b/HermesMobile/Networking/Bots/BotClient.swift
@@ -129,7 +129,8 @@ import Foundation
 
     func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)? = nil) async throws -> BotJSON {
         guard ["profiles.list", "profiles.get_asset", "session.list", "session.resume", "session.events.since",
-               "prompt.submit", "session.interrupt", "approval.respond", "clarify.respond"].contains(method)
+               "prompt.submit", "session.interrupt", "approval.respond", "clarify.respond",
+               "sudo.respond", "secret.respond"].contains(method)
         else { throw BotFailure.unsupported }
         guard let socket, !Task.isCancelled else { throw BotFailure.stale }
         nextID += 1

--- a/HermesMobile/Networking/Bots/BotClient.swift
+++ b/HermesMobile/Networking/Bots/BotClient.swift
@@ -130,7 +130,7 @@ import Foundation
     func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)? = nil) async throws -> BotJSON {
         guard ["profiles.list", "profiles.get_asset", "session.list", "session.resume", "session.events.since",
                "prompt.submit", "session.interrupt", "approval.respond", "clarify.respond",
-               "sudo.respond", "secret.respond"].contains(method)
+               "sudo.respond", "secret.respond", "mcp.setup.respond"].contains(method)
         else { throw BotFailure.unsupported }
         guard let socket, !Task.isCancelled else { throw BotFailure.stale }
         nextID += 1

--- a/HermesMobileTests/BotChatPresentationTests.swift
+++ b/HermesMobileTests/BotChatPresentationTests.swift
@@ -20,7 +20,7 @@ import XCTest
         let wire = BotFixtureWire()
         let model = make(wire)
         await model.recover()
-        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}))
+        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}, onShowRequest: {}))
         defer { model.suspend(); close(window) }
         await renderFrames()
         let ready = try screenshot(window, name: "ready-no-status")
@@ -41,7 +41,7 @@ import XCTest
         XCTAssertFalse(model.mayEditDraft)
         await model.recover()
         model.editDraft("Persistent text")
-        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}))
+        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}, onShowRequest: {}))
         defer { model.suspend(); close(window) }
         await renderFrames()
         let editor = try XCTUnwrap(descendants(window).compactMap { $0 as? ComposerChipTextView }.first)
@@ -76,12 +76,84 @@ import XCTest
         await model.recover()
         XCTAssertTrue(model.uncertainStop)
         XCTAssertEqual(model.turn, .needsAttention)
-        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}))
+        let window = try show(BotChatComposerView(model: model, onStop: {}, onReconnect: {}, onResolveHeldMessage: {}, onShowRequest: {}))
         defer { model.suspend(); close(window) }
         await renderFrames()
         let status = try screenshot(window, name: "attention-over-uncertain-stop")
-        XCTAssertTrue(status.contains("Needs attention"))
+        XCTAssertTrue(status.contains("Waiting for your answer"))
         XCTAssertFalse(status.contains("Outcome unknown"))
+    }
+
+    /// The approval card offers exactly what the host offered: this request was
+    /// smart-denied, so there is no session or permanent allow to hand out.
+    func testApprovalCardShowsOnlyTheHostsChoicesAndGoesInertOnceAnswered() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        wire.pendingApproval = BotFixtureWire.approval(command: "rm -rf build", choices: ["once", "deny"])
+        let model = make(wire)
+        let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .active))
+        defer { model.suspend(); close(window) }
+        await model.recover()
+        await renderFrames()
+        let shown = try screenshot(window, name: "bot-approval-card")
+        XCTAssertTrue(shown.contains("Approval required"), shown)
+        XCTAssertTrue(shown.contains("recursive delete"), shown)
+        XCTAssertTrue(shown.contains("Allow once"), shown)
+        XCTAssertTrue(shown.contains("Deny"), shown)
+        XCTAssertFalse(shown.contains("Always allow"), shown)
+        XCTAssertFalse(shown.contains("Allow session"), shown)
+        // Identity, so two hosts with equal Profile names never look alike.
+        XCTAssertTrue(shown.contains("Fixture Mac"), shown)
+
+        wire.approvalResolved = 0
+        await model.respond(try XCTUnwrap(model.prepareAnswer()), choice: .once)
+        await renderFrames()
+        let answered = try screenshot(window, name: "bot-approval-card-already-answered")
+        XCTAssertTrue(answered.contains("already answered"), answered)
+        XCTAssertFalse(model.mayAnswer)
+    }
+
+    /// The question card is the Sessions clarification vocabulary: the question
+    /// block, the host's choices, and a free-text response field.
+    func testQuestionCardShowsChoicesWithoutTheHostsPresentationLabel() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        wire.pendingClarify = BotFixtureWire.clarify()
+        let model = make(wire)
+        let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .active))
+        defer { model.suspend(); close(window) }
+        await model.recover()
+        await renderFrames()
+        let shown = try screenshot(window, name: "bot-question-card")
+        XCTAssertTrue(shown.contains("Clarification Required"), shown)
+        XCTAssertTrue(shown.contains("Which mailbox first?"), shown)
+        XCTAssertTrue(shown.contains("Primary"), shown)
+        XCTAssertTrue(shown.contains("Follow-ups"), shown)
+        XCTAssertTrue(shown.contains("Type a response"), shown)
+        // "(Recommended)" is the host's presentation suffix, shown as a tag.
+        XCTAssertFalse(shown.contains("Primary (Recommended)"), shown)
+    }
+
+    /// A kind the phone must never answer names itself and offers no input,
+    /// no choices and no credential field: only Desktop, or Stop.
+    func testDesktopOnlyCardNamesTheKindAndOffersNoInput() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire)
+        // Inactive so the view's own recovery task cannot race the injected event:
+        // a Desktop-only request lives only in the stream, so a reconnect drops it.
+        let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .inactive))
+        defer { model.suspend(); close(window) }
+        await model.recover()
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
+            "payload": .object(["request_id": .string("sudo-1")])
+        ]))
+        await renderFrames()
+        let shown = try screenshot(window, name: "bot-desktop-only-card")
+        XCTAssertTrue(shown.contains("Only Hermes Desktop can answer this"), shown)
+        XCTAssertTrue(shown.contains("administrator password"), shown)
+        XCTAssertTrue(shown.contains("Stop current work"), shown)
+        XCTAssertFalse(shown.contains("Type a response"), shown)
+        XCTAssertFalse(shown.contains("Allow once"), shown)
+        XCTAssertFalse(model.mayAnswer)
     }
 
     func testTextOnlyEditorRejectsAttachmentProviders() {

--- a/HermesMobileTests/BotChatPresentationTests.swift
+++ b/HermesMobileTests/BotChatPresentationTests.swift
@@ -210,6 +210,28 @@ import XCTest
         XCTAssertFalse(model.mayAnswer)
     }
 
+    /// The MCP setup card is the one Desktop task with a way out that is not
+    /// Stop: skipping calls off the request and leaves the bot's work running.
+    func testMCPSetupCardOffersSkipAlongsideStop() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire)
+        let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .inactive))
+        defer { model.suspend(); close(window) }
+        await model.recover()
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("mcp.setup.request"),
+            "payload": .object(["request_id": .string("mcp-1"), "server": .string("tavily")])
+        ]))
+        await awaitSnapshot(model)
+        await renderFrames()
+        let shown = try screenshot(window, name: "bot-mcp-setup-card")
+        XCTAssertTrue(shown.contains("Waiting on Hermes Desktop"), shown)
+        XCTAssertTrue(shown.contains("Skip it here"), shown)
+        XCTAssertTrue(shown.contains("Skip this setup"), shown)
+        XCTAssertTrue(shown.contains("Stop current work"), shown)
+        XCTAssertTrue(model.mayDecline)
+    }
+
     func testTextOnlyEditorRejectsAttachmentProviders() {
         let editor = ComposerChipTextView()
         let image = NSItemProvider(item: NSData(), typeIdentifier: UTType.png.identifier)
@@ -298,10 +320,10 @@ import XCTest
             "payload": .object(["tool_id": .string("t1"), "name": .string("write_file"), "args": .object(["path": .string("reply-delivery.md")])])
         ]))
         // A live tool row lands without a following snapshot (activity events
-        // during known work skip the refresh), so layout is the only thing left
-        // to settle. Three frames is not always enough for the disclosure row.
-        await renderFrames(12)
-        let shown = try screenshot(window, name: "bot-activity-cards-on")
+        // during known work skip the refresh), so nothing signals when the
+        // LazyVStack has materialized it — any fixed frame count is a guess.
+        let shown = try await screenshot(window, name: "bot-activity-cards-on",
+                                         awaiting: ["Ran", "Thinking", "Updated", "Plan"])
         XCTAssertTrue(shown.contains("Ran"), shown)
         XCTAssertTrue(shown.contains("Thinking"), shown)
         XCTAssertTrue(shown.contains("Updated"), shown)
@@ -349,6 +371,21 @@ import XCTest
         driver.start()
         await fulfillment(of: [rendered], timeout: 10)
         driver.stop()
+    }
+
+    /// Captures once layout has produced every `expected` string, or gives up
+    /// and returns the last read so the assertion fails with what was on screen.
+    /// Rows that arrive without a state change to wait on settle at their own
+    /// pace, so this waits on the content under test instead of a frame count.
+    private func screenshot(_ window: UIWindow, name: String,
+                            awaiting expected: [String]) async throws -> String {
+        var text = ""
+        for _ in 0..<8 {
+            await renderFrames(4)
+            text = try screenshot(window, name: name)
+            if expected.allSatisfy(text.contains) { break }
+        }
+        return text
     }
 
     @discardableResult

--- a/HermesMobileTests/BotChatPresentationTests.swift
+++ b/HermesMobileTests/BotChatPresentationTests.swift
@@ -146,7 +146,11 @@ import XCTest
             "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
             "payload": .object(["request_id": .string("sudo-1")])
         ]))
+        // The event only puts the turn in doubt; the coalesced snapshot is what
+        // settles it on needs-attention, which is when Stop becomes offerable.
+        await awaitSnapshot(model)
         await renderFrames()
+        XCTAssertTrue(model.mayStop)
         let shown = try screenshot(window, name: "bot-desktop-only-card")
         XCTAssertTrue(shown.contains("Only Hermes Desktop can answer this"), shown)
         XCTAssertTrue(shown.contains("administrator password"), shown)
@@ -243,7 +247,10 @@ import XCTest
             "session_id": .string("runtime"), "seq": .number(1), "type": .string("tool.start"),
             "payload": .object(["tool_id": .string("t1"), "name": .string("write_file"), "args": .object(["path": .string("reply-delivery.md")])])
         ]))
-        await renderFrames()
+        // A live tool row lands without a following snapshot (activity events
+        // during known work skip the refresh), so layout is the only thing left
+        // to settle. Three frames is not always enough for the disclosure row.
+        await renderFrames(12)
         let shown = try screenshot(window, name: "bot-activity-cards-on")
         XCTAssertTrue(shown.contains("Ran"), shown)
         XCTAssertTrue(shown.contains("Thinking"), shown)
@@ -251,7 +258,7 @@ import XCTest
         XCTAssertTrue(shown.contains("Plan"), shown)
         XCTAssertTrue(shown.contains("1 of 2"), shown)
         defaults.set(false, forKey: key)
-        await renderFrames()
+        await renderFrames(12)
         let hidden = try screenshot(window, name: "bot-activity-cards-off")
         XCTAssertFalse(hidden.contains("Thinking"), hidden)
         XCTAssertFalse(hidden.contains("Updated"), hidden)
@@ -278,9 +285,17 @@ import XCTest
         [view] + view.subviews.flatMap(descendants)
     }
 
-    private func renderFrames() async {
+    /// Waits for the conversation's coalesced snapshot read to land. Every
+    /// `applySnapshot` republishes the turn state, so it is the arrival signal.
+    private func awaitSnapshot(_ model: BotConversation) async {
+        let applied = expectation(description: "Snapshot applied")
+        withObservationTracking { _ = String(describing: model.turn) } onChange: { applied.fulfill() }
+        await fulfillment(of: [applied], timeout: 5)
+    }
+
+    private func renderFrames(_ target: Int = 3) async {
         let rendered = expectation(description: "Layout committed")
-        let driver = BotRenderFrameDriver { rendered.fulfill() }
+        let driver = BotRenderFrameDriver(target: target) { rendered.fulfill() }
         driver.start()
         await fulfillment(of: [rendered], timeout: 10)
         driver.stop()

--- a/HermesMobileTests/BotChatPresentationTests.swift
+++ b/HermesMobileTests/BotChatPresentationTests.swift
@@ -132,13 +132,13 @@ import XCTest
         XCTAssertFalse(shown.contains("Primary (Recommended)"), shown)
     }
 
-    /// A kind the phone must never answer names itself and offers no input,
-    /// no choices and no credential field: only Desktop, or Stop.
-    func testDesktopOnlyCardNamesTheKindAndOffersNoInput() async throws {
+    /// A sudo prompt is answered here, not at the Mac: a masked field, a Skip,
+    /// and the handling line stated before anything is typed.
+    func testSudoCardOffersAMaskedFieldAndSaysWhereTheValueGoes() async throws {
         let wire = BotFixtureWire(); wire.running = true
         let model = make(wire)
         // Inactive so the view's own recovery task cannot race the injected event:
-        // a Desktop-only request lives only in the stream, so a reconnect drops it.
+        // a credential prompt lives only in the stream, so a reconnect drops it.
         let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .inactive))
         defer { model.suspend(); close(window) }
         await model.recover()
@@ -146,14 +146,64 @@ import XCTest
             "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
             "payload": .object(["request_id": .string("sudo-1")])
         ]))
-        // The event only puts the turn in doubt; the coalesced snapshot is what
-        // settles it on needs-attention, which is when Stop becomes offerable.
+        // The event only puts the turn in doubt; the coalesced snapshot settles it.
+        await awaitSnapshot(model)
+        await renderFrames()
+        let shown = try screenshot(window, name: "bot-sudo-card")
+        XCTAssertTrue(shown.contains("Administrator password needed"), shown)
+        XCTAssertTrue(shown.contains("never saves it"), shown)
+        XCTAssertTrue(shown.contains("Skip"), shown)
+        XCTAssertTrue(shown.contains("Fixture Mac"), shown)
+        // Nothing here tells the user to go and find a desk.
+        XCTAssertFalse(shown.contains("Only Hermes Desktop"), shown)
+        XCTAssertTrue(model.mayAnswer)
+
+        let fields = descendants(window).compactMap { $0 as? UITextField }
+        XCTAssertFalse(fields.isEmpty, "Expected the credential field")
+        XCTAssertTrue(fields.allSatisfy(\.isSecureTextEntry), "A credential field is never in the clear")
+    }
+
+    /// A secret prompt shows the host's own words and the name the value is
+    /// saved under, so the user knows which key to paste.
+    func testSecretCardNamesTheVariableItWillBeSavedAs() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire)
+        let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .inactive))
+        defer { model.suspend(); close(window) }
+        await model.recover()
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("secret.request"),
+            "payload": .object(["request_id": .string("sec-1"), "env_var": .string("TAVILY_API_KEY"),
+                                "prompt": .string("Paste your Tavily key")])
+        ]))
+        await awaitSnapshot(model)
+        await renderFrames()
+        let shown = try screenshot(window, name: "bot-secret-card")
+        XCTAssertTrue(shown.contains("Secret needed"), shown)
+        XCTAssertTrue(shown.contains("Paste your Tavily key"), shown)
+        XCTAssertTrue(shown.contains("TAVILY_API_KEY"), shown)
+    }
+
+    /// A Desktop-renderer task has no input because there is no answer a person
+    /// gives — here or at the Mac. It says so, and keeps Stop.
+    func testDesktopTaskCardReportsTheWaitInsteadOfSendingTheUserToADesk() async throws {
+        let wire = BotFixtureWire(); wire.running = true
+        let model = make(wire)
+        let window = try show(NavigationStack { BotChatView(model: model) }.environment(\.scenePhase, .inactive))
+        defer { model.suspend(); close(window) }
+        await model.recover()
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("terminal.read.request"),
+            "payload": .object(["request_id": .string("term-1")])
+        ]))
+        // Stop only becomes offerable once the snapshot settles on needs-attention.
         await awaitSnapshot(model)
         await renderFrames()
         XCTAssertTrue(model.mayStop)
-        let shown = try screenshot(window, name: "bot-desktop-only-card")
-        XCTAssertTrue(shown.contains("Only Hermes Desktop can answer this"), shown)
-        XCTAssertTrue(shown.contains("administrator password"), shown)
+        let shown = try screenshot(window, name: "bot-desktop-task-card")
+        XCTAssertTrue(shown.contains("Hermes Desktop is handling this"), shown)
+        XCTAssertTrue(shown.contains("reading a terminal"), shown)
+        XCTAssertTrue(shown.contains("nothing to do"), shown)
         XCTAssertTrue(shown.contains("Stop current work"), shown)
         XCTAssertFalse(shown.contains("Type a response"), shown)
         XCTAssertFalse(shown.contains("Allow once"), shown)

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -475,11 +475,18 @@ import Vision
     }
 }
 
+/// Drives real display-link frames so a capture happens after layout, never
+/// after a wall-clock sleep. `target` is how many frames to let pass: a view
+/// whose content arrives from a live event needs more than the default.
 @MainActor final class BotRenderFrameDriver: NSObject {
     private let completion: () -> Void
+    private let target: Int
     private var link: CADisplayLink?
     private var frames = 0
-    init(completion: @escaping () -> Void) { self.completion = completion }
+    init(target: Int = 3, completion: @escaping () -> Void) {
+        self.target = target
+        self.completion = completion
+    }
     func start() {
         link = CADisplayLink(target: self, selector: #selector(tick))
         link?.add(to: .main, forMode: .common)
@@ -487,7 +494,7 @@ import Vision
     func stop() { link?.invalidate(); link = nil }
     @objc private func tick() {
         frames += 1
-        if frames == 3 { stop(); completion() }
+        if frames == target { stop(); completion() }
     }
 }
 

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -564,7 +564,7 @@ actor BotMemoryDrafts: ChatDraftPersisting {
             if let respondFailure { throw respondFailure }
             if clarifyStatus == "ok" { pendingClarify = .null }
             return .object(["status": .string(clarifyStatus)])
-        case "sudo.respond", "secret.respond":
+        case "sudo.respond", "secret.respond", "mcp.setup.respond":
             if let respondFailure { throw respondFailure }
             return .object(["status": .string(credentialStatus)])
         case "session.events.since": return replay

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -521,6 +521,8 @@ actor BotMemoryDrafts: ChatDraftPersisting {
     /// What `approval.respond` reports unblocking, and what `clarify.respond` reports.
     var approvalResolved = 1
     var clarifyStatus = "ok"
+    /// What `sudo.respond` / `secret.respond` report; "ok" or "expired".
+    var credentialStatus = "ok"
     var respondFailure: BotFailure?
     var todoState = BotJSON.null
     var history: [BotJSON] = [.object(["role": .string("assistant"), "text": .string("saved")])]
@@ -562,6 +564,9 @@ actor BotMemoryDrafts: ChatDraftPersisting {
             if let respondFailure { throw respondFailure }
             if clarifyStatus == "ok" { pendingClarify = .null }
             return .object(["status": .string(clarifyStatus)])
+        case "sudo.respond", "secret.respond":
+            if let respondFailure { throw respondFailure }
+            return .object(["status": .string(credentialStatus)])
         case "session.events.since": return replay
         case "prompt.submit":
             await beforeSubmit?()

--- a/HermesMobileTests/BotConversationTests.swift
+++ b/HermesMobileTests/BotConversationTests.swift
@@ -506,7 +506,15 @@ actor BotMemoryDrafts: ChatDraftPersisting {
     var tip = "tip"
     var running = false
     var inflight = BotJSON.null
+    /// Shorthand for "a command approval is blocking this session"; set
+    /// `pendingApproval` directly to control the payload.
     var attention = false
+    var pendingApproval: BotJSON?
+    var pendingClarify = BotJSON.null
+    /// What `approval.respond` reports unblocking, and what `clarify.respond` reports.
+    var approvalResolved = 1
+    var clarifyStatus = "ok"
+    var respondFailure: BotFailure?
     var todoState = BotJSON.null
     var history: [BotJSON] = [.object(["role": .string("assistant"), "text": .string("saved")])]
     var replay = BotFixtureWire.replay()
@@ -533,10 +541,20 @@ actor BotMemoryDrafts: ChatDraftPersisting {
             await beforeResume?()
             return .object([
                 "session_id": .string("runtime"), "session_key": .string(tip), "running": .bool(running),
-                "messages": .array(history), "inflight": inflight, "pending_approval": attention ? .object(["id": .string("approval")]) : .null,
+                "messages": .array(history), "inflight": inflight,
+                "pending_approval": pendingApproval ?? (attention ? BotFixtureWire.approval() : .null),
+                "pending_clarify": pendingClarify,
                 "todo_state": todoState,
                 "info": .object(["profile_name": .string("inbox-triage")])
             ])
+        case "approval.respond":
+            if let respondFailure { throw respondFailure }
+            if approvalResolved > 0 { attention = false; pendingApproval = nil }
+            return .object(["resolved": .number(Double(approvalResolved))])
+        case "clarify.respond":
+            if let respondFailure { throw respondFailure }
+            if clarifyStatus == "ok" { pendingClarify = .null }
+            return .object(["status": .string(clarifyStatus)])
         case "session.events.since": return replay
         case "prompt.submit":
             await beforeSubmit?()
@@ -549,6 +567,27 @@ actor BotMemoryDrafts: ChatDraftPersisting {
         default: throw BotFailure.unsupported
         }
     }
+    /// The gateway's `_approval_request_payload` shape, as it reaches both the
+    /// `approval.request` event and the resume snapshot.
+    static func approval(id: String = "req-1", command: String = "rm -rf build",
+                         choices: [String] = ["once", "session", "always", "deny"]) -> BotJSON {
+        .object([
+            "request_id": .string(id), "command": .string(command),
+            "description": .string("recursive delete"), "pattern_key": .string("rm"),
+            "choices": .array(choices.map(BotJSON.string))
+        ])
+    }
+
+    /// The single-question `clarify.request` / `pending_clarify` shape.
+    static func clarify(id: String = "clr-1", question: String = "Which mailbox first?",
+                        choices: [String] = ["Primary (Recommended)", "Follow-ups"],
+                        multiSelect: Bool = false) -> BotJSON {
+        .object([
+            "request_id": .string(id), "question": .string(question),
+            "choices": .array(choices.map(BotJSON.string)), "multi_select": .bool(multiSelect)
+        ])
+    }
+
     static func replay(latest: Int = 0, truncated: Bool = false, epoch: String = "epoch", events: [BotJSON] = []) -> BotJSON {
         .object(["latest_seq": .number(Double(latest)), "truncated": .bool(truncated), "epoch": .string(epoch), "events": .array(events)])
     }

--- a/HermesMobileTests/BotPendingRequestTests.swift
+++ b/HermesMobileTests/BotPendingRequestTests.swift
@@ -1,0 +1,489 @@
+import XCTest
+@testable import HermesMobile
+
+/// Parsing the host's blocking-request payloads. Everything here is pure, so it
+/// pins the wire contract without a socket.
+@MainActor final class BotPendingRequestParsingTests: XCTestCase {
+    func testApprovalKeepsTheHostsOwnChoiceSet() {
+        let request = BotApprovalRequest(BotFixtureWire.approval())
+        XCTAssertEqual(request?.requestID, "req-1")
+        XCTAssertEqual(request?.command, "rm -rf build")
+        XCTAssertEqual(request?.consequence, "recursive delete")
+        XCTAssertEqual(request?.choices, [.once, .session, .always, .deny])
+    }
+
+    func testApprovalDropsUnknownChoicesAndAlwaysOffersDeny() {
+        let request = BotApprovalRequest(.object([
+            "request_id": .string("req-2"),
+            "choices": .array([.string("once"), .string("teleport")])
+        ]))
+        XCTAssertEqual(request?.choices, [.once, .deny])
+    }
+
+    /// A host old enough to omit `choices` still gets the gateway's own rules.
+    func testApprovalRebuildsOmittedChoicesFromTheHostsFlags() {
+        XCTAssertEqual(
+            BotApprovalRequest(.object(["request_id": .string("a")]))?.choices,
+            [.once, .session, .always, .deny]
+        )
+        XCTAssertEqual(
+            BotApprovalRequest(.object(["request_id": .string("a"), "allow_permanent": .bool(false)]))?.choices,
+            [.once, .session, .deny]
+        )
+        XCTAssertEqual(
+            BotApprovalRequest(.object(["request_id": .string("a"), "smart_denied": .bool(true)]))?.choices,
+            [.once, .deny]
+        )
+    }
+
+    func testApprovalWithoutARequestIDIsNotShown() {
+        XCTAssertNil(BotApprovalRequest(.object(["command": .string("rm -rf /")])))
+        XCTAssertNil(BotApprovalRequest(.object(["request_id": .string("")])))
+        XCTAssertNil(BotApprovalRequest(.null))
+    }
+
+    func testSingleQuestionCarriesNoQuestionIDAndStripsTheRecommendationLabel() {
+        let request = BotQuestionRequest(BotFixtureWire.clarify())
+        XCTAssertEqual(request?.requestID, "clr-1")
+        XCTAssertEqual(request?.isBatch, false)
+        XCTAssertNil(request?.questions.first?.wireID)
+        XCTAssertEqual(request?.questions.first?.prompt, "Which mailbox first?")
+        XCTAssertEqual(request?.questions.first?.choices.map(\.label), ["Primary", "Follow-ups"])
+        // The answer echoes the host's own label back; only presentation is stripped.
+        XCTAssertEqual(request?.questions.first?.choices.map(\.wireLabel), ["Primary (Recommended)", "Follow-ups"])
+        XCTAssertEqual(request?.questions.first?.choices.map(\.isRecommended), [true, false])
+    }
+
+    func testOpenEndedQuestionHasNoChoices() {
+        let request = BotQuestionRequest(.object([
+            "request_id": .string("clr-2"), "question": .string("What should I name it?"), "choices": .null
+        ]))
+        XCTAssertEqual(request?.questions.first?.choices, [])
+        XCTAssertEqual(request?.questions.first?.allowsMultipleChoices, false)
+    }
+
+    func testBatchQuestionsKeepWireIDsOrderAndLockedAnswers() {
+        let request = BotQuestionRequest(.object([
+            "request_id": .string("clr-3"),
+            "questions": .array([
+                .object(["qid": .string("q0"), "question": .string("Which mailbox?"),
+                         "choices": .array([.string("Primary")]), "multi_select": .bool(false)]),
+                .object(["qid": .string("q1"), "question": .string("Newsletters?"),
+                         "choices": .array([.string("Archive"), .string("Unsubscribe")]), "multi_select": .bool(true)])
+            ]),
+            "answers": .object(["q0": .string("Primary")])
+        ]))
+        XCTAssertEqual(request?.isBatch, true)
+        XCTAssertEqual(request?.questions.map(\.wireID), ["q0", "q1"])
+        XCTAssertEqual(request?.questions.map(\.isAnswered), [true, false])
+        XCTAssertEqual(request?.unansweredCount, 1)
+        XCTAssertEqual(request?.questions.last?.allowsMultipleChoices, true)
+    }
+
+    func testQuestionWithNoReadableContentIsNotShown() {
+        XCTAssertNil(BotQuestionRequest(.object(["request_id": .string("clr-4")])))
+        XCTAssertNil(BotQuestionRequest(.object(["request_id": .string("clr-4"), "question": .string("   ")])))
+        XCTAssertNil(BotQuestionRequest(.object(["question": .string("orphan")])))
+        XCTAssertNil(BotQuestionRequest(.null))
+    }
+
+    func testMultiSelectAnswerIsAJSONArrayString() {
+        let answer = BotQuestionAnswer(questionID: "q1", selections: ["Archive", "Unsubscribe"])
+        XCTAssertEqual(answer.text, #"["Archive","Unsubscribe"]"#)
+    }
+
+    func testDesktopOnlyKindsMapFromTheirRequestAndExpireEvents() {
+        let expected: [String: BotDesktopOnlyRequest.Kind] = [
+            "sudo": .sudo, "secret": .secret, "terminal.read": .terminalRead,
+            "window.read": .windowRead, "mcp.setup": .mcpSetup,
+            "preview.read": .previewRead, "preview.act": .previewAct, "tour": .tour
+        ]
+        for (prefix, kind) in expected {
+            XCTAssertEqual(
+                BotDesktopOnlyRequest.requested(eventType: "\(prefix).request",
+                                                payload: .object(["request_id": .string("r")])),
+                BotDesktopOnlyRequest(kind: kind, requestID: "r")
+            )
+            XCTAssertEqual(BotDesktopOnlyRequest.expired(eventType: "\(prefix).expire"), kind)
+            XCTAssertFalse(kind.title.isEmpty)
+        }
+        XCTAssertNil(BotDesktopOnlyRequest.requested(eventType: "clarify.request", payload: .null))
+        XCTAssertNil(BotDesktopOnlyRequest.requested(eventType: "tool.start", payload: .null))
+        XCTAssertNil(BotDesktopOnlyRequest.expired(eventType: "clarify.expire"))
+    }
+}
+
+/// Answering from the phone: dispatch, revalidation, and every way an answer can
+/// fail to take effect.
+@MainActor final class BotAnsweringTests: XCTestCase {
+    private let server = URL(string: "https://webui.example")!
+    private func connection(_ address: String = "http://hermes.local:9120") -> BotConnection {
+        BotConnection(id: UUID(), name: "Mac", address: URL(string: address)!, username: "user", password: "fixture")
+    }
+    private var profile: BotProfile { BotProfile(.object(["name": .string("inbox-triage")]))! }
+
+    private func make(_ wire: BotFixtureWire, connection override: BotConnection? = nil) -> BotConversation {
+        BotConversation(server: server, connection: override ?? connection(), profile: profile, wire: wire,
+                        drafts: ChatDraftStore(persistence: BotMemoryDrafts(), debounceDuration: .seconds(60)))
+    }
+
+    /// A connected conversation whose bot is mid-turn, so a request can block it.
+    private func blocked(on wire: BotFixtureWire) async -> BotConversation {
+        wire.running = true
+        let model = make(wire)
+        await model.recover()
+        return model
+    }
+
+    /// The action `prepareAnswer()` must have produced. Fails rather than aborting,
+    /// so these non-throwing async tests stay readable.
+    private func action(_ model: BotConversation,
+                        file: StaticString = #filePath, line: UInt = #line) -> BotConversation.AnswerAction {
+        guard let action = model.prepareAnswer() else {
+            XCTFail("Expected an answerable request", file: file, line: line)
+            return BotConversation.AnswerAction(generation: -1, runtime: "", requestID: "")
+        }
+        return action
+    }
+
+    /// Waits for the conversation's coalesced snapshot read to land. Every
+    /// `applySnapshot` republishes the turn state, so it is the arrival signal.
+    private func awaitSnapshot(_ model: BotConversation) async {
+        let applied = expectation(description: "Snapshot applied")
+        withObservationTracking { _ = String(describing: model.turn) } onChange: { applied.fulfill() }
+        await fulfillment(of: [applied], timeout: 5)
+    }
+
+    // MARK: approvals
+
+    func testApprovalFromTheSnapshotIsAnswerableAndDispatchesTheHostsChoice() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        XCTAssertEqual(model.turn, .needsAttention)
+        XCTAssertFalse(model.maySend)
+        XCTAssertTrue(model.mayAnswer)
+        guard case .approval(let request)? = model.pendingRequest else { return XCTFail("Expected an approval") }
+        XCTAssertEqual(request.command, "rm -rf build")
+
+        await model.respond(action(model), choice: .session)
+        let sent = wire.calls.last { $0.0 == "approval.respond" }
+        XCTAssertEqual(sent?.1["session_id"], .string("runtime"))
+        XCTAssertEqual(sent?.1["request_id"], .string("req-1"))
+        XCTAssertEqual(sent?.1["choice"], .string("session"))
+        XCTAssertEqual(model.requestResolution, BotRequestResolution(requestID: "req-1", outcome: .answered))
+        XCTAssertFalse(model.mayAnswer)
+        model.suspend()
+    }
+
+    /// The host unblocked nothing: Desktop answered first, or it timed out. That is
+    /// an action failure, not a delivery failure, and the card must go inert.
+    func testResolvedZeroReportsAlreadyAnsweredAndDisablesTheCard() async {
+        let wire = BotFixtureWire(); wire.attention = true; wire.approvalResolved = 0
+        let model = await blocked(on: wire)
+        await model.respond(action(model), choice: .once)
+        XCTAssertEqual(model.requestResolution?.outcome, .alreadyResolved)
+        XCTAssertFalse(model.mayAnswer)
+        XCTAssertEqual(model.connectionState, .connected)
+        XCTAssertNil(model.errorMessage)
+        model.suspend()
+    }
+
+    func testAChoiceTheHostNeverOfferedIsNeverSent() async {
+        let wire = BotFixtureWire()
+        wire.pendingApproval = BotFixtureWire.approval(choices: ["once", "deny"])
+        let model = await blocked(on: wire)
+        await model.respond(action(model), choice: .always)
+        XCTAssertTrue(wire.calls.filter { $0.0 == "approval.respond" }.isEmpty)
+        XCTAssertNil(model.requestResolution)
+        model.suspend()
+    }
+
+    func testAnActionForADifferentRequestIsNeverDispatched() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        let current = action(model)
+        let foreign = BotConversation.AnswerAction(
+            generation: current.generation, runtime: current.runtime, requestID: "req-elsewhere")
+        await model.respond(foreign, choice: .once)
+        XCTAssertTrue(wire.calls.filter { $0.0 == "approval.respond" }.isEmpty)
+        XCTAssertNil(model.requestResolution)
+        model.suspend()
+    }
+
+    /// The connection was replaced between the tap and the socket write. The
+    /// dispatch guard fails closed, and nothing is left in doubt.
+    func testTheDispatchGuardRejectsAnActionThatWentStaleBeforeTheWrite() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        let captured = action(model)
+        wire.beforeDispatch = { [weak model] method in
+            if method == "approval.respond" { model?.suspend() }
+        }
+        await model.respond(captured, choice: .once)
+        XCTAssertTrue(wire.calls.filter { $0.0 == "approval.respond" }.isEmpty)
+        XCTAssertNil(model.requestResolution)
+        model.suspend()
+    }
+
+    /// A lost socket mid-answer cannot tell sent from not sent. The phone says so
+    /// and never resends by itself; reconnecting leaves the second answer to the user.
+    func testALostSocketLeavesTheOutcomeUnknownAndNeverResends() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        wire.respondFailure = .transport
+        await model.respond(action(model), choice: .deny)
+        XCTAssertEqual(model.requestResolution?.outcome, .uncertain)
+        XCTAssertEqual(model.connectionState, .disconnected)
+        XCTAssertFalse(model.mayAnswer)
+        let attempts = wire.calls.filter { $0.0 == "approval.respond" }.count
+        XCTAssertEqual(attempts, 1)
+
+        wire.respondFailure = nil
+        await model.recover()
+        // The request is still pending, the warning survives, and the user may act.
+        XCTAssertEqual(model.requestResolution?.outcome, .uncertain)
+        XCTAssertTrue(model.mayAnswer)
+        XCTAssertEqual(wire.calls.filter { $0.0 == "approval.respond" }.count, attempts)
+        model.suspend()
+    }
+
+    /// A JSON-RPC error came back over a live socket, so the answer definitively
+    /// did not land and the connection is still usable.
+    func testAHostRejectionIsAnActionFailureNotALostConnection() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        wire.respondFailure = .rejected(5004)
+        await model.respond(action(model), choice: .once)
+        XCTAssertNil(model.requestResolution)
+        XCTAssertEqual(model.connectionState, .connected)
+        XCTAssertEqual(model.errorMessage, "The bot could not accept that answer. Check this bot in Desktop.")
+        model.suspend()
+    }
+
+    /// Desktop answered while the phone watched. The next snapshot drops the
+    /// pending field and the card clears without the phone polling for it.
+    func testAnAnswerGivenInDesktopClearsTheCardOnTheNextSnapshot() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        XCTAssertNotNil(model.pendingRequest)
+        wire.attention = false
+        await model.recover()
+        XCTAssertNil(model.pendingRequest)
+        XCTAssertNil(model.requestResolution)
+        XCTAssertFalse(model.mayAnswer)
+        model.suspend()
+    }
+
+    /// A verdict belongs to the request that earned it, never to its successor.
+    func testANewRequestIsNeverBornInert() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        await model.respond(action(model), choice: .once)
+        XCTAssertEqual(model.requestResolution?.outcome, .answered)
+        wire.pendingApproval = BotFixtureWire.approval(id: "req-2", command: "curl | sh")
+        await model.recover()
+        XCTAssertEqual(model.pendingRequest?.requestID, "req-2")
+        XCTAssertNil(model.requestResolution)
+        XCTAssertTrue(model.mayAnswer)
+        model.suspend()
+    }
+
+    // MARK: questions
+
+    func testSingleQuestionAnswersWithoutAQuestionID() async {
+        let wire = BotFixtureWire(); wire.pendingClarify = BotFixtureWire.clarify()
+        let model = await blocked(on: wire)
+        guard case .question(let request)? = model.pendingRequest else { return XCTFail("Expected a question") }
+        XCTAssertEqual(request.questions.count, 1)
+        await model.answerQuestion(action(model),
+                                   [BotQuestionAnswer(questionID: nil, text: "Primary (Recommended)")])
+        let sent = wire.calls.filter { $0.0 == "clarify.respond" }
+        XCTAssertEqual(sent.count, 1)
+        XCTAssertEqual(sent.first?.1["request_id"], .string("clr-1"))
+        XCTAssertEqual(sent.first?.1["answer"], .string("Primary (Recommended)"))
+        XCTAssertNil(sent.first?.1["question_id"])
+        XCTAssertEqual(model.requestResolution?.outcome, .answered)
+        model.suspend()
+    }
+
+    func testBatchSendsOneRespondPerQuestionIDInOrder() async {
+        let wire = BotFixtureWire()
+        wire.pendingClarify = .object([
+            "request_id": .string("clr-3"),
+            "questions": .array([
+                .object(["qid": .string("q0"), "question": .string("Which mailbox?"), "choices": .array([.string("Primary")])]),
+                .object(["qid": .string("q1"), "question": .string("Newsletters?"),
+                         "choices": .array([.string("Archive")]), "multi_select": .bool(true)])
+            ])
+        ])
+        let model = await blocked(on: wire)
+        await model.answerQuestion(action(model), [
+            BotQuestionAnswer(questionID: "q0", text: "Primary"),
+            BotQuestionAnswer(questionID: "q1", selections: ["Archive"])
+        ])
+        let sent = wire.calls.filter { $0.0 == "clarify.respond" }
+        XCTAssertEqual(sent.map { $0.1["question_id"] }, [.string("q0"), .string("q1")])
+        XCTAssertEqual(sent.last?.1["answer"], .string(#"["Archive"]"#))
+        XCTAssertEqual(model.requestResolution?.outcome, .answered)
+        model.suspend()
+    }
+
+    func testAnswersForQuestionsTheHostNeverAskedAreNeverSent() async {
+        let wire = BotFixtureWire()
+        wire.pendingClarify = .object([
+            "request_id": .string("clr-3"),
+            "questions": .array([.object(["qid": .string("q0"), "question": .string("Which mailbox?")])])
+        ])
+        let model = await blocked(on: wire)
+        await model.answerQuestion(action(model), [BotQuestionAnswer(questionID: "q9", text: "nope")])
+        XCTAssertTrue(wire.calls.filter { $0.0 == "clarify.respond" }.isEmpty)
+        model.suspend()
+    }
+
+    /// The host dropped the prompt before the answer arrived. It kept nothing, so
+    /// the remaining questions have nothing left to lock either.
+    func testAnExpiredQuestionStopsTheBatchAndReportsItAsAlreadyResolved() async {
+        let wire = BotFixtureWire(); wire.clarifyStatus = "expired"
+        wire.pendingClarify = .object([
+            "request_id": .string("clr-3"),
+            "questions": .array([
+                .object(["qid": .string("q0"), "question": .string("First?")]),
+                .object(["qid": .string("q1"), "question": .string("Second?")])
+            ])
+        ])
+        let model = await blocked(on: wire)
+        await model.answerQuestion(action(model), [
+            BotQuestionAnswer(questionID: "q0", text: "a"), BotQuestionAnswer(questionID: "q1", text: "b")
+        ])
+        XCTAssertEqual(wire.calls.filter { $0.0 == "clarify.respond" }.count, 1)
+        XCTAssertEqual(model.requestResolution?.outcome, .alreadyResolved)
+        XCTAssertFalse(model.mayAnswer)
+        model.suspend()
+    }
+
+    func testSkipSendsOneUnkeyedEmptyAnswer() async {
+        let wire = BotFixtureWire()
+        wire.pendingClarify = .object([
+            "request_id": .string("clr-3"),
+            "questions": .array([.object(["qid": .string("q0"), "question": .string("First?")])])
+        ])
+        let model = await blocked(on: wire)
+        await model.skipQuestion(action(model))
+        let sent = wire.calls.filter { $0.0 == "clarify.respond" }
+        XCTAssertEqual(sent.count, 1)
+        XCTAssertEqual(sent.first?.1["answer"], .string(""))
+        XCTAssertNil(sent.first?.1["question_id"])
+        model.suspend()
+    }
+
+    /// Both keys present: the clarify is the outer blocker, so it owns the card.
+    func testAQuestionOutranksAnApproval() async {
+        let wire = BotFixtureWire(); wire.attention = true; wire.pendingClarify = BotFixtureWire.clarify()
+        let model = await blocked(on: wire)
+        guard case .question? = model.pendingRequest else { return XCTFail("Expected the question to win") }
+        model.suspend()
+    }
+
+    // MARK: Desktop-only kinds
+
+    func testADesktopOnlyRequestBlocksTheTurnAndIsNeverAnswerable() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        XCTAssertEqual(model.turn, .running)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
+            "payload": .object(["request_id": .string("sudo-1"), "prompt": .string("Password:")])
+        ]))
+        XCTAssertEqual(model.desktopOnlyRequest, BotDesktopOnlyRequest(kind: .sudo, requestID: "sudo-1"))
+        guard case .desktopOnly(let request)? = model.pendingRequest else { return XCTFail("Expected a Desktop-only request") }
+        XCTAssertFalse(request.kind.title.isEmpty)
+        XCTAssertFalse(model.pendingRequest?.isAnswerable ?? true)
+        XCTAssertFalse(model.mayAnswer)
+        XCTAssertNil(model.prepareAnswer())
+        // The snapshot read it triggers must stop the app claiming the bot is working.
+        await awaitSnapshot(model)
+        XCTAssertEqual(model.turn, .needsAttention)
+        model.suspend()
+    }
+
+    func testTheMatchingExpireEventClearsTheDesktopOnlyRequest() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(1),
+                               "type": .string("secret.request"), "payload": .object([:])]))
+        XCTAssertEqual(model.desktopOnlyRequest?.kind, .secret)
+        // A different kind's expiry is not this one's.
+        wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(2),
+                               "type": .string("sudo.expire"), "payload": .object([:])]))
+        XCTAssertEqual(model.desktopOnlyRequest?.kind, .secret)
+        wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(3),
+                               "type": .string("secret.expire"), "payload": .object([:])]))
+        XCTAssertNil(model.desktopOnlyRequest)
+        model.suspend()
+    }
+
+    /// These kinds exist only in the stream, so a gap or a lost socket makes their
+    /// state unknowable. Dropping the card beats showing a stale one.
+    func testASequenceGapAndADisconnectBothDropTheDesktopOnlyRequest() async {
+        for breakStream in [true, false] {
+            let wire = BotFixtureWire()
+            let model = await blocked(on: wire)
+            wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(1),
+                                   "type": .string("tour.request"), "payload": .object([:])]))
+            XCTAssertEqual(model.desktopOnlyRequest?.kind, .tour)
+            if breakStream {
+                wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(9),
+                                       "type": .string("tool.start"), "payload": .object([:])]))
+            } else {
+                wire.onDisconnect?(BotFailure.transport)
+            }
+            XCTAssertNil(model.desktopOnlyRequest)
+            model.suspend()
+        }
+    }
+
+    // MARK: isolation
+
+    /// Two connections whose Profile names match must not share request state.
+    func testTwoConnectionsWithTheSameProfileNameKeepTheirOwnRequests() async {
+        let first = BotFixtureWire(); first.attention = true; first.running = true
+        let second = BotFixtureWire(); second.running = true
+        second.pendingApproval = BotFixtureWire.approval(id: "req-other", command: "shutdown -h now")
+        let left = make(first, connection: connection("http://one.local:9120"))
+        let right = make(second, connection: connection("http://two.local:9120"))
+        await left.recover(); await right.recover()
+        XCTAssertEqual(left.pendingRequest?.requestID, "req-1")
+        XCTAssertEqual(right.pendingRequest?.requestID, "req-other")
+        await left.respond(action(left), choice: .deny)
+        XCTAssertEqual(left.requestResolution?.outcome, .answered)
+        XCTAssertNil(right.requestResolution)
+        XCTAssertTrue(second.calls.filter { $0.0 == "approval.respond" }.isEmpty)
+        left.suspend(); right.suspend()
+    }
+
+    /// A callback that outlived its connection must never answer on the new one.
+    func testAnActionCapturedBeforeSuspendNeverAnswersAfterRecovery() async {
+        let wire = BotFixtureWire(); wire.attention = true
+        let model = await blocked(on: wire)
+        let stale = action(model)
+        model.suspend()
+        await model.recover()
+        await model.respond(stale, choice: .once)
+        XCTAssertTrue(wire.calls.filter { $0.0 == "approval.respond" }.isEmpty)
+        XCTAssertNil(model.requestResolution)
+        model.suspend()
+    }
+
+    /// Unknown and missing server fields never produce a card the phone cannot
+    /// address. The bot is still blocked, so the turn still says so.
+    func testAnUnaddressableRequestShowsAttentionWithoutACard() async {
+        let wire = BotFixtureWire()
+        wire.pendingApproval = .object(["future_field": .string("?"), "choices": .string("not-a-list")])
+        wire.pendingClarify = .object(["questions": .array([])])
+        let model = await blocked(on: wire)
+        XCTAssertNil(model.pendingRequest)
+        XCTAssertFalse(model.mayAnswer)
+        XCTAssertEqual(model.turn, .needsAttention)
+        model.suspend()
+    }
+}

--- a/HermesMobileTests/BotPendingRequestTests.swift
+++ b/HermesMobileTests/BotPendingRequestTests.swift
@@ -92,24 +92,73 @@ import XCTest
         XCTAssertEqual(answer.text, #"["Archive","Unsubscribe"]"#)
     }
 
-    func testDesktopOnlyKindsMapFromTheirRequestAndExpireEvents() {
-        let expected: [String: BotDesktopOnlyRequest.Kind] = [
-            "sudo": .sudo, "secret": .secret, "terminal.read": .terminalRead,
-            "window.read": .windowRead, "mcp.setup": .mcpSetup,
+    func testCredentialKindsMapFromTheirRequestAndExpireEvents() {
+        for (prefix, kind) in ["sudo": BotCredentialRequest.Kind.sudo, "secret": .secret] {
+            let request = BotStreamRequest.requested(
+                eventType: "\(prefix).request",
+                payload: .object(["request_id": .string("r"), "env_var": .string("OPENAI_API_KEY"),
+                                  "prompt": .string("Paste the key")])
+            )
+            XCTAssertEqual(request, .credential(BotCredentialRequest(
+                kind: kind, requestID: "r", envVar: "OPENAI_API_KEY", prompt: "Paste the key"
+            )))
+            XCTAssertEqual(request?.eventPrefix, prefix)
+            XCTAssertEqual(BotStreamRequest.expiredPrefix(eventType: "\(prefix).expire"), prefix)
+            XCTAssertEqual(kind.respondMethod, "\(prefix).respond")
+        }
+        // Each kind's value rides the one param name its handler reads.
+        XCTAssertEqual(BotCredentialRequest.Kind.sudo.valueKey, "password")
+        XCTAssertEqual(BotCredentialRequest.Kind.secret.valueKey, "value")
+    }
+
+    /// `*.respond` is addressed by request id alone, so a prompt without one
+    /// cannot be answered and must not become an answerable card.
+    func testACredentialRequestWithoutARequestIdIsDropped() {
+        XCTAssertNil(BotStreamRequest.requested(eventType: "sudo.request", payload: .object([:])))
+        XCTAssertNil(BotStreamRequest.requested(eventType: "secret.request",
+                                                payload: .object(["request_id": .string("")])))
+    }
+
+    /// A sudo prompt carries no payload at all; a secret's fields are optional.
+    func testACredentialRequestReadsWithoutOptionalFields() {
+        guard case .credential(let request)? = BotStreamRequest.requested(
+            eventType: "sudo.request", payload: .object(["request_id": .string("s-1")])
+        ) else { return XCTFail("Expected a credential request") }
+        XCTAssertNil(request.envVar)
+        XCTAssertNil(request.prompt)
+        XCTAssertFalse(request.detail.isEmpty)
+        XCTAssertFalse(request.handling.isEmpty)
+    }
+
+    func testDesktopTaskKindsMapFromTheirRequestAndExpireEvents() {
+        let expected: [String: BotDesktopTaskRequest.Kind] = [
+            "terminal.read": .terminalRead, "window.read": .windowRead, "mcp.setup": .mcpSetup,
             "preview.read": .previewRead, "preview.act": .previewAct, "tour": .tour
         ]
         for (prefix, kind) in expected {
             XCTAssertEqual(
-                BotDesktopOnlyRequest.requested(eventType: "\(prefix).request",
-                                                payload: .object(["request_id": .string("r")])),
-                BotDesktopOnlyRequest(kind: kind, requestID: "r")
+                BotStreamRequest.requested(eventType: "\(prefix).request",
+                                           payload: .object(["request_id": .string("r")])),
+                .desktopTask(BotDesktopTaskRequest(kind: kind, requestID: "r"))
             )
-            XCTAssertEqual(BotDesktopOnlyRequest.expired(eventType: "\(prefix).expire"), kind)
+            XCTAssertEqual(BotStreamRequest.expiredPrefix(eventType: "\(prefix).expire"), prefix)
             XCTAssertFalse(kind.title.isEmpty)
+            XCTAssertFalse(kind.detail.isEmpty)
         }
-        XCTAssertNil(BotDesktopOnlyRequest.requested(eventType: "clarify.request", payload: .null))
-        XCTAssertNil(BotDesktopOnlyRequest.requested(eventType: "tool.start", payload: .null))
-        XCTAssertNil(BotDesktopOnlyRequest.expired(eventType: "clarify.expire"))
+        // Only the MCP setup card has a person at the Mac to wait for.
+        XCTAssertEqual(BotDesktopTaskRequest.Kind.allCases.filter(\.needsSomeoneAtTheMac), [.mcpSetup])
+        // A Desktop task has no id to answer with, and still reads.
+        XCTAssertEqual(BotStreamRequest.requested(eventType: "tour.request", payload: .object([:])),
+                       .desktopTask(BotDesktopTaskRequest(kind: .tour, requestID: nil)))
+    }
+
+    func testNonBlockingEventsAreNotStreamRequests() {
+        XCTAssertNil(BotStreamRequest.requested(eventType: "clarify.request", payload: .null))
+        XCTAssertNil(BotStreamRequest.requested(eventType: "tool.start", payload: .null))
+        XCTAssertNil(BotStreamRequest.expiredPrefix(eventType: "clarify.expired"))
+        // A prefix that is not a kind is nobody's request, expire or not.
+        XCTAssertNil(BotStreamRequest.requested(eventType: "approval.request",
+                                                payload: .object(["request_id": .string("r")])))
     }
 }
 
@@ -384,23 +433,162 @@ import XCTest
         model.suspend()
     }
 
-    // MARK: Desktop-only kinds
+    // MARK: credential prompts
 
-    func testADesktopOnlyRequestBlocksTheTurnAndIsNeverAnswerable() async {
+    /// `sudo.respond` takes a `request_id` from any client, so the phone answers
+    /// it rather than sending someone to a Mac they are not sitting at.
+    func testASudoPromptIsAnsweredFromThePhone() async {
         let wire = BotFixtureWire()
         let model = await blocked(on: wire)
         XCTAssertEqual(model.turn, .running)
         wire.onEvent?(.object([
             "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
-            "payload": .object(["request_id": .string("sudo-1"), "prompt": .string("Password:")])
+            "payload": .object(["request_id": .string("sudo-1")])
         ]))
-        XCTAssertEqual(model.desktopOnlyRequest, BotDesktopOnlyRequest(kind: .sudo, requestID: "sudo-1"))
-        guard case .desktopOnly(let request)? = model.pendingRequest else { return XCTFail("Expected a Desktop-only request") }
+        guard case .credential(let request)? = model.pendingRequest else { return XCTFail("Expected a credential prompt") }
+        XCTAssertEqual(request.kind, .sudo)
+        XCTAssertTrue(model.pendingRequest?.isAnswerable ?? false)
+        // The snapshot it triggers must stop the app claiming the bot is working.
+        await awaitSnapshot(model)
+        XCTAssertEqual(model.turn, .needsAttention)
+        XCTAssertTrue(model.mayAnswer)
+
+        await model.answerCredential(action(model), value: "hunter2")
+        let sent = wire.calls.last { $0.0 == "sudo.respond" }
+        XCTAssertEqual(sent?.1["request_id"], .string("sudo-1"))
+        XCTAssertEqual(sent?.1["password"], .string("hunter2"))
+        XCTAssertEqual(model.requestResolution, BotRequestResolution(requestID: "sudo-1", outcome: .answered))
+        // The host emits `.expire` only on timeout, so an answered prompt has to
+        // be retired here or the card would outlive the thing it was blocking.
+        XCTAssertNil(model.streamRequest)
+        XCTAssertNil(model.pendingRequest)
+        model.suspend()
+    }
+
+    /// The secret prompt carries the host's own wording and the name it will be
+    /// saved under, and answers on a differently named param.
+    func testASecretPromptSendsItsValueUnderTheHostsParamName() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("secret.request"),
+            "payload": .object(["request_id": .string("sec-1"), "env_var": .string("TAVILY_API_KEY"),
+                                "prompt": .string("Paste your Tavily key")])
+        ]))
+        guard case .credential(let request)? = model.pendingRequest else { return XCTFail("Expected a credential prompt") }
+        XCTAssertEqual(request.detail, "Paste your Tavily key")
+        XCTAssertTrue(request.handling.contains("TAVILY_API_KEY"))
+
+        await model.answerCredential(action(model), value: "tvly-123")
+        let sent = wire.calls.last { $0.0 == "secret.respond" }
+        XCTAssertEqual(sent?.1["value"], .string("tvly-123"))
+        XCTAssertNil(sent?.1["password"])
+        model.suspend()
+    }
+
+    /// Skipping is the host's own decline: an empty value releases the bot now
+    /// instead of parking it until the prompt times out.
+    func testSkippingACredentialSendsAnEmptyValue() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("secret.request"),
+            "payload": .object(["request_id": .string("sec-2")])
+        ]))
+        await model.skipCredential(action(model))
+        let sent = wire.calls.last { $0.0 == "secret.respond" }
+        XCTAssertEqual(sent?.1["value"], .string(""))
+        XCTAssertEqual(model.requestResolution?.outcome, .answered)
+        model.suspend()
+    }
+
+    /// A prompt the host already dropped answers `expired`: an action failure over
+    /// a live socket, so the card goes inert and the connection stays up.
+    func testAnExpiredCredentialPromptReportsAlreadyResolved() async {
+        let wire = BotFixtureWire(); wire.credentialStatus = "expired"
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
+            "payload": .object(["request_id": .string("sudo-3")])
+        ]))
+        await model.answerCredential(action(model), value: "hunter2")
+        XCTAssertEqual(model.requestResolution?.outcome, .alreadyResolved)
+        XCTAssertEqual(model.connectionState, .connected)
+        XCTAssertNil(model.errorMessage)
+        XCTAssertFalse(model.mayAnswer)
+        model.suspend()
+    }
+
+    /// The same rule the other kinds follow: a lost socket cannot tell sent from
+    /// not sent, and the phone never resends on its own.
+    func testALostSocketMidCredentialLeavesTheOutcomeUncertain() async {
+        let wire = BotFixtureWire(); wire.respondFailure = .transport
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
+            "payload": .object(["request_id": .string("sudo-4")])
+        ]))
+        await model.answerCredential(action(model), value: "hunter2")
+        XCTAssertEqual(model.requestResolution?.outcome, .uncertain)
+        XCTAssertEqual(model.connectionState, .disconnected)
+        XCTAssertEqual(wire.calls.filter { $0.0 == "sudo.respond" }.count, 1)
+        model.suspend()
+    }
+
+    /// An answer captured for one prompt must never satisfy the next one.
+    func testAnActionForAReplacedCredentialPromptIsNeverDispatched() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
+            "payload": .object(["request_id": .string("sudo-5")])
+        ]))
+        let stale = action(model)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(2), "type": .string("sudo.request"),
+            "payload": .object(["request_id": .string("sudo-6")])
+        ]))
+        XCTAssertEqual(model.pendingRequest?.requestID, "sudo-6")
+        await model.answerCredential(stale, value: "hunter2")
+        XCTAssertTrue(wire.calls.filter { $0.0 == "sudo.respond" }.isEmpty)
+        XCTAssertNil(model.requestResolution)
+        // The live prompt is still answerable; only the stale action was refused.
+        XCTAssertTrue(model.mayAnswer)
+        model.suspend()
+    }
+
+    /// A snapshot-borne clarify or approval is the outer blocker, so it wins the
+    /// card even while a credential prompt sits underneath it.
+    func testAQuestionOutranksACredentialPrompt() async {
+        let wire = BotFixtureWire(); wire.pendingClarify = BotFixtureWire.clarify()
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("sudo.request"),
+            "payload": .object(["request_id": .string("sudo-7")])
+        ]))
+        guard case .question? = model.pendingRequest else { return XCTFail("Expected the question to win") }
+        model.suspend()
+    }
+
+    // MARK: Desktop-task kinds
+
+    func testADesktopTaskBlocksTheTurnAndIsNeverAnswerable() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        XCTAssertEqual(model.turn, .running)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("terminal.read.request"),
+            "payload": .object(["request_id": .string("term-1")])
+        ]))
+        XCTAssertEqual(model.streamRequest,
+                       .desktopTask(BotDesktopTaskRequest(kind: .terminalRead, requestID: "term-1")))
+        guard case .desktopTask(let request)? = model.pendingRequest else { return XCTFail("Expected a Desktop task") }
         XCTAssertFalse(request.kind.title.isEmpty)
+        // Not because the phone is withheld: the answer is the renderer's buffer.
         XCTAssertFalse(model.pendingRequest?.isAnswerable ?? true)
         XCTAssertFalse(model.mayAnswer)
         XCTAssertNil(model.prepareAnswer())
-        // The snapshot read it triggers must stop the app claiming the bot is working.
+        // The snapshot it triggers must stop the app claiming the bot is working.
         await awaitSnapshot(model)
         XCTAssertEqual(model.turn, .needsAttention)
         // Answering is off the table, but stopping the blocked work is not.
@@ -408,38 +596,38 @@ import XCTest
         model.suspend()
     }
 
-    func testTheMatchingExpireEventClearsTheDesktopOnlyRequest() async {
+    func testTheMatchingExpireEventClearsTheStreamRequest() async {
         let wire = BotFixtureWire()
         let model = await blocked(on: wire)
         wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(1),
-                               "type": .string("secret.request"), "payload": .object([:])]))
-        XCTAssertEqual(model.desktopOnlyRequest?.kind, .secret)
+                               "type": .string("window.read.request"), "payload": .object([:])]))
+        XCTAssertEqual(model.streamRequest?.eventPrefix, "window.read")
         // A different kind's expiry is not this one's.
         wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(2),
-                               "type": .string("sudo.expire"), "payload": .object([:])]))
-        XCTAssertEqual(model.desktopOnlyRequest?.kind, .secret)
+                               "type": .string("terminal.read.expire"), "payload": .object([:])]))
+        XCTAssertEqual(model.streamRequest?.eventPrefix, "window.read")
         wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(3),
-                               "type": .string("secret.expire"), "payload": .object([:])]))
-        XCTAssertNil(model.desktopOnlyRequest)
+                               "type": .string("window.read.expire"), "payload": .object([:])]))
+        XCTAssertNil(model.streamRequest)
         model.suspend()
     }
 
     /// These kinds exist only in the stream, so a gap or a lost socket makes their
     /// state unknowable. Dropping the card beats showing a stale one.
-    func testASequenceGapAndADisconnectBothDropTheDesktopOnlyRequest() async {
+    func testASequenceGapAndADisconnectBothDropTheStreamRequest() async {
         for breakStream in [true, false] {
             let wire = BotFixtureWire()
             let model = await blocked(on: wire)
             wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(1),
                                    "type": .string("tour.request"), "payload": .object([:])]))
-            XCTAssertEqual(model.desktopOnlyRequest?.kind, .tour)
+            XCTAssertEqual(model.streamRequest?.eventPrefix, "tour")
             if breakStream {
                 wire.onEvent?(.object(["session_id": .string("runtime"), "seq": .number(9),
                                        "type": .string("tool.start"), "payload": .object([:])]))
             } else {
                 wire.onDisconnect?(BotFailure.transport)
             }
-            XCTAssertNil(model.desktopOnlyRequest)
+            XCTAssertNil(model.streamRequest)
             model.suspend()
         }
     }

--- a/HermesMobileTests/BotPendingRequestTests.swift
+++ b/HermesMobileTests/BotPendingRequestTests.swift
@@ -403,6 +403,8 @@ import XCTest
         // The snapshot read it triggers must stop the app claiming the bot is working.
         await awaitSnapshot(model)
         XCTAssertEqual(model.turn, .needsAttention)
+        // Answering is off the table, but stopping the blocked work is not.
+        XCTAssertTrue(model.mayStop)
         model.suspend()
     }
 

--- a/HermesMobileTests/BotPendingRequestTests.swift
+++ b/HermesMobileTests/BotPendingRequestTests.swift
@@ -145,8 +145,11 @@ import XCTest
             XCTAssertFalse(kind.title.isEmpty)
             XCTAssertFalse(kind.detail.isEmpty)
         }
-        // Only the MCP setup card has a person at the Mac to wait for.
+        // Only the MCP setup card has a person at the Mac to wait for, and it is
+        // the only one there is anything to decline.
         XCTAssertEqual(BotDesktopTaskRequest.Kind.allCases.filter(\.needsSomeoneAtTheMac), [.mcpSetup])
+        XCTAssertEqual(BotDesktopTaskRequest.Kind.allCases.filter(\.isDeclinable), [.mcpSetup])
+        XCTAssertEqual(BotDesktopTaskRequest.Kind.mcpSetup.respondMethod, "mcp.setup.respond")
         // A Desktop task has no id to answer with, and still reads.
         XCTAssertEqual(BotStreamRequest.requested(eventType: "tour.request", payload: .object([:])),
                        .desktopTask(BotDesktopTaskRequest(kind: .tour, requestID: nil)))
@@ -593,6 +596,49 @@ import XCTest
         XCTAssertEqual(model.turn, .needsAttention)
         // Answering is off the table, but stopping the blocked work is not.
         XCTAssertTrue(model.mayStop)
+        model.suspend()
+    }
+
+    /// The one Desktop task with a person in the loop can be called off from
+    /// the phone: a ten-minute park becomes one tap, and the host's tool is
+    /// told never to re-ask.
+    func testAnMCPSetupIsDeclinedFromThePhone() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("mcp.setup.request"),
+            "payload": .object(["request_id": .string("mcp-1"), "server": .string("tavily")])
+        ]))
+        // Declining is not answering: the setup itself still only happens in Desktop.
+        XCTAssertFalse(model.pendingRequest?.isAnswerable ?? true)
+        XCTAssertFalse(model.mayAnswer)
+        XCTAssertTrue(model.mayDecline)
+
+        await model.declineDesktopTask(action(model))
+        let sent = wire.calls.last { $0.0 == "mcp.setup.respond" }
+        XCTAssertEqual(sent?.1["request_id"], .string("mcp-1"))
+        XCTAssertEqual(sent?.1["result"], .string(#"{"status":"declined"}"#))
+        XCTAssertEqual(model.requestResolution?.outcome, .answered)
+        XCTAssertNil(model.streamRequest)
+        model.suspend()
+    }
+
+    /// Every other Desktop task has nothing to decline, and a decline aimed at
+    /// one must never reach the wire.
+    func testADesktopTaskThatCannotBeDeclinedNeverDispatches() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onEvent?(.object([
+            "session_id": .string("runtime"), "seq": .number(1), "type": .string("preview.read.request"),
+            "payload": .object(["request_id": .string("prev-1")])
+        ]))
+        XCTAssertFalse(model.mayDecline)
+        XCTAssertNil(model.prepareAnswer())
+        await model.declineDesktopTask(
+            BotConversation.AnswerAction(generation: 0, runtime: "runtime", requestID: "prev-1")
+        )
+        XCTAssertTrue(wire.calls.filter { $0.0.hasSuffix(".respond") }.isEmpty)
+        XCTAssertNil(model.requestResolution)
         model.suspend()
     }
 

--- a/HermesMobileTests/BotPendingRequestTests.swift
+++ b/HermesMobileTests/BotPendingRequestTests.swift
@@ -36,6 +36,22 @@ import XCTest
         )
     }
 
+    /// A host that renames every choice must not have a permission invented for
+    /// it. Deny is the only thing safe to offer when none of the list parses.
+    func testAnApprovalWhoseChoicesAreAllUnknownOffersOnlyDeny() {
+        let request = BotApprovalRequest(.object([
+            "request_id": .string("req-9"), "command": .string("rm -rf /"),
+            "choices": .array([.string("allow_forever"), .string("nope")]),
+            "allow_permanent": .bool(true)
+        ]))
+        XCTAssertEqual(request?.choices, [.deny])
+        // An explicitly empty list is the host offering nothing, not an old host.
+        XCTAssertEqual(
+            BotApprovalRequest(.object(["request_id": .string("req-10"), "choices": .array([])]))?.choices,
+            [.deny]
+        )
+    }
+
     func testApprovalWithoutARequestIDIsNotShown() {
         XCTAssertNil(BotApprovalRequest(.object(["command": .string("rm -rf /")])))
         XCTAssertNil(BotApprovalRequest(.object(["request_id": .string("")])))
@@ -394,6 +410,88 @@ import XCTest
 
     /// The host dropped the prompt before the answer arrived. It kept nothing, so
     /// the remaining questions have nothing left to lock either.
+    /// The host locks every answer it is handed, and an empty one is a skip, so
+    /// a partial batch would silently skip whatever the user never touched.
+    func testAPartialBatchAnswerIsNeverSent() async {
+        let wire = BotFixtureWire()
+        wire.pendingClarify = .object([
+            "request_id": .string("clr-5"),
+            "questions": .array([
+                .object(["qid": .string("q0"), "question": .string("First?")]),
+                .object(["qid": .string("q1"), "question": .string("Second?")])
+            ])
+        ])
+        let model = await blocked(on: wire)
+        await model.answerQuestion(action(model), [BotQuestionAnswer(questionID: "q0", text: "a")])
+        XCTAssertTrue(wire.calls.filter { $0.0 == "clarify.respond" }.isEmpty)
+        XCTAssertNil(model.requestResolution)
+        // Declining the whole request is still one deliberate unkeyed answer.
+        await model.skipQuestion(action(model))
+        XCTAssertEqual(wire.calls.filter { $0.0 == "clarify.respond" }.count, 1)
+        model.suspend()
+    }
+
+    /// A question the host already locked is not outstanding, so the rest of the
+    /// batch completes without re-answering it.
+    func testABatchIgnoresQuestionsTheHostHasAlreadyLocked() async {
+        let wire = BotFixtureWire()
+        wire.pendingClarify = .object([
+            "request_id": .string("clr-6"),
+            "questions": .array([
+                .object(["qid": .string("q0"), "question": .string("First?")]),
+                .object(["qid": .string("q1"), "question": .string("Second?")])
+            ]),
+            "answers": .object(["q0": .string("already")])
+        ])
+        let model = await blocked(on: wire)
+        await model.answerQuestion(action(model), [BotQuestionAnswer(questionID: "q1", text: "b")])
+        XCTAssertEqual(wire.calls.filter { $0.0 == "clarify.respond" }.map { $0.1["question_id"] },
+                       [.string("q1")])
+        model.suspend()
+    }
+
+    /// Credential prompts reach no snapshot, so while the ring still holds one,
+    /// replay is the only way back to it. Dropping it left a blocked bot looking
+    /// idle with nothing on screen to answer.
+    func testAReplayedCredentialPromptSurvivesAReconnect() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onDisconnect?(BotFailure.transport)
+        XCTAssertNil(model.streamRequest)
+
+        wire.replay = BotFixtureWire.replay(latest: 2, events: [
+            .object(["session_id": .string("runtime"), "seq": .number(1),
+                     "type": .string("tool.start"),
+                     "payload": .object(["tool_id": .string("t1"), "name": .string("terminal")])]),
+            .object(["session_id": .string("runtime"), "seq": .number(2),
+                     "type": .string("sudo.request"),
+                     "payload": .object(["request_id": .string("sudo-r")])])
+        ])
+        await model.recover()
+        XCTAssertFalse(model.replayWasReset)
+        XCTAssertEqual(model.pendingRequest?.requestID, "sudo-r")
+        XCTAssertEqual(model.turn, .needsAttention)
+        XCTAssertTrue(model.mayAnswer)
+        model.suspend()
+    }
+
+    /// A prompt whose expiry is also in the replay window is already over.
+    func testAReplayedPromptThatExpiredInTheSameWindowIsNotShown() async {
+        let wire = BotFixtureWire()
+        let model = await blocked(on: wire)
+        wire.onDisconnect?(BotFailure.transport)
+        wire.replay = BotFixtureWire.replay(latest: 2, events: [
+            .object(["session_id": .string("runtime"), "seq": .number(1),
+                     "type": .string("sudo.request"),
+                     "payload": .object(["request_id": .string("sudo-r")])]),
+            .object(["session_id": .string("runtime"), "seq": .number(2),
+                     "type": .string("sudo.expire"), "payload": .object([:])])
+        ])
+        await model.recover()
+        XCTAssertNil(model.streamRequest)
+        model.suspend()
+    }
+
     func testAnExpiredQuestionStopsTheBatchAndReportsItAsAlreadyResolved() async {
         let wire = BotFixtureWire(); wire.clarifyStatus = "expired"
         wire.pendingClarify = .object([

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -91,15 +91,24 @@ A JSON-RPC error arrives over a live socket, so it reports the answer failed
 without tearing the connection down. `approval.received` only acknowledges
 delivery and is deliberately never called. Batch answers send one
 `clarify.respond` per question id and stop at the first `expired`; multi-select
-answers go as a JSON array string, which is what the host parses.
+answers go as a JSON array string, which is what the host parses. A batch is
+all-or-none: the host locks every answer it is handed and reads an empty one as
+a skip, so a partial send would silently skip the questions the user never
+touched. `skipQuestion` is the deliberate none. A present `choices` array is the
+host speaking and nothing is added to it — if a future host renames the lot so
+none of it parses, only Deny is offered, because rebuilding there would invent
+an "Always allow" the host never sanctioned.
 
 `sudo`, `secret`, `terminal.read`, `window.read`, `mcp.setup`, `preview.read`,
 `preview.act` and `tour` never reach a snapshot, so `BotStreamRequest` tracks
 them from `<prefix>.request` to `<prefix>.expire` and they stop the app claiming
 the bot is working. Because the stream is their only record, a sequence gap, a
 `message.start`, an idle snapshot or a lost socket drops the card rather than
-showing a stale one; a reconnect cannot restore one. `.expire` fires only on
-timeout, so an answered one is retired at dispatch instead.
+showing a stale one. `.expire` fires only on timeout, so an answered one is
+retired at dispatch instead. Replay does restore one while the ring still holds
+it: `reconcileReplay` routes missed events through `applyStreamRequest` before
+the activity reducer, so backgrounding past a credential prompt and returning
+finds it still there rather than a blocked bot that looks idle.
 
 They split two ways. `sudo` and `secret` block on a value only the person has,
 and the phone sends it: `sudo.respond` and `secret.respond` take a `request_id`

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -78,8 +78,8 @@ outranks an approval: approvals resolve inside a tool batch, a clarify blocks th
 turn. A pending key the phone cannot address still reads as needing attention,
 without a card.
 
-Answering is `approval.respond` and `clarify.respond`, the only additions to
-`BotClient`'s allowlist. Nothing is ever sent without a tap. Generation, runtime
+Answering is `approval.respond`, `clarify.respond`, `sudo.respond` and
+`secret.respond`, the only additions to `BotClient`'s allowlist. Nothing is ever sent without a tap. Generation, runtime
 and request id are captured on tap and revalidated at the socket write, so a
 stale card fails closed. Three outcomes are distinguished: `resolved > 0` or
 `status: ok` is accepted; `resolved: 0` or `status: expired` means the host had
@@ -93,20 +93,41 @@ delivery and is deliberately never called. Batch answers send one
 answers go as a JSON array string, which is what the host parses.
 
 `sudo`, `secret`, `terminal.read`, `window.read`, `mcp.setup`, `preview.read`,
-`preview.act` and `tour` are Desktop-only. They never reach a snapshot, so
-`BotDesktopOnlyRequest` tracks them from `<prefix>.request` to `<prefix>.expire`
-and they stop the app claiming the bot is working. The phone names the kind and
-offers only Desktop or Stop: no input, no shell, no credential fallback. Because
-the stream is their only record, a sequence gap, a `message.start`, an idle
-snapshot or a lost socket drops the card rather than showing a stale one; a
-reconnect cannot restore one.
+`preview.act` and `tour` never reach a snapshot, so `BotStreamRequest` tracks
+them from `<prefix>.request` to `<prefix>.expire` and they stop the app claiming
+the bot is working. Because the stream is their only record, a sequence gap, a
+`message.start`, an idle snapshot or a lost socket drops the card rather than
+showing a stale one; a reconnect cannot restore one. `.expire` fires only on
+timeout, so an answered one is retired at dispatch instead.
+
+They split two ways. `sudo` and `secret` block on a value only the person has,
+and the phone sends it: `sudo.respond` and `secret.respond` take a `request_id`
+from any connected client, and the host's own terminal UI answers over the same
+methods. `BotCredentialRequest` carries the kind's `valueKey` (`password` vs
+`value`) because each handler reads one name and a mismatch answers empty. The
+field is a `SecureField`, the value is passed straight to the dispatch and held
+by no layer of the phone, and Skip sends the empty string the host documents as
+a decline — the sudo command fails, the secret tool records a skip, and the bot
+is released immediately instead of parking until the deadline.
+
+The other six are `BotDesktopTaskRequest`: the answer is data Hermes Desktop's
+own renderer holds — its terminal scrollback, the window beneath it, its preview
+pane — so no client without that window can produce one, on a phone or anywhere
+else. Nobody types an answer at the Mac either. Each has a host deadline (30s for
+the reads, 45s for preview and tour, ten minutes for `mcp.setup`) after which the
+tool takes an empty answer and the bot carries on, so the card reports the wait
+and keeps Stop rather than sending the user to a desk. `mcp.setup` is the one
+kind a person really does walk through in Desktop, and says so. Declining it from
+the phone (`mcp.setup.respond` with `{"status": "declined"}`) is possible and not
+yet built.
 
 The card renders in the transcript where the work stopped, so the command sits
 under the tool row that asked for it, and the composer's attention line doubles
 as the way back to it. Placement is the only Bot-specific part: the surfaces,
 choice buttons, decision buttons and copy are the Sessions approval and
 clarification vocabulary, shared through `PendingRequestSurfaces.swift` and
-`ChatDecisionButtonStyle` rather than copied. Like Sessions, "Always allow"
+`ChatDecisionButtonStyle` rather than copied; the credential field reuses the
+same response field and submit button as the Sessions clarification card. Like Sessions, "Always allow"
 writes a permanent host rule without a second confirmation.
 
 Bot drafts extend `ChatDraftStore` with server + connection UUID + Profile context.

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -78,8 +78,9 @@ outranks an approval: approvals resolve inside a tool batch, a clarify blocks th
 turn. A pending key the phone cannot address still reads as needing attention,
 without a card.
 
-Answering is `approval.respond`, `clarify.respond`, `sudo.respond` and
-`secret.respond`, the only additions to `BotClient`'s allowlist. Nothing is ever sent without a tap. Generation, runtime
+Answering is `approval.respond`, `clarify.respond`, `sudo.respond`,
+`secret.respond` and `mcp.setup.respond`, the only additions to `BotClient`'s
+allowlist. Nothing is ever sent without a tap. Generation, runtime
 and request id are captured on tap and revalidated at the socket write, so a
 stale card fails closed. Three outcomes are distinguished: `resolved > 0` or
 `status: ok` is accepted; `resolved: 0` or `status: expired` means the host had
@@ -116,10 +117,15 @@ pane — so no client without that window can produce one, on a phone or anywher
 else. Nobody types an answer at the Mac either. Each has a host deadline (30s for
 the reads, 45s for preview and tour, ten minutes for `mcp.setup`) after which the
 tool takes an empty answer and the bot carries on, so the card reports the wait
-and keeps Stop rather than sending the user to a desk. `mcp.setup` is the one
-kind a person really does walk through in Desktop, and says so. Declining it from
-the phone (`mcp.setup.respond` with `{"status": "declined"}`) is possible and not
-yet built.
+and keeps Stop rather than sending the user to a desk.
+
+`mcp.setup` is the one kind a person really does walk through in Desktop, and
+the only one with anything to decline. `mayDecline` gates it separately from
+`mayAnswer` — declining is not answering, since the setup still only happens in
+Desktop — and sends `mcp.setup.respond` with `{"status": "declined"}`, which the
+tool reads as a final no and is told never to re-ask. That turns the longest
+wait in the set into one tap, and it is the reason the composer's status line
+says "handling this" only where there is genuinely nothing to do.
 
 The card renders in the transcript where the work stopped, so the command sits
 under the tool row that asked for it, and the composer's attention line doubles

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -27,7 +27,7 @@ validates the contract just in time. Advancing the pin is described in AGENTS.md
 exact-title Bot Chat, keeps canonical root, compression tip and runtime IDs
 separate, and rejects a changed root before resume. Lookup can recover archived
 history; resume can auto-continue unfinished backend work. Neither is guaranteed
-to be read-only. Approvals remain in Desktop.
+to be read-only.
 
 History is memory-only. Open/recovery replaces it from a full resume snapshot.
 Replay detects discontinuity but never appends text to an overlapping snapshot.
@@ -63,6 +63,51 @@ global Chat display toggles; the plan row stays visible with cards off. Tool
 output is text only. `message.react` and `learning.frames` are deliberately
 not wired: the snapshot carries no reactions to show back, and the frames are
 terminal-sized renders.
+
+A blocking request is whatever has parked the bot. Approvals and questions come
+from the resume snapshot's `pending_approval` and `pending_clarify`, which ride
+both the full and the `omit_messages` read, so an answer given in Desktop clears
+the card on the next snapshot and nothing polls. `BotApprovalRequest` keeps the
+host's own `choices` (`once`/`session`/`always`/`deny`, already narrowed by
+smart-approval and permanent-allow policy) and rebuilds them the way the gateway
+would when an older host omits them; `BotQuestionRequest` reads the single
+(`question`/`choices`/`multi_select`) and batch (`questions` + locked `answers`)
+clarify shapes, keeping each choice's wire label so the host strips its own
+"(Recommended)" suffix rather than the phone reconstructing it. A clarify
+outranks an approval: approvals resolve inside a tool batch, a clarify blocks the
+turn. A pending key the phone cannot address still reads as needing attention,
+without a card.
+
+Answering is `approval.respond` and `clarify.respond`, the only additions to
+`BotClient`'s allowlist. Nothing is ever sent without a tap. Generation, runtime
+and request id are captured on tap and revalidated at the socket write, so a
+stale card fails closed. Three outcomes are distinguished: `resolved > 0` or
+`status: ok` is accepted; `resolved: 0` or `status: expired` means the host had
+nothing left to resolve, which is an action failure that leaves the card inert;
+a lost socket is a delivery failure whose outcome is unknown, warns, and is never
+resent, though a deliberate second answer after reconnect stays the user's call.
+A JSON-RPC error arrives over a live socket, so it reports the answer failed
+without tearing the connection down. `approval.received` only acknowledges
+delivery and is deliberately never called. Batch answers send one
+`clarify.respond` per question id and stop at the first `expired`; multi-select
+answers go as a JSON array string, which is what the host parses.
+
+`sudo`, `secret`, `terminal.read`, `window.read`, `mcp.setup`, `preview.read`,
+`preview.act` and `tour` are Desktop-only. They never reach a snapshot, so
+`BotDesktopOnlyRequest` tracks them from `<prefix>.request` to `<prefix>.expire`
+and they stop the app claiming the bot is working. The phone names the kind and
+offers only Desktop or Stop: no input, no shell, no credential fallback. Because
+the stream is their only record, a sequence gap, a `message.start`, an idle
+snapshot or a lost socket drops the card rather than showing a stale one; a
+reconnect cannot restore one.
+
+The card renders in the transcript where the work stopped, so the command sits
+under the tool row that asked for it, and the composer's attention line doubles
+as the way back to it. Placement is the only Bot-specific part: the surfaces,
+choice buttons, decision buttons and copy are the Sessions approval and
+clarification vocabulary, shared through `PendingRequestSurfaces.swift` and
+`ChatDecisionButtonStyle` rather than copied. Like Sessions, "Always allow"
+writes a permanent host rule without a second confirmation.
 
 Bot drafts extend `ChatDraftStore` with server + connection UUID + Profile context.
 Before sending, the client flushes an unresolved marker to disk. An acknowledged


### PR DESCRIPTION
## Linked issue

Fixes #476

## What changed

A bot that hit an approval, a question or a credential prompt was stuck until someone reached a Mac. Blocking requests are now answered from the phone, in the transcript where the work stopped.

- **Approvals and questions.** The card renders the request, its consequence and the command, and offers exactly the choices the host offered — a smart-denied request legitimately has no session or permanent allow, so neither does the phone. Read from the resume snapshot (`pending_approval`, `pending_clarify`), so an answer given in Desktop clears the card on the next read with no polling.
- **Sudo and secret prompts.** `#491` listed these as Desktop-only. That was a product call, not a wire constraint: `sudo.respond` and `secret.respond` take a `request_id` from any connected client, and the host's own terminal UI answers over the same methods (`ui-tui/src/app/useMainApp.ts:1025`). The phone now answers both — masked field, the host's own wording, the variable name a secret will be saved under — and Skip sends the empty string the host documents as a decline, releasing the bot immediately instead of parking it for 120s/300s.
- **MCP setup.** The only Desktop-renderer kind with a person in the loop and, at ten minutes, the longest wait in the set. Skip sends `{"status": "declined"}`, which the tool reads as a final no and is told never to re-ask.
- **The other five.** `terminal.read`, `window.read`, `preview.read`, `preview.act` and `tour` genuinely cannot be answered here — the answer is data Hermes Desktop's own renderer holds, and nobody types one at the Mac either. Each has a host deadline (30s/45s) after which the bot carries on, so the card reports the wait and keeps Stop rather than sending the user to a desk they are not sitting at.

Answering captures generation, runtime and request id on tap and revalidates at the socket write, so a stale card fails closed. Three outcomes are distinguished: accepted; `resolved: 0` / `status: expired`, an action failure that leaves the card inert with the connection intact; and a lost socket, whose outcome is unknown, warns, and is never resent. `approval.received` only acknowledges delivery and is deliberately never called.

Presentation is Variant A from the maintainer-selected mocks, in the Sessions vocabulary. The Sessions clarification card's surfaces, response field and submit button moved into a shared `PendingRequestSurfaces.swift` that both surfaces now use — a pure move with no visual change to Sessions, and the thing that caught two divergences in the Bot card.

Contract verified against hermes-agent `cd2bd16`: `tui_gateway/methods_prompt.py` (`clarify.respond`:1586, `sudo.respond`:1649, `secret.respond`:1654, `mcp.setup.respond`:1640), `server.py` (`_respond`:13834, `_block` deadlines:4547, pending snapshot keys:10881, callbacks:8137/8277), `tools/setup_mcp_tool.py:52` (declined vs unanswered), `tools/terminal_tool.py:530` (empty password is a documented skip).

## How it was tested

- Full suite: `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17' -parallel-testing-enabled NO` → **TEST SUCCEEDED**, 2436 tests, 0 failures, 2 pre-existing skips.
- New focused tests: `BotPendingRequestParsingTests` (host choice sets, omitted-choice rebuild, batch question ids and locked answers, credential and Desktop-task event mapping, a credential prompt without a request id is dropped), `BotAnsweringTests` (dispatch params per kind, already-resolved, stale-action refusal, dispatch-guard revalidation, lost socket → uncertain and never resent, Desktop answer reconciliation, connection isolation, decline gating), `BotChatPresentationTests` (approval / question / sudo / secret / MCP-setup / Desktop-task cards, secure field, no input where there is no answer).
- Signed Debug build installed and launched on iPhone 17 via `build_run_sim`.
- Not exercised: the live host. No mutations were run against it; the gateway contract above was read from the pinned source.

### Screenshots

All seven cards — approval, already-answered, question, sudo, secret, MCP setup, Desktop task — are in [this comment](https://github.com/uzairansaruzi/hermex/pull/504#issuecomment-5638038243). Rendered from the XCTest attachments under scripted gateway fixtures, not mocks.

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

## Notes for review

- **Sudo over a tunnel.** The password crosses as a JSON-RPC param on the same wss + basic-auth channel that already carries session content, and the host's terminal UI does the same over the same wire. On a LAN that is unremarkable; through a Cloudflare tunnel it is a Mac admin password leaving the network. Worth a deliberate yes rather than an inherited one. A LAN-only gate is easy to add if preferred.
- **"Always allow"** writes a permanent host rule with no second confirmation, matching the Sessions approval overlay. Desktop does confirm it. Possibly worth a follow-up for both surfaces.
- `BotConversation.swift` is 612 LOC against the 500 warning. The answering flow is the natural seam; splitting it would mean widening several `private` members, so it is left for a follow-up.
- `testActivityRowsRenderAndFollowTheCardsSetting` (from #503) is touched here: it now waits on the content it asserts rather than a frame count. A live tool row arrives with no state change to observe, so nothing signals when the `LazyVStack` has materialized it. Pre-existing, reproduced on a clean tree, and unrelated to this change — happy to split it out.

Model and harness: Claude Opus 5 (1M context), Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

