### PR TITLE
feat(bots): keep the Bots inbox live and honor Desktop pins and hidden bots

### DIFF
--- a/HermesMobile.xcodeproj/project.pbxproj
+++ b/HermesMobile.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		9510188AE84E41D9BAE025F1 /* BotConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */; };
 		9510188AE84E41D9BAE025FA /* BotPendingRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B077A87C9D846D7A9D27D7A /* BotPendingRequestTests.swift */; };
 		142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */; };
+		236D35656DC54FFC9A91767D /* BotInboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAB6E1003A74F1992A3C350 /* BotInboxTests.swift */; };
 		A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000002 /* BotModeGateTests.swift */; };
 		A496B07E0000000000000003 /* BotConnectionVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A496B07E0000000000000004 /* BotConnectionVersionTests.swift */; };
 		A4730000000000000000A003 /* BotAvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4730000000000000000A004 /* BotAvatarTests.swift */; };
@@ -451,6 +452,7 @@
 		D4E8321C0A744DE3A5B8C997 /* ChatComposerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */; };
 		A4C0A37288B742B9B284A67E /* BotChatPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */; };
 		9BB85D722406416798DFA518 /* BotPromptMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C75DCD3DB974E27A3CB405C /* BotPromptMode.swift */; };
+		880D30A697844D63B3EEDE4F /* BotInbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E5E34669724EA0938CD493 /* BotInbox.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -924,6 +926,7 @@
 		0B077A87C9D846D7A9D27D76 /* BotConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotConversationTests.swift"; sourceTree = "<group>"; };
 		0B077A87C9D846D7A9D27D7A /* BotPendingRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotPendingRequestTests.swift"; sourceTree = "<group>"; };
 		EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotDraftTests.swift"; sourceTree = "<group>"; };
+		5DAB6E1003A74F1992A3C350 /* BotInboxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotInboxTests.swift"; sourceTree = "<group>"; };
 		A496B07E0000000000000002 /* BotModeGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotModeGateTests.swift; sourceTree = "<group>"; };
 		A496B07E0000000000000004 /* BotConnectionVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotConnectionVersionTests.swift; sourceTree = "<group>"; };
 		A4730000000000000000A004 /* BotAvatarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotAvatarTests.swift; sourceTree = "<group>"; };
@@ -933,6 +936,7 @@
 		5B2FA0E3DFE844F8B3A710FD /* ChatComposerPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatComposerPresentation.swift"; sourceTree = "<group>"; };
 		26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BotChatPresentationTests.swift"; sourceTree = "<group>"; };
 		3C75DCD3DB974E27A3CB405C /* BotPromptMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotPromptMode.swift"; sourceTree = "<group>"; };
+		12E5E34669724EA0938CD493 /* BotInbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bots/BotInbox.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1036,6 +1040,7 @@
 				26C849A9CE6B47E79695E069 /* BotChatPresentationTests.swift */,
 				B0B04ED8E6164A75B069773D /* BotClientTests.swift */,
 				EE6A7BC5738C4EF9AB0A965B /* BotDraftTests.swift */,
+				5DAB6E1003A74F1992A3C350 /* BotInboxTests.swift */,
 				A496B07E0000000000000002 /* BotModeGateTests.swift */,
 				A496B07E0000000000000004 /* BotConnectionVersionTests.swift */,
 				A4730000000000000000A004 /* BotAvatarTests.swift */,
@@ -1262,6 +1267,7 @@
 				9FE221A56F264309AF71E18B /* BotsInboxView.swift */,
 				9D93D8EC41FE4FBABD1746AD /* BotConversation.swift */,
 				3C75DCD3DB974E27A3CB405C /* BotPromptMode.swift */,
+				12E5E34669724EA0938CD493 /* BotInbox.swift */,
 				40877A8534C94AAF97EA1C7C /* BotConnectionView.swift */,
 				0A712D3AE91645C9B8C27745 /* BotConnection.swift */,
 				A4730000000000000000A002 /* BotAvatarStore.swift */,
@@ -1860,6 +1866,7 @@
 				7EF4120B486B4243AF54FCAF /* BotsInboxView.swift in Sources */,
 				013E4253ACC0484FA59DC45F /* BotConversation.swift in Sources */,
 				9BB85D722406416798DFA518 /* BotPromptMode.swift in Sources */,
+				880D30A697844D63B3EEDE4F /* BotInbox.swift in Sources */,
 				C2A87F2CDEB941BB825EABA5 /* BotConnectionView.swift in Sources */,
 				13FED0A00B8A4C06B7F30BF0 /* BotConnection.swift in Sources */,
 				A4730000000000000000A001 /* BotAvatarStore.swift in Sources */,
@@ -2140,6 +2147,7 @@
 				A4C0A37288B742B9B284A67E /* BotChatPresentationTests.swift in Sources */,
 				D885F4C0DA3A438B8CE92635 /* BotClientTests.swift in Sources */,
 				142E7F57D82742678CF78DCA /* BotDraftTests.swift in Sources */,
+				236D35656DC54FFC9A91767D /* BotInboxTests.swift in Sources */,
 				A496B07E0000000000000001 /* BotModeGateTests.swift in Sources */,
 				A496B07E0000000000000003 /* BotConnectionVersionTests.swift in Sources */,
 				A4730000000000000000A003 /* BotAvatarTests.swift in Sources */,

--- a/HermesMobile/Features/Bots/BotConnection.swift
+++ b/HermesMobile/Features/Bots/BotConnection.swift
@@ -56,12 +56,20 @@ struct BotConnection: Codable, Equatable, Identifiable {
 /// One `profiles.list` row. Identity comes only from server fields: the Desktop
 /// title, then the core `display_name`, then the Profile name (`default` reads as
 /// Hermes, as in Desktop). Description follows the same Desktop-then-core order.
+/// Pinned and hidden are Desktop's roster organization; its user sections are
+/// not here because their catalog lives in Desktop's local storage, so a bare
+/// `sectionId` cannot be named, and `groups` are executable group rooms, not sections.
 struct BotProfile: Identifiable, Hashable {
     let id: String
     let name: String
     let description: String?
     let preview: String?
     let lastActive: Date?
+    let pinned: Bool
+    let hidden: Bool
+    /// Desktop's `ui_meta["hermes-bots"]` object as received. A pin or hide write
+    /// sends it back whole with one field changed, so Desktop-only fields survive.
+    let look: [String: BotJSON]
     /// True when the host has an avatar asset, so the inbox fetches only rows that have one.
     let hasAvatar: Bool
     /// Desktop's compare-and-swap revision for this bot's look
@@ -77,6 +85,9 @@ struct BotProfile: Identifiable, Hashable {
         description = Self.firstText(look["description"], row["description"])
         preview = row["canonical_session"]["preview"].text
         lastActive = row["canonical_session"]["last_active"].number.map(Date.init(timeIntervalSince1970:))
+        pinned = look["pinned"].flag == true
+        hidden = look["hidden"].flag == true
+        self.look = look.fields ?? [:]
         hasAvatar = row["has_avatar"].flag == true
         lookRevision = row["ui_meta_revisions"]["hermes-bots"].integer
     }

--- a/HermesMobile/Features/Bots/BotConnectionView.swift
+++ b/HermesMobile/Features/Bots/BotConnectionView.swift
@@ -71,6 +71,7 @@ import SwiftUI
                         if let saved {
                             await ChatDraftStore.shared.discardBotDrafts(server: server, connectionID: saved.id)
                             BotAvatarStore.shared.removeAll(connectionID: saved.id)
+                            BotUnreadStore().remove(connectionID: saved.id)
                         }
                         dismiss()
                     } catch { errorMessage = String(localized: "Could not remove saved sign-in details.") }

--- a/HermesMobile/Features/Bots/BotInbox.swift
+++ b/HermesMobile/Features/Bots/BotInbox.swift
@@ -1,0 +1,246 @@
+import Observation
+import UIKit
+
+/// The Bots inbox for one configured server: the roster, Desktop's pin and hidden
+/// organization, device-local unread marks, and one live subscription that lasts
+/// while the inbox is visible. `open()` owns the transport and `close()` ends it;
+/// every late reply is dropped by the wire identity check, so a replaced or closed
+/// connection never writes into the screen.
+@MainActor @Observable final class BotInbox {
+    enum Link: Equatable { case idle, connecting, live, disconnected }
+
+    /// The roster split the way Desktop draws it: pinned first, the rest in server
+    /// order, hidden bots apart and only when revealed or when a search names them.
+    struct Rows: Equatable {
+        var pinned: [BotProfile] = []
+        var others: [BotProfile] = []
+        var hidden: [BotProfile] = []
+    }
+
+    let server: URL
+    private(set) var connection: BotConnection?
+    private(set) var profiles: [BotProfile] = []
+    private(set) var avatars: [String: UIImage] = [:]
+    private(set) var link = Link.idle
+    private(set) var errorMessage: String?
+    /// Outcome of the last pin or hide write when it did not apply.
+    private(set) var notice: String?
+    /// Profiles with a pin or hide write in flight; their actions stay inert.
+    private(set) var editing: Set<String> = []
+    /// Session-only reveal of hidden bots, as in Desktop. Never persisted.
+    var showsHidden = false
+    /// Device-local watermarks for the current connection: the canonical
+    /// `last_active` the user last saw for each Profile. Never leaves the phone.
+    private(set) var seen: [String: Double] = [:]
+
+    private var wire: (any BotTransport)?
+    private var reloadTask: Task<Void, Never>?
+    private var reloadWanted = false
+    private var reloadSerial = 0
+    private var returnedFrom: String?
+    private let store: BotConnectionStore
+    private let unread: BotUnreadStore
+    private let avatarStore: BotAvatarStore
+    private let makeWire: @MainActor (BotConnection) -> any BotTransport
+    /// Minimum gap between event-driven roster reads; the host already floors
+    /// `sessions.changed` at two seconds, this guards against a chattier one.
+    private let reloadSpacing: Duration
+
+    init(server: URL, store: BotConnectionStore? = nil, unread: BotUnreadStore = BotUnreadStore(),
+         avatarStore: BotAvatarStore? = nil, reloadSpacing: Duration = .seconds(1),
+         makeWire: (@MainActor (BotConnection) -> any BotTransport)? = nil) {
+        self.server = server; self.store = store ?? BotConnectionStore(); self.unread = unread
+        self.avatarStore = avatarStore ?? .shared; self.reloadSpacing = reloadSpacing
+        self.makeWire = makeWire ?? { BotClient(connection: $0) }
+    }
+
+    var hiddenCount: Int { profiles.filter(\.hidden).count }
+
+    func rows(matching search: String) -> Rows {
+        let matching = profiles.filter { search.isEmpty || $0.name.localizedStandardContains(search) }
+        let shown = matching.filter { !$0.hidden }
+        return Rows(pinned: shown.filter(\.pinned), others: shown.filter { !$0.pinned },
+                    hidden: showsHidden || !search.isEmpty ? matching.filter(\.hidden) : [])
+    }
+
+    /// True when the canonical chat moved past what this device last showed.
+    /// A row without a watermark reads as seen: the first roster load seeds it.
+    func isUnread(_ profile: BotProfile) -> Bool {
+        guard let lastActive = profile.lastActive?.timeIntervalSince1970, let mark = seen[profile.id] else { return false }
+        return lastActive > mark
+    }
+
+    /// The user is entering this bot's chat: the row's activity is now seen.
+    func markSeen(_ profile: BotProfile) {
+        guard let lastActive = profile.lastActive?.timeIntervalSince1970, seen[profile.id] != lastActive else { return }
+        seen[profile.id] = lastActive
+        persistSeen()
+    }
+
+    /// The user came back from this bot's chat. Whatever the next roster read
+    /// shows was on screen while they were there, so it is marked seen once and
+    /// normal tracking resumes after that.
+    func noteReturn(from profile: BotProfile) {
+        markSeen(profile)
+        returnedFrom = profile.id
+    }
+
+    /// Connects, reads the roster and avatars, and keeps the socket for live
+    /// `sessions.changed` reloads. Also the pull-to-refresh and Reconnect path.
+    func open() async {
+        close()
+        do {
+            let saved = try store.load(server: server)
+            if connection?.id != saved?.id { profiles = []; avatars = [:]; seen = [:] }
+            connection = saved
+            guard let saved else { link = .idle; return }
+            if seen.isEmpty { seen = unread.load(connectionID: saved.id) }
+            let client = makeWire(saved)
+            wire = client; link = .connecting; errorMessage = nil; notice = nil
+            client.onEvent = { [weak self] event in
+                guard let self, self.wire === client, event["type"].text == "sessions.changed" else { return }
+                self.noteChange()
+            }
+            client.onDisconnect = { [weak self] _ in
+                guard let self, self.wire === client else { return }
+                self.drop(client, message: String(localized: "Live updates stopped. Pull down to refresh."))
+            }
+            try await client.connect()
+            guard wire === client, !Task.isCancelled else { return }
+            guard await reload(client) else { return }
+            link = .live
+            await refreshAvatars(client)
+        } catch {
+            guard let client = wire, !Task.isCancelled else { return }
+            drop(client, message: (error as? BotFailure ?? .transport).localizedDescription)
+        }
+    }
+
+    func close() {
+        reloadTask?.cancel(); reloadTask = nil; reloadWanted = false
+        wire?.close(); wire = nil
+        link = .idle
+    }
+
+    func mayEdit(_ profile: BotProfile) -> Bool { link == .live && !editing.contains(profile.id) }
+
+    func setPinned(_ pinned: Bool, _ profile: BotProfile) async { await configure(profile, "pinned", .bool(pinned)) }
+    func setHidden(_ hidden: Bool, _ profile: BotProfile) async { await configure(profile, "hidden", .bool(hidden)) }
+
+    /// Writes one Desktop look field through `profiles.configure`, sending the whole
+    /// `hermes-bots` object back so unrelated Desktop fields survive, under the look
+    /// revision the row was read at. Nothing is shown as done until the host says
+    /// it applied and the roster is re-read; a conflict means Desktop wrote in
+    /// between, so the fresh roster is shown and the user decides whether to retry.
+    private func configure(_ profile: BotProfile, _ field: String, _ value: BotJSON) async {
+        guard mayEdit(profile), let client = wire else { return }
+        editing.insert(profile.id); notice = nil
+        defer { editing.remove(profile.id) }
+        var look = profile.look
+        look[field] = value
+        do {
+            let reply = try await client.call("profiles.configure", [
+                "name": .string(profile.id),
+                "ui_meta": .object(["hermes-bots": .object(look)]),
+                "ui_meta_expected_revisions": .object(["hermes-bots": .number(Double(profile.lookRevision ?? 0))])
+            ])
+            guard wire === client else { return }
+            if reply["applied"]["ui_meta"].flag != true {
+                notice = reply["applied"]["ui_meta_conflicts"] != .null
+                    ? String(localized: "This bot changed in Hermes Desktop. The list was refreshed; try again.")
+                    : String(localized: "Hermes did not save this change.")
+            }
+            if await reload(client) { await refreshAvatars(client) }
+        } catch {
+            guard wire === client else { return }
+            notice = error as? BotFailure == .rejected(-32601)
+                ? String(localized: "This Hermes version cannot organize bots from the phone.")
+                : String(localized: "Hermes did not save this change.")
+        }
+    }
+
+    /// Coalesces `sessions.changed` bursts: one reload in flight, at most one
+    /// more queued, spaced by `reloadSpacing`. Avatars are not refreshed here
+    /// because the event follows session activity, and a look change never moves it.
+    private func noteChange() {
+        reloadWanted = true
+        guard reloadTask == nil, let client = wire else { return }
+        reloadTask = Task { [weak self] in
+            while let self, self.reloadWanted, self.wire === client, !Task.isCancelled {
+                self.reloadWanted = false
+                _ = await self.reload(client)
+                guard self.wire === client, (try? await Task.sleep(for: self.reloadSpacing)) != nil else { break }
+            }
+            guard let self, self.wire === client else { return }
+            self.reloadTask = nil
+        }
+    }
+
+    /// One `profiles.list` on the live socket. Only the newest request's reply is
+    /// applied, and only while `client` still owns the inbox.
+    private func reload(_ client: any BotTransport) async -> Bool {
+        reloadSerial += 1
+        let serial = reloadSerial
+        do {
+            let roster = try await client.call("profiles.list", ["include_sessions": .bool(true)])
+            guard wire === client, serial == reloadSerial else { return false }
+            guard let rows = roster["profiles"].list else { throw BotFailure.unsupported }
+            var ids = Set<String>()
+            profiles = rows.compactMap(BotProfile.init).filter { ids.insert($0.id).inserted }
+            var changed = false
+            for profile in profiles {
+                guard let lastActive = profile.lastActive?.timeIntervalSince1970,
+                      seen[profile.id] == nil || profile.id == returnedFrom else { continue }
+                seen[profile.id] = lastActive; changed = true
+            }
+            returnedFrom = nil
+            if changed { persistSeen() }
+            return true
+        } catch {
+            guard wire === client, serial == reloadSerial else { return false }
+            drop(client, message: (error as? BotFailure ?? .transport).localizedDescription)
+            return false
+        }
+    }
+
+    private func refreshAvatars(_ client: any BotTransport) async {
+        guard let connection else { return }
+        await avatarStore.refresh(profiles, connectionID: connection.id, using: client) {
+            if wire === client { avatars = avatarStore.images(connectionID: connection.id) }
+        }
+    }
+
+    private func drop(_ client: any BotTransport, message: String) {
+        reloadTask?.cancel(); reloadTask = nil; reloadWanted = false
+        client.close(); wire = nil
+        link = .disconnected
+        errorMessage = message
+    }
+
+    private func persistSeen() {
+        guard let connection else { return }
+        unread.save(seen, connectionID: connection.id)
+    }
+}
+
+/// Device-local record of the canonical activity the user last saw per bot,
+/// keyed by connection UUID so equal Profile names on two hosts never share a
+/// mark. Plain timestamps, so `UserDefaults` rather than the Keychain; the
+/// values never leave the phone and Desktop has no matching state to sync.
+struct BotUnreadStore {
+    var defaults: UserDefaults = .standard
+
+    private func key(_ connectionID: UUID) -> String { "bot-inbox-seen." + connectionID.uuidString }
+
+    func load(connectionID: UUID) -> [String: Double] {
+        defaults.dictionary(forKey: key(connectionID)) as? [String: Double] ?? [:]
+    }
+
+    func save(_ seen: [String: Double], connectionID: UUID) {
+        defaults.set(seen, forKey: key(connectionID))
+    }
+
+    func remove(connectionID: UUID) {
+        defaults.removeObject(forKey: key(connectionID))
+    }
+}

--- a/HermesMobile/Features/Bots/BotInbox.swift
+++ b/HermesMobile/Features/Bots/BotInbox.swift
@@ -111,8 +111,12 @@ import UIKit
             link = .live
             await refreshAvatars(client)
         } catch {
-            guard let client = wire, !Task.isCancelled else { return }
-            drop(client, message: (error as? BotFailure ?? .transport).localizedDescription)
+            guard !Task.isCancelled else { return }
+            let message = (error as? BotFailure ?? .transport).localizedDescription
+            // A saved-connection read can fail before any client exists; that is still
+            // a visible failure with the Reconnect path, not a quiet stale roster.
+            if let client = wire { drop(client, message: message) }
+            else { link = .disconnected; errorMessage = message }
         }
     }
 

--- a/HermesMobile/Features/Bots/BotsInboxView.swift
+++ b/HermesMobile/Features/Bots/BotsInboxView.swift
@@ -42,8 +42,10 @@ import SwiftUI
                     Text(notice).font(.callout).foregroundStyle(.secondary).listRowSeparator(.hidden)
                 }
                 if !rows.pinned.isEmpty {
-                    // Pinned bots sit above the list as large tiles, as in Desktop's mobile roster.
-                    HStack(alignment: .top, spacing: 32) {
+                    // Pinned bots sit above the list as large tiles: as many columns as
+                    // there are pinned bots, up to three, so one or two sit centered and
+                    // four or more wrap instead of being clipped away.
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: min(rows.pinned.count, 3)), spacing: 24) {
                         ForEach(rows.pinned) { profile in
                             Button { openProfile = profile } label: {
                                 BotHeroTile(profile: profile, avatar: inbox.avatars[profile.id], unread: inbox.isUnread(profile))
@@ -52,7 +54,6 @@ import SwiftUI
                             .contextMenu { organizeMenu(profile) }
                         }
                     }
-                    .frame(maxWidth: .infinity)
                     .padding(.vertical, 20)
                     .listRowSeparator(.hidden)
                 }
@@ -120,16 +121,18 @@ import SwiftUI
 
     /// Pin and hide write Desktop's own roster fields; both stay inert until the
     /// inbox is live and no write for this bot is in flight.
-    @ViewBuilder private func organizeMenu(_ profile: BotProfile) -> some View {
-        Button {
-            Task { await inbox.setPinned(!profile.pinned, profile) }
-        } label: {
-            Label(profile.pinned ? "Unpin" : "Pin", systemImage: profile.pinned ? "pin.slash" : "pin")
-        }
-        Button {
-            Task { await inbox.setHidden(!profile.hidden, profile) }
-        } label: {
-            Label(profile.hidden ? "Unhide" : "Hide bot", systemImage: profile.hidden ? "eye" : "eye.slash")
+    private func organizeMenu(_ profile: BotProfile) -> some View {
+        Group {
+            Button {
+                Task { await inbox.setPinned(!profile.pinned, profile) }
+            } label: {
+                Label(profile.pinned ? "Unpin" : "Pin", systemImage: profile.pinned ? "pin.slash" : "pin")
+            }
+            Button {
+                Task { await inbox.setHidden(!profile.hidden, profile) }
+            } label: {
+                Label(profile.hidden ? "Unhide" : "Hide bot", systemImage: profile.hidden ? "eye" : "eye.slash")
+            }
         }
         .disabled(!inbox.mayEdit(profile))
     }
@@ -144,10 +147,11 @@ private struct BotHeroTile: View {
         VStack(spacing: 14) {
             BotAvatarView(profile: profile, avatar: avatar, size: 84)
             HStack(spacing: 6) {
-                Text(profile.name).font(.body).foregroundStyle(.secondary)
+                Text(profile.name).font(.body).foregroundStyle(.secondary).lineLimit(1)
                 if unread { BotUnreadDot() }
             }
         }
+        .frame(maxWidth: 132)
         .accessibilityElement(children: .combine)
     }
 }

--- a/HermesMobile/Features/Bots/BotsInboxView.swift
+++ b/HermesMobile/Features/Bots/BotsInboxView.swift
@@ -4,20 +4,19 @@ import SwiftUI
     @Environment(\.scenePhase) private var scenePhase
     let server: URL
     let showSessions: () -> Void
-    @State private var connection: BotConnection?
-    @State private var profiles: [BotProfile] = []
-    @State private var avatars: [String: UIImage] = [:]
+    @State private var inbox: BotInbox
     @State private var search = ""
-    @State private var errorMessage: String?
-    @State private var loading = false
     @State private var showingSetup = false
     @State private var revision = UUID()
-    @State private var loadOwner = UUID()
-    @State private var wire: BotClient?
-    private let store = BotConnectionStore()
+
+    init(server: URL, showSessions: @escaping () -> Void) {
+        self.server = server
+        self.showSessions = showSessions
+        _inbox = State(initialValue: BotInbox(server: server))
+    }
 
     private var filteredProfiles: [BotProfile] {
-        profiles.filter { search.isEmpty || $0.name.localizedStandardContains(search) }
+        inbox.profiles.filter { search.isEmpty || $0.name.localizedStandardContains(search) }
     }
 
     var body: some View {
@@ -29,24 +28,26 @@ import SwiftUI
             .pickerStyle(.segmented)
             .listRowSeparator(.hidden)
 
-            if let connection {
+            if let connection = inbox.connection {
                 Text(connection.name)
                     .font(.footnote).foregroundStyle(.secondary)
                     .listRowSeparator(.hidden)
-                if let errorMessage {
+                if let errorMessage = inbox.errorMessage {
                     Text(errorMessage).font(.callout)
                     Button("Reconnect") { revision = UUID() }
-                } else if loading {
+                } else if inbox.link == .connecting {
                     Text("Connecting…")
-                } else if profiles.isEmpty {
+                } else if inbox.profiles.isEmpty {
                     Text("No bots found. Create one in Hermes Desktop, then refresh.")
                 }
                 ForEach(filteredProfiles) { profile in
                     NavigationLink {
                         BotChatView(server: server, connection: connection, profile: profile)
                             .id(profile.id + connection.id.uuidString)
+                            .onAppear { inbox.markSeen(profile) }
+                            .onDisappear { inbox.noteReturn(from: profile) }
                     } label: {
-                        BotInboxRow(profile: profile, avatar: avatars[profile.id])
+                        BotInboxRow(profile: profile, avatar: inbox.avatars[profile.id])
                     }
                     .listRowSeparator(.hidden)
                     .padding(.vertical, 10)
@@ -68,44 +69,15 @@ import SwiftUI
         .sheet(isPresented: $showingSetup, onDismiss: { revision = UUID() }) {
             NavigationStack { BotConnectionView(server: server) }
         }
-        .task(id: revision) { await load() }
-        .refreshable { await load() }
+        // The subscription lives while the inbox is on screen and the app is active;
+        // returning, refreshing and reconnecting all go through the same open().
+        .task(id: revision) { await inbox.open() }
+        .refreshable { await inbox.open() }
         .onChange(of: scenePhase) {
             if scenePhase == .active { revision = UUID() }
-            else { wire?.close() }
+            else { inbox.close() }
         }
-        .onDisappear { loadOwner = UUID(); wire?.close(); wire = nil }
-    }
-
-    private func load() async {
-        wire?.close()
-        let owner = UUID()
-        loadOwner = owner
-        // The stored client identity is the load owner; a replacement invalidates late results.
-        do {
-            let saved = try store.load(server: server)
-            if connection?.id != saved?.id { profiles = []; avatars = [:] }
-            connection = saved
-            guard let saved else { return }
-            let client = BotClient(connection: saved)
-            wire = client; loading = true; errorMessage = nil
-            defer { if wire === client { loading = false } }
-            try await client.connect()
-            guard !Task.isCancelled, wire === client else { return }
-            let roster = try await client.call("profiles.list", ["include_sessions": .bool(true)])
-            guard !Task.isCancelled, wire === client else { return }
-            guard let rows = roster["profiles"].list else { throw BotFailure.unsupported }
-            var seen = Set<String>()
-            profiles = rows.compactMap(BotProfile.init).filter { seen.insert($0.id).inserted }
-            await BotAvatarStore.shared.refresh(profiles, connectionID: saved.id, using: client) {
-                if wire === client { avatars = BotAvatarStore.shared.images(connectionID: saved.id) }
-            }
-            client.close()
-        } catch {
-            guard !Task.isCancelled, loadOwner == owner else { return }
-            errorMessage = (error as? BotFailure ?? .transport).localizedDescription
-            loading = false
-        }
+        .onDisappear { inbox.close() }
     }
 }
 

--- a/HermesMobile/Features/Bots/BotsInboxView.swift
+++ b/HermesMobile/Features/Bots/BotsInboxView.swift
@@ -8,6 +8,10 @@ import SwiftUI
     @State private var search = ""
     @State private var showingSetup = false
     @State private var revision = UUID()
+    /// The bot whose chat is open. One destination serves the hero tiles and the
+    /// rows, so a row shows no disclosure accessory and tiles sharing a row keep
+    /// separate tap targets.
+    @State private var openProfile: BotProfile?
 
     init(server: URL, showSessions: @escaping () -> Void) {
         self.server = server
@@ -15,11 +19,8 @@ import SwiftUI
         _inbox = State(initialValue: BotInbox(server: server))
     }
 
-    private var filteredProfiles: [BotProfile] {
-        inbox.profiles.filter { search.isEmpty || $0.name.localizedStandardContains(search) }
-    }
-
     var body: some View {
+        let rows = inbox.rows(matching: search)
         List {
             Picker("Screen", selection: Binding(get: { true }, set: { if !$0 { showSessions() } })) {
                 Text("Sessions").tag(false)
@@ -28,29 +29,45 @@ import SwiftUI
             .pickerStyle(.segmented)
             .listRowSeparator(.hidden)
 
-            if let connection = inbox.connection {
-                Text(connection.name)
-                    .font(.footnote).foregroundStyle(.secondary)
-                    .listRowSeparator(.hidden)
+            if inbox.connection != nil {
                 if let errorMessage = inbox.errorMessage {
                     Text(errorMessage).font(.callout)
                     Button("Reconnect") { revision = UUID() }
-                } else if inbox.link == .connecting {
+                } else if inbox.link == .connecting && inbox.profiles.isEmpty {
                     Text("Connecting…")
-                } else if inbox.profiles.isEmpty {
+                } else if inbox.profiles.isEmpty && inbox.link == .live {
                     Text("No bots found. Create one in Hermes Desktop, then refresh.")
                 }
-                ForEach(filteredProfiles) { profile in
-                    NavigationLink {
-                        BotChatView(server: server, connection: connection, profile: profile)
-                            .id(profile.id + connection.id.uuidString)
-                            .onAppear { inbox.markSeen(profile) }
-                            .onDisappear { inbox.noteReturn(from: profile) }
-                    } label: {
-                        BotInboxRow(profile: profile, avatar: inbox.avatars[profile.id])
+                if let notice = inbox.notice {
+                    Text(notice).font(.callout).foregroundStyle(.secondary).listRowSeparator(.hidden)
+                }
+                if !rows.pinned.isEmpty {
+                    // Pinned bots sit above the list as large tiles, as in Desktop's mobile roster.
+                    HStack(alignment: .top, spacing: 32) {
+                        ForEach(rows.pinned) { profile in
+                            Button { openProfile = profile } label: {
+                                BotHeroTile(profile: profile, avatar: inbox.avatars[profile.id], unread: inbox.isUnread(profile))
+                            }
+                            .buttonStyle(.plain)
+                            .contextMenu { organizeMenu(profile) }
+                        }
                     }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
                     .listRowSeparator(.hidden)
-                    .padding(.vertical, 10)
+                }
+                ForEach(rows.others) { profile in
+                    row(profile, dimmed: false)
+                }
+                ForEach(rows.hidden) { profile in
+                    row(profile, dimmed: true)
+                }
+                if inbox.hiddenCount > 0 && search.isEmpty {
+                    Button(inbox.showsHidden ? "Hide hidden bots" : "Show hidden bots (\(inbox.hiddenCount))") {
+                        inbox.showsHidden.toggle()
+                    }
+                    .font(.subheadline).foregroundStyle(.secondary)
+                    .listRowSeparator(.hidden)
                 }
             } else {
                 ContentUnavailableView("Connect to Hermes", systemImage: "bubble.left.and.bubble.right",
@@ -69,6 +86,9 @@ import SwiftUI
         .sheet(isPresented: $showingSetup, onDismiss: { revision = UUID() }) {
             NavigationStack { BotConnectionView(server: server) }
         }
+        .navigationDestination(item: $openProfile) { profile in
+            if let connection = inbox.connection { chat(profile, connection) }
+        }
         // The subscription lives while the inbox is on screen and the app is active;
         // returning, refreshing and reconnecting all go through the same open().
         .task(id: revision) { await inbox.open() }
@@ -79,50 +99,149 @@ import SwiftUI
         }
         .onDisappear { inbox.close() }
     }
+
+    private func row(_ profile: BotProfile, dimmed: Bool) -> some View {
+        Button { openProfile = profile } label: {
+            BotInboxRow(profile: profile, avatar: inbox.avatars[profile.id], unread: inbox.isUnread(profile))
+        }
+        .buttonStyle(.plain)
+        .opacity(dimmed ? 0.5 : 1)
+        .contextMenu { organizeMenu(profile) }
+        .listRowSeparator(.hidden)
+        .padding(.vertical, 12)
+    }
+
+    private func chat(_ profile: BotProfile, _ connection: BotConnection) -> some View {
+        BotChatView(server: server, connection: connection, profile: profile)
+            .id(profile.id + connection.id.uuidString)
+            .onAppear { inbox.markSeen(profile) }
+            .onDisappear { inbox.noteReturn(from: profile) }
+    }
+
+    /// Pin and hide write Desktop's own roster fields; both stay inert until the
+    /// inbox is live and no write for this bot is in flight.
+    @ViewBuilder private func organizeMenu(_ profile: BotProfile) -> some View {
+        Button {
+            Task { await inbox.setPinned(!profile.pinned, profile) }
+        } label: {
+            Label(profile.pinned ? "Unpin" : "Pin", systemImage: profile.pinned ? "pin.slash" : "pin")
+        }
+        Button {
+            Task { await inbox.setHidden(!profile.hidden, profile) }
+        } label: {
+            Label(profile.hidden ? "Unhide" : "Hide bot", systemImage: profile.hidden ? "eye" : "eye.slash")
+        }
+        .disabled(!inbox.mayEdit(profile))
+    }
 }
 
-/// One roster row: the Desktop avatar when the host has one, otherwise a letter
-/// tile; the server name; and the canonical preview, else the description, else
-/// the Profile name. The avatar is decorative; VoiceOver reads the text as one element.
+/// A pinned bot: the avatar large and centered with the name beneath it.
+private struct BotHeroTile: View {
+    let profile: BotProfile
+    let avatar: UIImage?
+    let unread: Bool
+    var body: some View {
+        VStack(spacing: 14) {
+            BotAvatarView(profile: profile, avatar: avatar, size: 84)
+            HStack(spacing: 6) {
+                Text(profile.name).font(.body).foregroundStyle(.secondary)
+                if unread { BotUnreadDot() }
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// One roster row: avatar, name with an optional short Desktop description chip,
+/// the last activity, then the canonical preview with a trailing unread mark.
+/// The avatar is decorative; VoiceOver reads the text as one element.
 private struct BotInboxRow: View {
     let profile: BotProfile
     let avatar: UIImage?
-    private var color: Color {
-        let colors: [Color] = [.green, .orange, .purple, .pink, .blue, .teal]
-        let value = profile.id.utf8.reduce(0) { ($0 + Int($1)) % colors.count }
-        return colors[value]
+    let unread: Bool
+    /// A description short enough to read as a role sits beside the name; a
+    /// longer one only stands in for the preview when the chat has none.
+    private var chip: String? {
+        guard let description = profile.description, description.count <= 24,
+              profile.preview?.isEmpty == false else { return nil }
+        return description
     }
     private var subline: String {
         if let preview = profile.preview, !preview.isEmpty { return preview }
         return profile.description ?? profile.id
     }
     var body: some View {
-        HStack(spacing: 16) {
-            tile
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(alignment: .firstTextBaseline) {
-                    Text(profile.name).font(.headline)
-                    Spacer()
+        HStack(spacing: 14) {
+            BotAvatarView(profile: profile, avatar: avatar, size: 44)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(profile.name).font(.headline).lineLimit(1)
+                    if let chip {
+                        Text(chip).font(.footnote).foregroundStyle(.secondary).lineLimit(1)
+                            .padding(.horizontal, 8).padding(.vertical, 3)
+                            .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 6))
+                            .layoutPriority(-1)
+                    }
+                    Spacer(minLength: 8)
                     if let date = profile.lastActive {
-                        Text(SessionRelativeDateFormatter.shared.localizedString(for: date, relativeTo: Date())).font(.caption).foregroundStyle(.secondary)
+                        Text(BotInboxDateLabel.text(for: date)).font(.subheadline).foregroundStyle(.secondary)
                     }
                 }
-                Text(subline).font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
+                HStack(spacing: 8) {
+                    Text(subline).font(.body).foregroundStyle(.secondary).lineLimit(1)
+                    Spacer(minLength: 0)
+                    if unread { BotUnreadDot() }
+                }
             }
         }
         .accessibilityElement(children: .combine)
     }
-    @ViewBuilder private var tile: some View {
+}
+
+/// The Desktop avatar fitted into a square, or a letter tile on a tinted circle.
+/// Desktop assets are shapes on a transparent background, so they are not clipped.
+private struct BotAvatarView: View {
+    let profile: BotProfile
+    let avatar: UIImage?
+    let size: CGFloat
+    private var color: Color {
+        let colors: [Color] = [.green, .orange, .purple, .pink, .blue, .teal]
+        let value = profile.id.utf8.reduce(0) { ($0 + Int($1)) % colors.count }
+        return colors[value]
+    }
+    var body: some View {
         if let avatar {
-            Image(uiImage: avatar).resizable().scaledToFill()
-                .frame(width: 48, height: 48)
-                .clipShape(RoundedRectangle(cornerRadius: 16))
+            Image(uiImage: avatar).resizable().scaledToFit()
+                .frame(width: size, height: size)
                 .accessibilityHidden(true)
         } else {
-            Text(String(profile.name.prefix(1))).font(.title2.weight(.semibold))
-                .frame(width: 48, height: 48)
-                .background(color.opacity(0.2), in: RoundedRectangle(cornerRadius: 16))
+            Text(String(profile.name.prefix(1))).font(.system(size: size * 0.42, weight: .semibold))
+                .frame(width: size, height: size)
+                .background(color.opacity(0.2), in: Circle())
                 .foregroundStyle(color).accessibilityHidden(true)
         }
+    }
+}
+
+/// Static unread mark. It never animates; VoiceOver reads it as "Unread".
+private struct BotUnreadDot: View {
+    var body: some View {
+        Circle().fill(Color.accentColor).frame(width: 10, height: 10)
+            .accessibilityLabel("Unread")
+    }
+}
+
+/// Last-activity label in the roster's style: the time today, the weekday within
+/// the past week, otherwise the month and day.
+enum BotInboxDateLabel {
+    static func text(for date: Date, now: Date = Date(), calendar: Calendar = .current, locale: Locale = .current) -> String {
+        let style = Date.FormatStyle(locale: locale, calendar: calendar, timeZone: calendar.timeZone)
+        if calendar.isDate(date, inSameDayAs: now) {
+            return date.formatted(style.hour().minute())
+        }
+        if let weekAgo = calendar.date(byAdding: .day, value: -6, to: calendar.startOfDay(for: now)), date >= weekAgo, date < now {
+            return date.formatted(style.weekday(.wide))
+        }
+        return date.formatted(style.month(.abbreviated).day())
     }
 }

--- a/HermesMobile/Networking/Bots/BotClient.swift
+++ b/HermesMobile/Networking/Bots/BotClient.swift
@@ -128,7 +128,7 @@ import Foundation
     }
 
     func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)? = nil) async throws -> BotJSON {
-        guard ["profiles.list", "profiles.get_asset", "session.list", "session.resume", "session.events.since",
+        guard ["profiles.list", "profiles.get_asset", "profiles.configure", "session.list", "session.resume", "session.events.since",
                "prompt.submit", "session.steer", "session.redirect", "session.interrupt", "approval.respond", "clarify.respond",
                "sudo.respond", "secret.respond", "mcp.setup.respond"].contains(method)
         else { throw BotFailure.unsupported }

--- a/HermesMobile/Networking/Bots/BotProtocol.swift
+++ b/HermesMobile/Networking/Bots/BotProtocol.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Direct Hermes payloads deliberately stay separate from webui endpoint models.
 /// Accessors tolerate absent and future fields; required capabilities are checked at use.
-indirect enum BotJSON: Codable, Equatable, Sendable {
+indirect enum BotJSON: Codable, Hashable, Sendable {
     case object([String: BotJSON]), array([BotJSON]), string(String), number(Double), bool(Bool), null
 
     init(from decoder: Decoder) throws {
@@ -30,6 +30,7 @@ indirect enum BotJSON: Codable, Equatable, Sendable {
     subscript(_ key: String) -> BotJSON { if case .object(let v) = self { return v[key] ?? .null }; return .null }
     var text: String? { if case .string(let v) = self { return v }; return nil }
     var list: [BotJSON]? { if case .array(let v) = self { return v }; return nil }
+    var fields: [String: BotJSON]? { if case .object(let v) = self { return v }; return nil }
     var flag: Bool? { if case .bool(let v) = self { return v }; return nil }
     var integer: Int? { if case .number(let v) = self { return Int(exactly: v) }; return nil }
     var number: Double? { if case .number(let v) = self { return v }; return nil }

--- a/HermesMobileTests/BotClientTests.swift
+++ b/HermesMobileTests/BotClientTests.swift
@@ -72,9 +72,11 @@ import XCTest
         try await client.connect()
         _ = try await client.call("profiles.get_asset", ["name": .string("inbox-triage"), "asset": .string("avatar")])
         XCTAssertEqual(socket.sentTextFrames, 1)
+        _ = try await client.call("profiles.configure", ["name": .string("inbox-triage"), "ui_meta": .object([:])])
+        XCTAssertEqual(socket.sentTextFrames, 2, "the inbox's pin and hide writes go through profiles.configure")
         do { _ = try await client.call("profiles.set_asset", ["name": .string("inbox-triage"), "clear": .bool(true)]); XCTFail("Writes stay off the allowlist") }
         catch { XCTAssertEqual(error as? BotFailure, .unsupported) }
-        XCTAssertEqual(socket.sentTextFrames, 1)
+        XCTAssertEqual(socket.sentTextFrames, 2)
         client.close()
     }
 

--- a/HermesMobileTests/BotInboxTests.swift
+++ b/HermesMobileTests/BotInboxTests.swift
@@ -234,6 +234,15 @@ import XCTest
         XCTAssertNil(inbox.errorMessage)
     }
 
+    func testUnreadableSavedConnectionShowsTheFailureInsteadOfAStaleRoster() async throws {
+        let keychain = InMemoryKeychainStore()
+        try keychain.save("not json", forKey: .botConnection, scope: server.absoluteString)
+        let inbox = try makeInbox(wires: [], store: BotConnectionStore(keychain: keychain))
+        await inbox.open()
+        XCTAssertEqual(inbox.link, .disconnected)
+        XCTAssertNotNil(inbox.errorMessage)
+    }
+
     func testActivityLabelUsesTimeTodayWeekdayThisWeekThenMonthAndDay() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!

--- a/HermesMobileTests/BotInboxTests.swift
+++ b/HermesMobileTests/BotInboxTests.swift
@@ -1,0 +1,328 @@
+import XCTest
+@testable import HermesMobile
+
+@MainActor final class BotInboxTests: XCTestCase {
+    private let server = URL(string: "https://one.example")!
+    private var defaults: UserDefaults!
+    private var suite = ""
+
+    override func setUp() {
+        super.setUp()
+        suite = "BotInboxTests." + UUID().uuidString
+        defaults = UserDefaults(suiteName: suite)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suite)
+        super.tearDown()
+    }
+
+    func testSessionsChangedBurstCoalescesIntoBoundedReloads() async throws {
+        let wire = BotInboxFixtureWire(roster: [row("triage", lastActive: 100, preview: "old")])
+        let inbox = try makeInbox(wires: [wire])
+        await inbox.open()
+        XCTAssertEqual(inbox.link, .live)
+        XCTAssertEqual(inbox.profiles.map(\.preview), ["old"])
+
+        wire.holdsList = true
+        let parked = expectation(description: "reload parked")
+        wire.onCall = { if $0 == "profiles.list" { parked.fulfill() } }
+        wire.emit("sessions.changed")
+        await fulfillment(of: [parked], timeout: 5)
+        for _ in 0..<4 { wire.emit("sessions.changed") }
+
+        wire.roster = [row("triage", lastActive: 200, preview: "new")]
+        wire.holdsList = false
+        let trailing = expectation(description: "one trailing reload")
+        wire.onCall = { if $0 == "profiles.list" { trailing.fulfill() } }
+        wire.release()
+        await fulfillment(of: [trailing], timeout: 5)
+        await settle(inbox) { $0.profiles.first?.preview == "new" }
+
+        XCTAssertEqual(wire.listCalls, 3, "open, the parked reload and exactly one trailing reload")
+        XCTAssertTrue(inbox.isUnread(inbox.profiles[0]))
+    }
+
+    func testStaleReloadAndEventsFromAReplacedWireAreDropped() async throws {
+        let first = BotInboxFixtureWire(roster: [row("triage", lastActive: 100, preview: "first")])
+        let second = BotInboxFixtureWire(roster: [row("triage", lastActive: 300, preview: "second")])
+        let inbox = try makeInbox(wires: [first, second])
+        await inbox.open()
+
+        first.holdsList = true
+        let parked = expectation(description: "reload parked")
+        first.onCall = { if $0 == "profiles.list" { parked.fulfill() } }
+        first.emit("sessions.changed")
+        await fulfillment(of: [parked], timeout: 5)
+
+        await inbox.open()
+        XCTAssertEqual(first.closed, 1)
+        XCTAssertEqual(inbox.profiles.map(\.preview), ["second"])
+
+        first.roster = [row("triage", lastActive: 200, preview: "stale")]
+        first.release()
+        // The parked reply resumes on the main actor ahead of this task; one yield lets it be dropped.
+        await Task.yield()
+        first.emit("sessions.changed")
+        await Task.yield()
+        XCTAssertEqual(inbox.profiles.map(\.preview), ["second"])
+        XCTAssertEqual(first.listCalls, 2)
+        XCTAssertEqual(second.listCalls, 1)
+        XCTAssertEqual(inbox.link, .live)
+    }
+
+    func testChangedCanonicalTipUpdatesPreviewAndUnreadFollowsActivity() async throws {
+        let wire = BotInboxFixtureWire(roster: [row("triage", lastActive: 100, preview: "before", tip: "tip-1")])
+        let inbox = try makeInbox(wires: [wire])
+        await inbox.open()
+        XCTAssertFalse(inbox.isUnread(inbox.profiles[0]), "the first load seeds the watermark")
+
+        wire.roster = [row("triage", lastActive: 200, preview: "after", tip: "tip-2")]
+        wire.emit("sessions.changed")
+        await settle(inbox) { $0.profiles.first?.preview == "after" }
+        XCTAssertTrue(inbox.isUnread(inbox.profiles[0]))
+
+        inbox.markSeen(inbox.profiles[0])
+        XCTAssertFalse(inbox.isUnread(inbox.profiles[0]))
+        XCTAssertEqual(BotUnreadStore(defaults: defaults).load(connectionID: inbox.connection!.id), ["triage": 200])
+    }
+
+    func testReturningFromChatMarksTheNextRosterSeenOnce() async throws {
+        let wire = BotInboxFixtureWire(roster: [row("triage", lastActive: 100)])
+        let inbox = try makeInbox(wires: [wire])
+        await inbox.open()
+        inbox.noteReturn(from: inbox.profiles[0])
+
+        wire.roster = [row("triage", lastActive: 200)]
+        wire.emit("sessions.changed")
+        await settle(inbox) { $0.profiles.first?.lastActive == Date(timeIntervalSince1970: 200) }
+        XCTAssertFalse(inbox.isUnread(inbox.profiles[0]), "activity during the visit was on screen")
+
+        wire.roster = [row("triage", lastActive: 300)]
+        wire.emit("sessions.changed")
+        await settle(inbox) { $0.profiles.first?.lastActive == Date(timeIntervalSince1970: 300) }
+        XCTAssertTrue(inbox.isUnread(inbox.profiles[0]))
+    }
+
+    func testUnreadSurvivesRelaunchAndStaysWithItsConnection() async throws {
+        let wire = BotInboxFixtureWire(roster: [row("triage", lastActive: 100)])
+        let store = BotConnectionStore(keychain: InMemoryKeychainStore())
+        let connection = BotConnection(id: UUID(), name: "Mac", address: URL(string: "https://mac.example")!,
+                                       username: "u", password: "p", hermesVersion: nil)
+        try store.save(connection, server: server)
+        let inbox = try makeInbox(wires: [wire], store: store)
+        await inbox.open()
+        wire.roster = [row("triage", lastActive: 200)]
+        wire.emit("sessions.changed")
+        await settle(inbox) { $0.profiles.first?.lastActive == Date(timeIntervalSince1970: 200) }
+        XCTAssertTrue(inbox.isUnread(inbox.profiles[0]))
+        inbox.close()
+
+        let relaunched = try makeInbox(wires: [BotInboxFixtureWire(roster: [row("triage", lastActive: 200)])], store: store)
+        await relaunched.open()
+        XCTAssertTrue(relaunched.isUnread(relaunched.profiles[0]), "the watermark outlives the process")
+
+        // A second host with the same Profile name has its own marks: nothing seen there yet.
+        let otherServer = URL(string: "https://two.example")!
+        let otherStore = BotConnectionStore(keychain: InMemoryKeychainStore())
+        try otherStore.save(BotConnection(id: UUID(), name: "Other", address: URL(string: "https://other.example")!,
+                                          username: "u", password: "p", hermesVersion: nil), server: otherServer)
+        let other = try makeInbox(wires: [BotInboxFixtureWire(roster: [row("triage", lastActive: 200)])],
+                                  store: otherStore, server: otherServer)
+        await other.open()
+        XCTAssertFalse(other.isUnread(other.profiles[0]))
+        XCTAssertEqual(BotUnreadStore(defaults: defaults).load(connectionID: connection.id), ["triage": 100])
+    }
+
+    func testMissingMetadataReadsPlainAndPinWritesUnderRevisionZero() async throws {
+        let wire = BotInboxFixtureWire(roster: [row("triage", look: nil, revision: nil)])
+        var configured: [String: BotJSON]?
+        wire.configure = { params in
+            configured = params
+            wire.roster = [self.row("triage", look: ["pinned": .bool(true)], revision: 1)]
+            return .object(["ok": .bool(true), "applied": .object(["ui_meta": .bool(true), "ui_meta_revisions": .object(["hermes-bots": .number(1)])])])
+        }
+        let inbox = try makeInbox(wires: [wire])
+        await inbox.open()
+        let plain = inbox.profiles[0]
+        XCTAssertFalse(plain.pinned); XCTAssertFalse(plain.hidden); XCTAssertEqual(plain.look, [:]); XCTAssertNil(plain.lookRevision)
+        XCTAssertEqual(inbox.rows(matching: "").others.map(\.id), ["triage"])
+
+        await inbox.setPinned(true, plain)
+        XCTAssertEqual(configured?["name"], .string("triage"))
+        XCTAssertEqual(configured?["ui_meta"], .object(["hermes-bots": .object(["pinned": .bool(true)])]))
+        XCTAssertEqual(configured?["ui_meta_expected_revisions"], .object(["hermes-bots": .number(0)]))
+        XCTAssertEqual(Set(configured?.keys.map { $0 } ?? []), ["name", "ui_meta", "ui_meta_expected_revisions"])
+        XCTAssertEqual(inbox.rows(matching: "").pinned.map(\.id), ["triage"], "the row moves only after the host applied and the roster was re-read")
+        XCTAssertNil(inbox.notice)
+        XCTAssertEqual(wire.listCalls, 2)
+    }
+
+    func testHideRoundTripsDesktopFieldsAndConflictShowsNoSuccess() async throws {
+        let look: [String: BotJSON] = ["title": .string("Triage"), "sectionId": .string("sec-1"), "groups": .array([.string("ops")]),
+                                       "color": .string("teal"), "pinned": .bool(true)]
+        let wire = BotInboxFixtureWire(roster: [row("triage", look: look, revision: 4)])
+        var configured: [String: BotJSON]?
+        wire.configure = { params in
+            configured = params
+            wire.roster = [self.row("triage", look: look.merging(["title": .string("Renamed")]) { $1 }, revision: 5)]
+            return .object(["ok": .bool(false), "applied": .object([
+                "ui_meta": .bool(false),
+                "ui_meta_conflicts": .object(["hermes-bots": .object(["expected": .number(4), "actual": .number(5)])]),
+                "ui_meta_revisions": .object(["hermes-bots": .number(5)])])])
+        }
+        let inbox = try makeInbox(wires: [wire])
+        await inbox.open()
+        let before = inbox.profiles[0]
+        XCTAssertTrue(before.pinned)
+
+        await inbox.setHidden(true, before)
+        var expected = look; expected["hidden"] = .bool(true)
+        XCTAssertEqual(configured?["ui_meta"], .object(["hermes-bots": .object(expected)]), "unrelated Desktop fields ride along untouched")
+        XCTAssertEqual(configured?["ui_meta_expected_revisions"], .object(["hermes-bots": .number(4)]))
+        XCTAssertEqual(inbox.notice, "This bot changed in Hermes Desktop. The list was refreshed; try again.")
+        XCTAssertEqual(inbox.profiles[0].name, "Renamed", "the conflict re-read the roster")
+        XCTAssertFalse(inbox.profiles[0].hidden)
+        XCTAssertEqual(inbox.profiles[0].lookRevision, 5)
+        XCTAssertTrue(inbox.mayEdit(inbox.profiles[0]))
+    }
+
+    func testHiddenBotsStayOutUntilRevealedOrSearched() async throws {
+        let wire = BotInboxFixtureWire(roster: [
+            row("alpha", look: ["pinned": .bool(true)], revision: 1),
+            row("beta"),
+            row("gamma", look: ["hidden": .bool(true)], revision: 2),
+            row("gamma", preview: "duplicate row")
+        ])
+        let inbox = try makeInbox(wires: [wire])
+        await inbox.open()
+        XCTAssertEqual(inbox.profiles.map(\.id), ["alpha", "beta", "gamma"], "a repeated Profile name keeps its first row")
+        XCTAssertEqual(inbox.hiddenCount, 1)
+
+        var rows = inbox.rows(matching: "")
+        XCTAssertEqual(rows.pinned.map(\.id), ["alpha"])
+        XCTAssertEqual(rows.others.map(\.id), ["beta"])
+        XCTAssertEqual(rows.hidden, [])
+
+        inbox.showsHidden = true
+        rows = inbox.rows(matching: "")
+        XCTAssertEqual(rows.hidden.map(\.id), ["gamma"])
+
+        inbox.showsHidden = false
+        rows = inbox.rows(matching: "gam")
+        XCTAssertEqual(rows.pinned, []); XCTAssertEqual(rows.others, [])
+        XCTAssertEqual(rows.hidden.map(\.id), ["gamma"], "a search names hidden bots too")
+    }
+
+    func testSocketLossKeepsTheRosterAndBlocksEditsUntilReconnect() async throws {
+        let wire = BotInboxFixtureWire(roster: [row("triage")])
+        wire.configure = { _ in XCTFail("no write on a dead socket"); return .null }
+        let inbox = try makeInbox(wires: [wire, BotInboxFixtureWire(roster: [row("triage")])])
+        await inbox.open()
+        wire.onDisconnect?(BotFailure.transport)
+        XCTAssertEqual(inbox.link, .disconnected)
+        XCTAssertEqual(inbox.errorMessage, "Live updates stopped. Pull down to refresh.")
+        XCTAssertEqual(inbox.profiles.map(\.id), ["triage"])
+        XCTAssertFalse(inbox.mayEdit(inbox.profiles[0]))
+        await inbox.setPinned(true, inbox.profiles[0])
+        wire.emit("sessions.changed")
+        await Task.yield()
+        XCTAssertEqual(wire.listCalls, 1)
+
+        await inbox.open()
+        XCTAssertEqual(inbox.link, .live)
+        XCTAssertNil(inbox.errorMessage)
+    }
+
+    // MARK: - Helpers
+
+    private func makeInbox(wires: [BotInboxFixtureWire], store: BotConnectionStore? = nil, server: URL? = nil) throws -> BotInbox {
+        let server = server ?? self.server
+        let store = try store ?? {
+            let store = BotConnectionStore(keychain: InMemoryKeychainStore())
+            try store.save(BotConnection(id: UUID(), name: "Mac", address: URL(string: "https://mac.example")!,
+                                         username: "u", password: "p", hermesVersion: nil), server: server)
+            return store
+        }()
+        var queue = wires
+        return BotInbox(server: server, store: store, unread: BotUnreadStore(defaults: defaults),
+                        avatarStore: BotAvatarStore(), reloadSpacing: .zero) { _ in queue.removeFirst() }
+    }
+
+    private func row(_ name: String, lastActive: Double? = 100, preview: String = "hi", tip: String = "tip",
+                     look: [String: BotJSON]? = nil, revision: Int? = nil) -> BotJSON {
+        var fields: [String: BotJSON] = [
+            "name": .string(name), "display_name": .string(""), "description": .string(""), "has_avatar": .bool(false),
+            "canonical_session": .object([
+                "id": .string("root"), "resolved_id": .string(tip), "preview": .string(preview),
+                "last_active": lastActive.map(BotJSON.number) ?? .null
+            ])
+        ]
+        if let look { fields["ui_meta"] = .object(["hermes-bots": .object(look)]) }
+        if let revision { fields["ui_meta_revisions"] = .object(["hermes-bots": .number(Double(revision))]) }
+        return .object(fields)
+    }
+
+    /// Waits for `condition` through Observation rather than sleeping: each change to
+    /// the inbox re-evaluates it, and the expectation bounds a broken test.
+    private func settle(_ inbox: BotInbox, until condition: @escaping @MainActor (BotInbox) -> Bool) async {
+        let done = expectation(description: "inbox settled")
+        Task { @MainActor in
+            while !condition(inbox) {
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    withObservationTracking { _ = condition(inbox) } onChange: { continuation.resume() }
+                }
+            }
+            done.fulfill()
+        }
+        await fulfillment(of: [done], timeout: 5)
+    }
+}
+
+/// Answers `profiles.list` from `roster`, `profiles.configure` from `configure`, and
+/// lets a test park a list reply or push gateway events.
+@MainActor final class BotInboxFixtureWire: BotTransport {
+    var replayEpoch: String? = "epoch"
+    var onEvent: ((BotJSON) -> Void)?
+    var onDisconnect: ((Error) -> Void)?
+    var roster: [BotJSON]
+    var configure: (([String: BotJSON]) -> BotJSON)?
+    var calls: [(String, [String: BotJSON])] = []
+    var onCall: ((String) -> Void)?
+    /// While true, `profiles.list` waits for `release()`.
+    var holdsList = false
+    private(set) var closed = 0
+    private var held: [CheckedContinuation<Void, Never>] = []
+
+    init(roster: [BotJSON]) { self.roster = roster }
+
+    var listCalls: Int { calls.filter { $0.0 == "profiles.list" }.count }
+
+    func connect() async throws {}
+    func close() { closed += 1 }
+
+    func call(_ method: String, _ params: [String: BotJSON], validateDispatch: (() throws -> Void)?) async throws -> BotJSON {
+        try validateDispatch?()
+        calls.append((method, params))
+        onCall?(method)
+        switch method {
+        case "profiles.list":
+            if holdsList { await withCheckedContinuation { held.append($0) } }
+            return .object(["profiles": .array(roster), "bot_mode_protocol": .bool(true)])
+        case "profiles.configure":
+            guard let configure else { throw BotFailure.unsupported }
+            return configure(params)
+        default:
+            throw BotFailure.unsupported
+        }
+    }
+
+    func release() {
+        let waiting = held; held = []
+        for continuation in waiting { continuation.resume() }
+    }
+
+    func emit(_ type: String) {
+        onEvent?(.object(["type": .string(type), "session_id": .string("")]))
+    }
+}

--- a/HermesMobileTests/BotInboxTests.swift
+++ b/HermesMobileTests/BotInboxTests.swift
@@ -234,6 +234,22 @@ import XCTest
         XCTAssertNil(inbox.errorMessage)
     }
 
+    func testActivityLabelUsesTimeTodayWeekdayThisWeekThenMonthAndDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let locale = Locale(identifier: "en_US")
+        // Thursday 2026-09-10 15:00 UTC.
+        let now = Date(timeIntervalSince1970: 1_789_052_400)
+        let label = { (offset: TimeInterval) in
+            BotInboxDateLabel.text(for: now.addingTimeInterval(offset), now: now, calendar: calendar, locale: locale)
+        }
+        XCTAssertEqual(label(-6 * 3600), "9:00\u{202F}AM")
+        XCTAssertEqual(label(-24 * 3600), "Wednesday")
+        XCTAssertEqual(label(-6 * 86_400), "Friday")
+        XCTAssertEqual(label(-7 * 86_400), "Sep 3")
+        XCTAssertEqual(label(-40 * 86_400), "Aug 1")
+    }
+
     // MARK: - Helpers
 
     private func makeInbox(wires: [BotInboxFixtureWire], store: BotConnectionStore? = nil, server: URL? = nil) throws -> BotInbox {

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -213,6 +213,45 @@ its entries, so equal Profile names on two hosts never share a picture. A
 malformed, oversized or missing asset leaves the row on its letter tile. Desktop's
 animated faces are not ported; the phone shows the static asset only.
 
+`BotInbox` owns the roster for one configured server and one live subscription
+that lasts while the inbox is on screen. `open()` connects, reads
+`profiles.list`, then keeps the socket; the gateway advertises `change_events`
+in `gateway.ready` and broadcasts `sessions.changed` whenever any served
+Profile's `state.db` moves (floored at two seconds, `change_watcher.py`). Each
+event coalesces into one `profiles.list` reload with at most one more queued,
+spaced by one second, applied only when the reply is the newest request and the
+wire still owns the inbox. Event reloads skip the avatar pass: a look change
+never moves `state.db`, so nothing new would be there. Leaving the screen,
+backgrounding, pull-to-refresh and Reconnect all go through `close()` then
+`open()`; a dropped socket keeps the roster on screen, says live updates
+stopped, and makes pin and hide inert until the next `open()`.
+
+Roster organization is Desktop's. `pinned` and `hidden` in
+`ui_meta["hermes-bots"]` are honored: pinned bots come first, hidden bots are
+out of the list unless revealed for the session or named by a search. Desktop's
+user sections are not shown because their catalog (`bot-sections-v1`) lives in
+Desktop's local plugin storage and only an opaque `sectionId` reaches the phone;
+`groups` are executable group rooms, not sections, and stay untouched. A pin or
+hide write is `profiles.configure` with the whole `hermes-bots` object as
+received plus one changed field, under `ui_meta_expected_revisions` set to the
+row's `ui_meta_revisions["hermes-bots"]` (0 when absent), which is how the
+gateway's key-wise merge keeps Desktop-only fields intact. Nothing moves until
+`applied.ui_meta` is true and the roster is re-read; a conflict re-reads the
+roster, shows the fresh state and a one-line notice, and never claims success.
+`profiles.configure` is on the allowlist for this use only; the phone sends no
+`soul`, `model` or capability fields through it.
+
+Unread is device-local. `BotUnreadStore` keeps, per connection UUID and Profile,
+the canonical `last_active` the user last saw, in `UserDefaults` because the
+values are timestamps and never leave the phone. The first roster load seeds a
+missing mark so a fresh install starts quiet; opening a chat marks it seen, and
+returning marks the next roster read seen once so activity that was on screen
+during the visit does not come back as unread. Removing the connection deletes
+its marks with its drafts. Working and needs-attention states are not shown in
+the inbox: the roster row carries no turn state for the canonical chat, and the
+only live signal, `worker_session` heartbeats, describes kanban and tool
+workers rather than the conversation.
+
 Bot Mode ships behind `BotModeGate`, one app-wide `@AppStorage` bool that is off
 by default and owned by the Settings "Bot Mode (beta)" row (#496). Off hides the
 Sessions/Bots switch, the Bots inbox and the per-server Bot connection row;

--- a/docs/agents/bots.md
+++ b/docs/agents/bots.md
@@ -227,11 +227,17 @@ backgrounding, pull-to-refresh and Reconnect all go through `close()` then
 stopped, and makes pin and hide inert until the next `open()`.
 
 Roster organization is Desktop's. `pinned` and `hidden` in
-`ui_meta["hermes-bots"]` are honored: pinned bots come first, hidden bots are
-out of the list unless revealed for the session or named by a search. Desktop's
+`ui_meta["hermes-bots"]` are honored: pinned bots sit above the list as large
+avatar tiles with the name beneath, the rest follow in server order, and hidden
+bots stay out unless revealed for the session (dimmed, in place) or named by a
+search. Pin, Unpin, Hide and Unhide are the row's long-press menu. Desktop's
 user sections are not shown because their catalog (`bot-sections-v1`) lives in
-Desktop's local plugin storage and only an opaque `sectionId` reaches the phone;
-`groups` are executable group rooms, not sections, and stay untouched. A pin or
+the Desktop renderer's `localStorage` and only an opaque `sectionId` reaches the
+phone; named section headers need upstream to publish the catalog on the host.
+`groups` are executable group rooms, not sections, and stay untouched. A
+description of 24 characters or fewer reads as a role chip beside the name when
+the chat has a preview; the activity label is the time today, the weekday within
+the past week, otherwise month and day (`BotInboxDateLabel`). A pin or
 hide write is `profiles.configure` with the whole `hermes-bots` object as
 received plus one changed field, under `ui_meta_expected_revisions` set to the
 row's `ui_meta_revisions["hermes-bots"]` (0 when absent), which is how the


### PR DESCRIPTION
## Linked issue

Fixes #474

## What changed

The Bots inbox loaded the roster once and went stale until you refreshed or foregrounded. It also ignored the pins and hidden bots you set in Hermes Desktop.

Now the inbox keeps its socket while on screen. Each `sessions.changed` broadcast coalesces into one roster reload with at most one queued, stale replies are dropped by wire identity, and a dropped socket keeps the roster with a one-line explanation plus Reconnect and pull-to-refresh. Pinned bots sit above the list as large avatar tiles, hidden bots stay out until revealed from a footer button or matched by a search, and the row's long-press menu offers Pin, Unpin, Hide and Unhide. A blue dot marks a bot whose canonical chat moved past what this phone last showed; the mark is device-local and clears on open or return.

Pin and hide writes go through `profiles.configure` with the whole `hermes-bots` object plus `ui_meta_expected_revisions`, so unrelated Desktop fields survive and a Desktop write in between is reported as a conflict with a fresh roster, never as success. Desktop's named sections are not shown: their catalog lives in Desktop's renderer `localStorage` and only an opaque `sectionId` reaches the host, recorded in `docs/agents/bots.md` as an upstream gap.

Contract verified against hermes-agent `ee35a4624fa22237a90426f5e21d8b4f2ce3a49b`: `profiles.list` row shape, `profiles.configure` key-wise merge and CAS in `tui_gateway/methods_profiles.py`, `sessions.changed` in `tui_gateway/change_watcher.py`, `gateway.ready.change_events` in `tui_gateway/ws.py`, and Desktop's `hidden-bots.ts` / `user-sections.ts`. Pin and hide were also exercised live against the maintainer's host on the test bot.

## How it was tested

- Full suite: `xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17' -parallel-testing-enabled NO` → 2464 tests, 0 failures.
- New `BotInboxTests` cover event bursts, stale reloads, a changed canonical tip, missing metadata, revision round-trip and conflict, hidden reveal and search, socket loss, unread across relaunch and per-connection isolation, and the activity label.
- Signed Debug build on the iPhone 17 simulator against the live host: live update with unread dot, open/return clears it, pin to the tile, hide/reveal/unhide, a Desktop-side rename forcing a conflict, background and return. Screenshots: https://e1du2wo7bft9.postplan.dev
- Not yet done: backgrounding past the Cloudflare idle timeout on a physical iPhone (the simulator cannot suspend the socket) and a second Hermes connection on the same phone (covered by unit test only).

## Checklist

- [x] The full test suite passes locally (`xcodebuild test -project HermesMobile.xcodeproj -scheme HermesMobile -destination 'platform=iOS Simulator,name=iPhone 17'`)
- [x] New/changed `Codable` models decode tolerantly (optionals for fields the server might add or rename)
- [x] No new third-party dependencies (the list in `AGENTS.md` is locked)
- [x] No invented API endpoints or JSON shapes (verified against upstream source or a running server)

Model and harness: Claude Fable 5.1, Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
